### PR TITLE
Add lldb addons

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,0 +1,4 @@
+command script import lldb_addons.py
+
+type summary add --python-function "lldb_addons.class_with_toString" facebook::velox::Type
+type summary add --python-function "lldb_addons.class_with_toString" facebook::axiom::logical_plan::Expr

--- a/lldb_addons.py
+++ b/lldb_addons.py
@@ -1,0 +1,12 @@
+import lldb
+
+def class_with_toString(valobj, internal_dict, options):
+    # assign the object to v
+    if valobj.TypeIsPointerType():
+        v = valobj.Dereference()
+        if not v.GetAddress().IsValid():
+            return "NULL"
+    else:
+        v = valobj
+    s = v.GetNonSyntheticValue().EvaluateExpression('toString()').GetSummary()
+    return "" if s is None else str(s)


### PR DESCRIPTION
After merging this PR and adding `"initCommands": ["command source ${workspaceRoot}/.lldbinit"]` line into lldb configuration in `.vscode/launch.json`, we will see better summary for some types in debugger.
Example:

Before
![before](https://github.com/user-attachments/assets/70b5a6f1-113c-401c-b654-bc2f22ed4af7)

After
![after](https://github.com/user-attachments/assets/65faa080-b040-4ac0-a718-a2f59ce2b75c)

List of supported types can be trivially expanded.