### PR TITLE
fix: Use ForeignId for distributeShardsLike serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ WindowsLibraries/
 p/
 /tests/sqllogic/.venv/**
 .venv/*
-private
 
 TAGS
 
@@ -75,7 +74,6 @@ server/aql/grammar.output
 
 /bin
 logs/
-out/
 
 etc/serenedb/*.conf
 

--- a/server/catalog/table.cpp
+++ b/server/catalog/table.cpp
@@ -136,7 +136,7 @@ Table::Table(TableOptions&& options, ObjectId database_id)
       auto plan_db = options.planDb.value_or(ObjectId{});
       return plan_db.isSet() ? plan_db : database_id;
     }()},
-    _distribute_shards_like{options.distributeShardsLike.value_or(ObjectId{})},
+    _distribute_shards_like{options.distributeShardsLike.value_or(ForeignId{})},
     _from{options.from},
     _to{options.to},
     _key_generator{std::move(options.keyOptions)},
@@ -177,7 +177,7 @@ TableOptions Table::MakeTableOptions() const {
     .keyOptions = _key_generator,
     .shards = _shard_ids,
     .id = Identifier{GetId().id()},
-    .distributeShardsLike = _distribute_shards_like,
+    .distributeShardsLike = ForeignId{_distribute_shards_like.id()},
     .planId = Identifier{_plan_id.id()},
     .planDb = _plan_db,
     .from = ForeignId{_from.id()},

--- a/server/catalog/table_options.cpp
+++ b/server/catalog/table_options.cpp
@@ -217,7 +217,7 @@ Result MakeTableOptions(CreateTableRequest&& request, ObjectId database_id,
               leader->shardKeys().size()};
     }
 
-    options.distributeShardsLike = leader->GetId();
+    options.distributeShardsLike = ForeignId{leader->GetId().id()};
   } else {
     if (request.shardingStrategy) {
       if (*request.shardingStrategy != "hash") {

--- a/server/catalog/table_options.h
+++ b/server/catalog/table_options.h
@@ -180,7 +180,7 @@ struct TableOptions {
   std::shared_ptr<KeyGenerator> keyOptions;
   std::shared_ptr<ShardMap> shards = std::make_shared<ShardMap>();
   Identifier id;
-  std::optional<ObjectId> distributeShardsLike;
+  std::optional<ForeignId> distributeShardsLike;
   std::optional<Identifier> planId;  // TODO(gnusi): remove
   std::optional<ObjectId> planDb;    // TODO(gnusi): remove
   ForeignId from;


### PR DESCRIPTION
Proper fix should include rollback recent changes made by @pashandor789 

We don't want to use stateful struct for serialization