### PR TITLE
feat: Proximity PHRASE

### DIFF
--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -665,21 +665,12 @@ Result FromVeloxLike(irs::BooleanFilter& filter, const VeloxFilterContext& ctx,
 Result FromSearchPhrase(irs::BooleanFilter& filter,
                         const VeloxFilterContext& ctx,
                         const velox::core::CallTypedExpr& call) {
-  if (call.inputs().size() != 2) {
-    return {ERROR_BAD_PARAMETER, "PHRASE has ", call.inputs().size(),
-            " inputs but 2 expected"};
+  if (call.inputs().size() < 2) {
+    return {ERROR_BAD_PARAMETER, "PHRASE requires at least 2 arguments"};
   }
   if (!call.inputs()[0]->isFieldAccessKind()) {
-    return {ERROR_BAD_PARAMETER, "Input is not field access"};
-  }
-
-  auto value = EvaluateConstant(call.inputs()[1]);
-  if (!value.has_value()) {
-    return {ERROR_BAD_PARAMETER, "Failed to evaluate value as constant"};
-  }
-
-  if (value->kind() != velox::TypeKind::VARCHAR) {
-    return {ERROR_BAD_PARAMETER, "Failed to evaluate value as VARCHAR"};
+    return {ERROR_BAD_PARAMETER,
+            "PHRASE first argument must be a field access"};
   }
 
   auto* field_typed = static_cast<const velox::core::FieldAccessTypedExpr*>(
@@ -694,10 +685,6 @@ Result FromSearchPhrase(irs::BooleanFilter& filter,
     return {ERROR_BAD_PARAMETER, "PHRASE field '", field_typed->name(),
             "' is not VARCHAR"};
   }
-
-  std::string field_name;
-  MakeFieldName(*column_info, field_name);
-
   if ((column_info->analyzer.features &
        irs::PhraseQuery<irs::FixedPhraseState>::kRequiredFeatures) !=
       irs::PhraseQuery<irs::FixedPhraseState>::kRequiredFeatures) {
@@ -705,18 +692,138 @@ Result FromSearchPhrase(irs::BooleanFilter& filter,
             "' should have Positions and Frequency features enabled"};
   }
 
+  std::string field_name;
+  MakeFieldName(*column_info, field_name);
+  search::mangling::MangleString(field_name);
+
   auto& phrase = ctx.negated ? Negate<irs::ByPhrase>(filter)
                              : AddFilter<irs::ByPhrase>(filter);
-  column_info->analyzer.analyzer->reset(
-    static_cast<std::string_view>(value.value().value<velox::StringView>()));
+  phrase.boost(ctx.boost);
+  *phrase.mutable_field() = field_name;
+  auto* opts = phrase.mutable_options();
   const irs::TermAttr* token =
     irs::get<irs::TermAttr>(*column_info->analyzer.analyzer);
-  search::mangling::MangleString(field_name);
-  *phrase.mutable_field() = field_name;
-  phrase.boost(ctx.boost);
-  while (column_info->analyzer.analyzer->next()) {
-    phrase.mutable_options()->push_back<irs::ByTermOptions>().term.assign(
-      token->value);
+
+  bool has_pending_gap = false;
+  size_t pending_gap_min = 0;
+  size_t pending_gap_max = 0;
+
+  auto extract_uint = [](const velox::Variant& v) -> std::optional<size_t> {
+    if (v.kind() == velox::TypeKind::BIGINT) {
+      return static_cast<size_t>(v.value<int64_t>());
+    }
+    if (v.kind() == velox::TypeKind::INTEGER) {
+      return static_cast<size_t>(v.value<int32_t>());
+    }
+    return std::nullopt;
+  };
+
+  for (size_t i = 1; i < call.inputs().size(); ++i) {
+    const auto& input = call.inputs()[i];
+    const auto kind = input->type()->kind();
+    switch (kind) {
+      case velox::TypeKind::VARCHAR: {
+        auto value = EvaluateConstant(input);
+        if (!value.has_value()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE text argument ", i,
+                  " must be a constant"};
+        }
+        column_info->analyzer.analyzer->reset(
+          static_cast<std::string_view>(value->value<velox::StringView>()));
+        while (column_info->analyzer.analyzer->next()) {
+          if (has_pending_gap) {
+            // First token of a new text pattern: apply pending gap.
+            // push_back(offs_min, offs_max) has no implicit +1 unlike
+            // push_back(offs), so add 1 to convert "N words between" to
+            // "N+1 position offset".
+            opts
+              ->push_back<irs::ByTermOptions>(pending_gap_min + 1,
+                                              pending_gap_max + 1)
+              .term.assign(token->value);
+          } else {
+            // No pending gap: first term or adjacent token within same pattern.
+            opts->push_back<irs::ByTermOptions>().term.assign(token->value);
+          }
+          has_pending_gap = false;
+        }
+        break;
+      }
+      case velox::TypeKind::BIGINT:
+      case velox::TypeKind::INTEGER: {
+        if (opts->empty()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap at argument ", i,
+                  " must be preceded by a text pattern"};
+        }
+        if (has_pending_gap) {
+          return {ERROR_BAD_PARAMETER,
+                  "PHRASE has consecutive gaps at argument ", i};
+        }
+        auto value = EvaluateConstant(input);
+        if (!value.has_value()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap argument ", i,
+                  " must be a constant"};
+        }
+        const auto gap = extract_uint(value.value()).value();
+        pending_gap_min = pending_gap_max = gap;
+        has_pending_gap = true;
+        break;
+      }
+      case velox::TypeKind::ARRAY: {
+        if (opts->empty()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap at argument ", i,
+                  " must be preceded by a text pattern"};
+        }
+        if (has_pending_gap) {
+          return {ERROR_BAD_PARAMETER,
+                  "PHRASE has consecutive gaps at argument ", i};
+        }
+        auto value = EvaluateConstant(input);
+        if (!value.has_value()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap argument ", i,
+                  " must be a constant"};
+        }
+        const auto& elements = value->array();
+        if (elements.size() != 2) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap array at argument ", i,
+                  " must have exactly 2 elements [min, max], got ",
+                  elements.size()};
+        }
+        const auto min_val = extract_uint(elements[0]);
+        const auto max_val = extract_uint(elements[1]);
+        if (!min_val || !max_val) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap array at argument ", i,
+                  " elements must be integers"};
+        }
+        if (*min_val > *max_val) {
+          return {ERROR_BAD_PARAMETER,
+                  "PHRASE gap array at argument ",
+                  i,
+                  " min (",
+                  *min_val,
+                  ") must not exceed max (",
+                  *max_val,
+                  ")"};
+        }
+        pending_gap_min = *min_val;
+        pending_gap_max = *max_val;
+        has_pending_gap = true;
+        break;
+      }
+      default: {
+        return {
+          ERROR_BAD_PARAMETER, "PHRASE argument ", i,
+          " has unsupported type; expected text, integer, or integer array"};
+      }
+    }
+  }
+
+  if (has_pending_gap) {
+    return {ERROR_BAD_PARAMETER,
+            "PHRASE ends with a gap; a text pattern must follow each gap"};
+  }
+  if (opts->empty()) {
+    return {ERROR_BAD_PARAMETER,
+            "PHRASE text arguments produced no searchable terms"};
   }
   return {};
 }

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -30,6 +30,7 @@
 
 #include <velox/expression/ExprConstants.h>
 #include <velox/type/Type.h>
