### PR TITLE
Use common type Columnd::Id for column identifiers

### DIFF
--- a/server/connector/data_sink.cpp
+++ b/server/connector/data_sink.cpp
@@ -65,7 +65,7 @@ RocksDBDataSink::RocksDBDataSink(
   rocksdb::Transaction& transaction, rocksdb::ColumnFamilyHandle& cf,
   const velox::RowTypePtr& row_type, velox::memory::MemoryPool& memory_pool,
   ObjectId object_key, std::span<const velox::column_index_t> key_childs,
-  std::vector<key_utils::ColumnId> column_oids, bool skip_primary_key_columns)
+  std::vector<catalog::Column::Id> column_oids, bool skip_primary_key_columns)
   : _row_type{std::move(row_type)},
     _transaction{transaction},
     _cf{cf},
@@ -1996,7 +1996,7 @@ velox::connector::DataSink::Stats RocksDBDataSink::stats() const {
 RocksDBDeleteDataSink::RocksDBDeleteDataSink(
   rocksdb::Transaction& transaction, rocksdb::ColumnFamilyHandle& cf,
   velox::RowTypePtr row_type, ObjectId object_key,
-  std::vector<key_utils::ColumnId> column_oids)
+  std::vector<catalog::Column::Id> column_oids)
   : _row_type{std::move(row_type)},
     _transaction{transaction},
     _cf{cf},

--- a/server/connector/data_sink.hpp
+++ b/server/connector/data_sink.hpp
@@ -30,7 +30,7 @@
 #include <vector>
 
 #include "catalog/identifiers/object_id.h"
-#include "connector/key_utils.hpp"
+#include "catalog/table_options.h"
 #include "primary_key.hpp"
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/write_batch.h"
@@ -44,7 +44,7 @@ class RocksDBDataSink : public velox::connector::DataSink {
                   const velox::RowTypePtr& row_type,
                   velox::memory::MemoryPool& memory_pool, ObjectId object_key,
                   std::span<const velox::column_index_t> key_childs,
-                  std::vector<key_utils::ColumnId> column_ids,
+                  std::vector<catalog::Column::Id> column_ids,
                   bool skip_primary_key_columns = false);
 
   void appendData(velox::RowVectorPtr input) final;
@@ -185,7 +185,7 @@ class RocksDBDataSink : public velox::connector::DataSink {
   rocksdb::ColumnFamilyHandle& _cf;
   ObjectId _object_key;
   std::vector<velox::column_index_t> _key_childs;
-  std::vector<key_utils::ColumnId> _column_ids;
+  std::vector<catalog::Column::Id> _column_ids;
   velox::memory::MemoryPool& _memory_pool;
   SliceVector _row_slices;
   primary_key::Keys _row_keys;
@@ -198,7 +198,7 @@ class RocksDBDeleteDataSink : public velox::connector::DataSink {
   RocksDBDeleteDataSink(rocksdb::Transaction& transaction,
                         rocksdb::ColumnFamilyHandle& cf,
                         velox::RowTypePtr row_type, ObjectId object_key,
-                        std::vector<key_utils::ColumnId> column_ids);
+                        std::vector<catalog::Column::Id> column_ids);
 
   void appendData(velox::RowVectorPtr input) final;
   bool finish() final;
@@ -213,7 +213,7 @@ class RocksDBDeleteDataSink : public velox::connector::DataSink {
   rocksdb::Transaction& _transaction;
   rocksdb::ColumnFamilyHandle& _cf;
   ObjectId _object_key;
-  std::vector<key_utils::ColumnId> _column_ids;
+  std::vector<catalog::Column::Id> _column_ids;
 };
 
 }  // namespace sdb::connector

--- a/server/connector/data_source.cpp
+++ b/server/connector/data_source.cpp
@@ -25,14 +25,14 @@
 
 #include "basics/assert.h"
 #include "common.h"
-#include "connector/key_utils.hpp"
+#include "key_utils.hpp"
 
 namespace sdb::connector {
 
 RocksDBDataSource::RocksDBDataSource(
   velox::memory::MemoryPool& memory_pool, rocksdb::Snapshot* snapshot,
   rocksdb::DB& db, rocksdb::ColumnFamilyHandle& cf, velox::RowTypePtr row_type,
-  std::vector<key_utils::ColumnId> column_oids, ObjectId object_key)
+  std::vector<catalog::Column::Id> column_oids, ObjectId object_key)
   : velox::connector::DataSource{},
     _memory_pool{memory_pool},
     _snapshot{snapshot},

--- a/server/connector/data_source.hpp
+++ b/server/connector/data_source.hpp
@@ -24,7 +24,7 @@
 
 #include "basics/fwd.h"
 #include "catalog/identifiers/object_id.h"
