### PR TITLE
feat: Multi-arch Docker images and split CI into separate workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,70 @@
+name: SereneDB-Build-Images
+
+run-name: "SereneDB [build image]"
+
+on:
+  workflow_dispatch:
+    inputs:
+      LOCATION:
+        description: 'Where the build is executed'
+        type: choice
+        required: true
+        options:
+          - X64
+          - arm
+          - self-hosted
+        default: 'X64'
+      PUSH_IMAGES_2_REGISTRY:
+        description: 'Push build images to Docker Hub'
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-image:
+    name: Produce Build Image
+    runs-on:
+      - ${{ inputs.LOCATION }}
+    steps:
+      - name: Checkout SereneDB
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - name: Setup QEMU for multi-arch
+        run: docker run --rm --privileged tonistiigi/binfmt --install all
+
+      - name: Build and push build images
+        working-directory: ./scripts/ci
+        env:
+          DOCKER_REGISTRY: serenedb
+          DOCKER_USERNAME: serenedb
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
+          PUSH_IMAGES_2_REGISTRY: ${{ inputs.PUSH_IMAGES_2_REGISTRY }}
+        run: ./build_images.sh
+
+      - name: Docker cleanup
+        if: always()
+        run: |
+          docker system prune -f || true
+          docker volume prune -f || true
+
+      - name: Send Telegram notification
+        if: always() && !cancelled()
+        env:
+          TG_TOKEN: ${{ secrets.TG_TOKEN }}
+          TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}
+          TG_THREAD_ID_MAIN: "51"
+          TG_THREAD_ID_BUILD: "53"
+          TG_USER_MAP: ${{ secrets.TG_USER_MAP }}
+          BRANCH: ${{ github.ref_name }}
+          JOB_STATUS: ${{ job.status }}
+          ACTOR: ${{ github.actor }}
+          RUN_NAME: "SereneDB [build image]"
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: ./scripts/notify_telegram.bash

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -1,6 +1,6 @@
 name: SereneDB-Build-Manual
 
-run-name: "SereneDB [${{ inputs.DOCKER_BUILD_IMAGES && 'build image' || inputs.PRESET }}]"
+run-name: "SereneDB [${{ inputs.PRESET }}]"
 
 on:
   workflow_dispatch:
@@ -17,7 +17,6 @@ on:
           - ubsan
           - coverage
           - build
-          - release
       LOCATION:
         description: 'Where the load is executed'
         type: choice
@@ -27,46 +26,17 @@ on:
           - arm
           - self-hosted
         default: 'X64'
-      DOCKER_SERENEDB_IMAGE:
-        description: 'Produce SereneDB Docker Images'
-        required: true
-        type: boolean
-        default: false
-      PUSH_IMAGES_2_REGISTRY:
-        description: 'Push images to Docker Hub/Registry'
-        required: true
-        type: boolean
-        default: false
-      CREATE_GITHUB_RELEASE:
-        description: 'Create a GitHub Release draft'
-        required: true
-        type: boolean
-        default: false
-      DOCKER_EXTRA_TAGS:
-        description: 'Optional Custom TAGS for DOCKER_SERENEDB_IMAGE'
-        required: false
-        type: string
-        default: ''
       EXTRA_ARTIFACTS:
         description: 'Keep these artifacts additionally'
         type: string
         required: false
         default: ''
-      DOCKER_BUILD_IMAGES:
-        description: 'Produce SereneDB Build Images'
-        required: true
-        type: boolean
-        default: false
       BUILD_CONFIG:
         description: 'JSON configuration for builds and job settings'
         type: string
         required: false
         default: '{"BUILD_IMAGE":"serenedb/serenedb-build-ubuntu:latest","DEBUG_PRINT_ENV":"false"}'
-      SERENEDB_VERSION_PATCH:
-        description: 'Version patch number for release builds (>0). Leave empty to auto-increment from latest GitHub release.'
-        required: false
-        type: string
-        default: ''
+
 permissions:
   statuses: write
   contents: write
@@ -75,17 +45,9 @@ jobs:
   call-reusable:
     uses: ./.github/workflows/build-reusable.yml
     with:
-      # General environment
       PRESET: ${{ inputs.PRESET }}
       LOCATION: ${{ inputs.LOCATION }}
-      DOCKER_SERENEDB_IMAGE: ${{ inputs.DOCKER_SERENEDB_IMAGE }}
-      PUSH_IMAGES_2_REGISTRY: ${{ inputs.PUSH_IMAGES_2_REGISTRY }}
-      DOCKER_EXTRA_TAGS: ${{ inputs.DOCKER_EXTRA_TAGS }}
       EXTRA_ARTIFACTS: ${{ inputs.EXTRA_ARTIFACTS }}
-      DOCKER_BUILD_IMAGES: ${{ inputs.DOCKER_BUILD_IMAGES }}
-      # Build config environment
       BUILD_CONFIG: ${{ inputs.BUILD_CONFIG }}
-      CREATE_GITHUB_RELEASE: ${{ inputs.CREATE_GITHUB_RELEASE }}
-      SERENEDB_VERSION_PATCH: ${{ inputs.SERENEDB_VERSION_PATCH }}
 
     secrets: inherit

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -18,41 +18,16 @@ on:
         type: string
         required: false
         default: ""
-      DOCKER_SERENEDB_IMAGE:
-        description: "Produce SereneDB Docker Images"
-        required: true
-        type: boolean
-        default: false
-      DOCKER_EXTRA_TAGS:
-        description: "(Optional) Custom TAGS for DOCKER_SERENEDB_IMAGE"
-        required: false
-        type: string
-        default: ""
-      PUSH_IMAGES_2_REGISTRY:
-        description: "Push images to Docker Hub"
-        required: true
-        type: boolean
-        default: false
       EXTRA_ARTIFACTS:
         description: "Keep these artifacts additionally"
         type: string
         required: false
         default: ""
-      DOCKER_BUILD_IMAGES:
-        description: "Produce SereneDB Build Images"
-        required: true
-        type: boolean
-        default: false
       BUILD_CONFIG:
         description: "JSON configuration for builds and job settings"
         type: string
         required: false
         default: '{"BUILD_IMAGE":"serenedb/serenedb-build-ubuntu:latest","DEBUG_PRINT_ENV":"false"}'
-      CREATE_GITHUB_RELEASE:
-        description: 'Create a GitHub Release with packages'
-        required: true
-        type: boolean
-        default: false
       SERENEDB_VERSION_PATCH:
         description: "Version patch number for release builds (>0). Leave empty to auto-increment from latest GitHub release."
         required: false
@@ -67,16 +42,10 @@ on:
         required: true
       TG_USER_MAP:
         required: true
