### PR TITLE
feat: protect from malicious code execution

### DIFF
--- a/.github/workflows/pr-build-trigger.yml
+++ b/.github/workflows/pr-build-trigger.yml
@@ -86,6 +86,22 @@ jobs:
             core.setOutput('sha', pr.head.sha);
             core.setOutput('base_ref', pr.base.ref);
 
+      - name: Verify triggering user has write access
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.sender.login,
+            });
+            const allowed = ['write', 'maintain', 'admin'];
+            if (!allowed.includes(perm.permission)) {
+              core.setFailed(`User ${context.payload.sender.login} has permission '${perm.permission}' - write or above required to trigger builds`);
+            } else {
+              core.info(`Authorized: ${context.payload.sender.login} (${perm.permission})`);
+            }
+
       - name: Parse options and trigger build
         env:
           PR_BRANCH: ${{ steps.pr-info.outputs.branch }}

--- a/.github/workflows/protect-workflows.yml
+++ b/.github/workflows/protect-workflows.yml
@@ -41,7 +41,9 @@ jobs:
               per_page: 100,
             });
             const workflowFiles = files.filter(f =>
-              f.filename.startsWith('.github/workflows/') || f.filename.startsWith('.github/actions/')
+              f.filename.startsWith('.github/workflows/') ||
+              f.filename.startsWith('.github/actions/') ||
+              f.filename.startsWith('scripts/ci/')
             );
             if (workflowFiles.length > 0) {
               core.setFailed(`Workflow file changes from forks are not allowed: ${workflowFiles.map(f => f.filename).join(', ')}`);


### PR DESCRIPTION
- protect `scripts` from accidental changes coming from forks 
- explicitly check access rights to start a build to avoid relying on GitHub implicit logic