### PR TITLE
Add Union Tokenizer

### DIFF
--- a/libs/iresearch/include/iresearch/CMakeLists.txt
+++ b/libs/iresearch/include/iresearch/CMakeLists.txt
@@ -58,6 +58,7 @@ set(IResearch_core_sources
     ./analysis/stopwords_tokenizer.cpp
     ./analysis/ngram_tokenizer.cpp
     ./analysis/pipeline_tokenizer.cpp
+    ./analysis/union_tokenizer.cpp
     ./analysis/segmentation_tokenizer.cpp
     ./analysis/classification_tokenizer.cpp
     ./analysis/nearest_neighbors_tokenizer.cpp

--- a/libs/iresearch/include/iresearch/analysis/analyzers.cpp
+++ b/libs/iresearch/include/iresearch/analysis/analyzers.cpp
@@ -44,6 +44,7 @@
 #include "iresearch/analysis/stopwords_tokenizer.hpp"
 #include "iresearch/analysis/text_tokenizer.hpp"
 #include "iresearch/analysis/tokenizers.hpp"
+#include "iresearch/analysis/union_tokenizer.hpp"
 #include "iresearch/utils/vpack_utils.hpp"
 
 namespace irs::analysis {
@@ -268,6 +269,7 @@ void Init() {
   NGramTokenizerBase::init();
   PatternTokenizer::init();
   PipelineTokenizer::init();
+  UnionTokenizer::init();
   SegmentationTokenizer::init();
   NormalizingTokenizer::init();
   StemmingTokenizer::init();

--- a/libs/iresearch/include/iresearch/analysis/union_tokenizer.cpp
+++ b/libs/iresearch/include/iresearch/analysis/union_tokenizer.cpp
@@ -1,0 +1,399 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "union_tokenizer.hpp"
+
+#include <vpack/builder.h>
+#include <vpack/common.h>
+#include <vpack/iterator.h>
+#include <vpack/parser.h>
+#include <vpack/slice.h>
+
+#include <string_view>
+
+#include "iresearch/utils/vpack_utils.hpp"
+
+namespace irs::analysis {
+namespace {
+
+constexpr std::string_view kUnionParamName = "union";
+constexpr std::string_view kTypeParamName = "type";
+constexpr std::string_view kPropertiesParamName = "properties";
+
+using OptionsNormalize = std::vector<std::pair<std::string, std::string>>;
+
+template<typename T>
+bool ParseVPackOptions(const vpack::Slice slice, T& options) {
+  if constexpr (std::is_same_v<T, UnionTokenizer::OptionsT>) {
+    SDB_ASSERT(options.empty());
+  }
+  if (!slice.isObject()) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "Not a VPack object passed while constructing union_tokenizer");
+    return false;
+  }
+
+  if (auto union_slice = slice.get(kUnionParamName); !union_slice.isNone()) {
+    if (union_slice.isArray()) {
+      for (const auto member : vpack::ArrayIterator(union_slice)) {
+        if (member.isObject()) {
+          std::string_view type;
+          if (auto type_attr_slice = member.get(kTypeParamName);
+              !type_attr_slice.isNone()) {
+            if (type_attr_slice.isString()) {
+              type = type_attr_slice.stringView();
+            } else {
+              SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Failed to read '",
+                        kTypeParamName, "' attribute of '", kUnionParamName,
+                        "' member as string while constructing "
+                        "union_tokenizer from VPack arguments");
+              return false;
+            }
+          } else {
+            SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Failed to get '",
+                      kTypeParamName, "' attribute of '", kUnionParamName,
+                      "' member while constructing union_tokenizer "
+                      "from VPack arguments");
+            return false;
+          }
+          if (auto properties_attr_slice = member.get(kPropertiesParamName);
+              !properties_attr_slice.isNone()) {
+            if constexpr (std::is_same_v<T, UnionTokenizer::OptionsT>) {
+              auto analyzer =
+                analyzers::Get(type, irs::Type<text_format::VPack>::get(),
+                               {properties_attr_slice.startAs<char>(),
+                                properties_attr_slice.byteSize()});
+
+              // fallback to json format if vpack isn't available
+              if (!analyzer) {
+                analyzer =
+                  analyzers::Get(type, irs::Type<text_format::Json>::get(),
+                                 slice_to_string(properties_attr_slice));
+              }
+
+              if (analyzer) {
+                options.push_back(std::move(analyzer));
+              } else {
+                SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+                          "Failed to create union member of type '", type,
+                          "' with properties '",
+                          slice_to_string(properties_attr_slice),
+                          "' while constructing union_tokenizer "
+                          "from VPack arguments");
+                return false;
+              }
+            } else {
+              std::string normalized;
+              if (analyzers::Normalize(normalized, type,
+                                       irs::Type<text_format::VPack>::get(),
+                                       {properties_attr_slice.startAs<char>(),
+                                        properties_attr_slice.byteSize()})) {
+                options.emplace_back(std::piecewise_construct,
+                                     std::forward_as_tuple(type),
+                                     std::forward_as_tuple(normalized));
+
+                // fallback to json format if vpack isn't available
+              } else if (analyzers::Normalize(
+                           normalized, type,
+                           irs::Type<text_format::Json>::get(),
+                           slice_to_string(properties_attr_slice))) {
+                // in options we'll store vpack as string
+                auto vpack = vpack::Parser::fromJson(normalized.c_str(),
+                                                     normalized.size());
+                options.emplace_back(
+                  std::piecewise_construct, std::forward_as_tuple(type),
+                  std::forward_as_tuple(vpack->slice().startAs<char>(),
+                                        vpack->slice().byteSize()));
+              } else {
+                SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+                          "Failed to normalize union member of type '", type,
+                          "' with properties '",
+                          slice_to_string(properties_attr_slice),
+                          "' while constructing union_tokenizer "
+                          "from VPack arguments");
+                return false;
+              }
+            }
+          } else {
+            SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Failed to get '",
+                      kPropertiesParamName, "' attribute of '", kUnionParamName,
+                      "' member while constructing union_tokenizer "
+                      "from VPack arguments");
+            return false;
+          }
+        } else {
+          SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Failed to read '",
+                    kUnionParamName,
+                    "' member as object while constructing "
+                    "union_tokenizer from VPack arguments");
+          return false;
+        }
+      }
+    } else {
+      SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Failed to read '",
+                kUnionParamName,
+                "' attribute as array while constructing "
+                "union_tokenizer from VPack arguments");
+      return false;
+    }
+  } else {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Not found parameter '",
+              kUnionParamName, "' while constructing union_tokenizer");
+    return false;
+  }
+  if (options.empty()) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "Empty union found while constructing union_tokenizer");
+    return false;
+  }
+  return true;
+}
+
+bool NormalizeVPackConfig(const vpack::Slice slice, vpack::Builder* builder) {
+  OptionsNormalize options;
+  if (ParseVPackOptions(slice, options)) {
+    vpack::ObjectBuilder object(builder);
+    {
+      vpack::ArrayBuilder array(builder, kUnionParamName.data());
+      {
+        for (const auto& analyzer : options) {
+          vpack::ObjectBuilder analyzers_obj(builder);
+          {
+            builder->add(kTypeParamName, analyzer.first);
+            vpack::Slice sub_slice(
+              reinterpret_cast<const uint8_t*>(analyzer.second.c_str()));
+            builder->add(kPropertiesParamName, sub_slice);
+          }
+        }
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+bool NormalizeVPackConfig(std::string_view args, std::string& config) {
+  vpack::Slice slice(reinterpret_cast<const uint8_t*>(args.data()));
+  vpack::Builder builder;
+  if (NormalizeVPackConfig(slice, &builder)) {
+    config.assign(builder.slice().startAs<char>(), builder.slice().byteSize());
+    return true;
+  }
+  return false;
+}
+
+Analyzer::ptr MakeVPack(const vpack::Slice slice) {
+  UnionTokenizer::OptionsT options;
+  if (ParseVPackOptions(slice, options)) {
+    return std::make_unique<UnionTokenizer>(std::move(options));
+  }
+  return nullptr;
+}
+
+Analyzer::ptr MakeVPack(std::string_view args) {
+  vpack::Slice slice(reinterpret_cast<const uint8_t*>(args.data()));
+  return MakeVPack(slice);
+}
+
+Analyzer::ptr MakeJson(std::string_view args) {
+  try {
+    if (IsNull(args)) {
+      SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+                "Null arguments while constructing union_tokenizer");
+      return nullptr;
+    }
+    auto vpack = vpack::Parser::fromJson(args.data(), args.size());
+    return MakeVPack(vpack->slice());
+  } catch (const vpack::Exception& ex) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Caught error '", ex.what(),
+              "' while constructing union_tokenizer from JSON");
+  } catch (...) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "Caught error while constructing union_tokenizer from JSON");
+  }
+  return nullptr;
+}
+
+bool NormalizeJsonConfig(std::string_view args, std::string& definition) {
+  try {
+    if (IsNull(args)) {
+      SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+                "Null arguments while normalizing union_tokenizer");
+      return false;
+    }
+    auto vpack = vpack::Parser::fromJson(args.data(), args.size());
+    vpack::Builder builder;
+    if (NormalizeVPackConfig(vpack->slice(), &builder)) {
+      definition = builder.toString();
+      return !definition.empty();
+    }
+  } catch (const vpack::Exception& ex) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Caught error '", ex.what(),
+              "' while normalizing union_tokenizer from JSON");
+  } catch (...) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "Caught error while normalizing union_tokenizer from JSON");
+  }
+  return false;
+}
+
+PayAttr* FindPayload(std::span<const Analyzer::ptr> subs) {
+  for (auto it = subs.rbegin(); it != subs.rend(); ++it) {
+    auto* payload = irs::GetMutable<PayAttr>(it->get());
+    if (payload) {
+      return payload;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+UnionTokenizer::UnionTokenizer(UnionTokenizer::OptionsT&& options)
+  : _attrs{{}, {}, FindPayload(options) ? &_payload : AttributePtr<PayAttr>{}} {
+  _subs.reserve(options.size());
+  for (auto& p : options) {
+    SDB_ASSERT(p);
+    _subs.emplace_back(std::move(p));
+  }
+  options.clear();  // mimic move semantic
+  if (_subs.empty()) {
+    _subs.emplace_back();
+  }
+}
+
+uint32_t UnionTokenizer::FindMinPosition() const noexcept {
+  uint32_t min_pos = std::numeric_limits<uint32_t>::max();
+  for (const auto& sub : _subs) {
+    if (sub.has_token && sub.position < min_pos) {
+      min_pos = sub.position;
+    }
+  }
+  return min_pos;
+}
+
+// Interleaves tokens from all sub-tokenizers by position.
+// At each position, tokens are emitted in sub-tokenizer index order (0,
+// 1, 2...). Within a single sub, all same-position tokens (inc=0) are emitted
+// before moving to the next sub.
+//
+// IncAttr is computed as delta from the last emitted union position:
+//   inc = current_min_pos - last_emitted_pos
+// This is always valid because positions are monotonically non-decreasing.
+bool UnionTokenizer::next() {
+  for (;;) {
+    // Scan from _emit_index for a sub at _current_min_pos
+    while (_emit_index < _subs.size()) {
+      auto& sub = _subs[_emit_index];
+      if (sub.has_token && sub.position == _current_min_pos) {
+        // Copy term bytes into owning buffer
+        _term_buf.assign(sub.term->value.begin(), sub.term->value.end());
+        std::get<TermAttr>(_attrs).value = bytes_view{_term_buf};
+
+        // Copy payload if this sub has one, else clear
+        if (sub.pay) {
+          _payload_buf.assign(sub.pay->value.begin(), sub.pay->value.end());
+          _payload.value = bytes_view{_payload_buf};
+        } else {
+          _payload.value = {};
+        }
+
+        // IncAttr: delta from last emitted position
+        SDB_ASSERT(_current_min_pos >= _last_emitted_pos);
+        std::get<IncAttr>(_attrs).value = _current_min_pos - _last_emitted_pos;
+        _last_emitted_pos = _current_min_pos;
+
+        // Advance this sub.
+        sub.Advance();
+
+        // Stay at this index if sub still has a token at _current_min_pos
+        // (handles inc=0 tokens within a single sub-tokenizer)
+        if (!(sub.has_token && sub.position == _current_min_pos)) {
+          ++_emit_index;
+        }
+        return true;
+      }
+      ++_emit_index;
+    }
+
+    // All subs at _current_min_pos exhausted; find next minimum.
+    _current_min_pos = FindMinPosition();
+    if (_current_min_pos == std::numeric_limits<uint32_t>::max()) {
+      return false;  // all sub-tokenizers exhausted
+    }
+    _emit_index = 0;
+  }
+}
+
+bool UnionTokenizer::reset(std::string_view data) {
+  bool any_has_token = false;
+  for (auto& sub : _subs) {
+    if (sub.DoReset(data)) {
+      any_has_token = true;
+    }
+  }
+  _last_emitted_pos = 0;
+  _emit_index = 0;
+  _current_min_pos = FindMinPosition();
+  return any_has_token;
+}
+
+void UnionTokenizer::init() {
+  REGISTER_ANALYZER_JSON(UnionTokenizer, MakeJson, NormalizeJsonConfig);
+  REGISTER_ANALYZER_VPACK(UnionTokenizer, MakeVPack, NormalizeVPackConfig);
+}
+
+UnionTokenizer::SubAnalyzer::SubAnalyzer(Analyzer::ptr a)
+  : term(irs::get<TermAttr>(*a)),
+    inc(irs::get<IncAttr>(*a)),
+    pay(irs::GetMutable<PayAttr>(a.get())),
+    _analyzer(std::move(a)) {
+  SDB_ASSERT(inc);
+  SDB_ASSERT(term);
+}
+
+UnionTokenizer::SubAnalyzer::SubAnalyzer()
+  : _analyzer(std::make_unique<EmptyAnalyzer>()) {}
+
+bool UnionTokenizer::SubAnalyzer::DoReset(std::string_view data) {
+  position = 0;
+  has_token = false;
+  if (!_analyzer->reset(data)) {
+    return false;
+  }
+  if (_analyzer->next()) {
+    position = inc->value;  // typically 1 (first valid position)
+    has_token = true;
+    return true;
+  }
+  return false;
+}
+
+bool UnionTokenizer::SubAnalyzer::Advance() {
+  if (_analyzer->next()) {
+    position += inc->value;
+    has_token = true;
+    return true;
+  }
+  has_token = false;
+  return false;
+}
+
+}  // namespace irs::analysis

--- a/libs/iresearch/include/iresearch/analysis/union_tokenizer.hpp
+++ b/libs/iresearch/include/iresearch/analysis/union_tokenizer.hpp
@@ -1,0 +1,121 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "analyzers.hpp"
+#include "basics/shared.hpp"
+#include "iresearch/utils/attribute_helper.hpp"
+#include "token_attributes.hpp"
+#include "tokenizer.hpp"
+
+namespace irs::analysis {
+
+// Runs multiple sub-tokenizers independently on the same input and interleaves
+// their token streams by position. Tokens from different sub-tokenizers at the
+// same logical position overlap (inc=0). This enables indexing a single field
+// with multiple analysis strategies simultaneously.
+//
+// Position alignment is by each child tokenizer's own position counter.
+// Cross-tokenizer positional relationships are intentionally approximate for
+// heterogeneous analyzers (e.g. text + ngram).
+//
+// OffsAttr is not exposed because interleaving tokens from independent
+// tokenizers over the same input violates the monotonic offset invariant
+// required by the indexer.
+class UnionTokenizer final : public TypedAnalyzer<UnionTokenizer>,
+                             private util::Noncopyable {
+ public:
+  using OptionsT = std::vector<Analyzer::ptr>;
+
+  static constexpr std::string_view type_name() noexcept { return "union"; }
+  static void init();  // for triggering registration in a static build
+
+  explicit UnionTokenizer(OptionsT&& options);
+
+  Attribute* GetMutable(TypeInfo::type_id id) noexcept final {
+    // Only return union-owned attributes. Do not delegate to sub-analyzers:
+    // the "active" sub changes on each next() call, so any delegated pointer
+    // would be unstable.
+    return irs::GetMutable(_attrs, id);
+  }
+
+  bool next() final;
+  bool reset(std::string_view data) final;
+
+  /// @brief calls visitor on union members in respective order.
+  /// Visiting is interrupted on first visitor returning false.
+  /// @return true if all visits returned true, false otherwise
+  template<typename Visitor>
+  bool VisitMembers(Visitor&& visitor) const {
+    for (const auto& sub : _subs) {
+      const auto& stream = sub.GetStream();
+      if (stream.type() == type()) {
+        // union inside union - forward visiting
+        const auto& sub_union = sdb::basics::downCast<UnionTokenizer>(stream);
+        if (!sub_union.VisitMembers(visitor)) {
+          return false;
+        }
+      } else if (!visitor(sub.GetStream())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  struct SubAnalyzer {
+    explicit SubAnalyzer(Analyzer::ptr a);
+    SubAnalyzer();
+
+    bool DoReset(std::string_view data);
+    bool Advance();
+
+    const Analyzer& GetStream() const noexcept {
+      SDB_ASSERT(_analyzer);
+      return *_analyzer;
+    }
+
+    const TermAttr* term{nullptr};
+    const IncAttr* inc{nullptr};
+    const PayAttr* pay{nullptr};  // nullptr if sub has no payload
+    bool has_token{false};
+    uint32_t position{0};
+
+   private:
+    Analyzer::ptr _analyzer;
+  };
+
+  uint32_t FindMinPosition() const noexcept;
+
+  using SubAnalyzers = std::vector<SubAnalyzer>;
+  using Attributes = std::tuple<IncAttr, TermAttr, AttributePtr<PayAttr>>;
+
+  SubAnalyzers _subs;
+  size_t _emit_index = 0;
+  uint32_t _current_min_pos = std::numeric_limits<uint32_t>::max();
+  uint32_t _last_emitted_pos = 0;
+  PayAttr _payload;
+  bstring _term_buf;
+  bstring _payload_buf;
+  Attributes _attrs;
+};
+
+}  // namespace irs::analysis

--- a/server/catalog/search_analyzer_impl.cpp
+++ b/server/catalog/search_analyzer_impl.cpp
@@ -26,6 +26,7 @@
 #include <iresearch/analysis/geo_analyzer.hpp>
 #include <iresearch/analysis/pipeline_tokenizer.hpp>
 #include <iresearch/analysis/tokenizers.hpp>
+#include <iresearch/analysis/union_tokenizer.hpp>
 #include <iresearch/index/norm.hpp>
 
 #include "app/name_validator.h"
@@ -193,6 +194,13 @@ Result Features::Validate(std::string_view type) const {
     }
     if (IsGeoAnalyzer(type)) {
       return irs::IndexFeatures::None;
+    }
+    if (type == irs::analysis::UnionTokenizer::type_name()) {
+      // Union does not expose OffsAttr; interleaving tokens from independent
+      // sub-tokenizers over the same input breaks the monotonic offset
+      // invariant required by the indexer.
+      return irs::IndexFeatures::Freq | irs::IndexFeatures::Pos |
+             irs::IndexFeatures::Norm;
     }
     return irs::IndexFeatures::Freq | irs::IndexFeatures::Pos |
            irs::IndexFeatures::Norm | irs::IndexFeatures::Offs;

--- a/server/pg/commands/create_tsdictionary.cpp
+++ b/server/pg/commands/create_tsdictionary.cpp
@@ -42,6 +42,7 @@
 #include <iresearch/analysis/stopwords_tokenizer.hpp>
 #include <iresearch/analysis/text_tokenizer.hpp>
 #include <iresearch/analysis/tokenizer.hpp>
+#include <iresearch/analysis/union_tokenizer.hpp>
 #include <iresearch/index/index_features.hpp>
 #include <iresearch/utils/attribute_provider.hpp>
 #include <type_traits>
@@ -159,6 +160,16 @@ class CreateTSDictionaryOptions : public OptionsParser {
   auto Result() && { return std::make_pair(std::move(_builder), _features); }
 
  private:
+  bool HasUnionChildOption(std::string_view prefix) const {
+    auto child_prefix = OptionInfo::AdjustPrefix(prefix, "tokenizer");
+    for (const auto& [name, _] : _options) {
+      if (name.starts_with(child_prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   void ParseTemplateType(std::string_view type, std::string_view prefix) {
     bool found = false;
     VisitValues<kTSDictionaryGroup.subgroups>([&]<const OptionGroup & Group> {
@@ -308,6 +319,9 @@ class CreateTSDictionaryOptions : public OptionsParser {
     } else if constexpr (Group.name == tokenizer_options::kPipelineGroup.name) {
       ParsePipeline(prefix);
       return;
+    } else if constexpr (Group.name == tokenizer_options::kUnionGroup.name) {
+      ParseUnion(prefix);
+      return;
     } else if constexpr (Group.name == tokenizer_options::kCopyFromGroup.name) {
       ParseCopyFrom(prefix);
       return;
@@ -371,6 +385,62 @@ class CreateTSDictionaryOptions : public OptionsParser {
       step++;
     }
     _builder.close();  // close array for pipeline
+  }
+
+  void ParseUnion(std::string_view prefix) {
+    int tokenizer_num = 1;
+    _builder.add(tokenizer_options::kUnionGroup.name,
+                 vpack::Value{vpack::ValueType::Array});
+    auto slice = vpack::Slice::noneSlice();
+    if (!_copy_from.empty() && _copy_from.back().first == prefix) {
+      slice = GetFromPath(tokenizer_options::kUnionGroup.name, prefix,
+                          _copy_from.back().first, _copy_from.back().second);
+      SDB_ASSERT(slice.isArray());
+    }
+    while (true) {
+      auto tok_prefix =
+        OptionInfo::AdjustPrefix(prefix, "tokenizer", tokenizer_num);
+      std::string_view type;
+      bool type_from_copy = false;
+      if (OptionsParser::HasOption(tokenizer_options::kTemplate, tok_prefix)) {
+        type =
+          OptionsParser::EraseOptionOrDefault<tokenizer_options::kTemplate>(
+            tok_prefix);
+      } else if (!slice.isNone()) {
+        if (tokenizer_num > static_cast<int>(slice.length())) {
+          break;
+        }
+        auto elem = slice.at(tokenizer_num - 1);
+        if (elem.isNone()) {
+          break;
+        }
+        type_from_copy = true;
+        type = elem.get(kTypeField).stringView();
+        _copy_from.emplace_back(tok_prefix, elem.get(kPropertiesField));
+      }
+      if (type.empty()) {
+        break;
+      }
+      _builder.openObject();
+      Parse<false>(type, tok_prefix);
+      _builder.close();
+      if (type_from_copy) {
+        _copy_from.pop_back();
+      }
+
+      tokenizer_num++;
+    }
+    if (tokenizer_num == 1) {
+      if (!slice.isNone() || !HasUnionChildOption(prefix)) {
+        THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                        ERR_MSG("Union tokenizer requires at least one "
+                                "tokenizer<N> child"));
+      }
+      THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                      ERR_MSG("Union tokenizer children must be numbered "
+                              "densely starting from tokenizer1"));
+    }
+    _builder.close();  // close array for union
   }
 
   void ParseMinHash(std::string_view prefix) {
@@ -479,6 +549,17 @@ yaclib::Future<> CreateTokenizer(ExecContext& ctx, const DefineStmt& stmt) {
         THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                         ERR_MSG("Failed to create text search dictionary \"",
                                 tokenizer_name.relation, "\""));
+      }
+      if (features.HasFeatures(irs::IndexFeatures::Offs)) {
+        auto test_analyzer = irs::analysis::analyzers::Get(
+          type_slice.stringView(), irs::Type<irs::text_format::VPack>::get(),
+          {reinterpret_cast<const char*>(properties_slice.getDataPtr()),
+           properties_slice.byteSize()},
+          false);
+        if (test_analyzer && !irs::get<irs::OffsAttr>(*test_analyzer)) {
+          THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                          ERR_MSG("Unsupported index features are specified"));
+        }
       }
     }
   }

--- a/server/pg/tokenizer_options.h
+++ b/server/pg/tokenizer_options.h
@@ -36,6 +36,7 @@
 #include <iresearch/analysis/stopwords_tokenizer.hpp>
 #include <iresearch/analysis/text_tokenizer.hpp>
 #include <iresearch/analysis/token_attributes.hpp>
+#include <iresearch/analysis/union_tokenizer.hpp>
 #include <iresearch/index/norm.hpp>
 #include <iresearch/utils/type_id.hpp>
 #include <variant>
@@ -313,6 +314,11 @@ inline constexpr OptionGroup kPathHierarchyGroup{
   kPathHierarchyOptions,
   {},
 };
+inline constexpr OptionGroup kUnionGroup{
+  irs::analysis::UnionTokenizer::type_name(),
+  {},
+  {},
+};
 
 inline constexpr OptionGroup kTokenizerSubgroups[] = {
   kFeaturesGroup,         kTextGroup,      kNGramGroup,
@@ -320,6 +326,6 @@ inline constexpr OptionGroup kTokenizerSubgroups[] = {
   kClassificationGroup,   kCollationGroup, kDelimiterGroup,
   kMultiDelimiterGroup,   kMinHashGroup,   kNormGroup,
   kSegmentationGroup,     kPipelineGroup,  kPatternGroup,
-  kPathHierarchyGroup,    kCopyFromGroup};
+  kPathHierarchyGroup,    kUnionGroup,     kCopyFromGroup};
 
 }  // namespace sdb::pg::tokenizer_options

--- a/tests/libs/iresearch/CMakeLists.txt
+++ b/tests/libs/iresearch/CMakeLists.txt
@@ -8,6 +8,7 @@ set(iresearch-tests_sources
     ./analysis/minhash_tokenizer_test.cpp
     ./analysis/multi_delimited_tokenizer_tests.cpp
     ./analysis/pipeline_tokenizer_tests.cpp
+    ./analysis/union_tokenizer_tests.cpp
     ./analysis/segmentation_tokenizer_tests.cpp
     ./analysis/normalizing_tokenizer_tests.cpp
     ./analysis/stemming_tokenizer_tests.cpp

--- a/tests/libs/iresearch/analysis/union_tokenizer_tests.cpp
+++ b/tests/libs/iresearch/analysis/union_tokenizer_tests.cpp
@@ -1,0 +1,430 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include <vpack/common.h>
+#include <vpack/parser.h>
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "iresearch/analysis/analyzers.hpp"
+#include "iresearch/analysis/ngram_tokenizer.hpp"
+#include "iresearch/analysis/text_tokenizer.hpp"
+#include "iresearch/analysis/token_attributes.hpp"
+#include "iresearch/analysis/tokenizers.hpp"
+#include "iresearch/analysis/union_tokenizer.hpp"
+#include "tests_config.hpp"
+
+namespace {
+
+struct UnionToken {
+  std::string_view value;
+  uint32_t inc;
+  uint32_t pos;
+};
+
+using UnionTokens = std::vector<UnionToken>;
+
+// Assert a union tokenizer produces the expected token sequence.
+// No offset checking; union does not expose OffsAttr.
+void AssertUnion(irs::analysis::Analyzer* u, const std::string& data,
+                 const UnionTokens& expected_tokens) {
+  SCOPED_TRACE(data);
+  auto* offset = irs::get<irs::OffsAttr>(*u);
+  ASSERT_FALSE(offset) << "Union must not expose OffsAttr";
+  auto* term = irs::get<irs::TermAttr>(*u);
+  ASSERT_TRUE(term);
+  auto* inc = irs::get<irs::IncAttr>(*u);
+  ASSERT_TRUE(inc);
+  ASSERT_TRUE(u->reset(data));
+  uint32_t pos{0};  // consumer starts at pos_limits::invalid() == 0
+  auto expected = expected_tokens.begin();
+  while (u->next()) {
+    pos += inc->value;
+    auto term_str =
+      std::string(irs::ViewCast<char>(term->value).data(), term->value.size());
+    SCOPED_TRACE(testing::Message("Term:") << term_str);
+    ASSERT_NE(expected, expected_tokens.end())
+      << "More tokens produced than expected";
+    EXPECT_EQ(expected->value,
+              std::string_view(irs::ViewCast<char>(term->value).data(),
+                               term->value.size()));
+    EXPECT_EQ(expected->inc, inc->value) << "inc mismatch for: " << term_str;
+    EXPECT_EQ(expected->pos, pos) << "pos mismatch for: " << term_str;
+    ++expected;
+  }
+  ASSERT_EQ(expected, expected_tokens.end())
+    << "Fewer tokens produced than expected";
+}
+
+void AssertUnionMembers(irs::analysis::UnionTokenizer& u,
+                        const std::vector<irs::TypeInfo::type_id>& expected) {
+  size_t i{0};
+  auto visitor = [&expected, &i](const irs::analysis::Analyzer& a) {
+    EXPECT_LT(i, expected.size());
+    if (i >= expected.size()) {
+      return false;
+    }
+    EXPECT_EQ(a.type(), expected[i++]);
+    return true;
+  };
+  ASSERT_TRUE(u.VisitMembers(visitor));
+  ASSERT_EQ(i, expected.size());
+}
+
+}  // namespace
+
+TEST(union_tokenizer_test, consts) {
+  static_assert("union" == irs::Type<irs::analysis::UnionTokenizer>::name());
+}
+
+TEST(union_tokenizer_test, empty_union) {
+  irs::analysis::UnionTokenizer::OptionsT options;
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  std::string data = "hello world";
+  ASSERT_FALSE(u.reset(data));
+}
+
+TEST(union_tokenizer_test, single_sub) {
+  // A union with a single text tokenizer should produce the same tokens
+  // as the text tokenizer alone.
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  const UnionTokens expected{
+    {"hello", 1, 1},
+    {"world", 1, 2},
+  };
+  AssertUnion(&u, "hello world", expected);
+}
+
+TEST(union_tokenizer_test, text_plus_ngram) {
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text);
+
+  auto ngram = irs::analysis::analyzers::Get(
+    "ngram", irs::Type<irs::text_format::Json>::get(),
+    R"({"min":3, "max":3, "preserveOriginal":false})");
+  ASSERT_NE(nullptr, ngram);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));
+  options.emplace_back(std::move(ngram));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  // text: "hello"(pos=1) "world"(pos=2)
+  // ngram(3,3): "hel"(1) "ell"(2) "llo"(3) "lo "(4) "o w"(5)
+  //             " wo"(6) "wor"(7) "orl"(8) "rld"(9)
+  // Interleaved by position, sub-index order (text=0, ngram=1):
+  const UnionTokens expected{
+    {"hello", 1, 1},  // text pos=1
+    {"hel", 0, 1},    // ngram pos=1, same union position
+    {"world", 1, 2},  // text pos=2
+    {"ell", 0, 2},    // ngram pos=2, same union position
+    {"llo", 1, 3},    // ngram only from here on
+    {"lo ", 1, 4},   {"o w", 1, 5}, {" wo", 1, 6},
+    {"wor", 1, 7},   {"orl", 1, 8}, {"rld", 1, 9},
+  };
+  AssertUnion(&u, "hello world", expected);
+}
+
+TEST(union_tokenizer_test, two_text_tokenizers_homogeneous) {
+  // For homogeneous sub-tokenizers, positions are truly comparable.
+  auto text_lower = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text_lower);
+
+  auto text_none = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"none",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text_none);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text_lower));
+  options.emplace_back(std::move(text_none));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  // Sub 0 (lower): "hello"(1), "world"(2)
+  // Sub 1 (none):  "Hello"(1), "World"(2)
+  const UnionTokens expected{
+    {"hello", 1, 1},
+    {"Hello", 0, 1},
+    {"world", 1, 2},
+    {"World", 0, 2},
+  };
+  AssertUnion(&u, "Hello World", expected);
+}
+
+TEST(union_tokenizer_test, unequal_token_counts) {
+  // Sub with fewer tokens exhausts first; remaining sub continues alone.
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":["quick","brown","fox"],
+        "case":"lower", "stemming":false})");
+  ASSERT_NE(nullptr, text);
+
+  auto text2 = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[],
+        "case":"lower", "stemming":false})");
+  ASSERT_NE(nullptr, text2);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));   // sub 0: stopwords filtered
+  options.emplace_back(std::move(text2));  // sub 1: all words
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  // Input: "quick brown fox"
+  // Sub 0 (with stopwords): all filtered: no tokens
+  // Sub 1 (no stopwords): "quick"(1) "brown"(2) "fox"(3)
+  // Union: only sub 1 tokens
+  const UnionTokens expected{
+    {"quick", 1, 1},
+    {"brown", 1, 2},
+    {"fox", 1, 3},
+  };
+  AssertUnion(&u, "quick brown fox", expected);
+}
+
+TEST(union_tokenizer_test, no_offset_attr) {
+  // Union must NOT expose OffsAttr.
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  auto* offset = irs::get<irs::OffsAttr>(u);
+  ASSERT_EQ(nullptr, offset);
+}
+
+TEST(union_tokenizer_test, get_mutable_non_core) {
+  // GetMutable returns nullptr for non-managed attributes.
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  ASSERT_NE(nullptr, irs::get<irs::TermAttr>(u));
+  ASSERT_NE(nullptr, irs::get<irs::IncAttr>(u));
+  ASSERT_EQ(nullptr, irs::get<irs::OffsAttr>(u));
+}
+
+TEST(union_tokenizer_test, VisitMembers) {
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  auto ngram = irs::analysis::analyzers::Get(
+    "ngram", irs::Type<irs::text_format::Json>::get(),
+    R"({"min":2, "max":3, "preserveOriginal":false})");
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));
+  options.emplace_back(std::move(ngram));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  AssertUnionMembers(
+    u, {irs::Type<irs::analysis::TextTokenizer>::id(),
+        irs::Type<irs::analysis::NGramTokenizer<
+          irs::analysis::NGramTokenizerBase::InputType::UTF8>>::id()});
+}
+
+TEST(union_tokenizer_test, json_construction) {
+  std::string config =
+    R"({"union":[
+      {"type":"text", "properties":{"locale":"en_US.UTF-8","stopwords":[],
+       "case":"lower","stemming":false}},
+      {"type":"ngram", "properties":{"min":3,"max":3,
+       "preserveOriginal":false}}
+    ]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_NE(nullptr, stream);
+  ASSERT_EQ(irs::Type<irs::analysis::UnionTokenizer>::id(), stream->type());
+
+  const UnionTokens expected{
+    {"hello", 1, 1}, {"hel", 0, 1}, {"world", 1, 2}, {"ell", 0, 2},
+    {"llo", 1, 3},   {"lo ", 1, 4}, {"o w", 1, 5},   {" wo", 1, 6},
+    {"wor", 1, 7},   {"orl", 1, 8}, {"rld", 1, 9},
+  };
+  AssertUnion(stream.get(), "hello world", expected);
+}
+
+TEST(union_tokenizer_test, vpack_construction) {
+  std::string json_config =
+    R"({"union":[
+      {"type":"text", "properties":{"locale":"en_US.UTF-8","stopwords":[],
+       "case":"lower","stemming":false}},
+      {"type":"ngram", "properties":{"min":3,"max":3,
+       "preserveOriginal":false}}
+    ]})";
+  auto vpack = vpack::Parser::fromJson(json_config);
+
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::VPack>::get(),
+    {vpack->slice().startAs<char>(), vpack->slice().byteSize()});
+  ASSERT_NE(nullptr, stream);
+  ASSERT_EQ(irs::Type<irs::analysis::UnionTokenizer>::id(), stream->type());
+}
+
+TEST(union_tokenizer_test, normalize_json) {
+  // Unknown top-level parameters should be stripped
+  {
+    std::string config =
+      R"({"unknown_param":123, "union":[
+        {"type":"delimiter","properties":{"delimiter":"A"}}]})";
+    std::string actual;
+    ASSERT_TRUE(irs::analysis::analyzers::Normalize(
+      actual, "union", irs::Type<irs::text_format::Json>::get(), config));
+    ASSERT_EQ(
+      vpack::Parser::fromJson(
+        R"({"union":[{"type":"delimiter","properties":{"delimiter":"A"}}]})")
+        ->toString(),
+      actual);
+  }
+  // Unknown member parameters should be stripped
+  {
+    std::string config =
+      R"({"union":[{"unknown":1,"type":"delimiter",
+        "properties":{"delimiter":"A"}}]})";
+    std::string actual;
+    ASSERT_TRUE(irs::analysis::analyzers::Normalize(
+      actual, "union", irs::Type<irs::text_format::Json>::get(), config));
+    ASSERT_EQ(
+      vpack::Parser::fromJson(
+        R"({"union":[{"type":"delimiter","properties":{"delimiter":"A"}}]})")
+        ->toString(),
+      actual);
+  }
+  // Unknown analyzer type: normalization fails
+  {
+    std::string config =
+      R"({"union":[{"type":"UNKNOWN","properties":{"foo":"bar"}}]})";
+    std::string actual;
+    ASSERT_FALSE(irs::analysis::analyzers::Normalize(
+      actual, "union", irs::Type<irs::text_format::Json>::get(), config));
+  }
+}
+
+// Invalid config tests
+
+TEST(union_tokenizer_test, construct_empty_array) {
+  std::string config = R"({"union":[]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_missing_union_key) {
+  std::string config = R"({"pipeline":[{"type":"delimiter",
+    "properties":{"delimiter":"A"}}]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_invalid_child_type) {
+  std::string config = R"({"union":[{"type":"NONEXISTENT","properties":{}}]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_non_string_type) {
+  std::string config =
+    R"({"union":[{"type":1, "properties":{"delimiter":"A"}}]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_no_properties) {
+  std::string config = R"({"union":[{"type":"delimiter"}]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_member_not_object) {
+  std::string config = R"({"union":["not_an_object"]})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_union_not_array) {
+  std::string config = R"({"union":"not_an_array"})";
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), config);
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, construct_null_args) {
+  auto stream = irs::analysis::analyzers::Get(
+    "union", irs::Type<irs::text_format::Json>::get(), std::string_view{});
+  ASSERT_EQ(nullptr, stream);
+}
+
+TEST(union_tokenizer_test, reset_twice) {
+  // Verify that reset() works correctly when called multiple times.
+  auto text = irs::analysis::analyzers::Get(
+    "text", irs::Type<irs::text_format::Json>::get(),
+    R"({"locale":"en_US.UTF-8", "stopwords":[], "case":"lower",
+        "stemming":false})");
+  ASSERT_NE(nullptr, text);
+
+  irs::analysis::UnionTokenizer::OptionsT options;
+  options.emplace_back(std::move(text));
+  irs::analysis::UnionTokenizer u(std::move(options));
+
+  {
+    const UnionTokens expected{{"hello", 1, 1}, {"world", 1, 2}};
+    AssertUnion(&u, "hello world", expected);
+  }
+  // Reset with different data
+  {
+    const UnionTokens expected{{"foo", 1, 1}};
+    AssertUnion(&u, "foo", expected);
+  }
+}

