### PR TITLE
perf: Speedup iresearch search and count

### DIFF
--- a/libs/iresearch/include/iresearch/formats/columnstore2.cpp
+++ b/libs/iresearch/include/iresearch/formats/columnstore2.cpp
@@ -228,6 +228,15 @@ class RangeColumnIterator : public ResettableDocIterator,
     return std::get<DocAttr>(_attrs).value;
   }
 
+  doc_id_t advance() final {
+    if (_min_doc <= _max_doc) {
+      std::get<PayAttr>(_attrs).value = this->payload(_min_doc - _min_base);
+      return std::get<DocAttr>(_attrs).value = _min_doc++;
+    }
+    std::get<PayAttr>(_attrs).value = {};
+    return std::get<DocAttr>(_attrs).value = doc_limits::eof();
+  }
+
   doc_id_t seek(doc_id_t doc) final {
     if (_min_doc <= doc && doc <= _max_doc) [[likely]] {
       std::get<DocAttr>(_attrs).value = doc;
@@ -251,17 +260,6 @@ class RangeColumnIterator : public ResettableDocIterator,
     }
 
     return value();
-  }
-
-  bool next() final {
-    if (_min_doc <= _max_doc) {
-      std::get<PayAttr>(_attrs).value = this->payload(_min_doc - _min_base);
-      std::get<DocAttr>(_attrs).value = _min_doc++;
-      return true;
-    }
-    std::get<PayAttr>(_attrs).value = {};
-    std::get<DocAttr>(_attrs).value = doc_limits::eof();
-    return false;
   }
 
   void reset() noexcept final {
@@ -313,26 +311,20 @@ class BitmapColumnIterator : public ResettableDocIterator,
     return std::get<AttributePtr<DocAttr>>(_attrs).ptr->value;
   }
 