+#include <velox/type/Variant.h>
 
 #include <iresearch/analysis/tokenizers.hpp>
 #include <iresearch/search/all_filter.hpp>
@@ -47,6 +48,8 @@
 #include <iresearch/search/wildcard_filter.hpp>
 #include <iresearch/types.hpp>
 #include <iresearch/utils/wildcard_utils.hpp>
+#include <optional>
+#include <type_traits>
 
 #include "catalog/mangling.h"
 #include "functions/search.h"
@@ -69,6 +72,35 @@ Result FromVeloxExpression(irs::BooleanFilter& filter,
                            const velox::core::TypedExprPtr& expr);
 
 namespace {
+
+template<velox::TypeKind Kind>
+std::optional<size_t> ReadGapValueImpl(const velox::Variant& v) {
+  using T = velox::TypeTraits<Kind>::NativeType;
+  static_assert(std::is_integral_v<T>, "Gap argument should be integral");
+  const auto value = v.value<T>();
+  if (value < 0) {
+    return std::nullopt;
+  }
+  return static_cast<size_t>(value);
+}
+
+std::optional<size_t> ReadGapValue(const velox::Variant& v) {
+  if (v.isNull()) {
+    return std::nullopt;
+  }
+  switch (v.kind()) {
+    case velox::TypeKind::BIGINT:
+      return ReadGapValueImpl<velox::TypeKind::BIGINT>(v);
+    case velox::TypeKind::INTEGER:
+      return ReadGapValueImpl<velox::TypeKind::INTEGER>(v);
+    case velox::TypeKind::SMALLINT:
+      return ReadGapValueImpl<velox::TypeKind::SMALLINT>(v);
+    case velox::TypeKind::TINYINT:
+      return ReadGapValueImpl<velox::TypeKind::TINYINT>(v);
+    default:
+      return std::nullopt;
+  }
+}
 
 template<typename SearchType>
 void ResetNumericStream(irs::NumericTokenizer& stream,
@@ -708,16 +740,6 @@ Result FromSearchPhrase(irs::BooleanFilter& filter,
   size_t pending_gap_min = 0;
   size_t pending_gap_max = 0;
 
-  auto extract_uint = [](const velox::Variant& v) -> std::optional<size_t> {
-    if (v.kind() == velox::TypeKind::BIGINT) {
-      return static_cast<size_t>(v.value<int64_t>());
-    }
-    if (v.kind() == velox::TypeKind::INTEGER) {
-      return static_cast<size_t>(v.value<int32_t>());
-    }
-    return std::nullopt;
-  };
-
   for (size_t i = 1; i < call.inputs().size(); ++i) {
     const auto& input = call.inputs()[i];
     const auto kind = input->type()->kind();
@@ -748,26 +770,6 @@ Result FromSearchPhrase(irs::BooleanFilter& filter,
         }
         break;
       }
-      case velox::TypeKind::BIGINT:
-      case velox::TypeKind::INTEGER: {
-        if (opts->empty()) {
-          return {ERROR_BAD_PARAMETER, "PHRASE gap at argument ", i,
-                  " must be preceded by a text pattern"};
-        }
-        if (has_pending_gap) {
-          return {ERROR_BAD_PARAMETER,
-                  "PHRASE has consecutive gaps at argument ", i};
-        }
-        auto value = EvaluateConstant(input);
-        if (!value.has_value()) {
-          return {ERROR_BAD_PARAMETER, "PHRASE gap argument ", i,
-                  " must be a constant"};
-        }
-        const auto gap = extract_uint(value.value()).value();
-        pending_gap_min = pending_gap_max = gap;
-        has_pending_gap = true;
-        break;
-      }
       case velox::TypeKind::ARRAY: {
         if (opts->empty()) {
           return {ERROR_BAD_PARAMETER, "PHRASE gap at argument ", i,
@@ -788,11 +790,11 @@ Result FromSearchPhrase(irs::BooleanFilter& filter,
                   " must have exactly 2 elements [min, max], got ",
                   elements.size()};
         }
-        const auto min_val = extract_uint(elements[0]);
-        const auto max_val = extract_uint(elements[1]);
+        const auto min_val = ReadGapValue(elements[0]);
+        const auto max_val = ReadGapValue(elements[1]);
         if (!min_val || !max_val) {
           return {ERROR_BAD_PARAMETER, "PHRASE gap array at argument ", i,
-                  " elements must be integers"};
+                  " elements must be non-negative integers"};
         }
         if (*min_val > *max_val) {
           return {ERROR_BAD_PARAMETER,
@@ -810,9 +812,29 @@ Result FromSearchPhrase(irs::BooleanFilter& filter,
         break;
       }
       default: {
-        return {
-          ERROR_BAD_PARAMETER, "PHRASE argument ", i,
-          " has unsupported type; expected text, integer, or integer array"};
+        auto value = EvaluateConstant(input);
+        if (!value.has_value()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap argument ", i,
+                  " must be a constant"};
+        }
+        const auto gap = ReadGapValue(value.value());
+        if (!gap) {
+          return {ERROR_BAD_PARAMETER, "PHRASE argument ", i,
+                  " has unsupported type; expected text, non-negative integer, "
+                  "or non-negative integer array"};
+        }
+
+        if (opts->empty()) {
+          return {ERROR_BAD_PARAMETER, "PHRASE gap at argument ", i,
+                  " must be preceded by a text pattern"};
+        }
+        if (has_pending_gap) {
+          return {ERROR_BAD_PARAMETER,
+                  "PHRASE has consecutive gaps at argument ", i};
+        }
+        pending_gap_min = pending_gap_max = gap.value();
+        has_pending_gap = true;
+        break;
       }
     }
   }

--- a/server/functions/search.cpp
+++ b/server/functions/search.cpp
@@ -50,6 +50,14 @@ struct SearchStubFunction {
               "Inverted index function called outside inverted index context");
   }
 
+  // PHRASE(field, text_or_gap, ...) variadic mixed-type overload
+  FOLLY_ALWAYS_INLINE void call(  // NOLINT
+    out_type<bool>& result, const arg_type<velox::Varchar>& field_arg,
+    const arg_type<velox::Variadic<velox::Any>>& args) {
+    SDB_THROW(ERROR_NOT_IMPLEMENTED,
+              "Inverted index function called outside inverted index context");
+  }
+
   // NGRAM_MATCH(path, target, threshold)
   void call(bool& out, const arg_type<velox::Varchar>&,
             const arg_type<velox::Varchar>&, const double&) {
@@ -100,6 +108,8 @@ struct SearchStubFunction {
 void RegisterSearchFunctions() {
   velox::registerFunction<SearchStubFunction, bool, velox::Varchar,
                           velox::Varchar>({std::string{kPhrase}});
+  velox::registerFunction<SearchStubFunction, bool, velox::Varchar,
+                          velox::Variadic<velox::Any>>({std::string{kPhrase}});
   velox::registerFunction<SearchStubFunction, bool, velox::Varchar,
                           velox::Varchar>({std::string{kTermEq}});
   velox::registerFunction<SearchStubFunction, bool, velox::Varchar,

--- a/tests/server/connector/search_filter_builder_test.cpp
+++ b/tests/server/connector/search_filter_builder_test.cpp
@@ -1701,6 +1701,138 @@ TEST_F(SearchFilterBuilderTest, test_SimpleOrPhrase) {
                std::move(columns), true, SegmentationAnalyzerProvider);
 }
 
+TEST_F(SearchFilterBuilderTest, test_PhraseExactGap) {
+  // PHRASE(field, 'quick', 2, 'fox') -- exactly 2 words between 'quick' and
+  // 'fox', e.g. "quick brown lazy fox"
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  irs::And expected;
+
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<velox::StringView>(1);
+  // First term: offsets zeroed by insert() for the first element
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  // Second term: gap=2 words -> offs_min=offs_max=3 (2+1, no implicit +1)
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(3, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE PHRASE(category, 'quick', 2, 'fox')",
+               std::move(columns), true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseRangeGap) {
+  // PHRASE(field, 'quick', ARRAY[1,2], 'fox') -- 1 to 2 words between 'quick'
+  // and 'fox'
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  irs::And expected;
+
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<velox::StringView>(1);
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  // gap=[1,2] words -> offs_min=2, offs_max=3 (min+1, max+1)
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(2, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE PHRASE(category, 'quick', ARRAY[1,2], 'fox')",
+    std::move(columns), true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMultipleGaps) {
+  // PHRASE(field, 'quick', 1, 'brown', 2, 'fox') -- multiple gaps
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  irs::And expected;
+
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<velox::StringView>(1);
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  // gap=1 -> offs=2 (1+1)
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(2, 2).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"brown"});
+  // gap=2 -> offs=3 (2+1)
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(3, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE PHRASE(category, 'quick', 1, 'brown', 2, 'fox')",
+    std::move(columns), true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseGapBetweenMultiTokenPatterns) {
+  // PHRASE(field, 'quick brown', 2, 'lazy fox') -- multi-token patterns with a
+  // gap: 'quick' adj 'brown', then gap=2, then 'lazy' adj 'fox'
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  irs::And expected;
+
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<velox::StringView>(1);
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  // 'brown' is adjacent to 'quick' (within same pattern)
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"brown"});
+  // 'lazy' is the first token of the next pattern -- gap=2 -> offs=3
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(3, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"lazy"});
+  // 'fox' is adjacent to 'lazy' (within same pattern)
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE PHRASE(category, 'quick brown', 2, 'lazy fox')",
+    std::move(columns), true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseGapTrailingError) {
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(irs::And{},
+               "SELECT * FROM foo WHERE PHRASE(category, 'quick', 2)",
+               std::move(columns), false, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseGapLeadingError) {
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(irs::And{}, "SELECT * FROM foo WHERE PHRASE(category, 2, 'fox')",
+               std::move(columns), false, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseConsecutiveGapsError) {
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(irs::And{},
+               "SELECT * FROM foo WHERE PHRASE(category, 'quick', 1, 2, 'fox')",
+               std::move(columns), false, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseGapRangeMinExceedsMaxError) {
+  std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
+  columns.emplace_back(std::make_unique<connector::SereneDBColumn>(
+    "category", velox::VARCHAR(), 1));
+  AssertFilter(
+    irs::And{},
+    "SELECT * FROM foo WHERE PHRASE(category, 'quick', ARRAY[3,1], 'fox')",
+    std::move(columns), false, SegmentationAnalyzerProvider);
+}
+
 TEST_F(SearchFilterBuilderTest, test_TermEq_Segmentation) {
   std::vector<std::unique_ptr<const axiom::connector::Column>> columns;
   irs::And expected;

--- a/tests/sqllogic/sdb/pg/index/inverted_index.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index.test
@@ -83,6 +83,94 @@ a	b	c
 4	quick brown fox jumps over big dog	value b
 
 statement ok
+INSERT INTO foo values (5, 'quick brown lazy fox runs over big dog', 'value c');
+
+statement ok
+INSERT INTO foo values (6, 'quick fox over big dog', 'value c');
+
+statement ok
+VACUUM (UPDATE_INDEXES) foo;
+
+# Exact gap: 1 word between 'quick' and 'fox' — matches rows with 'quick brown fox' and 'quick red fox'
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick', 1, 'fox') ORDER BY a;
+----
+a	b
+1	quick brown fox jumps over lazy dog
+2	quick red fox jumps over lazy dog
+3	quick red fox jumps over big dog
+4	quick brown fox jumps over big dog
+
+# Exact gap: 2 words between 'quick' and 'fox' — matches only row 5 ('quick brown lazy fox')
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick', 2, 'fox') ORDER BY a;
+----
+a	b
+5	quick brown lazy fox runs over big dog
+
+# Exact gap: 0 words between (adjacent) — matches only row 6 ('quick fox')
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick', 0, 'fox') ORDER BY a;
+----
+a	b
+6	quick fox over big dog
+
+# Range gap [0,1]: 0 or 1 words between 'quick' and 'fox'
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick', ARRAY[0,1], 'fox') ORDER BY a;
+----
+a	b
+1	quick brown fox jumps over lazy dog
+2	quick red fox jumps over lazy dog
+3	quick red fox jumps over big dog
+4	quick brown fox jumps over big dog
+6	quick fox over big dog
+
+# Range gap [1,2]: 1 or 2 words between 'quick' and 'fox'
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick', ARRAY[1,2], 'fox') ORDER BY a;
+----
+a	b
+1	quick brown fox jumps over lazy dog
+2	quick red fox jumps over lazy dog
+3	quick red fox jumps over big dog
+4	quick brown fox jumps over big dog
+5	quick brown lazy fox runs over big dog
+
+# Multi-token pattern with gap: 'quick brown' then 1 word then 'fox' — only row 5 has 'brown lazy fox'
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick brown', 1, 'fox') ORDER BY a;
+----
+a	b
+5	quick brown lazy fox runs over big dog
+
+# Multiple gaps: 'quick' +1 word+ 'fox' +3 words+ 'dog'
+query
+SELECT a, b FROM foo_idx WHERE PHRASE(b, 'quick', 1, 'fox', 3, 'dog') ORDER BY a;
+----
+a	b
+1	quick brown fox jumps over lazy dog
+2	quick red fox jumps over lazy dog
+3	quick red fox jumps over big dog
+4	quick brown fox jumps over big dog
+
+# Error: gap at end with no following text pattern
+statement error
+SELECT a FROM foo_idx WHERE PHRASE(b, 'quick', 1);
+
+# Error: gap before any text pattern
+statement error
+SELECT a FROM foo_idx WHERE PHRASE(b, 1, 'fox');
+
+# Error: two consecutive gaps
+statement error
+SELECT a FROM foo_idx WHERE PHRASE(b, 'quick', 1, 2, 'fox');
+
+# Error: range gap with min > max
+statement error
+SELECT a FROM foo_idx WHERE PHRASE(b, 'quick', ARRAY[3,1], 'fox');
+
+statement ok
 DROP TABLE foo;
 
 control substitution on


### PR DESCRIPTION
Add proximity feature for PHRASE function.
Text patterns could be now interleaved with integral gaps
PHRASE ('quick', 2, 'fox') - > matches "quick" and "fox" that has exactly 2 arbitrary words in between. 
PHRASE ('quick', ARRAY:[1, 2], 'fox') - > matches "quick" and "fox" that has 1 or 2 arbitrary words in between. 