### PR TITLE
Update sqllogictest-rs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+        exclude: \.test$
 
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.22.3

--- a/tests/sqllogic/any/pg/simple/bytea_escape.test
+++ b/tests/sqllogic/any/pg/simple/bytea_escape.test
@@ -166,7 +166,7 @@ query
 SELECT '  spaces  '::bytea;
 ----
 bytea
-  spaces
+  spaces  
 
 
 # Bytea representing binary data - DEADBEEF

--- a/tests/sqllogic/any/pg/simple/json_single.test
+++ b/tests/sqllogic/any/pg/simple/json_single.test
@@ -240,7 +240,7 @@ query
 SELECT '   {  "spaced" : [ 1 , 2 , 3 ] }   '::json;
 ----
 json
-   {  "spaced" : [ 1 , 2 , 3 ] }
+   {  "spaced" : [ 1 , 2 , 3 ] }   
 
 
 # Larger object sample

--- a/tests/sqllogic/any/pg/simple/simple.test
+++ b/tests/sqllogic/any/pg/simple/simple.test
@@ -775,7 +775,7 @@ query
 SELECT ltrim('   hello   ');
 ----
 ltrim
-hello
+hello   
 
 
 query

--- a/tests/sqllogic/any/pg/simple/varchar.test
+++ b/tests/sqllogic/any/pg/simple/varchar.test
@@ -19,7 +19,7 @@ query
 SELECT '  spaces  '::varchar;
 ----
 varchar
-  spaces
+  spaces  
 
 
 # Varchar with special characters

--- a/tests/sqllogic/run.sh
+++ b/tests/sqllogic/run.sh
@@ -161,7 +161,7 @@ run_tests() {
   if [[ -n "$skip_failed" ]]; then
     skip_failed_opt="--skip-failed"
   fi
-  
+
   # Execute the command and capture the exit code
   sqllogictest "$test" \
     --host "$host" --port "$port" --engine "$engine" \

--- a/tests/sqllogic/run.sh
+++ b/tests/sqllogic/run.sh
@@ -25,6 +25,7 @@ declare -A defaults=(
     [force_override]=false
     [format]=false
     [show_all_errors]=false
+    [skip_failed]=''
     [database]='serenedb'
     [host]='localhost'
 )
@@ -54,7 +55,7 @@ parse_options() {
         fi
 
         case "$key" in
-            single-port|cluster-port|jobs|protocol|test|junit|runner|debug|override|format|force-override|show-all-errors|database|host)
+            single-port|cluster-port|jobs|protocol|test|junit|runner|debug|override|format|force-override|show-all-errors|skip-failed|database|host)
                 local var_name="${key//-/_}"  # Convert dashes to underscores
 
                 # For non-equal format (--option value), get the next argument
@@ -123,6 +124,7 @@ echo "Override: $override"
 echo "Force override: $force_override"
 echo "Format: $format"
 echo "Show all errors: $show_all_errors"
+echo "Skip failed: $skip_failed"
 
 # Run tests based on parameters
 run_tests() {
@@ -155,13 +157,19 @@ run_tests() {
     fi
   done
 
+  local skip_failed_opt=""
+  if [[ -n "$skip_failed" ]]; then
+    skip_failed_opt="--skip-failed"
+  fi
+  
   # Execute the command and capture the exit code
   sqllogictest "$test" \
     --host "$host" --port "$port" --engine "$engine" \
     --jobs "$jobs" \
     --label "$database" --label "$mode" --label "$engine-protocol" \
     --junit "$junit-$mode-$engine" \
-    $options
+    $options \
+    $skip_failed_opt ${skip_failed:+"$skip_failed"}
   return $?
 }
 

--- a/tests/sqllogic/sdb/pg/system/reuse.test
+++ b/tests/sqllogic/sdb/pg/system/reuse.test
@@ -3,8 +3,13 @@ select * from pg_namespace as t1, pg_namespace as t2;
 ----
 oid	nspname	nspowner	nspacl	oid	nspname	nspowner	nspacl
 11	pg_catalog	NULL	NULL	11	pg_catalog	NULL	NULL
+11	pg_catalog	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
 11	pg_catalog	NULL	NULL	<slt:ignore>	public	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	11	pg_catalog	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	<slt:ignore>	public	NULL	NULL
 <slt:ignore>	public	NULL	NULL	11	pg_catalog	NULL	NULL
+<slt:ignore>	public	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
 <slt:ignore>	public	NULL	NULL	<slt:ignore>	public	NULL	NULL
 
 
@@ -13,8 +18,13 @@ select * from pg_namespace as t1(a, b, c, d), pg_namespace as t2(x, y, z, w);
 ----
 a	b	c	d	x	y	z	w
 11	pg_catalog	NULL	NULL	11	pg_catalog	NULL	NULL
+11	pg_catalog	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
 11	pg_catalog	NULL	NULL	<slt:ignore>	public	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	11	pg_catalog	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	<slt:ignore>	public	NULL	NULL
 <slt:ignore>	public	NULL	NULL	11	pg_catalog	NULL	NULL
+<slt:ignore>	public	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
 <slt:ignore>	public	NULL	NULL	<slt:ignore>	public	NULL	NULL
 
 
@@ -23,6 +33,11 @@ select * from pg_namespace as t1(x, y, z, w), pg_namespace as t2(x, y, z, w);
 ----
 x	y	z	w	x	y	z	w
 11	pg_catalog	NULL	NULL	11	pg_catalog	NULL	NULL
+11	pg_catalog	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
 11	pg_catalog	NULL	NULL	<slt:ignore>	public	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	11	pg_catalog	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
+<slt:ignore>	information_schema	NULL	NULL	<slt:ignore>	public	NULL	NULL
 <slt:ignore>	public	NULL	NULL	11	pg_catalog	NULL	NULL
+<slt:ignore>	public	NULL	NULL	<slt:ignore>	information_schema	NULL	NULL
 <slt:ignore>	public	NULL	NULL	<slt:ignore>	public	NULL	NULL


### PR DESCRIPTION
- Fix failed tests in `reuse.test` (they were passing because of bug in sqllogctest-rs, fixed now)
- Add trailing whitespaces to some specific tests, disable some pre-hooks check for `.test` files
- Add `--skip-failed` option. We may run test script with `--skip-failed 'serenedb, TODO issue-123` and it add `skipif serenedb # TODO issue-123` line before failed queries and statements