### PR TITLE
Fix reading block in cse of missing tail

### DIFF
--- a/libs/iresearch/include/iresearch/formats/formats_impl.hpp
+++ b/libs/iresearch/include/iresearch/formats/formats_impl.hpp
@@ -3007,6 +3007,11 @@ void BitUnionImpl(DataInput& doc_in, doc_id_t docs_count, uint32_t (&docs)[N],
   }
 
   const auto tail = docs_count % FieldTraits::kBlockSize;
+
+  if (!tail) {
+    return;
+  }
+
   const uint16_t size = doc_in.ReadI16();
   const auto* buf = doc_in.ReadView(size);
   if (!buf) {

--- a/tests/libs/iresearch/index/doc_generator.cpp
+++ b/tests/libs/iresearch/index/doc_generator.cpp
@@ -509,18 +509,16 @@ irs::Tokenizer& StringField::GetTokens() const {
 }
 
 StringViewField::StringViewField(const std::string& name,
-                                 irs::IndexFeatures extra_index_features) {
-  this->index_features =
-    (irs::IndexFeatures::Freq | irs::IndexFeatures::Pos) | extra_index_features;
+                                 irs::IndexFeatures index_features) {
+  this->index_features = index_features;
   this->name = name;
 }
 
 StringViewField::StringViewField(const std::string& name,
                                  const std::string_view& value,
-                                 irs::IndexFeatures extra_index_features)
+                                 irs::IndexFeatures index_features)
   : _value(value) {
-  this->index_features =
-    (irs::IndexFeatures::Freq | irs::IndexFeatures::Pos) | extra_index_features;
+  this->index_features = index_features;
   this->name = name;
 }
 

--- a/tests/libs/iresearch/index/doc_generator.hpp
+++ b/tests/libs/iresearch/index/doc_generator.hpp
@@ -690,11 +690,12 @@ class StringField : public tests::FieldBase {
 // field which uses simple analyzer without tokenization
 class StringViewField : public tests::FieldBase {
  public:
-  StringViewField(
-    const std::string& name,
-    irs::IndexFeatures extra_index_features = irs::IndexFeatures::None);
+  StringViewField(const std::string& name,
+                  irs::IndexFeatures index_features = irs::IndexFeatures::Freq |
+                                                      irs::IndexFeatures::Pos);
   StringViewField(const std::string& name, const std::string_view& value,
-                  irs::IndexFeatures index_features = irs::IndexFeatures::None);
+                  irs::IndexFeatures index_features = irs::IndexFeatures::Freq |
+                                                      irs::IndexFeatures::Pos);
 
   void value(std::string_view str);
   std::string_view value() const { return _value; }

--- a/tests/libs/iresearch/index/index_tests.cpp
+++ b/tests/libs/iresearch/index/index_tests.cpp
@@ -2300,20 +2300,31 @@ class IndexTestCase : public tests::IndexTestBase {
     }
   }
 
-  void DocsBitUnion(irs::IndexFeatures features);
+  void DocsBitUnion(irs::IndexFeatures features, size_t docs_count_per_term);
 };
 