--- a/tests/sqllogic/sdb/pg/simple/tokenizers/text_tokenizer.test
+++ b/tests/sqllogic/sdb/pg/simple/tokenizers/text_tokenizer.test
@@ -1413,6 +1413,236 @@ ts_lexize
 {CL4pTgTN/r4,aA/5fo9OvB4,X0zdNxFFkdY}
 
 
+# ========================
+# UNION TOKENIZER
+# ========================
+
+# --- Basic union: text + delimiter ---
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY union_text_delim(
+    template = 'union',
+    tokenizer1_template = 'text',
+    tokenizer1_locale = 'en_US.UTF-8',
+    tokenizer1_case = 'lower',
+    tokenizer1_stemming = false,
+    tokenizer2_template = 'delimiter',
+    tokenizer2_delimiter = ' ',
+    frequency = true,
+    position = true
+)
+
+
+query
+SELECT ts_lexize('union_text_delim', 'Hello World');
+----
+ts_lexize
+{hello,Hello,world,World}
+
+
+# --- Basic union: text + fixed-size ngram ---
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY union_text_ngram3(
+    template = 'union',
+    tokenizer1_template = 'text',
+    tokenizer1_locale = 'en_US.UTF-8',
+    tokenizer1_case = 'lower',
+    tokenizer1_stemming = true,
+    tokenizer2_template = 'ngram',
+    tokenizer2_mingram = 3,
+    tokenizer2_maxgram = 3,
+    frequency = true,
+    position = true
+)
+
+
+query
+SELECT ts_lexize('union_text_ngram3', 'Hello');
+----
+ts_lexize
+{hello,Hel,ell,llo}
+
+
+# --- Basic union: three children ---
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY union_three_children(
+    template = 'union',
+    tokenizer1_template = 'text',
+    tokenizer1_locale = 'en_US.UTF-8',
+    tokenizer1_case = 'lower',
+    tokenizer1_stemming = false,
+    tokenizer2_template = 'text',
+    tokenizer2_locale = 'en_US.UTF-8',
+    tokenizer2_case = 'upper',
+    tokenizer2_stemming = false,
+    tokenizer3_template = 'delimiter',
+    tokenizer3_delimiter = ' ',
+    frequency = true,
+    position = true
+)
+
+
+query
+SELECT ts_lexize('union_three_children', 'Hello World');
+----
+ts_lexize
+{hello,HELLO,Hello,world,WORLD,World}
+
+
+# --- OFFSET = true must be rejected for union ---
+
+statement error Unsupported index features are specified
+CREATE TEXT SEARCH DICTIONARY union_offset_err(
+    template = 'union',
+    tokenizer1_template = 'text',
+    tokenizer1_locale = 'en_US.UTF-8',
+    offset = true,
+    position = true,
+    frequency = true
+)
+
+
+# --- OFFSET = true must be rejected for pipeline containing union ---
+
+statement error Unsupported index features are specified
+CREATE TEXT SEARCH DICTIONARY pipe_union_offset_err(
+    template = 'pipeline',
+    step1_template = 'union',
+    step1_tokenizer1_template = 'text',
+    step1_tokenizer1_locale = 'en_US.UTF-8',
+    step1_tokenizer2_template = 'delimiter',
+    step1_tokenizer2_delimiter = ' ',
+    offset = true,
+    position = true,
+    frequency = true
+)
+
+
+# --- Nested: union containing a pipeline ---
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY union_with_pipe(
+    template = 'union',
+    tokenizer1_template = 'pipeline',
+    tokenizer1_step1_template = 'delimiter',
+    tokenizer1_step1_delimiter = '.',
+    tokenizer1_step2_template = 'norm',
+    tokenizer1_step2_locale = 'en_US.UTF-8',
+    tokenizer1_step2_case = 'upper',
+    tokenizer2_template = 'delimiter',
+    tokenizer2_delimiter = '.',
+    frequency = true,
+    position = true
+)
+
+
+query
+SELECT ts_lexize('union_with_pipe', 'a.b.c');
+----
+ts_lexize
+{A,a,B,b,C,c}
+
+
+# --- Nested: pipeline containing a union ---
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY pipe_with_union(
+    template = 'pipeline',
+    step1_template = 'delimiter',
+    step1_delimiter = '|',
+    step2_template = 'union',
+    step2_tokenizer1_template = 'norm',
+    step2_tokenizer1_locale = 'en_US.UTF-8',
+    step2_tokenizer1_case = 'lower',
+    step2_tokenizer2_template = 'norm',
+    step2_tokenizer2_locale = 'en_US.UTF-8',
+    step2_tokenizer2_case = 'upper',
+    frequency = true,
+    position = true
+)
+
+
+query
+SELECT ts_lexize('pipe_with_union', 'Hello|World');
+----
+ts_lexize
+{hello,HELLO,world,WORLD}
+
+
+# --- copy_from with union, overriding a sub-tokenizer option ---
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY union_base(
+    template = 'union',
+    tokenizer1_template = 'text',
+    tokenizer1_locale = 'en_US.UTF-8',
+    tokenizer1_case = 'lower',
+    tokenizer1_stemming = false,
+    tokenizer2_template = 'delimiter',
+    tokenizer2_delimiter = ' ',
+    frequency = true,
+    position = true
+)
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY union_copy(
+    template = 'copy_from',
+    from = 'union_base',
+    tokenizer1_case = 'upper'
+)
+
+
+query
+SELECT ts_lexize('union_copy', 'Hello World');
+----
+ts_lexize
+{HELLO,Hello,WORLD,World}
+
+
+# --- Error: empty union (no tokenizer<N>_ children) ---
+
+statement error
+CREATE TEXT SEARCH DICTIONARY union_empty_err(
+    template = 'union',
+    frequency = true
+)
+
+
+# --- Error: sparse numbering (tokenizer2_ without tokenizer1_) ---
+
+statement error
+CREATE TEXT SEARCH DICTIONARY union_sparse(
+    template = 'union',
+    tokenizer2_template = 'text',
+    tokenizer2_locale = 'en_US.UTF-8',
+    frequency = true,
+    position = true
+)
+
+
+# --- Error: invalid child template ---
+
+statement error Invalid type of text search dictionary
+CREATE TEXT SEARCH DICTIONARY union_badchild(
+    template = 'union',
+    tokenizer1_template = 'nonexistent_type',
+    frequency = true
+)
+
+
+# --- Error: missing required child option (delimiter without delimiter=) ---
+
+statement error
+CREATE TEXT SEARCH DICTIONARY union_missing_opt(
+    template = 'union',
+    tokenizer1_template = 'delimiter',
+    frequency = true
+)
+
+
 # HELP
 
 statement error
