### PR TITLE
fix: Pass real actor to TG notification for checkbox triggers

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -359,7 +359,7 @@ jobs:
           TG_USER_MAP: ${{ secrets.TG_USER_MAP }}
           BRANCH: ${{ inputs.BRANCH }}
           JOB_STATUS: ${{ env.HAS_FAILURES == 'true' && 'failure' || 'success' }}
-          ACTOR: ${{ github.actor }}
+          ACTOR: ${{ contains(inputs.BUILD_CONFIG, 'TRIGGERED_BY') && fromJSON(inputs.BUILD_CONFIG).TRIGGERED_BY || github.actor }}
           WORKFLOW: ${{ github.workflow }}
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-build-trigger.yml
+++ b/.github/workflows/pr-build-trigger.yml
@@ -112,7 +112,7 @@ jobs:
                   PUSH_IMAGES_2_REGISTRY: 'false',
                   EXTRA_ARTIFACTS: '',
                   DOCKER_BUILD_IMAGES: 'false',
-                  BUILD_CONFIG: '{}',
+                  BUILD_CONFIG: JSON.stringify({ TRIGGERED_BY: context.actor }),
                 },
               });
 


### PR DESCRIPTION
## Summary
- When a build is triggered via PR checkbox, `github.actor` is the bot, not the person who clicked
- Pass the real user via `BUILD_CONFIG.TRIGGERED_BY` so telegram tags the right person
- Falls back to `github.actor` for manual triggers (no `TRIGGERED_BY` in `BUILD_CONFIG`)