-void IndexTestCase::DocsBitUnion(irs::IndexFeatures features) {
+void IndexTestCase::DocsBitUnion(irs::IndexFeatures features,
+                                 size_t docs_count_per_term) {
   tests::StringViewField field("0", features);
-  const size_t n = irs::BitsRequired<uint64_t>(2) + 7;
-
+  const auto docs_count = docs_count_per_term * 2 + 1;
+  std::vector<uint64_t> expected_a;
+  std::vector<uint64_t> expected_b;
+  constexpr auto WordBits = irs::BitsRequired<uint64_t>();
+  const size_t num_words = (docs_count + WordBits - 1) / WordBits;
+  expected_a.resize(num_words, 0);
+  expected_b.resize(num_words, 0);
   {
     auto writer = open_writer();
 
     {
       auto docs = writer->GetBatch();
-      for (size_t i = 1; i <= n; ++i) {
+      for (size_t i = 1; i < docs_count; ++i) {
         const std::string_view value = i % 2 ? "A" : "B";
+        if (value == "A") {
+          irs::SetBit(expected_a[i / WordBits], i % WordBits);
+        } else {
+          irs::SetBit(expected_b[i / WordBits], i % WordBits);
+        }
         field.value(value);
         ASSERT_TRUE(docs.Insert().Insert<irs::Action::INDEX>(field));
       }
@@ -2330,27 +2341,17 @@ void IndexTestCase::DocsBitUnion(irs::IndexFeatures features) {
   ASSERT_NE(nullptr, reader);
   ASSERT_EQ(1, reader->size());
   auto& segment = (*reader)[0];
-  ASSERT_EQ(n + 1, segment.docs_count());
-  ASSERT_EQ(n + 1, segment.live_docs_count());
+  ASSERT_EQ(docs_count, segment.docs_count());
+  ASSERT_EQ(docs_count, segment.live_docs_count());
 
   const auto* term_reader = segment.field(field.Name());
   ASSERT_NE(nullptr, term_reader);
-  ASSERT_EQ(n + 1, term_reader->docs_count());
+  ASSERT_EQ(docs_count, term_reader->docs_count());
   ASSERT_EQ(3, term_reader->size());
   ASSERT_EQ("A", irs::ViewCast<char>(term_reader->min()));
   ASSERT_EQ("C", irs::ViewCast<char>(term_reader->max()));
   ASSERT_EQ(field.Name(), term_reader->meta().name);
   ASSERT_EQ(field.GetIndexFeatures(), term_reader->meta().index_features);
-
-  constexpr size_t kExpectedDocsB[]{
-    0b0101010101010101010101010101010101010101010101010101010101010100,
-    0b0101010101010101010101010101010101010101010101010101010101010101,
-    0b0000000000000000000000000000000000000000000000000000000001010101};
-
-  constexpr size_t kExpectedDocsA[]{
-    0b1010101010101010101010101010101010101010101010101010101010101010,
-    0b1010101010101010101010101010101010101010101010101010101010101010,
-    0b0000000000000000000000000000000000000000000000000000000010101010};
 
   irs::SeekCookie::ptr cookies[2];
 
@@ -2375,11 +2376,13 @@ void IndexTestCase::DocsBitUnion(irs::IndexFeatures features) {
     return nullptr;
   };
 
-  size_t actual_docs_ab[3]{};
-  ASSERT_EQ(n, term_reader->BitUnion(cookie_provider, actual_docs_ab));
-  ASSERT_EQ(kExpectedDocsA[0] | kExpectedDocsB[0], actual_docs_ab[0]);
-  ASSERT_EQ(kExpectedDocsA[1] | kExpectedDocsB[1], actual_docs_ab[1]);
-  ASSERT_EQ(kExpectedDocsA[2] | kExpectedDocsB[2], actual_docs_ab[2]);
+  std::vector<uint64_t> actual_docs_ab(num_words);
+  // -1 as we exclude C term
+  ASSERT_EQ(docs_count - 1,
+            term_reader->BitUnion(cookie_provider, actual_docs_ab.data()));
+  for (size_t i = 0; i < num_words; ++i) {
+    ASSERT_EQ(expected_a[i] | expected_b[i], actual_docs_ab[i]);
+  }
 }
 
 TEST_P(IndexTestCase, s2sequence) {
@@ -2826,8 +2829,25 @@ TEST_P(IndexTestCase, europarl_docs_big_automaton) {
 }
 
 TEST_P(IndexTestCase, docs_bit_union) {
-  DocsBitUnion(irs::IndexFeatures::None);
-  DocsBitUnion(irs::IndexFeatures::Freq);
+  // less than block
+  DocsBitUnion(irs::IndexFeatures::None, 63);
+  DocsBitUnion(irs::IndexFeatures::Freq, 63);
+
+  // exactly one block
+  DocsBitUnion(irs::IndexFeatures::None, 128);
+  DocsBitUnion(irs::IndexFeatures::Freq, 128);
+
+  // more than block
+  DocsBitUnion(irs::IndexFeatures::None, 135);
+  DocsBitUnion(irs::IndexFeatures::Freq, 135);
+
+  // exactly two blocks
+  DocsBitUnion(irs::IndexFeatures::None, 256);
+  DocsBitUnion(irs::IndexFeatures::Freq, 256);
+
+  // more than two blocks
+  DocsBitUnion(irs::IndexFeatures::None, 257);
+  DocsBitUnion(irs::IndexFeatures::Freq, 257);
 }
 
 TEST_P(IndexTestCase, monarch_eco_onthology) {


### PR DESCRIPTION
Fixed reading block without tail
Added tests to check issue.
Fixed tests - to actually have field with/without frequency in test -before that ctor always added pos + freq.