-      DOCKER_HUB_TOKEN:
-        required: false
 
 env:
   WORKSPACE: ${{ github.workspace }}
   BUILD_CONFIG: ${{ inputs.BUILD_CONFIG }}
-  DOCKER_EXTRA_TAGS: ${{ inputs.DOCKER_EXTRA_TAGS }}
-  DOCKER_SERENEDB_IMAGE: ${{ inputs.DOCKER_SERENEDB_IMAGE }}
-  DOCKER_BUILD_IMAGES: ${{ inputs.DOCKER_BUILD_IMAGES }}
-  PUSH_IMAGES_2_REGISTRY: ${{ inputs.PUSH_IMAGES_2_REGISTRY }}
   # Defaults from BUILD_CONFIG (overridden at runtime by the Load preset step)
   BUILD_IMAGE: serenedb/serenedb-build-ubuntu:latest
   DEBUG_PRINT_ENV: "false"
@@ -204,13 +173,11 @@ jobs:
         run: ./scripts/ci/steps/01-ci-set-sanitizer-options.bash
 
       - name: Build Docker environment file
-        if: env.DOCKER_BUILD_IMAGES != 'true'
         run: ./scripts/ci/steps/02-ci-build-docker-env-file.bash
 
       # ==================== GTEST PARALLEL CACHE ====================
       - name: Restore gtest-parallel timing cache
         id: gtest-cache
-        if: env.DOCKER_BUILD_IMAGES != 'true'
         uses: actions/cache@v4
         with:
           path: .gtest-parallel-cache
@@ -221,16 +188,13 @@ jobs:
             gtest-times-${{ inputs.PRESET }}-
 
       - name: Prepare gtest-parallel cache directory
-        if: env.DOCKER_BUILD_IMAGES != 'true'
         run: |
           mkdir -p .gtest-parallel-cache
           echo "GTEST_PARALLEL_CACHE_DIR=${WORKSPACE}/.gtest-parallel-cache" >> $GITHUB_ENV
 
       # ==================== BUILD ====================
-      # if selected, DOCKER_BUILD_IMAGES owns the build
       - name: SereneDB build
         id: serenedb_build
-        if: env.DOCKER_BUILD_IMAGES != 'true'
         run: ./scripts/ci/steps/03-ci-in-docker-build-targets.bash
 
       # ==================== TESTS ====================
@@ -254,41 +218,21 @@ jobs:
       # ==================== COVERAGE REPORT ====================
       - name: Generate coverage report
         id: coverage_report
-        if: steps.serenedb_build.outcome == 'success' && inputs.USE_COVERAGE != ''
+        if: steps.serenedb_build.outcome == 'success' && env.USE_COVERAGE != ''
         run: ./scripts/ci/steps/06-ci-in-docker-generate-coverage-report.bash
 
-      # ==================== BUILD DOCKER IMAGES ====================
-      - name: Build Docker Images
-        id: build_docker_images
-        if: steps.serenedb_packages.outcome == 'success' && steps.rta.outcome == 'success' && env.DOCKER_SERENEDB_IMAGE == 'true'
-        env:
-          DOCKER_REGISTRY: serenedb
-          DOCKER_USERNAME: serenedb
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
-        run: ./packages/build_docker.bash
-
-      # ==================== CREATE GITHUB RELEASE ====================
-      - name: Create GitHub Release
-        id: create_release
-        if: steps.build_docker_images.outcome == 'success' && inputs.CREATE_GITHUB_RELEASE == true && inputs.PUSH_IMAGES_2_REGISTRY == true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./scripts/ci/steps/09-ci-create-github-release.bash
-
-      # ==================== PRODUCE BUILD IMAGES ====================
-      - name: Produce Build Image
-        id: produce_build_images
-        if: env.DOCKER_BUILD_IMAGES == 'true'
-        working-directory: ./scripts/ci
-        env:
-          DOCKER_REGISTRY: serenedb
-          DOCKER_USERNAME: serenedb
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
-        run: ./build_images.sh
+      # ==================== UPLOAD RELEASE TARBALL ====================
+      - name: Upload release tarball
+        if: steps.serenedb_packages.outcome == 'success' && env.DEB_TAR_PACKAGES == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarball-${{ inputs.LOCATION }}
+          path: packages/tarball/install-*.tar.gz
+          retention-days: 1
 
       # ==================== UPDATE FILE OWNERSHIP ====================
       - name: Update file ownership
-        if: always() && env.DOCKER_BUILD_IMAGES != 'true'
+        if: always()
         run: ./scripts/ci/steps/07-ci-in-docker-update-file-ownership.bash
 
       # ==================== DETERMINE FINAL STATUS ====================
@@ -318,23 +262,8 @@ jobs:
             HAS_FAILURES=true
           fi
 
-          if [[ "${{ steps.build_docker_images.outcome }}" == "failure" ]]; then
-            echo "Build Docker Images failed"
-            HAS_FAILURES=true
-          fi
-
-          if [[ "${{ steps.produce_build_images.outcome }}" == "failure" ]]; then
-            echo "Produce Build Images failed"
-            HAS_FAILURES=true
-          fi
-
           if [[ "${{ steps.rta.outcome }}" == "failure" ]]; then
             echo "RTA failed"
-            HAS_FAILURES=true
-          fi
-
-          if [[ "${{ steps.create_release.outcome }}" == "failure" ]]; then
-            echo "GitHub Release creation failed"
             HAS_FAILURES=true
           fi
 
@@ -345,7 +274,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ github.run_number }}
+          name: build-artifacts-${{ inputs.LOCATION }}-${{ github.run_number }}
           path: |
             binaries.tar.gz
             build_description.txt
@@ -379,7 +308,7 @@ jobs:
         if: steps.serenedb_packages.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: packages-${{ github.run_number }}
+          name: packages-${{ inputs.LOCATION }}-${{ github.run_number }}
           path: |
             *.deb
             *.tar.gz
@@ -389,7 +318,7 @@ jobs:
         if: always() && !cancelled() && inputs.EXTRA_ARTIFACTS != ''
         uses: actions/upload-artifact@v4
         with:
-          name: extra-artifacts-${{ github.run_number }}
+          name: extra-artifacts-${{ inputs.LOCATION }}-${{ github.run_number }}
           path: ${{ inputs.EXTRA_ARTIFACTS }}
           if-no-files-found: ignore
           retention-days: 30
@@ -398,7 +327,7 @@ jobs:
         if: always() && !cancelled()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ github.run_number }}
+          name: test-results-${{ inputs.LOCATION }}-${{ github.run_number }}
           path: |
             **/vpack-tests.xml
             **/iresearch-tests.xml