-#include "connector/key_utils.hpp"
+#include "catalog/table_options.h"
 #include "rocksdb/utilities/transaction.h"
 
 namespace sdb::connector {
@@ -39,7 +39,7 @@ class RocksDBDataSource final : public velox::connector::DataSource {
                     // WriteBatchWithindex or plain DB with snapshot
                     rocksdb::Snapshot* snapshot, rocksdb::DB& db,
                     rocksdb::ColumnFamilyHandle& cf, velox::RowTypePtr row_type,
-                    std::vector<key_utils::ColumnId> column_ids,
+                    std::vector<catalog::Column::Id> column_ids,
                     ObjectId object_key);
 
   void addSplit(std::shared_ptr<velox::connector::ConnectorSplit> split) final;
@@ -81,7 +81,7 @@ class RocksDBDataSource final : public velox::connector::DataSource {
   rocksdb::DB& _db;
   rocksdb::ColumnFamilyHandle& _cf;
   velox::RowTypePtr _row_type;
-  std::vector<key_utils::ColumnId> _column_ids;
+  std::vector<catalog::Column::Id> _column_ids;
   std::shared_ptr<velox::connector::ConnectorSplit> _current_split;
   ObjectId _object_key;
   std::string _last_read_key;

--- a/server/connector/key_utils.cpp
+++ b/server/connector/key_utils.cpp
@@ -29,19 +29,19 @@ std::string PrepareTableKey(ObjectId id) {
   return key;
 }
 
-std::string PrepareColumnKey(ObjectId id, ColumnId column_oid) {
+std::string PrepareColumnKey(ObjectId id, catalog::Column::Id column_oid) {
   SDB_ASSERT(id.isSet());
   std::string key;
   rocksutils::Concat(key, id, column_oid);
   return key;
 }
 
-void AppendColumnKey(std::string& key, ColumnId column_oid) {
+void AppendColumnKey(std::string& key, catalog::Column::Id column_oid) {
   SDB_ASSERT(!key.empty());
   rocksutils::Append(key, column_oid);
 }
 
-void AppendCellKey(std::string& key, ColumnId column_oid,
+void AppendCellKey(std::string& key, catalog::Column::Id column_oid,
                    std::string_view primary_key) {
   SDB_ASSERT(!primary_key.empty());
   SDB_ASSERT(!key.empty());
@@ -59,13 +59,14 @@ std::pair<std::string, std::string> CreateTableRange(ObjectId id) {
   if (id.id() != std::numeric_limits<decltype(id.id())>::max()) {
     return {PrepareTableKey(id), PrepareTableKey(ObjectId{id.id() + 1})};
   }
-  return {PrepareTableKey(id),
-          PrepareColumnKey(id, std::numeric_limits<ColumnId>::max())};
+  return {
+    PrepareTableKey(id),
+    PrepareColumnKey(id, std::numeric_limits<catalog::Column::Id>::max())};
 }
 
 std::pair<std::string, std::string> CreateTableColumnRange(
-  ObjectId id, ColumnId column_oid) {
-  SDB_ASSERT(column_oid != std::numeric_limits<ColumnId>::max());
+  ObjectId id, catalog::Column::Id column_oid) {
+  SDB_ASSERT(column_oid != std::numeric_limits<catalog::Column::Id>::max());
   return {PrepareColumnKey(id, column_oid),
           PrepareColumnKey(id, column_oid + 1)};
 }

--- a/server/connector/key_utils.hpp
+++ b/server/connector/key_utils.hpp
@@ -21,25 +21,24 @@
 #pragma once
 
 #include "catalog/identifiers/object_id.h"
+#include "catalog/table_options.h"
 #include "rocksdb_engine_catalog/concat.h"
 
 namespace sdb::connector::key_utils {
-
-using ColumnId = uint32_t;
 
 // Constructs common part of table row. Result could be used with AppendXXX
 // methods to construct full keys.
 std::string PrepareTableKey(ObjectId id);
 
 // Same as above but base part is constructed for specific column.
-std::string PrepareColumnKey(ObjectId id, ColumnId column_oid);
+std::string PrepareColumnKey(ObjectId id, catalog::Column::Id column_oid);
 
 // Appends column OID to the Table key created with PrepareTableKey.
-void AppendColumnKey(std::string& key, ColumnId column_oid);
+void AppendColumnKey(std::string& key, catalog::Column::Id column_oid);
 
 // Gets full row key by appending column OID and primary key to the Table key
 // created with PrepareTableKey.
-void AppendCellKey(std::string& key, ColumnId column_oid,
+void AppendCellKey(std::string& key, catalog::Column::Id column_oid,
                    std::string_view primary_key);
 
 // Appends primary key to the base key part. Could be table key for creating
@@ -50,7 +49,7 @@ void AppendPrimaryKey(std::string& key, std::string_view primary_key);
 std::pair<std::string, std::string> CreateTableRange(ObjectId id);
 
 // creates range covering all rows of specific column of the table
-std::pair<std::string, std::string> CreateTableColumnRange(ObjectId id,
-                                                           ColumnId column_oid);
+std::pair<std::string, std::string> CreateTableColumnRange(
+  ObjectId id, catalog::Column::Id column_oid);
 
 }  // namespace sdb::connector::key_utils

--- a/tests/server/connector/data_sink_test.cpp
+++ b/tests/server/connector/data_sink_test.cpp
@@ -22,6 +22,7 @@
 
 #include "connector/common.h"
 #include "connector/data_sink.hpp"
+#include "connector/key_utils.hpp"
 #include "connector/primary_key.hpp"
 #include "gtest/gtest.h"
 #include "iresearch/utils/bytes_utils.hpp"
@@ -90,11 +91,10 @@ class DataSinkTest : public ::testing::Test,
     rocksdb::WriteOptions wo;
     transaction.reset(_db->BeginTransaction(wo, trx_opts, nullptr));
     ASSERT_NE(transaction, nullptr);
-    std::vector<sdb::connector::key_utils::ColumnId> column_oids;
+    std::vector<sdb::catalog::Column::Id> column_oids;
     column_oids.reserve(data->childrenSize());
     for (velox::column_index_t i = 0; i < data->childrenSize(); ++i) {
-      column_oids.push_back(
-        static_cast<sdb::connector::key_utils::ColumnId>(i));
+      column_oids.push_back(static_cast<sdb::catalog::Column::Id>(i));
     }
     sdb::connector::primary_key::Create(*data, pk, written_row_keys);
     sdb::connector::RocksDBDataSink sink(
@@ -2490,8 +2490,7 @@ TEST_F(DataSinkTest, test_deleteDataSink) {
 }
 
 TEST_F(DataSinkTest, test_deleteDataSinkPartial) {
-  const std::vector<sdb::connector::key_utils::ColumnId> column_ids = {0, 1, 2,
-                                                                       3};
+  const std::vector<sdb::catalog::Column::Id> column_ids = {0, 1, 2, 3};
   std::vector<std::string> names = {"hero", "role", "skill_level"};
   std::vector<velox::TypePtr> types = {velox::VARCHAR(), velox::VARCHAR(),
                                        velox::INTEGER()};
@@ -2569,7 +2568,7 @@ TEST_F(DataSinkTest, test_deleteDataSinkPartial) {
 }
 
 TEST_F(DataSinkTest, test_insertDeleteConflict) {
-  const std::vector<sdb::connector::key_utils::ColumnId> column_ids = {0, 1};
+  const std::vector<sdb::catalog::Column::Id> column_ids = {0, 1};
   std::vector<std::string> names = {"id", "name"};
   auto row_type =
     velox::ROW(names, {velox::createScalarType(velox::TypeKind::INTEGER),

--- a/tests/server/connector/data_source_test.cpp
+++ b/tests/server/connector/data_source_test.cpp
@@ -72,7 +72,7 @@ class DataSourceTest : public ::testing::Test,
 
   void MakeRocksDBWrite(velox::RowVectorPtr data, sdb::ObjectId object_key) {
     std::vector<velox::column_index_t> pk;
-    std::vector<sdb::connector::key_utils::ColumnId> column_ids;
+    std::vector<sdb::catalog::Column::Id> column_ids;
     column_ids.reserve(data->type()->asRow().size());
     for (velox::vector_size_t i = 0; i < data->type()->asRow().size(); ++i) {
       if (!data->childAt(i)->mayHaveNulls()) {
@@ -100,7 +100,7 @@ class DataSourceTest : public ::testing::Test,
   void MakeRocksDBWriteRead(velox::RowVectorPtr data,
                             sdb::ObjectId object_key) {
     MakeRocksDBWrite(data, object_key);
-    std::vector<sdb::connector::key_utils::ColumnId> column_ids;
+    std::vector<sdb::catalog::Column::Id> column_ids;
     column_ids.reserve(data->type()->asRow().size());
     for (velox::vector_size_t i = 0; i < data->type()->asRow().size(); ++i) {
       column_ids.emplace_back(i);

--- a/tests/server/connector/key_utils_test.cpp
+++ b/tests/server/connector/key_utils_test.cpp
@@ -34,7 +34,7 @@ TEST(KeyUtilsTest, PrepareTableKey) {
 
 TEST(KeyUtilsTest, PrepareColumnKey) {
   ObjectId id{1};
-  ColumnId col = 7;
+  catalog::Column::Id col = 7;
   std::string key = PrepareColumnKey(id, col);
   ASSERT_EQ(key, std::string_view(
                    "\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07", 12));
@@ -87,7 +87,7 @@ TEST(KeyUtilsTest, CreateTableRangeMax) {
 
 TEST(KeyUtilsTest, CreateTableColumnRange) {
   ObjectId id{11};
-  ColumnId col = 2;
+  catalog::Column::Id col = 2;
   auto range = CreateTableColumnRange(id, col);
   ASSERT_EQ(
     range.first,
@@ -99,7 +99,7 @@ TEST(KeyUtilsTest, CreateTableColumnRange) {
 
 TEST(KeyUtilsTest, CreateTableColumnRangeMax) {
   ObjectId id{std::numeric_limits<decltype(id.id())>::max()};
-  ColumnId col = std::numeric_limits<ColumnId>::max() - 1;
+  catalog::Column::Id col = std::numeric_limits<catalog::Column::Id>::max() - 1;
   auto range = CreateTableColumnRange(id, col);
   ASSERT_EQ(
     range.first,


### PR DESCRIPTION
Trivial change - replace `key_utils::ColumnId` with more common `catalog::Column::Id`
No behavioral changes