-  doc_id_t seek(doc_id_t doc) final {
-    SDB_ASSERT(doc_limits::valid(doc) || doc_limits::valid(value()));
-    doc = _bitmap.seek(doc);
-
-    if (!doc_limits::eof(doc)) {
-      std::get<PayAttr>(_attrs).value = this->payload(_bitmap.index());
-      return doc;
-    }
-
-    std::get<PayAttr>(_attrs).value = {};
-    return doc_limits::eof();
+  doc_id_t advance() final {
+    const auto doc = _bitmap.advance();
+    std::get<PayAttr>(_attrs).value =
+      doc_limits::eof(doc) ? bytes_view{} : this->payload(_bitmap.index());
+    return doc;
   }
 
-  bool next() final {
-    if (_bitmap.next()) {
-      std::get<PayAttr>(_attrs).value = this->payload(_bitmap.index());
-      return true;
-    }
-    std::get<PayAttr>(_attrs).value = {};
-    return false;
+  doc_id_t seek(doc_id_t doc) final {
+    // TODO(mbkkt) assert is strange
+    SDB_ASSERT(doc_limits::valid(doc) || doc_limits::valid(value()));
+    doc = _bitmap.seek(doc);
+    std::get<PayAttr>(_attrs).value =
+      doc_limits::eof(doc) ? bytes_view{} : this->payload(_bitmap.index());
+    return doc;
   }
 
   void reset() final { _bitmap.reset(); }
@@ -1514,8 +1506,8 @@ void Column::finish(IndexOutput& index_out) {
                                        .track_prev_doc = false,
                                        .use_block_index = false,
                                        .blocks = {}}};
-  if (it.next()) {
-    hdr.min = it.value();
+  if (const auto min = it.advance(); !doc_limits::eof(min)) {
+    hdr.min = min;
   }
 
   // FIXME(gnusi): how to deal with rollback() and docs_writer_.back()?

--- a/libs/iresearch/include/iresearch/formats/sparse_bitmap.hpp
+++ b/libs/iresearch/include/iresearch/formats/sparse_bitmap.hpp
@@ -215,7 +215,7 @@ class SparseBitmapIterator : public ResettableDocIterator {
     return std::get<DocAttr>(_attrs).value;
   }
 
-  bool next() final { return !doc_limits::eof(seek(value() + 1)); }
+  doc_id_t advance() final { return seek(value() + 1); }
 
   doc_id_t seek(doc_id_t target) final;
 

--- a/libs/iresearch/include/iresearch/index/buffered_column_iterator.hpp
+++ b/libs/iresearch/include/iresearch/index/buffered_column_iterator.hpp
@@ -69,12 +69,11 @@ class BufferedColumnIterator : public ResettableDocIterator {
     return std::get<DocAttr>(_attrs).value;
   }
 
-  bool next() noexcept final {
+  doc_id_t advance() noexcept final {
     auto& doc_value = std::get<DocAttr>(_attrs).value;
 
     if (_next == _end) [[unlikely]] {
-      doc_value = doc_limits::eof();
-      return false;
+      return doc_value = doc_limits::eof();
     }
 
     auto& payload = std::get<irs::PayAttr>(_attrs);
@@ -84,7 +83,7 @@ class BufferedColumnIterator : public ResettableDocIterator {
 
     ++_next;
 
-    return true;
+    return doc_value;
   }
 
   doc_id_t seek(doc_id_t target) noexcept final {
@@ -103,8 +102,7 @@ class BufferedColumnIterator : public ResettableDocIterator {
     }
 
     _next = curr;
-    next();
-    return value();
+    return advance();
   }
 
   void reset() final {

--- a/libs/iresearch/include/iresearch/index/field_data.cpp
+++ b/libs/iresearch/include/iresearch/index/field_data.cpp
@@ -261,13 +261,12 @@ class DocIteratorImpl : public DocIterator {
     return std::get<DocAttr>(_attrs).value;
   }
 
-  bool next() final {
+  doc_id_t advance() final {
     auto& doc_value = std::get<DocAttr>(_attrs).value;
 
     if (_freq_in.eof()) {
       if (!_posting) {
-        doc_value = doc_limits::eof();
-        return false;
+        return doc_value = doc_limits::eof();
       }
 
       doc_value = _posting->doc;
@@ -304,7 +303,7 @@ class DocIteratorImpl : public DocIterator {
 
     _pos.Clear();
 
-    return true;
+    return doc_value;
   }
 
   doc_id_t seek(doc_id_t doc) final {
@@ -385,7 +384,7 @@ class SortingDocIteratorImpl : public DocIterator {
     return std::get<DocAttr>(_attrs).value;
   }
 
-  bool next() noexcept final {
+  doc_id_t advance() noexcept final {
     auto& doc_value = std::get<DocAttr>(_attrs).value;
 
     while (_it != _docs.end()) {
@@ -404,12 +403,11 @@ class SortingDocIteratorImpl : public DocIterator {
       }
 
       ++_it;
-      return true;
+      return doc_value;
     }
 
     _freq.value = 0;
-    doc_value = doc_limits::eof();
-    return false;
+    return doc_value = doc_limits::eof();
   }
 
   doc_id_t seek(doc_id_t doc) noexcept final {

--- a/libs/iresearch/include/iresearch/index/iterators.cpp
+++ b/libs/iresearch/include/iresearch/index/iterators.cpp
@@ -41,9 +41,10 @@ struct EmptyDocIterator : ResettableDocIterator {
     return Type<CostAttr>::id() == id ? &_cost : nullptr;
   }
   doc_id_t value() const final { return doc_limits::eof(); }
-  bool next() final { return false; }
+  doc_id_t advance() final { return doc_limits::eof(); }
   doc_id_t seek(doc_id_t /*target*/) final { return doc_limits::eof(); }
   doc_id_t shallow_seek(doc_id_t /*target*/) final { return doc_limits::eof(); }
+  uint32_t count() final { return 0; }
   void reset() final {}
 
  private:

--- a/libs/iresearch/include/iresearch/index/iterators.hpp
+++ b/libs/iresearch/include/iresearch/index/iterators.hpp
@@ -51,7 +51,10 @@ struct DocIterator : AttributeProvider {
 
   virtual doc_id_t value() const = 0;
 
-  virtual bool next() = 0;
+  virtual doc_id_t advance() = 0;
+
+  // deprecated: use advance() instead
+  IRS_FORCE_INLINE bool next() { return !doc_limits::eof(advance()); }
 
   // Position iterator at a specified target and returns current value
   // (for more information see class description)
@@ -72,6 +75,18 @@ struct DocIterator : AttributeProvider {
   virtual doc_id_t shallow_seek(doc_id_t target) {
     seek(target);
     return doc_limits::eof();
+  }
+
+  virtual uint32_t count() { return Count(*this); }
+
+ protected:
+  template<typename Iterator>
+  static uint32_t Count(Iterator& it) {
+    uint32_t count = 0;
+    while (it.next()) {
+      ++count;
+    }
+    return count;
   }
 };
 

--- a/libs/iresearch/include/iresearch/index/merge_writer.cpp
+++ b/libs/iresearch/include/iresearch/index/merge_writer.cpp
@@ -137,9 +137,8 @@ class ProgressTracker {
 class RemappingDocIterator : public DocIterator {
  public:
   RemappingDocIterator(DocIterator::ptr&& it, const DocMapF& mapper) noexcept
-    : _it{std::move(it)}, _mapper{&mapper}, _src{irs::get<DocAttr>(*_it)} {
+    : _it{std::move(it)}, _mapper{&mapper} {
     SDB_ASSERT(_it);
-    SDB_ASSERT(_src);
   }
 
   Attribute* GetMutable(TypeInfo::type_id type) noexcept final {
@@ -149,7 +148,7 @@ class RemappingDocIterator : public DocIterator {
 
   doc_id_t value() const noexcept final { return _doc.value; }
 
-  bool next() final;
+  doc_id_t advance() final;
 
   doc_id_t seek(doc_id_t target) final {
     irs::seek(*this, target);
@@ -159,22 +158,22 @@ class RemappingDocIterator : public DocIterator {
  private:
   DocIterator::ptr _it;
   const DocMapF* _mapper;
-  const irs::DocAttr* _src;
   irs::DocAttr _doc;
 };
 
-bool RemappingDocIterator::next() {
-  while (_it->next()) {
-    _doc.value = (*_mapper)(_src->value);
+doc_id_t RemappingDocIterator::advance() {
+  while (true) {
+    const auto it_value = _it->advance();
+    if (doc_limits::eof(it_value)) {
+      return _doc.value = doc_limits::eof();
+    }
 
+    _doc.value = (*_mapper)(it_value);
     if (doc_limits::eof(_doc.value)) {
       continue;  // masked doc_id
     }
-
-    return true;
+    return _doc.value;
   }
-
-  return false;
 }
 
 // Iterator over doc_ids for a term over all readers
@@ -217,7 +216,7 @@ class CompoundDocIterator : public DocIterator {
 
   doc_id_t value() const noexcept final { return _doc.value; }
 
-  bool next() final;
+  doc_id_t advance() final;
 
   doc_id_t seek(doc_id_t target) final {
     irs::seek(*this, target);
@@ -234,45 +233,45 @@ class CompoundDocIterator : public DocIterator {
   DocAttr _doc;
 };
 
-bool CompoundDocIterator::next() {
+doc_id_t CompoundDocIterator::advance() {
   _progress();
 
   if (Aborted()) {
-    _doc.value = doc_limits::eof();
     _iterators.clear();
-    return false;
+    return _doc.value = doc_limits::eof();
   }
 
   for (bool notify = !doc_limits::valid(_doc.value);
        _current_itr < _iterators.size(); notify = true, ++_current_itr) {
-    auto& itr_entry = _iterators[_current_itr];
-    auto& itr = itr_entry.first;
-    auto& id_map = itr_entry.second.get();
+    auto& it_entry = _iterators[_current_itr];
+    auto& it = it_entry.first;
+    auto& id_map = it_entry.second.get();
 
-    if (!itr) {
+    if (!it) {
       continue;
     }
 
     if (notify) {
-      _attribute_change(*itr);
+      _attribute_change(*it);
     }
 
-    while (itr->next()) {
-      _doc.value = id_map(itr->value());
+    while (true) {
+      auto it_value = it->advance();
+      if (doc_limits::eof(it_value)) {
+        break;
+      }
 
+      _doc.value = id_map(it_value);
       if (doc_limits::eof(_doc.value)) {
         continue;  // masked doc_id
       }
-
-      return true;
+      return _doc.value;
     }
 
-    itr.reset();
+    it.reset();
   }
 
-  _doc.value = doc_limits::eof();
-
-  return false;
+  return _doc.value = doc_limits::eof();
 }
 
 // Iterator over sorted doc_ids for a term over all readers
@@ -299,7 +298,7 @@ class SortingCompoundDocIterator : public DocIterator {
 
   doc_id_t value() const noexcept final { return _doc_it->value(); }
 
-  bool next() final;
+  doc_id_t advance() final;
 
   doc_id_t seek(doc_id_t target) final {
     irs::seek(*this, target);
@@ -334,14 +333,13 @@ class SortingCompoundDocIterator : public DocIterator {
   CompoundDocIterator::DocIteratorT* _lead{};
 };
 
-bool SortingCompoundDocIterator::next() {
+doc_id_t SortingCompoundDocIterator::advance() {
   _doc_it->_progress();
 
   auto& current_id = _doc_it->_doc.value;
   if (_doc_it->Aborted()) {
     _doc_it->_iterators.clear();
-    current_id = doc_limits::eof();
-    return false;
+    return current_id = doc_limits::eof();
   }
 
   while (_merge_it.Next()) {
@@ -357,12 +355,11 @@ bool SortingCompoundDocIterator::next() {
 
     current_id = doc_map(it->value());
     if (!doc_limits::eof(current_id)) {
-      return true;
+      return current_id;
     }
   }
 
-  current_id = doc_limits::eof();
-  return false;
+  return current_id = doc_limits::eof();
 }
 
 class DocIteratorContainer {

--- a/libs/iresearch/include/iresearch/search/all_iterator.hpp
+++ b/libs/iresearch/include/iresearch/search/all_iterator.hpp
@@ -45,16 +45,26 @@ class AllIterator : public DocIterator {
     return std::get<DocAttr>(_attrs).value;
   }
 
-  bool next() noexcept final {
+  doc_id_t advance() noexcept final {
     auto& doc_value = std::get<DocAttr>(_attrs).value;
     doc_value = doc_value < _max_doc ? doc_value + 1 : doc_limits::eof();
-    return !doc_limits::eof(doc_value);
+    return doc_value;
   }
 
   doc_id_t seek(doc_id_t target) noexcept final {
     auto& doc_value = std::get<DocAttr>(_attrs).value;
     doc_value = target <= _max_doc ? target : doc_limits::eof();
     return doc_value;
+  }
+
+  uint32_t count() final {
+    auto& doc_value = std::get<DocAttr>(_attrs).value;
+    if (doc_limits::eof(doc_value)) {
+      return 0;
+    }
+    const auto count = _max_doc - doc_value;
+    doc_value = doc_limits::eof();
+    return count;
   }
 
  private:

--- a/libs/iresearch/include/iresearch/search/bitset_doc_iterator.cpp
+++ b/libs/iresearch/include/iresearch/search/bitset_doc_iterator.cpp
@@ -44,7 +44,7 @@ Attribute* BitsetDocIterator::GetMutable(TypeInfo::type_id id) noexcept {
   return Type<CostAttr>::id() == id ? &_cost : nullptr;
 }
 
-bool BitsetDocIterator::next() noexcept {
+doc_id_t BitsetDocIterator::advance() noexcept {
   while (!_word) {
     if (_next >= _end) {
       if (refill(&_begin, &_end)) {
@@ -53,8 +53,7 @@ bool BitsetDocIterator::next() noexcept {
       }
 
       _word = 0;
-      _doc.value = doc_limits::eof();
-      return false;
+      return _doc.value = doc_limits::eof();
     }
 
     _word = *_next++;
@@ -67,8 +66,7 @@ bool BitsetDocIterator::next() noexcept {
   SDB_ASSERT(delta < BitsRequired<word_t>());
 
   _word = (_word >> delta) >> 1;
-  _doc.value += 1 + delta;
-  return true;
+  return _doc.value += 1 + delta;
 }
 
 doc_id_t BitsetDocIterator::seek(doc_id_t target) noexcept {
@@ -98,8 +96,12 @@ doc_id_t BitsetDocIterator::seek(doc_id_t target) noexcept {
   _doc.value = _base - 1 + bit_idx;
 
   // FIXME consider inlining to speedup
-  next();
-  return _doc.value;
+  return advance();
+}
+
+uint32_t BitsetDocIterator::count() noexcept {
+  // TODO(mbkkt) custom implementation?
+  return Count(*this);
 }
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/bitset_doc_iterator.hpp
+++ b/libs/iresearch/include/iresearch/search/bitset_doc_iterator.hpp
@@ -38,8 +38,9 @@ class BitsetDocIterator : public DocIterator, private util::Noncopyable {
 
   Attribute* GetMutable(TypeInfo::type_id id) noexcept override;
   doc_id_t value() const noexcept final { return _doc.value; }
-  bool next() noexcept final;
+  doc_id_t advance() noexcept final;
   doc_id_t seek(doc_id_t target) noexcept final;
+  uint32_t count() noexcept final;
 
  protected:
   explicit BitsetDocIterator(CostAttr::Type cost) noexcept

--- a/libs/iresearch/include/iresearch/search/score.hpp
+++ b/libs/iresearch/include/iresearch/search/score.hpp
@@ -59,7 +59,7 @@ struct ScoreAttr : Attribute, ScoreFunction {
   } max;
 };
 
-using ScoreFunctions = sdb::containers::SmallVector<ScoreFunction, 2>;
+using ScoreFunctions = sdb::containers::SmallVector<ScoreFunction, 1>;
 
 // Prepare scorer for each of the bucket.
 ScoreFunctions PrepareScorers(std::span<const ScorerBucket> buckets,

--- a/libs/iresearch/include/iresearch/search/scorer.hpp
+++ b/libs/iresearch/include/iresearch/search/scorer.hpp
@@ -274,7 +274,7 @@ class Scorers final : private util::Noncopyable {
   IndexFeatures features() const noexcept { return _features; }
 
  private:
-  using ScorerBuckets = sdb::containers::SmallVector<ScorerBucket, 2>;
+  using ScorerBuckets = sdb::containers::SmallVector<ScorerBucket, 1>;
 
   template<typename Iterator>
   static Scorers Prepare(Iterator begin, Iterator end);
@@ -429,12 +429,6 @@ auto ResolveMergeType(ScoreMergeType type, size_t num_buckets,
         return visitor(NoopAggregator{});
       case 1:
         return visitor(Aggregator<Merger, 1>{});
-      case 2:
-        return visitor(Aggregator<Merger, 2>{});
-      case 3:
-        return visitor(Aggregator<Merger, 3>{});
-      case 4:
-        return visitor(Aggregator<Merger, 4>{});
       default:
         return visitor(Aggregator<Merger, kBufferRuntimeSize>{num_buckets});
     }

--- a/tests/libs/iresearch/formats/formats_15_tests.cpp
+++ b/tests/libs/iresearch/formats/formats_15_tests.cpp
@@ -80,14 +80,13 @@ class FreqThresholdDocIterator : public irs::DocIterator {
 
   irs::doc_id_t value() const final { return _impl->value(); }
 
-  bool next() final {
+  irs::doc_id_t advance() final {
     while (_impl->next()) {
-      if (_freq && Less()) {
-        continue;
+      if (!_freq || !Less()) {
+        break;
       }
-      return true;
     }
-    return false;
+    return value();
   }
 
   irs::doc_id_t seek(irs::doc_id_t target) final {

--- a/tests/libs/iresearch/formats/formats_test_case_base.hpp
+++ b/tests/libs/iresearch/formats/formats_test_case_base.hpp
@@ -146,14 +146,13 @@ class FormatTestCase : public IndexTestBase {
       }
     }
 
-    bool next() final {
+    irs::doc_id_t advance() final {
       if (!irs::doc_limits::valid(_doc.value)) {
         _callback(*this);
       }
 
       if (_next == _end) {
-        _doc.value = irs::doc_limits::eof();
-        return false;
+        return _doc.value = irs::doc_limits::eof();
       }
 
       std::tie(_doc.value, _freq.value) = *_next;
@@ -165,7 +164,7 @@ class FormatTestCase : public IndexTestBase {
       _pos.clear();
       ++_next;
 
-      return true;
+      return _doc.value;
     }
 
     irs::doc_id_t value() const final { return _doc.value; }

--- a/tests/libs/iresearch/index/assert_format.cpp
+++ b/tests/libs/iresearch/index/assert_format.cpp
@@ -432,10 +432,9 @@ class DocIteratorImpl : public irs::DocIterator {
     return it == _attrs.end() ? nullptr : it->second;
   }
 
-  bool next() final {
+  irs::doc_id_t advance() final {
     if (_next == _data.postings.end()) {
-      _doc.value = irs::doc_limits::eof();
-      return false;
+      return _doc.value = irs::doc_limits::eof();
     }
 
     _prev = _next, ++_next;
@@ -443,7 +442,7 @@ class DocIteratorImpl : public irs::DocIterator {
     _freq.value = static_cast<uint32_t>(_prev->positions().size());
     _pos.Clear();
 
-    return true;
+    return _doc.value;
   }
 
   irs::doc_id_t seek(irs::doc_id_t id) final {

--- a/tests/libs/iresearch/search/proxy_filter_test.cpp
+++ b/tests/libs/iresearch/search/proxy_filter_test.cpp
@@ -43,30 +43,6 @@ class DoclistTestIterator : public DocIterator, private util::Noncopyable {
     Reset();
   }
 
-  bool next() final {
-    if (_resetted) {
-      _resetted = false;
-      _current = _begin;
-    }
-
-    if (_current != _end) {
-      _doc.value = *_current;
-      ++_current;
-      return true;
-    } else {
-      _doc.value = doc_limits::eof();
-      return false;
-    }
-  }
-
-  doc_id_t seek(doc_id_t target) final {
-    while (_doc.value < target && next()) {
-    }
-    return _doc.value;
-  }
-
-  doc_id_t value() const noexcept final { return _doc.value; }
-
   Attribute* GetMutable(irs::TypeInfo::type_id id) noexcept final {
     if (irs::Type<irs::DocAttr>::id() == id) {
       return &_doc;
@@ -75,6 +51,29 @@ class DoclistTestIterator : public DocIterator, private util::Noncopyable {
       return &_cost;
     }
     return nullptr;
+  }
+
+  doc_id_t value() const noexcept final { return _doc.value; }
+
+  doc_id_t advance() final {
+    if (_resetted) {
+      _resetted = false;
+      _current = _begin;
+    }
+
+    if (_current != _end) {
+      _doc.value = *_current;
+      ++_current;
+    } else {
+      _doc.value = doc_limits::eof();
+    }
+    return _doc.value;
+  }
+
+  doc_id_t seek(doc_id_t target) final {
+    while (_doc.value < target && next()) {
+    }
+    return _doc.value;
   }
 
   void Reset() noexcept {


### PR DESCRIPTION
- perf: Implement count for DocIterator
- perf: Implement and use advance instead of next for DocIterator
- perf: Make scorer specialization only for 1 scorer, 2+ scorers can be slow case => less template instantiations
