### PR TITLE
feat: Add boost query

### DIFF
--- a/libs/iresearch/include/iresearch/search/boolean_query.cpp
+++ b/libs/iresearch/include/iresearch/search/boolean_query.cpp
@@ -23,6 +23,8 @@
 #include "iresearch/search/boolean_query.hpp"
 
 #include "iresearch/formats/formats_impl.hpp"
+#include "iresearch/search/boolean_filter.hpp"
+#include "iresearch/search/boost_iterator.hpp"
 #include "iresearch/search/conjunction.hpp"
 #include "iresearch/search/disjunction.hpp"
 #include "iresearch/search/make_disjunction.hpp"
@@ -290,6 +292,32 @@ DocIterator::ptr MinMatchQuery::execute(const ExecutionContext& ctx,
     return MakeWeakDisjunction<Disjunction>(ctx.wand, std::move(itrs),
                                             min_match_count);
   });
+}
+
+void BoostQuery::Prepare(const PrepareContext& ctx, const BooleanFilter& req,
+                         const BooleanFilter& opt) {
+  SDB_ASSERT(!req.empty());
+  _req = req.prepare(ctx);
+  _opt = opt.prepare(ctx);
+}
+
+DocIterator::ptr BoostQuery::execute(const ExecutionContext& ctx) const {
+  auto req = _req->execute(ctx);
+  if (!ctx.scorer || doc_limits::eof(req->value())) {
+    return req;
+  }
+  auto opt = _opt->execute(ctx);
+  if (doc_limits::eof(opt->value())) {
+    return req;
+  }
+  // TODO(mbkkt) Optimize with term adapters specializations
+  return memory::make_managed<BoostIterator<ScoreAdapter, ScoreAdapter>>(
+    ScoreAdapter{std::move(req)}, ScoreAdapter{std::move(opt)});
+}
+
+void BoostQuery::visit(const SubReader& segment, PreparedStateVisitor& visitor,
+                       score_t boost) const {
+  _req->visit(segment, visitor, boost);
 }
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/boolean_query.hpp
+++ b/libs/iresearch/include/iresearch/search/boolean_query.hpp
@@ -29,6 +29,8 @@
 
 namespace irs {
 
+class BooleanFilter;
+
 // Base class for boolean queries
 class BooleanQuery : public Filter::Query {
  public:
@@ -37,7 +39,7 @@ class BooleanQuery : public Filter::Query {
 
   DocIterator::ptr execute(const ExecutionContext& ctx) const final;
 
-  void visit(const irs::SubReader& segment, irs::PreparedStateVisitor& visitor,
+  void visit(const SubReader& segment, PreparedStateVisitor& visitor,
              score_t boost) const final;
 
   score_t Boost() const noexcept final { return _boost; }
@@ -100,6 +102,26 @@ class MinMatchQuery : public BooleanQuery {
 
  private:
   size_t _min_match_count;
+};
+
+class BoostQuery : public Filter::Query {
+ public:
+  DocIterator::ptr execute(const ExecutionContext& ctx) const final;
+
+  void visit(const SubReader& segment, PreparedStateVisitor& visitor,
+             score_t boost) const final;
+
+  score_t Boost() const noexcept final {
+    SDB_ASSERT(false);
+    return {};
+  }
+
+  void Prepare(const PrepareContext& ctx, const BooleanFilter& req,
+               const BooleanFilter& opt);
+
+ private:
+  Query::ptr _req;
+  Query::ptr _opt;
 };
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/boost_iterator.hpp
+++ b/libs/iresearch/include/iresearch/search/boost_iterator.hpp
@@ -1,0 +1,153 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "iresearch/index/iterators.hpp"
+#include "iresearch/search/scorer.hpp"
+
+namespace irs {
+
+class BoostIteratorScore : public ScoreOperator {
+ public:
+  BoostIteratorScore(ScoreFunction req, ScoreFunction opt,
+                     const bool* opt_matched) noexcept
+    : _req{std::move(req)}, _opt{std::move(opt)}, _matches{opt_matched} {}
+
+  score_t Score() const noexcept final {
+    auto s = _req.Score();
+    if (_matches[0]) {
+      Merge<ScoreMergeType::Sum>(s, _opt.Score());
+    }
+    return s;
+  }
+
+  void Score(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Noop>(res, n);
+  }
+  void ScoreSum(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, n);
+  }
+  void ScoreMax(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, n);
+  }
+
+  void ScoreBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Noop>(res, kScoreBlock);
+  }
+  void ScoreSumBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, kScoreBlock);
+  }
+  void ScoreMaxBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, kScoreBlock);
+  }
+
+ private:
+  template<ScoreMergeType OuterType>
+  IRS_FORCE_INLINE void ScoreImpl(score_t* IRS_RESTRICT res,
+                                  scores_size_t n) const noexcept {
+    _req.Score<ScoreMergeType::Noop>(_req_scores, n);
+    _opt.Score<ScoreMergeType::Noop>(_opt_scores, n);
+    for (scores_size_t i = 0; i < n; ++i) {
+      auto s = _req_scores[i];
+      if (_matches[i]) {
+        Merge<ScoreMergeType::Sum>(s, _opt_scores[i]);
+      }
+      Merge<OuterType>(res[i], s);
+    }
+  }
+
+  ScoreFunction _req;
+  ScoreFunction _opt;
+  ABSL_CACHELINE_ALIGNED mutable score_t _req_scores[kScoreBlock]{};
+  ABSL_CACHELINE_ALIGNED mutable score_t _opt_scores[kScoreBlock]{};
+  const bool* IRS_RESTRICT _matches;
+};
+
+template<typename RequiredAdapter, typename OptionalAdapter>
+class BoostIterator : public DocIterator {
+ public:
+  BoostIterator(RequiredAdapter req, OptionalAdapter opt) noexcept
+    : _req{std::move(req)}, _opt{std::move(opt)} {}
+
+  Attribute* GetMutable(TypeInfo::type_id type) noexcept final {
+    return _req.GetMutable(type);
+  }
+
+  doc_id_t advance() final { return _doc = _req.advance(); }
+
+  doc_id_t seek(doc_id_t target) final {
+    if (target <= value()) [[unlikely]] {
+      return value();
+    }
+    return _doc = _req.seek(target);
+  }
+
+  doc_id_t LazySeek(doc_id_t target) final {
+    const auto doc = _req.LazySeek(target);
+    _doc = _req.value();
+    return doc;
+  }
+
+  void FetchScoreArgs(uint16_t index) final {
+    _req.FetchScoreArgs(index);
+    auto opt_doc = _opt.value();
+    if (opt_doc < _doc) {
+      opt_doc = _opt.LazySeek(_doc);
+    }
+    _matches[index] = opt_doc == _doc;
+    if (_matches[index]) {
+      _opt.FetchScoreArgs(index);
+    }
+  }
+
+  ScoreFunction PrepareScore(const PrepareScoreContext& ctx) final {
+    auto req_score = _req.PrepareScore(ctx);
+    auto opt_score = _opt.PrepareScore(ctx);
+    if (opt_score.IsDefault()) {
+      return req_score;
+    }
+    // TODO(mbkkt) optimize opt_score default?
+    return ScoreFunction::Make<BoostIteratorScore>(
+      std::move(req_score), std::move(opt_score), _matches.data());
+  }
+
+  uint32_t count() final { return CountImpl(*this); }
+
+  void Collect(const ScoreFunction& scorer, ColumnArgsFetcher& fetcher,
+               ScoreCollector& collector) final {
+    CollectImpl(*this, scorer, fetcher, collector);
+  }
+
+  std::pair<doc_id_t, bool> FillBlock(doc_id_t min, doc_id_t max,
+                                      uint64_t* mask,
+                                      FillBlockScoreContext score,
+                                      FillBlockMatchContext match) final {
+    return FillBlockImpl(*this, min, max, mask, score, match);
+  }
+
+ private:
+  RequiredAdapter _req;
+  OptionalAdapter _opt;
+  // TODO(mbkkt) make it score_t 0x0 or 0xFFFFFFF and XOR like mask
+  std::array<bool, kScoreBlock> _matches{};
+};
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/mixed_boolean_filter.cpp
+++ b/libs/iresearch/include/iresearch/search/mixed_boolean_filter.cpp
@@ -20,17 +20,21 @@
 
 #include "mixed_boolean_filter.hpp"
 
