### PR TITLE
Make Column::Id uint64_t

### DIFF
--- a/server/catalog/table_options.h
+++ b/server/catalog/table_options.h
@@ -142,7 +142,7 @@ struct Column {
     return generated_type != GeneratedType::kNone;
   }
 
-  using Id = uint32_t;
+  using Id = uint64_t;
 
   Id id;
   velox::TypePtr type;


### PR DESCRIPTION
I've benchmarked `uint16_t` vs `uint64_t` for `Column::Id`. Query is
```SQL
CREATE TABLE series_table3(a INTEGER PRIMARY KEY, b INTEGER, c INTEGER);

\timing on

INSERT INTO series_table3 SELECT t1.x * 10000 + t2.x * 100 + t3.x, t2.x, t3.x  FROM
generate_series(1, 100) as t1(x),
  generate_series(1, 100) as t2(x),
  generate_series(1, 100) as t3(x);
```

Result is following:
```
====== UINT64 =====
Number of runs: 100

Table of 3 keys:
  p50:  2107.739 ms
  p75:  2178.495 ms
  p90:  2291.023 ms
  p95:  2301.911 ms
  max:  2346.106 ms
  avg:  2149.008 ms


====== UINT16 =====
Number of runs: 100

Table of 3 keys:
  p50:  2076.630 ms (-1.48%)
  p75:  2121.445 ms (-2.62%)
  p90:  2253.482 ms (-1.64%)
  p95:  2266.324 ms (-1.55%)
  max:  2297.710 ms (-2.06%)
  avg:  2104.463 ms (-2.07%)

3 keys p-value: 0.000
```

So we've decided that it's better to make `Column::Id` type as `uint64_t` because it's more convenient and performance cons are not so large, but may be changed later though.