@@ -429,7 +358,7 @@ jobs:
           BRANCH: ${{ env.BRANCH }}
           JOB_STATUS: ${{ env.HAS_FAILURES == 'true' && 'failure' || 'success' }}
           ACTOR: ${{ contains(inputs.BUILD_CONFIG, 'TRIGGERED_BY') && fromJSON(inputs.BUILD_CONFIG).TRIGGERED_BY || github.actor }}
-          RUN_NAME: "SereneDB [${{ inputs.DOCKER_BUILD_IMAGES && 'build image' || inputs.PRESET }}]"
+          RUN_NAME: "SereneDB [${{ inputs.PRESET }}]"
           RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: ./scripts/notify_telegram.bash

--- a/.github/workflows/jobs-schedule.yml
+++ b/.github/workflows/jobs-schedule.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/build-reusable.yml
     with:
       PRESET: 'coverage'
-      LOCATION: 'x86'
+      LOCATION: 'X64'
       BRANCH: 'main'
       BUILD_CONFIG: '{"SDB_ALLOC":"JE","SDB_DEV":"On","USE_IPO":"Off","ENSURE_VTUNE_SYMBOLS":"Off","BUILDMODE":"RelWithDebInfo","USE_DEBUG_INFO":"COLUMNS"}'
     secrets:
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/build-reusable.yml
     with:
       PRESET: 'msan'
-      LOCATION: 'x86'
+      LOCATION: 'X64'
       BRANCH: 'main'
       BUILD_CONFIG: '{"SDB_ALLOC":"JE","SDB_DEV":"On","USE_IPO":"Off","ENSURE_VTUNE_SYMBOLS":"Off","BUILDMODE":"RelWithDebInfo","USE_DEBUG_INFO":"COLUMNS"}'
     secrets:
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/build-reusable.yml
     with:
       PRESET: 'asan'
-      LOCATION: 'x86'
+      LOCATION: 'X64'
       BRANCH: 'main'
       BUILD_CONFIG: '{"SDB_ALLOC":"JE","SDB_DEV":"On","USE_IPO":"Off","ENSURE_VTUNE_SYMBOLS":"Off","BUILDMODE":"RelWithDebInfo","USE_DEBUG_INFO":"COLUMNS"}'
     secrets:
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/build-reusable.yml
     with:
       PRESET: 'ubsan'
-      LOCATION: 'x86'
+      LOCATION: 'X64'
       BRANCH: 'main'
       BUILD_CONFIG: '{"SDB_ALLOC":"JE","SDB_DEV":"On","USE_IPO":"Off","ENSURE_VTUNE_SYMBOLS":"Off","BUILDMODE":"RelWithDebInfo","USE_DEBUG_INFO":"COLUMNS"}'
     secrets:
@@ -80,7 +80,7 @@ jobs:
     uses: ./.github/workflows/build-reusable.yml
     with:
       PRESET: 'tsan'
-      LOCATION: 'x86'
+      LOCATION: 'X64'
       BRANCH: 'main'
       BUILD_CONFIG: '{"SDB_ALLOC":"JE","SDB_DEV":"On","USE_IPO":"Off","ENSURE_VTUNE_SYMBOLS":"Off","BUILDMODE":"RelWithDebInfo","USE_DEBUG_INFO":"COLUMNS"}'
     secrets:

--- a/.github/workflows/pr-build-trigger.yml
+++ b/.github/workflows/pr-build-trigger.yml
@@ -110,8 +110,25 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: actions/checkout@v5
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
         with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            const isFork = pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+            core.setOutput('branch', pr.head.ref);