+#include "iresearch/search/boolean_query.hpp"
+
 namespace irs {
 
 Filter::Query::ptr MixedBooleanFilter::prepare(
   const PrepareContext& ctx) const {
-  if (_or->empty()) {
-    return _and->prepare(ctx);
-  }
   if (_and->empty()) {
     return _or->prepare(ctx);
   }
-  return _root.prepare(ctx);
+  if (_or->empty()) {
+    return _and->prepare(ctx);
+  }
+  auto q = memory::make_tracked<BoostQuery>(ctx.memory);
+  q->Prepare(ctx, *_and, *_or);
+  return q;
 }
 
 bool MixedBooleanFilter::equals(const Filter& rhs) const noexcept {
@@ -38,7 +42,7 @@ bool MixedBooleanFilter::equals(const Filter& rhs) const noexcept {
     return false;
   }
   const auto& typed_rhs = sdb::basics::downCast<MixedBooleanFilter>(rhs);
-  return _root == typed_rhs._root;
+  return *_and == *typed_rhs._and && *_or == *typed_rhs._or;
 }
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/mixed_boolean_filter.hpp
+++ b/libs/iresearch/include/iresearch/search/mixed_boolean_filter.hpp
@@ -27,7 +27,8 @@ namespace irs {
 class MixedBooleanFilter final : public FilterWithType<MixedBooleanFilter>,
                                  public AllDocsProvider {
  public:
-  MixedBooleanFilter() : _and{&_root.add<And>()}, _or{&_root.add<Or>()} {}
+  MixedBooleanFilter()
+    : _and{std::make_unique<And>()}, _or{std::make_unique<Or>()} {}
 
   auto& GetRequired(this auto& self) noexcept { return *self._and; }
 
@@ -37,13 +38,12 @@ class MixedBooleanFilter final : public FilterWithType<MixedBooleanFilter>,
 
   Query::ptr prepare(const PrepareContext& ctx) const final;
 
- protected:
+ private:
   bool equals(const Filter& rhs) const noexcept final;
 
- private:
   And _root;
-  And* _and;
-  Or* _or;
+  std::unique_ptr<And> _and;
+  std::unique_ptr<Or> _or;
 };
 
 }  // namespace irs

--- a/tests/libs/iresearch/CMakeLists.txt
+++ b/tests/libs/iresearch/CMakeLists.txt
@@ -75,6 +75,7 @@ set(iresearch-tests_sources
     ./search/geo_analyzer_test.cpp
     ./search/doc_collector_test.cpp
     ./search/block_scoring_test.cpp
+    ./search/boost_query_test.cpp
     ./search/wand_scoring_test.cpp
     ./utils/async_utils_tests.cpp
     ./utils/automaton_test.cpp

--- a/tests/libs/iresearch/parser/lucene_parser_test.cpp
+++ b/tests/libs/iresearch/parser/lucene_parser_test.cpp
@@ -1749,4 +1749,34 @@ TEST_F(LuceneParserTest, ComplexMultiFieldNested) {
   AssertTerm(g2.GetOptional()[1], "author", "bar");
 }
 
+// Query: "+open source software licenses"
+// Expected: required=[open], optional=[source, software, licenses]
+TEST_F(LuceneParserTest, RequiredWithOptionals) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "+open source software licenses").ok());
+  ASSERT_EQ(1, RequiredRoot().size());
+  ASSERT_EQ(3, OptionalRoot().size());
+
+  AssertTerm(RequiredRoot()[0], "content", "open");
+  AssertTerm(OptionalRoot()[0], "content", "source");
+  AssertTerm(OptionalRoot()[1], "content", "software");
+  AssertTerm(OptionalRoot()[2], "content", "licenses");
+}
+
+// Query: "+open" — required only, no optional
+TEST_F(LuceneParserTest, RequiredOnly) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "+open").ok());
+  ASSERT_EQ(1, RequiredRoot().size());
+  ASSERT_TRUE(OptionalRoot().empty());
+  AssertTerm(RequiredRoot()[0], "content", "open");
+}
+
+// Query: "open source" — optional only (no + prefix), no required
+TEST_F(LuceneParserTest, OptionalOnly) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "open source").ok());
+  ASSERT_TRUE(RequiredRoot().empty());
+  ASSERT_EQ(2, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], "content", "open");
+  AssertTerm(OptionalRoot()[1], "content", "source");
+}
+
 }  // namespace