@@ -1482,5 +1712,7 @@ Text Search Dictionary:
     reverse (boolean) [default: false] - Use reverse tokenization for domain-like hierarchies
     skip (integer) [default: 0] - Number of initial tokens to skip
     buffersize (integer) [default: 1024] - Term buffer size hint (characters per pass)
+  union:
+    (no additional options)
   copy_from:
     from[required] (string) [default: none] - the source tokenizer name


### PR DESCRIPTION
Fixes #440 
## Summary

This PR adds a new `union` tokenizer that runs multiple child tokenizers on the same input and merges their output into a single token stream.

## Behavior

  - `reset(data)` resets every child on the same input
  - `next()` interleaves child tokens by each child tokenizer's own logical position
  - Tokens from different children at the same position overlap in the merged stream
  - `OffsAttr` is not exposed

`union` cannot safely expose `OffsAttr` because merged child streams do not have a single globally monotonic offset order. With heterogeneous children, such as text and ngram, preserving original child offsets would make offsets move backwards in the merged stream, which is invalid for indexing. 

```
For example, given the input `hello world`:

  - `text` emits:
    - `hello` at offsets `[0,5)`
    - `world` at offsets `[6,11)`
  - `ngram(3)` emits:
    - `hel` at `[0,3)`
    - `ell` at `[1,4)`
    - `llo` at `[2,5)`
    - ...

The union tokenizer interleaves by child position, not by byte offset. The merged order is roughly:

  - `hello` at position `1`, offsets `[0,5)`
  - `hel` at position `1`, offsets `[0,3)`
  - `world` at position `2`, offsets `[6,11)`
  - `ell` at position `2`, offsets `[1,4)`

If child offsets were preserved, the start-offset sequence would be:

  - `0`
  - `0`
  - `6`
  - `1`

That final step goes backwards, which breaks the monotonic offset ordering expected from a single token
stream during indexing.
```

## Tests

Added tests for construction, normalization, invalid configs, nesting with `pipeline`, and merged-token behavior.