+            core.setOutput('is_fork', isFork.toString());
+            // For forks: use main (trusted workflows). For same-repo: use PR branch (testable CI changes).
+            core.setOutput('checkout_ref', isFork ? pr.base.ref : pr.head.ref);
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr-info.outputs.checkout_ref }}
           sparse-checkout: .github/workflows/build-manual.yml
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,239 @@
+name: SereneDB-Release
+
+run-name: "SereneDB Release [${{ inputs.BUILD_X64 && inputs.BUILD_ARM64 && 'x64+arm64' || inputs.BUILD_X64 && 'x64' || 'arm64' }}]"
+
+on:
+  workflow_dispatch:
+    inputs:
+      SERENEDB_VERSION_PATCH:
+        description: 'Version patch number (>0). Leave empty to auto-increment.'
+        required: false
+        type: string
+        default: ''
+      PUSH_IMAGES_2_REGISTRY:
+        description: 'Push Docker images to Docker Hub'
+        required: true
+        type: boolean
+        default: false
+      CREATE_GITHUB_RELEASE:
+        description: 'Create a GitHub Release draft'
+        required: true
+        type: boolean
+        default: false
+      DOCKER_EXTRA_TAGS:
+        description: 'Optional extra Docker tags (comma-separated)'
+        required: false
+        type: string
+        default: ''
+      BUILD_X64:
+        description: 'Build for x86_64 (amd64)'
+        required: true
+        type: boolean
+        default: true
+      BUILD_ARM64:
+        description: 'Build for aarch64 (arm64)'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  statuses: write
+  contents: write
+  actions: write
+
+jobs:
+  # ==================== RESOLVE VERSION ====================
+  resolve-version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      patch: ${{ steps.version.outputs.patch }}
+    steps:
+      - name: Resolve version patch
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PATCH="${{ inputs.SERENEDB_VERSION_PATCH }}"
+          if [[ -z "$PATCH" ]]; then
+            MAJOR=$(date -u +%y)
+            MINOR=$(date -u +%m)
+            LAST=$(gh release list --repo "${{ github.repository }}" --limit 100 --json tagName \
+              --jq "[.[] | .tagName | ltrimstr(\"v\") | select(startswith(\"${MAJOR}.${MINOR}.\")) | ltrimstr(\"${MAJOR}.${MINOR}.\") | select(test(\"^[0-9]+\")) | split(\"-\")[0]] | map(tonumber) | max // 0" \
+              2>/dev/null || echo "0")
+            PATCH=$(( LAST + 1 ))
+          fi
+          echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+
+  # ==================== BUILD X64 ====================
+  build-x64:
+    if: inputs.BUILD_X64
+    needs: [resolve-version]
+    uses: ./.github/workflows/build-reusable.yml
+    with:
+      PRESET: release
+      LOCATION: X64
+      SERENEDB_VERSION_PATCH: ${{ needs.resolve-version.outputs.patch }}
+    secrets: inherit
+
+  # ==================== BUILD ARM64 ====================
+  build-arm64:
+    if: inputs.BUILD_ARM64
+    needs: [resolve-version]
+    uses: ./.github/workflows/build-reusable.yml
+    with:
+      PRESET: release
+      LOCATION: arm
+      SERENEDB_VERSION_PATCH: ${{ needs.resolve-version.outputs.patch }}
+    secrets: inherit
+
+  # ==================== RELEASE ====================
+  release:
+    name: Docker & Release
+    needs: [resolve-version, build-x64, build-arm64]
+    if: >-
+      always() && !cancelled() &&
+      (needs.build-x64.result == 'success' || needs.build-arm64.result == 'success')
+    runs-on:
+      - X64
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - name: Set version
+        run: |
+          PATCH="${{ needs.resolve-version.outputs.patch }}"
+          echo "SERENEDB_VERSION_PATCH=$PATCH" >> $GITHUB_ENV
+          MAJOR=$(date -u +%y)
+          MINOR=$(date -u +%m)
+          echo "DOCKER_TAG=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_ENV
+
+      # Download tarball artifacts and map to Docker arch names
+      - name: Download x64 tarball
+        if: needs.build-x64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: tarball-X64
+          path: packages/tarball/
+
+      - name: Download arm64 tarball
+        if: needs.build-arm64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: tarball-arm
+          path: packages/tarball/
+
+      - name: Map tarballs to Docker arch names
+        id: map_tarballs
+        run: |
+          mkdir -p packages/tarball
+          cd packages/tarball
+          HAS_TARBALLS=false
+          for f in install-*.tar.gz; do
+            [ -e "$f" ] || continue
+            case "$f" in
+              *x86_64*) ln -sf "$f" install-amd64.tar.gz ;;
+              *arm64*|*aarch64*) ln -sf "$f" install-arm64.tar.gz ;;
+            esac
+            HAS_TARBALLS=true
+          done
+          echo "has_tarballs=$HAS_TARBALLS" >> "$GITHUB_OUTPUT"
+          echo "Available tarballs:"
+          ls -la install-*.tar.gz 2>/dev/null || echo "  (none)"
+
+      # Build multi-arch Docker image
+      - name: Setup QEMU
+        if: inputs.PUSH_IMAGES_2_REGISTRY && steps.map_tarballs.outputs.has_tarballs == 'true'
+        run: docker run --rm --privileged tonistiigi/binfmt --install all
+
+      - name: Build and push Docker images
+        if: inputs.PUSH_IMAGES_2_REGISTRY && steps.map_tarballs.outputs.has_tarballs == 'true'
+        env:
+          DOCKER_REGISTRY: serenedb
+          DOCKER_USERNAME: serenedb
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
+          PUSH_IMAGES_2_REGISTRY: "true"
+          DOCKER_EXTRA_TAGS: ${{ inputs.DOCKER_EXTRA_TAGS }}
+          DOCKER_TAG: ${{ env.DOCKER_TAG }}
+        run: ./packages/build_docker.bash
+
+      # Download package artifacts for GitHub release
+      - name: Download x64 packages
+        if: inputs.CREATE_GITHUB_RELEASE && needs.build-x64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: packages-X64-${{ github.run_number }}
+          path: release-packages/
+
+      - name: Download arm64 packages
+        if: inputs.CREATE_GITHUB_RELEASE && needs.build-arm64.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: packages-arm-${{ github.run_number }}
+          path: release-packages/
+
+      # Create GitHub Release
+      - name: Create GitHub Release
+        if: inputs.CREATE_GITHUB_RELEASE && steps.map_tarballs.outputs.has_tarballs == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DOCKER_TAG: ${{ env.DOCKER_TAG }}
+        run: |
+          TAG="v${DOCKER_TAG}"
+          TITLE="SereneDB ${TAG}"
+          BODY="Docker image: https://hub.docker.com/r/serenedb/serenedb/tags?name=${DOCKER_TAG}"
+
+          ASSETS=()
+          for f in release-packages/*.deb release-packages/*.tar.gz; do
+            [ -e "$f" ] && ASSETS+=("$f")
+          done
+
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "::error::No packages found, skipping GitHub release"
+            exit 1
+          fi
+
+          gh release create "${TAG}" \
+            --draft \
+            --title "${TITLE}" \
+            --notes "${BODY}" \
+            "${ASSETS[@]}"
+
+      # Cleanup artifacts
+      - name: Delete tarball artifacts
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for name in tarball-X64 tarball-arm; do
+            ARTIFACT_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+              --jq ".artifacts[] | select(.name == \"${name}\") | .id" 2>/dev/null || true)
+            if [[ -n "$ARTIFACT_ID" ]]; then
+              gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}" || true
+              echo "Deleted artifact: ${name}"
+            fi
+          done
+
+      # Telegram notification
+      - name: Send Telegram notification
+        if: always() && !cancelled()
+        env:
+          TG_TOKEN: ${{ secrets.TG_TOKEN }}
+          TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}
+          TG_THREAD_ID_MAIN: "51"
+          TG_THREAD_ID_BUILD: "53"
+          TG_USER_MAP: ${{ secrets.TG_USER_MAP }}
+          BRANCH: ${{ github.ref_name }}
+          JOB_STATUS: ${{ (needs.build-x64.result == 'success' || needs.build-x64.result == 'skipped') && (needs.build-arm64.result == 'success' || needs.build-arm64.result == 'skipped') && 'success' || 'failure' }}
+          ACTOR: ${{ github.actor }}
+          RUN_NAME: "SereneDB [release]"
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: ./scripts/notify_telegram.bash

--- a/.github/workflows/serene-ui-manual.yml
+++ b/.github/workflows/serene-ui-manual.yml
@@ -73,3 +73,4 @@ jobs:
             APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
             APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
             DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
+            TG_USER_MAP: ${{ secrets.TG_USER_MAP }}

--- a/.github/workflows/serene-ui-reusable.yml
+++ b/.github/workflows/serene-ui-reusable.yml
@@ -64,6 +64,8 @@ on:
             DOCKER_PASSWORD:
                 required: false
                 description: "Docker registry password / token"
+            TG_USER_MAP:
+                required: true
 
 jobs:
     build-docker:
@@ -90,7 +92,7 @@ jobs:
               run: echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
             - name: Checkout SereneUI
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: serenedb/serenedb
                   ref: ${{ env.BRANCH }}
@@ -123,6 +125,10 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 30
 
+            - name: Setup QEMU for multi-arch
+              if: inputs.BUILD_IMAGE
+              run: docker run --rm --privileged tonistiigi/binfmt --install all
+
             - name: Build Docker image
               if: inputs.BUILD_IMAGE
               env:
@@ -152,7 +158,7 @@ jobs:
               run: echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
             - name: Checkout SereneUI
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: serenedb/serenedb
                   ref: ${{ env.BRANCH }}
@@ -227,7 +233,7 @@ jobs:
               run: echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
             - name: Checkout SereneUI
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: serenedb/serenedb
                   ref: ${{ env.BRANCH }}
@@ -291,7 +297,7 @@ jobs:
         runs-on: macOS
         permissions:
             contents: read
-        timeout-minutes: 144000
+        timeout-minutes: 240
         defaults:
             run:
                 working-directory: ./serene-ui
@@ -301,7 +307,7 @@ jobs:
               run: echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
             - name: Checkout SereneUI
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: serenedb/serenedb
                   ref: ${{ env.BRANCH }}
@@ -435,7 +441,7 @@ jobs:
               run: echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
             - name: Checkout (for notify script)
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: serenedb/serenedb
                   ref: ${{ env.BRANCH }}

--- a/packages/build_docker.bash
+++ b/packages/build_docker.bash
@@ -3,9 +3,8 @@
 # Environment Configuration:
 #   DOCKER_TAG               Set version (if unset, derived from find_version.bash)
 #   DOCKER_EXTRA_TAGS        Comma or space-separated list of additional tags
-#   PUSH_IMAGES_2_REGISTRY   'true' to push to registry after build
+#   PUSH_IMAGES_2_REGISTRY   'true' to push multi-arch to registry
 #   DOCKER_REGISTRY          Registry URL (default: serenedb)
-#   DOCKER_PLATFORM          Target platform (default: linux/amd64)
 #   DOCKER_USERNAME          Registry username (for push)
 #   DOCKER_PASSWORD          Registry password (for push)
 
@@ -17,12 +16,11 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DOCKER_DIR="${SCRIPT_DIR}/docker"
 TARBALL_DIR="${SCRIPT_DIR}/tarball"
 IMAGE_NAME="serenedb"
+BUILDER_NAME="serenedb-image-builder"
 
 : "${DOCKER_REGISTRY:=serenedb}"
-: "${DOCKER_PLATFORM:=linux/amd64}"
 : "${PUSH_IMAGES_2_REGISTRY:=false}"
 
-# Parse DOCKER_EXTRA_TAGS into a bash array (handles commas and spaces)
 IFS=', ' read -r -a EXTRA_TAGS_ARRAY <<<"${DOCKER_EXTRA_TAGS:-}"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
@@ -31,118 +29,175 @@ error() {
 	exit 1
 }
 
-# Determine version and Docker tag
+NEEDS_LOGOUT=""
+cleanup() {
+	rm -rf "${BUILD_DIR:-}"
+	docker buildx rm "${BUILDER_NAME}" 2>/dev/null || true
+	if [ -n "$NEEDS_LOGOUT" ]; then
+		if [ "$NEEDS_LOGOUT" = "hub" ]; then
+			docker logout 2>/dev/null || true
+		else
+			docker logout "$NEEDS_LOGOUT" 2>/dev/null || true
+		fi
+	fi
+}
+
+# --- Detect host architecture ---
+RAW_ARCH=$(uname -m)
+case $RAW_ARCH in
+x86_64) HOST_ARCH="amd64" ;;
+aarch64) HOST_ARCH="arm64" ;;
+*) error "Unsupported architecture: $RAW_ARCH" ;;
+esac
+
+# --- Determine version ---
 [ -z "${DOCKER_TAG:-}" ] && source "${SCRIPT_DIR}/find_version.bash"
 [ -z "${DOCKER_TAG:-}" ] && error "Failed to determine DOCKER_TAG"
 VERSION="$DOCKER_TAG"
-
 FULL_IMAGE_NAME="${DOCKER_REGISTRY}/${IMAGE_NAME}"
+
+# --- Detect available arch tarballs ---
+AVAILABLE_ARCHES=()
+for arch in amd64 arm64; do
+	tarball="${TARBALL_DIR}/install-${arch}.tar.gz"
+	if [ -f "$tarball" ] || [ -L "$tarball" ]; then
+		AVAILABLE_ARCHES+=("$arch")
+	fi
+done
+
+if [ ${#AVAILABLE_ARCHES[@]} -eq 0 ]; then
+	error "No install-{arch}.tar.gz found in ${TARBALL_DIR}. Run build_targz.bash first."
+fi
+
+# --- Prepare build context ---
 BUILD_DIR=$(mktemp -d)
-trap "rm -rf ${BUILD_DIR}" EXIT
+trap cleanup EXIT
 
 log "=== SereneDB Docker Build ==="
 log "Version:  ${VERSION}"
 log "Image:    ${FULL_IMAGE_NAME}"
-log "Platform: ${DOCKER_PLATFORM}"
-log "Build:    ${BUILD_DIR}"
-
-# Verify prerequisites
-log "Checking prerequisites..."
-
-# Check for tarball
-TARBALL="${TARBALL_DIR}/install.tar.gz"
-if [ ! -f "$TARBALL" ] && [ ! -L "$TARBALL" ]; then
-	# Try alternative location
-	TARBALL="${PROJECT_ROOT}/package_all/install.tar.gz"
-fi
-
-if [ ! -f "$TARBALL" ] && [ ! -L "$TARBALL" ]; then
-	error "install.tar.gz not found. Run build_targz.bash first."
-fi
-
-log "  Tarball: ${TARBALL} ($(du -h "$TARBALL" | cut -f1))"
-
-# Prepare build context
-log "Preparing build context..."
+log "Arches:   ${AVAILABLE_ARCHES[*]}"
 
 cp "${DOCKER_DIR}/Dockerfile" "${BUILD_DIR}/"
 cp "${DOCKER_DIR}/setup.sh" "${BUILD_DIR}/"
 cp "${DOCKER_DIR}/entrypoint.sh" "${BUILD_DIR}/"
-cp "${TARBALL}" "${BUILD_DIR}/install.tar.gz"
+
+for arch in "${AVAILABLE_ARCHES[@]}"; do
+	cp "${TARBALL_DIR}/install-${arch}.tar.gz" "${BUILD_DIR}/install-${arch}.tar.gz"
+	log "  Tarball (${arch}): $(du -h "${BUILD_DIR}/install-${arch}.tar.gz" | cut -f1)"
+done
 
 log "  Context size: $(du -sh "${BUILD_DIR}" | cut -f1)"
 
-# Build image
-log "Building Docker image..."
+# --- Setup buildx ---
+log "Configuring Docker Buildx..."
+if docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+	docker buildx rm "$BUILDER_NAME" >/dev/null
+fi
+docker buildx create --name "$BUILDER_NAME" --use --driver-opt network=host >/dev/null
 
-BUILD_ARGS=(
-	--platform "${DOCKER_PLATFORM}"
-	--tag "${FULL_IMAGE_NAME}:${VERSION}"
+LABEL_ARGS=(
 	--label "org.opencontainers.image.version=${VERSION}"
 	--label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	--label "org.opencontainers.image.revision=$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
-	--file "${BUILD_DIR}/Dockerfile"
-	--no-cache
 )
 
-# Add extra tags
-for tag in "${EXTRA_TAGS_ARRAY[@]}"; do
-	if [ -n "$tag" ]; then
-		BUILD_ARGS+=(--tag "${FULL_IMAGE_NAME}:${tag}")
-	fi
-done
-
-docker build "${BUILD_ARGS[@]}" "${BUILD_DIR}"
-
-log "Build complete!"
-
-# Show image info
-log ""
-log "=== Image Info ==="
-docker images "${FULL_IMAGE_NAME}" --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.CreatedAt}}"
-
-# Test image
-log ""
-log "=== Testing Image ==="
-
-# Quick smoke test
-if docker run --rm "${FULL_IMAGE_NAME}:${VERSION}" --version 2>/dev/null; then
-	log "  ✓ Version check passed"
-else
-	error "  ✗ Version check failed"
-fi
-
-# Push to registry
-if [ "${PUSH_IMAGES_2_REGISTRY:=false}" = true ]; then
-	log ""
-	log "=== Pushing to Registry ==="
-
-	# Login if credentials provided
-	if [ -n "${DOCKER_USERNAME:-}" ] && [ -n "${DOCKER_PASSWORD:-}" ]; then
-		if [[ "${DOCKER_REGISTRY}" =~ [.:] ]]; then
-			log "Logging in to ${DOCKER_REGISTRY}..."
-			echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REGISTRY" -u "$DOCKER_USERNAME" --password-stdin
-			trap "docker logout ${DOCKER_REGISTRY}; log 'Logged out from ${DOCKER_REGISTRY}'" EXIT
-		else
-			log "Logging in to Docker Hub..."
-			echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-			trap "docker logout; log 'Logged out from Docker Hub'" EXIT
-		fi
+# --- Build & Push ---
+if [ "${PUSH_IMAGES_2_REGISTRY}" = "true" ]; then
+	if [ -z "${DOCKER_USERNAME:-}" ] || [ -z "${DOCKER_PASSWORD:-}" ]; then
+		error "DOCKER_USERNAME and DOCKER_PASSWORD are required to push."
 	fi
 
-	# Push version tag
-	log "Pushing ${FULL_IMAGE_NAME}:${VERSION}..."
-	docker push "${FULL_IMAGE_NAME}:${VERSION}"
+	# Build each arch separately and export (anonymous pulls)
+	for arch in "${AVAILABLE_ARCHES[@]}"; do
+		log "Building linux/${arch}..."
+		docker buildx build \
+			--platform "linux/${arch}" \
+			-t "${FULL_IMAGE_NAME}:${VERSION}-${arch}" \
+			"${LABEL_ARGS[@]}" \
+			--output "type=docker,dest=/tmp/serenedb-${arch}.tar" \
+			--no-cache \
+			--file "${BUILD_DIR}/Dockerfile" \
+			"${BUILD_DIR}"
+	done
 
-	# Push extra tags
+	# Load into docker daemon
+	log "Loading images..."
+	for arch in "${AVAILABLE_ARCHES[@]}"; do
+		docker load </tmp/serenedb-${arch}.tar
+		rm -f "/tmp/serenedb-${arch}.tar"
+	done
+
+	# Smoke test
+	log "=== Smoke test ==="
+	if docker run --rm "${FULL_IMAGE_NAME}:${VERSION}-${HOST_ARCH}" --version 2>/dev/null; then
+		log "  Version check passed"
+	else
+		error "  Version check failed"
+	fi
+
+	# Login and push
+	docker logout >/dev/null 2>&1 || true
+	log "Logging in to Docker Hub as ${DOCKER_USERNAME}..."
+	if [[ "${DOCKER_REGISTRY}" =~ [.:] ]]; then
+		echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REGISTRY" -u "$DOCKER_USERNAME" --password-stdin
+		NEEDS_LOGOUT="$DOCKER_REGISTRY"
+	else
+		echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+		NEEDS_LOGOUT="hub"
+	fi
+
+	for arch in "${AVAILABLE_ARCHES[@]}"; do
+		log "Pushing ${FULL_IMAGE_NAME}:${VERSION}-${arch}..."
+		docker push "${FULL_IMAGE_NAME}:${VERSION}-${arch}"
+	done
+
+	# Build manifest sources list
+	MANIFEST_SOURCES=()
+	for arch in "${AVAILABLE_ARCHES[@]}"; do
+		MANIFEST_SOURCES+=("${FULL_IMAGE_NAME}:${VERSION}-${arch}")
+	done
+
+	# Create and push multi-arch manifests
+	log "Creating multi-arch manifests..."
+	ALL_TAGS=("${VERSION}")
 	for tag in "${EXTRA_TAGS_ARRAY[@]}"; do
-		if [ -n "$tag" ]; then
-			log "Pushing ${FULL_IMAGE_NAME}:${tag}..."
-			docker push "${FULL_IMAGE_NAME}:${tag}"
-		fi
+		[ -n "$tag" ] && ALL_TAGS+=("$tag")
+	done
+
+	for tag in "${ALL_TAGS[@]}"; do
+		docker manifest create --amend "${FULL_IMAGE_NAME}:${tag}" "${MANIFEST_SOURCES[@]}"
+		docker manifest push "${FULL_IMAGE_NAME}:${tag}"
+		log "  Pushed ${FULL_IMAGE_NAME}:${tag}"
+	done
+
+	# Cleanup arch-specific images
+	for arch in "${AVAILABLE_ARCHES[@]}"; do
+		docker rmi "${FULL_IMAGE_NAME}:${VERSION}-${arch}" >/dev/null 2>&1 || true
 	done
 
 	log "Push complete!"
+else
+	# Local build: single arch, --load
+	log "Building for local use (linux/${HOST_ARCH})..."
+	docker buildx build \
+		--load \
+		--platform "linux/${HOST_ARCH}" \
+		--tag "${FULL_IMAGE_NAME}:${VERSION}" \
+		"${LABEL_ARGS[@]}" \
+		--no-cache \
+		--file "${BUILD_DIR}/Dockerfile" \
+		"${BUILD_DIR}"
+
+	log "Build complete!"
+
+	# Smoke test
+	log "=== Testing Image ==="
+	if docker run --rm "${FULL_IMAGE_NAME}:${VERSION}" --version 2>/dev/null; then
+		log "  Version check passed"
+	else
+		error "  Version check failed"
+	fi
 fi
 
 # Summary
@@ -152,6 +207,3 @@ log "Image: ${FULL_IMAGE_NAME}:${VERSION}"
 log ""
 log "Run with:"
 log "  docker run -d -p 8529:8529 ${FULL_IMAGE_NAME}:${VERSION}"
-log ""
-log "Or with docker-compose:"
-log "  See ${DOCKER_DIR}/docker-compose.yml"

--- a/packages/build_targz.bash
+++ b/packages/build_targz.bash
@@ -75,7 +75,15 @@ if [[ "${DEBUG_SYMBOLS:-false}" == "true" ]]; then
 	echo "Created: ${NAME}-dbgsym.tar.gz ($(du -h "${NAME}-dbgsym.tar.gz" | cut -f1))"
 fi
 
-# Create symlink for follow-up docker image production step
+# Create arch-specific symlink for multi-arch build_docker.bash
 mkdir -p "${PROJECT_ROOT}/packages/tarball"
 cd "${PROJECT_ROOT}/packages/tarball"
-ln -sf "../../${NAME}.tar.gz" "install.tar.gz"
+case "$ARCH" in
+x86_64) DOCKER_ARCH="amd64" ;;
+aarch64) DOCKER_ARCH="arm64" ;;
+*)
+	echo "fatal, unknown architecture $ARCH for Docker symlink"
+	exit 1
+	;;
+esac
+ln -sf "../../${NAME}.tar.gz" "install-${DOCKER_ARCH}.tar.gz"

--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -1,9 +1,11 @@
 # ---- Extract Stage ----
 FROM ubuntu:24.04 AS extractor
 
-COPY install.tar.gz /tmp/
+ARG TARGETARCH
+COPY install-${TARGETARCH}.tar.gz /tmp/install.tar.gz
 RUN mkdir -p /tmp/serenedb-extract \
     && tar -xzf /tmp/install.tar.gz -C /tmp/serenedb-extract --strip-components=1 \
+    && rm /tmp/install.tar.gz \
     && cd /tmp/serenedb-extract \
     && if [ -d sbin ]; then cp -f sbin/* usr/sbin/; rm -rf sbin; fi \
     && if [ -d bin ]; then cp -f bin/* usr/bin/; rm -rf bin; fi

--- a/packages/docker/setup.sh
+++ b/packages/docker/setup.sh
@@ -29,7 +29,7 @@ fi
 echo "Installing rclone..."
 
 RCLONE_VERSION="1.73.1"
-RCLONE_ARCH="linux-amd64"
+RCLONE_ARCH="linux-$(dpkg --print-architecture)"
 RCLONE_URL="https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-${RCLONE_ARCH}.zip"
 
 apt-get update

--- a/serene-ui/scripts/build_docker.sh
+++ b/serene-ui/scripts/build_docker.sh
@@ -6,45 +6,124 @@ set -eo pipefail
 [ -z "$DOCKER_TAG" ] && exit 1             # DOCKER_TAG="1.2.3"
 [ -z "$PUSH_IMAGE_TO_REGISTRY" ] && exit 1 # PUSH_IMAGE_TO_REGISTRY="false"
 
-FULL_IMAGE_NAME="${DOCKER_REGISTRY}/${IMAGE}:${DOCKER_TAG}"
+FULL_IMAGE_NAME="${DOCKER_REGISTRY}/${IMAGE}"
+BUILDER_NAME="sereneui-builder"
 [ -d logs ] || mkdir logs
-echo ">>> Building $FULL_IMAGE_NAME"
-docker build --pull --no-cache \
-	--tag "$FULL_IMAGE_NAME" \
-	--label "org.opencontainers.image.version=${DOCKER_TAG}" \
-	--label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-	--label "org.opencontainers.image.revision=$(git rev-parse HEAD 2>/dev/null || echo 'unknown')" \
-	--label "org.opencontainers.image.title=${IMAGE}" \
-	. 2>&1 | tee -a logs/build.log
-echo ">>> PUSH_IMAGE_TO_REGISTRY='${PUSH_IMAGE_TO_REGISTRY}' (hex: $(echo -n "$PUSH_IMAGE_TO_REGISTRY" | xxd -p))"
-if [ "$PUSH_IMAGE_TO_REGISTRY" = true ]; then
-	echo ">>> DOCKER_USERNAME set: $([ -n "$DOCKER_USERNAME" ] && echo yes || echo no), DOCKER_PASSWORD set: $([ -n "$DOCKER_PASSWORD" ] && echo yes || echo no)"
-	if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then
-		echo ">>> DOCKER_REGISTRY='$DOCKER_REGISTRY' (contains dot/colon: $(echo "$DOCKER_REGISTRY" | grep -q '[.:]' && echo yes || echo no))"
-		if [[ "$DOCKER_REGISTRY" =~ [.:] ]]; then
-			echo ">>> Logging in to $DOCKER_REGISTRY"
-			echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REGISTRY" -u "$DOCKER_USERNAME" --password-stdin
-			trap "docker logout $DOCKER_REGISTRY" EXIT
+
+# Detect host architecture
+RAW_ARCH=$(uname -m)
+case $RAW_ARCH in
+x86_64) HOST_ARCH="amd64" ;;
+aarch64) HOST_ARCH="arm64" ;;
+*)
+	echo "[-] Error: Unsupported architecture: $RAW_ARCH"
+	exit 1
+	;;
+esac
+
+NEEDS_LOGOUT=""
+cleanup() {
+	docker buildx rm "${BUILDER_NAME}" 2>/dev/null || true
+	if [ -n "$NEEDS_LOGOUT" ]; then
+		if [ "$NEEDS_LOGOUT" = "hub" ]; then
+			docker logout 2>/dev/null || true
 		else
-			echo ">>> Logging in to $DOCKER_REGISTRY"
-			echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-			trap "docker logout" EXIT
+			docker logout "$NEEDS_LOGOUT" 2>/dev/null || true
 		fi
-	else
-		echo ">>> Skipping login (credentials not set)"
 	fi
-	echo ">>> Pushing $FULL_IMAGE_NAME"
-	docker push "$FULL_IMAGE_NAME" 2>&1 | tee -a logs/build.log
-	extra_tags="$EXTRA_DOCKER_TAGS"
-	if [ "$PUSH_RELEASE" = true ]; then
-		extra_tags="latest $extra_tags"
+}
+
+# Ensure no stale login interferes with anonymous pulls
+docker logout >/dev/null 2>&1 || true
+
+# Setup buildx
+echo ">>> Configuring Docker Buildx..."
+if docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
+	docker buildx rm "$BUILDER_NAME" >/dev/null
+fi
+docker buildx create --name "$BUILDER_NAME" --use --driver-opt network=host >/dev/null
+trap cleanup EXIT
+
+LABEL_ARGS=(
+	--label "org.opencontainers.image.version=${DOCKER_TAG}"
+	--label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	--label "org.opencontainers.image.revision=$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+	--label "org.opencontainers.image.title=${IMAGE}"
+)
+
+if [ "$PUSH_IMAGE_TO_REGISTRY" = true ]; then
+	if [ -z "${DOCKER_USERNAME:-}" ] || [ -z "${DOCKER_PASSWORD:-}" ]; then
+		echo "[-] Error: DOCKER_USERNAME and DOCKER_PASSWORD are required to push."
+		exit 1
 	fi
-	IFS=', ' read -ra EXTRA_TAGS <<<"$extra_tags"
-	for tag in "${EXTRA_TAGS[@]}"; do
-		[ -z "$tag" ] && continue
-		TARGET="${DOCKER_REGISTRY}/${IMAGE}:${tag}"
-		echo ">>> Tagging and pushing: $TARGET"
-		docker tag "$FULL_IMAGE_NAME" "$TARGET"
-		docker push "$TARGET" 2>&1 | tee -a logs/build.log
+
+	# Build each arch separately and export (anonymous pulls, no login needed)
+	for arch in amd64 arm64; do
+		echo ">>> Building linux/${arch}..."
+		docker buildx build \
+			--platform "linux/${arch}" \
+			-t "${FULL_IMAGE_NAME}:${DOCKER_TAG}-${arch}" \
+			"${LABEL_ARGS[@]}" \
+			--output "type=docker,dest=/tmp/serene-ui-${arch}.tar" \
+			--pull --no-cache \
+			. 2>&1 | tee -a logs/build.log
 	done
+
+	# Load into docker daemon
+	echo ">>> Loading images..."
+	for arch in amd64 arm64; do
+		docker load </tmp/serene-ui-${arch}.tar
+		rm -f "/tmp/serene-ui-${arch}.tar"
+	done
+
+	# Login and push
+	if [[ "$DOCKER_REGISTRY" =~ [.:] ]]; then
+		echo ">>> Logging in to $DOCKER_REGISTRY"
+		echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REGISTRY" -u "$DOCKER_USERNAME" --password-stdin
+		NEEDS_LOGOUT="$DOCKER_REGISTRY"
+	else
+		echo ">>> Logging in to Docker Hub"
+		echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+		NEEDS_LOGOUT="hub"
+	fi
+
+	for arch in amd64 arm64; do
+		echo ">>> Pushing ${FULL_IMAGE_NAME}:${DOCKER_TAG}-${arch}..."
+		docker push "${FULL_IMAGE_NAME}:${DOCKER_TAG}-${arch}" 2>&1 | tee -a logs/build.log
+	done
+
+	# Build list of all tags to create manifests for
+	ALL_TAGS=("${DOCKER_TAG}")
+	if [ "$PUSH_RELEASE" = true ]; then
+		ALL_TAGS+=("latest")
+	fi
+	IFS=', ' read -ra EXTRA_TAGS <<<"${EXTRA_DOCKER_TAGS:-}"
+	for tag in "${EXTRA_TAGS[@]}"; do
+		[ -n "$tag" ] && ALL_TAGS+=("$tag")
+	done
+
+	# Create and push multi-arch manifests
+	echo ">>> Creating multi-arch manifests..."
+	for tag in "${ALL_TAGS[@]}"; do
+		docker manifest create --amend "${FULL_IMAGE_NAME}:${tag}" \
+			"${FULL_IMAGE_NAME}:${DOCKER_TAG}-amd64" \
+			"${FULL_IMAGE_NAME}:${DOCKER_TAG}-arm64"
+		docker manifest push "${FULL_IMAGE_NAME}:${tag}"
+		echo ">>> Pushed ${FULL_IMAGE_NAME}:${tag}"
+	done
+
+	# Cleanup arch-specific images
+	for arch in amd64 arm64; do
+		docker rmi "${FULL_IMAGE_NAME}:${DOCKER_TAG}-${arch}" >/dev/null 2>&1 || true
+	done
+else
+	# Local build: single arch, --load
+	echo ">>> Building ${FULL_IMAGE_NAME}:${DOCKER_TAG} (linux/${HOST_ARCH})"
+	docker buildx build \
+		--load \
+		--platform "linux/${HOST_ARCH}" \
+		--tag "${FULL_IMAGE_NAME}:${DOCKER_TAG}" \
+		"${LABEL_ARGS[@]}" \
+		--pull --no-cache \
+		. 2>&1 | tee -a logs/build.log
 fi


### PR DESCRIPTION
## Summary
- Add multi-arch (amd64 + arm64) support for all three Docker images: `serenedb`, `serene-ui`, `serenedb-build-ubuntu`
- Split monolith CI workflow into focused workflows: `release.yml`, `build-images.yml`
- Fix several pre-existing bugs

## New workflows
- **`release.yml`** — multi-arch release: runs `build-reusable.yml` in parallel on X64 + arm runners, combines tarballs into multi-arch Docker image, creates GitHub release. Supports single-arch fallback via `BUILD_X64`/`BUILD_ARM64` toggles
- **`build-images.yml`** — standalone workflow for producing `serenedb-build-ubuntu` images (was embedded in `build-reusable.yml`)

## Multi-arch changes
- `packages/build_docker.bash` — rewritten to use `docker buildx`, detects available arch tarballs, builds per-arch and creates multi-arch manifests
- `serene-ui/scripts/build_docker.sh` — rewritten for multi-arch buildx (QEMU handles arm64 npm build)
- `packages/docker/Dockerfile` — uses `ARG TARGETARCH` to pick correct tarball
- `packages/docker/setup.sh` — rclone arch detected at runtime via `dpkg --print-architecture`
- `packages/build_targz.bash` — creates `install-{arch}.tar.gz` symlinks (removed legacy `install.tar.gz`)

## Cleanup
- Removed from `build-reusable.yml`: Docker image build, GitHub release, build-images production (all moved to dedicated workflows)
- Removed inputs: `DOCKER_SERENEDB_IMAGE`, `DOCKER_BUILD_IMAGES`, `PUSH_IMAGES_2_REGISTRY`, `CREATE_GITHUB_RELEASE`, `DOCKER_EXTRA_TAGS`
- Removed `release` from `build-manual.yml` presets (use `release.yml` instead)
- Cleaned up `jobs-schedule.yml`: proper `PRESET` usage, fixed `LOCATION: 'x86'` → `'X64'`

## Bug fixes
- `build-reusable.yml`: `inputs.USE_COVERAGE` → `env.USE_COVERAGE` (coverage reports never ran)
- `serene-ui-reusable.yml`: timeout 144000 → 240 minutes (was 100 days)
- `serene-ui-reusable.yml` + `serene-ui-manual.yml`: added missing `TG_USER_MAP` secret
- `pr-build-trigger.yml`: `actions/checkout@v5` → `@v6`
- `serene-ui-reusable.yml`: `actions/checkout@v4` → `@v6` (5 occurrences)
- `jobs-schedule.yml`: `LOCATION: 'x86'` → `'X64'` (5 occurrences)