--- a/tests/libs/iresearch/search/boost_query_test.cpp
+++ b/tests/libs/iresearch/search/boost_query_test.cpp
@@ -1,0 +1,205 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include "index/index_tests.hpp"
+#include "iresearch/analysis/delimited_tokenizer.hpp"
+#include "iresearch/parser/parser.h"
+#include "iresearch/search/boolean_filter.hpp"
+#include "iresearch/search/column_collector.hpp"
+#include "iresearch/search/doc_collector.hpp"
+#include "iresearch/search/mixed_boolean_filter.hpp"
+#include "iresearch/search/term_filter.hpp"
+#include "iresearch/search/tfidf.hpp"
+#include "iresearch/types.hpp"
+#include "tests_shared.hpp"
+
+namespace {
+
+// A field that tokenises its value by spaces (for multi-term documents).
+class SpaceField : public tests::FieldBase {
+ public:
+  explicit SpaceField(std::string_view field_name)
+    : _tokenizer{std::make_unique<irs::analysis::DelimitedTokenizer>(" ")} {
+    name = field_name;
+    index_features = irs::IndexFeatures::Freq | irs::IndexFeatures::Norm;
+  }
+
+  void value(std::string_view v) { _value = v; }
+
+  irs::Tokenizer& GetTokens() const final {
+    _tokenizer->reset(_value);
+    return *_tokenizer;
+  }
+
+  bool Write(irs::DataOutput& o) const final {
+    o.WriteByte(1);
+    return true;
+  }
+
+ private:
+  mutable std::unique_ptr<irs::analysis::DelimitedTokenizer> _tokenizer;
+  std::string _value;
+};
+
+class BoostQueryTestCase : public tests::IndexTestBase {
+ protected:
+  // Collect all (score, doc_id) results sorted by score descending.
+  std::vector<irs::ScoreDoc> CollectAll(const irs::DirectoryReader& reader,
+                                        const irs::Filter& filter) {
+    constexpr size_t kK = 1024;
+    irs::TFIDF scorer{/*normalize=*/false};
+    std::vector<irs::ScoreDoc> hits(irs::BlockSize(kK));
+    size_t count =
+      irs::ExecuteTopKWithCount(reader, filter, scorer, kK, std::span{hits});
+    hits.resize(std::min(count, kK));
+    return hits;
+  }
+
+  // Parse a Lucene query string into a MixedBooleanFilter.
+  static irs::Filter::ptr ParseQuery(std::string_view query) {
+    irs::analysis::DelimitedTokenizer tokenizer(" ");
+    auto root = std::make_unique<irs::MixedBooleanFilter>();
+    sdb::ParserContext ctx{*root, "content", tokenizer};
+    EXPECT_TRUE(sdb::ParseQuery(ctx, query).ok());
+    return root;
+  }
+
+  // Create a single-segment index with 4 documents:
+  //   doc A – "open"                  (required only)
+  //   doc B – "open source"           (required + 1 optional)
+  //   doc C – "open source software"  (required + 2 optionals)
+  //   doc D – "source software"       (no required term → must be excluded)
+  irs::DirectoryReader CreateIndex() {
+    auto writer = open_writer(irs::kOmCreate);
+
+    auto insert = [&](std::string_view content) {
+      SpaceField f{"content"};
+      f.value(content);
+      auto batch = writer->GetBatch();
+      auto d = batch.Insert();
+      EXPECT_TRUE(d.Insert<irs::Action::INDEX>(f));
+    };
+
+    insert("open");
+    insert("open source");
+    insert("open source software");
+    insert("source software");
+
+    writer->Commit();
+
+    auto reader = irs::DirectoryReader(dir(), codec());
+    EXPECT_EQ(1, reader.size());
+    return reader;
+  }
+};
+
+// "+open source software" – only docs with "open" must be returned.
+// Doc D ("source software") does NOT contain "open" and must be excluded.
+TEST_P(BoostQueryTestCase, RequiredExcludesNonMatchingDocs) {
+  auto reader = CreateIndex();
+  auto filter = ParseQuery("+open source software");
+  ASSERT_NE(nullptr, filter);
+
+  auto hits = CollectAll(reader, *filter);
+  ASSERT_EQ(3u, hits.size())
+    << "Expected exactly 3 docs matching required 'open'";
+
+  for (auto& [score, doc] : hits) {
+    EXPECT_FALSE(irs::doc_limits::eof(doc));
+    EXPECT_NE(irs::doc_limits::invalid(), doc);
+    EXPECT_GT(score, 0.f);
+  }
+}
+
+// Documents that match more optional terms must score higher.
+// Score ordering (descending): doc C > doc B > doc A.
+TEST_P(BoostQueryTestCase, MoreOptionalMatchesYieldHigherScore) {
+  auto reader = CreateIndex();
+  auto filter = ParseQuery("+open source software");
+  ASSERT_NE(nullptr, filter);
+
+  auto hits = CollectAll(reader, *filter);
+  ASSERT_EQ(3u, hits.size());
+
+  // hits[0] = doc C (2 optionals),
+  // hits[1] = doc B (1 optional),
+  // hits[2] = doc A (0)
+  EXPECT_GT(std::get<irs::score_t>(hits[0]), std::get<irs::score_t>(hits[1]))
+    << "doc with 2 optional matches should outscore doc with 1";
+  EXPECT_GT(std::get<irs::score_t>(hits[1]), std::get<irs::score_t>(hits[2]))
+    << "doc with 1 optional match should outscore doc with 0";
+}
+
+// "+open" with no optional terms: behaves like a simple term query.
+TEST_P(BoostQueryTestCase, RequiredOnlyReturnsAllMatchingDocs) {
+  auto reader = CreateIndex();
+  auto filter = ParseQuery("+open");
+  ASSERT_NE(nullptr, filter);
+
+  auto hits = CollectAll(reader, *filter);
+  ASSERT_EQ(3u, hits.size());
+}
+
+// "source software" with no required term: behaves like a plain OR disjunction.
+TEST_P(BoostQueryTestCase, OptionalOnlyActsAsDisjunction) {
+  auto reader = CreateIndex();
+  auto filter = ParseQuery("source software");
+  ASSERT_NE(nullptr, filter);
+
+  auto hits = CollectAll(reader, *filter);
+  // Docs B, C, D all contain at least one of "source" / "software"
+  ASSERT_EQ(3u, hits.size());
+}
+
+// Programmatic construction of required/optional: verify same behavior as
+// the parser path.
+TEST_P(BoostQueryTestCase, ManualRequiredOptionalConstruction) {
+  auto reader = CreateIndex();
+  auto root = std::make_unique<irs::MixedBooleanFilter>();
+
+  auto make_term = [](std::string_view value) {
+    auto f = std::make_unique<irs::ByTerm>();
+    *f->mutable_field() = "content";
+    f->mutable_options()->term = irs::ViewCast<irs::byte_type>(value);
+    return f;
+  };
+
+  root->GetRequired().add(make_term("open"));
+  root->GetOptional().add(make_term("source"));
+  root->GetOptional().add(make_term("software"));
+
+  auto hits = CollectAll(reader, *root);
+  ASSERT_EQ(3u, hits.size());
+
+  // Score ordering must be: C > B > A
+  EXPECT_GT(std::get<irs::score_t>(hits[0]), std::get<irs::score_t>(hits[1]));
+  EXPECT_GT(std::get<irs::score_t>(hits[1]), std::get<irs::score_t>(hits[2]));
+}
+
+static constexpr auto kTestDirs = tests::GetDirectories<tests::kTypesDefault>();
+
+INSTANTIATE_TEST_SUITE_P(boost_query_test, BoostQueryTestCase,
+                         ::testing::Combine(::testing::ValuesIn(kTestDirs),
+                                            ::testing::Values("1_5simd")),
+                         BoostQueryTestCase::to_string);
+
+}  // namespace


### PR DESCRIPTION
It's mostly used by lucene parser: for queries like `+open some stuff` for such queries we need to return all docs that has open, but for score also "boost" docs that have `some` or `stuff`