### PR TITLE
fix(CI): Add test results summary and fail-fast to parallel test runner

### DIFF
--- a/scripts/ci/steps/04-ci-run-tests.bash
+++ b/scripts/ci/steps/04-ci-run-tests.bash
@@ -51,7 +51,7 @@ if [[ -s "$JOBLOG" ]]; then
 		else
 			echo "  FAILED  ${name} (${jobruntime}s, exit code ${exitval})"
 		fi
-	done < "$JOBLOG"
+	done <"$JOBLOG"
 fi
 rm -f "$JOBLOG"
 if [[ $PARALLEL_RC -ne 0 || $SERIAL_RC -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Add a clear **TEST RESULTS SUMMARY** printed at the end of the test step, showing PASSED/FAILED/KILLED status per suite with runtime
- Switch GNU parallel from `--halt soon` to `--halt now,fail=1` to immediately kill remaining suites on first failure (saves CI time)
- Use `--joblog` to reliably track per-suite exit codes and signals

## Problem
When a test suite (e.g. `serenedb-tests`) fails during parallel execution, its failure message gets buried under thousands of lines from longer-running suites (e.g. `iresearch-tests` with 3500+ tests). The last visible output is `IRESEARCH_TESTS=PASSED` followed by `exit code 123`, making it very hard to identify which suite actually failed.