### PR TITLE
Fix bug with deleting all rows from table without PK

### DIFF
--- a/server/connector/data_source.hpp
+++ b/server/connector/data_source.hpp
@@ -40,7 +40,8 @@ class RocksDBDataSource final : public velox::connector::DataSource {
                     const rocksdb::Snapshot* snapshot, rocksdb::DB& db,
                     rocksdb::ColumnFamilyHandle& cf, velox::RowTypePtr row_type,
                     std::vector<catalog::Column::Id> column_ids,
-                    catalog::Column::Id present_column_id, ObjectId object_key);
+                    catalog::Column::Id effective_column_id,
+                    ObjectId object_key);
 
   void addSplit(std::shared_ptr<velox::connector::ConnectorSplit> split) final;
   std::optional<velox::RowVectorPtr> next(uint64_t size,

--- a/server/connector/data_source.hpp
+++ b/server/connector/data_source.hpp
@@ -40,7 +40,7 @@ class RocksDBDataSource final : public velox::connector::DataSource {
                     const rocksdb::Snapshot* snapshot, rocksdb::DB& db,
                     rocksdb::ColumnFamilyHandle& cf, velox::RowTypePtr row_type,
                     std::vector<catalog::Column::Id> column_ids,
-                    ObjectId object_key);
+                    catalog::Column::Id present_column_id, ObjectId object_key);
 
   void addSplit(std::shared_ptr<velox::connector::ConnectorSplit> split) final;
   std::optional<velox::RowVectorPtr> next(uint64_t size,
@@ -88,6 +88,14 @@ class RocksDBDataSource final : public velox::connector::DataSource {
   rocksdb::ColumnFamilyHandle& _cf;
   velox::RowTypePtr _row_type;
   std::vector<catalog::Column::Id> _column_ids;
+  // Column ID to use for iteration when the requested column is stored in the
+  // key (e.g., kGeneratedPKId). This points to a column whose values are stored
+  // in RocksDB as *values*, not inside *keys*. It's convenient to store it here
+  // for scans where we need only columns that are stored as parts of the key.
+  // Tables with only such columns are tables without columns at all *for now*,
+  // this case is handled in SqlAnalyzer code, such scans are replaced with
+  // empty Values node.
+  catalog::Column::Id _effective_column_id;
   std::shared_ptr<velox::connector::ConnectorSplit> _current_split;
   ObjectId _object_key;
   std::string _last_read_key;

--- a/server/connector/serenedb_connector.cpp
+++ b/server/connector/serenedb_connector.cpp
@@ -33,17 +33,17 @@ SereneDBConnectorTableHandle::SereneDBConnectorTableHandle(
   SDB_ASSERT(!column_map.empty(),
              "Tables without columns must be processed in analyzer step");
 
-  // TODO(Dronplane): measure the performance! Maybe it worth select smallest
-  // possible field as count field not just first
-  _table_count_field =
+  // TODO(Dronplane): measure the performance! Maybe it's worth selecting the
+  // smallest possible field as the effective column, not just the first
+  _effective_column_id =
     basics::downCast<const SereneDBColumn>(column_map.begin()->second)->Id();
-  if (_table_count_field == catalog::Column::kGeneratedPKId) {
+  if (_effective_column_id == catalog::Column::kGeneratedPKId) {
     // Iterating over generated primary key gives 0 rows,
     // use another one
     SDB_ASSERT(column_map.size() >= 2);
-    _table_count_field = basics::downCast<const SereneDBColumn>(
-                           std::next(column_map.begin())->second)
-                           ->Id();
+    _effective_column_id = basics::downCast<const SereneDBColumn>(
+                             std::next(column_map.begin())->second)
+                             ->Id();
   }
   _transaction.AddRocksDBRead();
 }

--- a/server/connector/serenedb_connector.hpp
+++ b/server/connector/serenedb_connector.hpp
@@ -71,8 +71,8 @@ class SereneDBConnectorTableHandle final
 
   ObjectId TableId() const noexcept { return _table_id; }
 
-  const catalog::Column::Id& GetCountField() const noexcept {
-    return _table_count_field;
+  const catalog::Column::Id& GetEffectiveColumnId() const noexcept {
+    return _effective_column_id;
   }
 
   auto& GetTransaction() const noexcept { return _transaction; }
@@ -80,7 +80,7 @@ class SereneDBConnectorTableHandle final
  private:
   std::string _name;
   ObjectId _table_id;
-  catalog::Column::Id _table_count_field;
+  catalog::Column::Id _effective_column_id;
   query::Transaction& _transaction;
 };
 
@@ -442,13 +442,13 @@ class SereneDBConnector final : public velox::connector::Connector {
           basics::downCast<const SereneDBColumnHandle>(handle->second)->Id());
       }
     } else {
-      column_oids.push_back(serene_table_handle.GetCountField());
+      column_oids.push_back(serene_table_handle.GetEffectiveColumnId());
     }
     auto& transaction = serene_table_handle.GetTransaction();
     const auto& snapshot = transaction.EnsureRocksDBSnapshot();
     return std::make_unique<RocksDBDataSource>(
       *connector_query_ctx->memoryPool(), &snapshot, _db, _cf, output_type,
-      column_oids, object_key);
+      column_oids, serene_table_handle.GetEffectiveColumnId(), object_key);
   }
 
   std::shared_ptr<velox::connector::IndexSource> createIndexSource(

--- a/tests/sqllogic/any/pg/simple/table_without_pk.test
+++ b/tests/sqllogic/any/pg/simple/table_without_pk.test
@@ -88,6 +88,31 @@ count
 5
 
 
+statement count 5
+DELETE FROM no_pk;
+
+
+statement count 0
+UPDATE no_pk SET b = 300 WHERE a = 42;
+
+
+query
+SELECT * FROM no_pk ORDER BY a;
+----
+a	b	c
+
+
+statement count 1
+INSERT INTO no_pk VALUES (123, 456, NULL);
+
+
+query
+SELECT * FROM no_pk ORDER BY a;
+----
+a	b	c
+123	456	NULL
+
+
 # Column name as for generated column
 statement ok
 CREATE TABLE collision (a INTEGER, sdb_generated_pk VARCHAR);


### PR DESCRIPTION
In some scans in `RocksDBDatasource` we need only columns that are not stored as effective columns (using RocksDB values), or even we need not any specific column at all as for count query. But we need some column id to construct prefix of RocksDB key to iterate over all existing keys and column specific values. I've named such a column as **effective** one, it means this column **effectively** stored as a RocksDB values. Connector always passes such a column id to `RocksDBDatasource` creation.