### PR TITLE
feat: improve path hierarchy & add benches

### DIFF
--- a/libs/iresearch/include/iresearch/analysis/path_hierarchy_tokenizer.cpp
+++ b/libs/iresearch/include/iresearch/analysis/path_hierarchy_tokenizer.cpp
@@ -188,6 +188,10 @@ Attribute* PathHierarchyTokenizer::GetMutable(TypeInfo::type_id type) noexcept {
   return irs::GetMutable(_attrs, type);
 }
 
+// Template parameters:
+//   SingleChar: true if delimiter.size() == 1 (fast path)
+//   NoReplacement: true if delimiter == replacement (zero-copy path)
+template<bool SingleChar, bool NoReplacement>
 class ForwardPathHierarchyTokenizer final : public PathHierarchyTokenizer {
  public:
   explicit ForwardPathHierarchyTokenizer(Options&& options) noexcept
@@ -197,18 +201,38 @@ class ForwardPathHierarchyTokenizer final : public PathHierarchyTokenizer {
   bool next() final;
 
  private:
-  std::string_view _data;  // input
-  std::string _buffer;     // buffer for case delimiter != replacement
+  // delimiter search
+  size_t FindNextDelimiter(size_t from_position) const noexcept {
+    if constexpr (SingleChar) {
+      return _data.find(_options.delimiter[0], from_position);
+    } else {
+      return _data.find(_options.delimiter, from_position);
+    }
+  }
+
+  // check if substring at position matches delimiter
+  bool IsDelimiterAt(size_t position) const noexcept {
+    if constexpr (SingleChar) {
+      return position < _data.size() &&
+             _data[position] == _options.delimiter[0];
+    } else {
+      return position + _delimiter_size <= _data.size() &&
+             _data.substr(position, _delimiter_size) == _options.delimiter;
+    }
+  }
+
+  std::string _buffer;  // buffer for NoReplacement = false mode
   size_t _prefix_start_in_input =
     0;  // left edge of prefix; every token's offset.start
   size_t _prefix_end_in_input =
     0;  // input merged into _buffer ends before this index
   size_t _delimiter_search_from = 0;  // find(next delimiter) starts here
   size_t _delimiter_size = 0;         // delimiter length
-  bool _need_replacement = false;     // delimiter != replacement, using _buffer
 };
 
-bool ForwardPathHierarchyTokenizer::reset(std::string_view data) {
+template<bool SingleChar, bool NoReplacement>
+bool ForwardPathHierarchyTokenizer<SingleChar, NoReplacement>::reset(
+  std::string_view data) {
   _data = data;
   _term_eof = data.empty();
 
@@ -217,21 +241,21 @@ bool ForwardPathHierarchyTokenizer::reset(std::string_view data) {
   }
 
   _delimiter_size = _options.delimiter.size();
-  _need_replacement = _options.delimiter != _options.replacement;
   SDB_ASSERT(_delimiter_size > 0);
 
   _prefix_start_in_input = 0;
+
+  // skip: walk left-to-right, advancing prefix start to skip leading tokens
   if (_options.skip > 0) {
     size_t skip_step_idx = 0;
     size_t scan_from = 0;
     // leading delimiter counts as one skip step: (/a/b/c equal a/b/c)
     // without +1, skip would line up wrong on paths that start with a delimiter
     size_t delimiter_steps_to_skip =
-      _options.skip + (_data.find(_options.delimiter) == 0);
+      _options.skip + (FindNextDelimiter(0) == 0);
 
     while (skip_step_idx < delimiter_steps_to_skip) {
-      size_t next_delimiter_position =
-        _data.find(_options.delimiter, scan_from);
+      size_t next_delimiter_position = FindNextDelimiter(scan_from);
       if (next_delimiter_position == std::string_view::npos) {
         _term_eof = true;
         return true;
@@ -248,13 +272,12 @@ bool ForwardPathHierarchyTokenizer::reset(std::string_view data) {
 
   // for leading delimiter: /a/b/c
   // bump search cursor past it so the first segment token isn't empty
-  if (_delimiter_search_from + _delimiter_size <= _data.size() &&
-      _data.substr(_delimiter_search_from, _delimiter_size) ==
-        _options.delimiter) {
+  if (IsDelimiterAt(_delimiter_search_from)) {
     _delimiter_search_from += _delimiter_size;
   }
 
-  if (_need_replacement) {
+  if constexpr (!NoReplacement) {
+    // buffered path: delimiter != replacement
     _buffer.clear();
     _buffer.reserve(_options.buffer_size);
   }
@@ -262,7 +285,8 @@ bool ForwardPathHierarchyTokenizer::reset(std::string_view data) {
   return true;
 }
 
-bool ForwardPathHierarchyTokenizer::next() {
+template<bool SingleChar, bool NoReplacement>
+bool ForwardPathHierarchyTokenizer<SingleChar, NoReplacement>::next() {
   if (_term_eof) {
     return false;
   }
@@ -271,9 +295,9 @@ bool ForwardPathHierarchyTokenizer::next() {
   auto& offset_attr = std::get<OffsAttr>(_attrs);
   auto& inc_attr = std::get<IncAttr>(_attrs);
 
+  // find next delimiter from search position
   size_t token_end_position = _data.size();
-  size_t next_delimiter_position =
-    _data.find(_options.delimiter, _delimiter_search_from);
+  size_t next_delimiter_position = FindNextDelimiter(_delimiter_search_from);
 
   if (next_delimiter_position != std::string_view::npos) {
     token_end_position = next_delimiter_position;
@@ -285,7 +309,7 @@ bool ForwardPathHierarchyTokenizer::next() {
   SDB_ASSERT(_prefix_start_in_input <= token_end_position);
   SDB_ASSERT(token_end_position <= _data.size());
 
-  if (!_need_replacement) {
+  if constexpr (NoReplacement) {
     term_attr.value = ViewCast<byte_type>(_data.substr(
       _prefix_start_in_input, token_end_position - _prefix_start_in_input));
   } else {
@@ -293,8 +317,7 @@ bool ForwardPathHierarchyTokenizer::next() {
 
     // when first character isn't delimiter: a/b/c
     // if cursor is on delimiter, emit replacement then tail; else append input
-    if (_data.substr(_prefix_end_in_input, _delimiter_size) ==
-        _options.delimiter) {
+    if (IsDelimiterAt(_prefix_end_in_input)) {
       _buffer.append(_options.replacement);
 
       size_t segment_len = _prefix_end_in_input + _delimiter_size;
@@ -316,6 +339,10 @@ bool ForwardPathHierarchyTokenizer::next() {
   return true;
 }
 
+// Template parameters:
+//   SingleChar: true if delimiter.size() == 1 (fast path)
+//   NoReplacement: true if delimiter == replacement (zero-copy path)
+template<bool SingleChar, bool NoReplacement>
 class ReversePathHierarchyTokenizer final : public PathHierarchyTokenizer {
  public:
   explicit ReversePathHierarchyTokenizer(Options&& options) noexcept
@@ -325,18 +352,43 @@ class ReversePathHierarchyTokenizer final : public PathHierarchyTokenizer {
   bool next() final;
 
  private:
-  std::string_view _data;  // input
-  std::string _buffer;     // buffer for case delimiter != replacement
+  // delimiter search
+  size_t FindNextDelimiter(size_t from_position) const noexcept {
+    if constexpr (SingleChar) {
+      return _data.find(_options.delimiter[0], from_position);
+    } else {
+      return _data.find(_options.delimiter, from_position);
+    }
+  }
+
+  // find previous delimiter (right-to-left search)
+  size_t FindPreviousDelimiter(size_t search_end) const noexcept {
+    if (search_end <= _delimiter_size) {
+      return std::string_view::npos;
+    }
+
+    // search from one position before the end minus delimiter size to skip past
+    // the current delimiter boundary and find the previous one
+    size_t actual_search_end = search_end - _delimiter_size - 1;
+    if constexpr (SingleChar) {
+      return _data.rfind(_options.delimiter[0], actual_search_end);
+    } else {
+      return _data.rfind(_options.delimiter, actual_search_end);
+    }
+  }
+
+  std::string _buffer;                 // buffer for NoReplacement = false mode
   size_t _suffix_start_in_buffer = 0;  // current token's left edge in _buffer
   size_t _suffix_start_in_input =
     0;  // current token's left edge in input (for offset.start)
   size_t _suffix_window_end =
     0;  // path ends here after skip-from-right (past last byte)
-  size_t _delimiter_size = 0;      // delimiter length
-  bool _need_replacement = false;  // delimiter != replacement, using _buffer
+  size_t _delimiter_size = 0;  // delimiter length
 };
 
-bool ReversePathHierarchyTokenizer::reset(std::string_view data) {
+template<bool SingleChar, bool NoReplacement>
+bool ReversePathHierarchyTokenizer<SingleChar, NoReplacement>::reset(
+  std::string_view data) {
   _data = data;
   _term_eof = data.empty();
 
@@ -345,10 +397,9 @@ bool ReversePathHierarchyTokenizer::reset(std::string_view data) {
   }
 
   _delimiter_size = _options.delimiter.size();
-  _need_replacement = _options.delimiter != _options.replacement;
   SDB_ASSERT(_delimiter_size > 0);
 
-  // walk right-to-left: each skip drops one trailing segment
+  // skip: walk right-to-left, dropping trailing segments
   size_t trimmed_window_end = data.size();
   for (size_t skip_idx = 0; skip_idx < _options.skip; ++skip_idx) {
     if (trimmed_window_end <= _delimiter_size) {
@@ -356,8 +407,7 @@ bool ReversePathHierarchyTokenizer::reset(std::string_view data) {
       return true;
     }
 
-    size_t rfind_delimiter_position =
-      data.rfind(_options.delimiter, trimmed_window_end - _delimiter_size - 1);
+    size_t rfind_delimiter_position = FindPreviousDelimiter(trimmed_window_end);
     if (rfind_delimiter_position == std::string_view::npos) {
       _term_eof = true;
       return true;
@@ -365,25 +415,25 @@ bool ReversePathHierarchyTokenizer::reset(std::string_view data) {
     trimmed_window_end = rfind_delimiter_position + _delimiter_size;
   }
   _suffix_window_end = trimmed_window_end;
-
   _suffix_start_in_input = 0;
-  _suffix_start_in_buffer = 0;
 
-  if (!_need_replacement) {
+  if constexpr (NoReplacement) {
     if (_suffix_window_end == 0) {
       _term_eof = true;
     }
     return true;
   }
 
+  // buffered path: delimiter != replacement
+  // pre-build full buffer with all delimiters replaced (left-to-right)
   _buffer.clear();
   _buffer.reserve(_options.buffer_size);
+  _suffix_start_in_buffer = 0;
 
-  // left-to-right: segments joined with replacement (offsets still use input
-  // indices)
+  // scan left-to-right through window, joining segments with replacement
   size_t scan_from = 0;
   while (scan_from < _suffix_window_end) {
-    size_t next_delimiter_position = data.find(_options.delimiter, scan_from);
+    size_t next_delimiter_position = FindNextDelimiter(scan_from);
     if (next_delimiter_position == std::string_view::npos) {
       SDB_ASSERT(scan_from <= _suffix_window_end);
       _buffer.append(data.data() + scan_from, _suffix_window_end - scan_from);
@@ -405,7 +455,8 @@ bool ReversePathHierarchyTokenizer::reset(std::string_view data) {
   return true;
 }
 
-bool ReversePathHierarchyTokenizer::next() {
+template<bool SingleChar, bool NoReplacement>
+bool ReversePathHierarchyTokenizer<SingleChar, NoReplacement>::next() {
   if (_term_eof) {
     return false;
   }
@@ -417,7 +468,7 @@ bool ReversePathHierarchyTokenizer::next() {
   auto& offset_attr = std::get<OffsAttr>(_attrs);
   auto& inc_attr = std::get<IncAttr>(_attrs);
 
-  if (!_need_replacement) {
+  if constexpr (NoReplacement) {
     term_attr.value = ViewCast<byte_type>(_data.substr(
       _suffix_start_in_input, _suffix_window_end - _suffix_start_in_input));
   } else {
@@ -430,8 +481,7 @@ bool ReversePathHierarchyTokenizer::next() {
   offset_attr.end = static_cast<uint32_t>(_suffix_window_end);
   inc_attr.value = 1;
 
-  size_t next_delimiter_position =
-    _data.find(_options.delimiter, _suffix_start_in_input);
+  size_t next_delimiter_position = FindNextDelimiter(_suffix_start_in_input);
 
   if (next_delimiter_position == std::string_view::npos ||
       next_delimiter_position >= _suffix_window_end) {
@@ -443,7 +493,7 @@ bool ReversePathHierarchyTokenizer::next() {
     size_t segment_len = next_delimiter_position - _suffix_start_in_input;
     _suffix_start_in_input = next_delimiter_position + _delimiter_size;
 
-    if (_need_replacement) {
+    if constexpr (!NoReplacement) {
       _suffix_start_in_buffer += segment_len + _options.replacement.size();
     }
 
@@ -456,10 +506,38 @@ bool ReversePathHierarchyTokenizer::next() {
 }
 
 Analyzer::ptr PathHierarchyTokenizer::make(Options&& options) {
+  const bool single_char = (options.delimiter.size() == 1);
+  const bool no_replacement = (options.delimiter == options.replacement);
+
   if (options.reverse) {
-    return std::make_unique<ReversePathHierarchyTokenizer>(std::move(options));
+    if (single_char && no_replacement) {
+      return std::make_unique<ReversePathHierarchyTokenizer<true, true>>(
+        std::move(options));
+    } else if (single_char && !no_replacement) {
+      return std::make_unique<ReversePathHierarchyTokenizer<true, false>>(
+        std::move(options));
+    } else if (!single_char && no_replacement) {
+      return std::make_unique<ReversePathHierarchyTokenizer<false, true>>(
+        std::move(options));
+    } else {
+      return std::make_unique<ReversePathHierarchyTokenizer<false, false>>(
+        std::move(options));
+    }
+  } else {
+    if (single_char && no_replacement) {
+      return std::make_unique<ForwardPathHierarchyTokenizer<true, true>>(
+        std::move(options));
+    } else if (single_char && !no_replacement) {
+      return std::make_unique<ForwardPathHierarchyTokenizer<true, false>>(
+        std::move(options));
+    } else if (!single_char && no_replacement) {
+      return std::make_unique<ForwardPathHierarchyTokenizer<false, true>>(
+        std::move(options));
+    } else {
+      return std::make_unique<ForwardPathHierarchyTokenizer<false, false>>(
+        std::move(options));
+    }
   }
-  return std::make_unique<ForwardPathHierarchyTokenizer>(std::move(options));
 }
 
 }  // namespace irs::analysis

--- a/libs/iresearch/include/iresearch/analysis/path_hierarchy_tokenizer.hpp
+++ b/libs/iresearch/include/iresearch/analysis/path_hierarchy_tokenizer.hpp
@@ -74,6 +74,7 @@ class PathHierarchyTokenizer : public TypedAnalyzer<PathHierarchyTokenizer> {
   const Options _options;
 
   bool _term_eof = true;
+  std::string_view _data;  // input data
 };
 
 }  // namespace analysis

--- a/tests/bench/micro/CMakeLists.txt
+++ b/tests/bench/micro/CMakeLists.txt
@@ -27,6 +27,7 @@ add_bench(uuid_print)
 add_bench(json_functions)
 add_bench(config_var_lookup)
 add_bench(norm_gather)
+add_bench(path_hierarchy_tokenizer)
 
 # vector distances
 add_executable(vector-distances-bench vector_distances.cpp)

--- a/tests/bench/micro/path_hierarchy_tokenizer.cpp
+++ b/tests/bench/micro/path_hierarchy_tokenizer.cpp
@@ -1,0 +1,345 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include <benchmark/benchmark.h>
+
+#include <iresearch/analysis/path_hierarchy_tokenizer.hpp>
+
+namespace {
+
+using Options = irs::analysis::PathHierarchyTokenizer::Options;
+
+void InitOnce() {
+  static bool gInitialized = []() {
+    irs::analysis::PathHierarchyTokenizer::init();
+    return true;
+  }();
+  (void)gInitialized;
+}
+
+std::string GeneratePath(size_t segments, std::string_view delimiter) {
+  std::string path;
+  path.reserve(segments * (delimiter.size() + 6));
+
+  for (size_t i = 0; i < segments; ++i) {
+    path += delimiter;
+    path += "seg";
+    path += std::to_string(i);
+  }
+
+  path += delimiter;
+  return path;
+}
+
+std::string GenerateNoDelimiterPath(size_t size) {
+  return std::string(size, 'a');
+}
+
+// fastest path: single-char delimiter + no replacement
+static void BmForwardSingleCharZeroCopy(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GeneratePath(state.range(0), "/");
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "/";
+  options.reverse = false;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    size_t token_count = 0;
+    while (tokenizer->next()) {
+      ++token_count;
+    }
+
+    benchmark::DoNotOptimize(token_count);
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+// multi-char delimiter, still zero-copy
+static void BmForwardMultiCharZeroCopy(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GeneratePath(state.range(0), "::");
+
+  Options options;
+  options.delimiter = "::";
+  options.replacement = "::";
+  options.reverse = false;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    size_t token_count = 0;
+    while (tokenizer->next()) {
+      ++token_count;
+    }
+
+    benchmark::DoNotOptimize(token_count);
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+// buffered path (delimiter != replacement)
+static void BmForwardBuffered(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GeneratePath(state.range(0), "/");
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "//";
+  options.reverse = false;
+  options.buffer_size = 4096;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    size_t token_count = 0;
+    while (tokenizer->next()) {
+      ++token_count;
+    }
+
+    benchmark::DoNotOptimize(token_count);
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+// reverse benchmarks
+static void BmReverseSingleCharZeroCopy(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GeneratePath(state.range(0), "/");
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "/";
+  options.reverse = true;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    size_t token_count = 0;
+    while (tokenizer->next()) {
+      ++token_count;
+    }
+
+    benchmark::DoNotOptimize(token_count);
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+static void BmReverseMultiCharZeroCopy(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GeneratePath(state.range(0), "::");
+
+  Options options;
+  options.delimiter = "::";
+  options.replacement = "::";
+  options.reverse = true;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    size_t token_count = 0;
+    while (tokenizer->next()) {
+      ++token_count;
+    }
+
+    benchmark::DoNotOptimize(token_count);
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+static void BmReverseBuffered(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GeneratePath(state.range(0), "/");
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "->";
+  options.reverse = true;
+  options.buffer_size = 4096;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    size_t token_count = 0;
+    while (tokenizer->next()) {
+      ++token_count;
+    }
+
+    benchmark::DoNotOptimize(token_count);
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+// skip benchmarks
+static void BmForwardWithSkip(benchmark::State& state) {
+  InitOnce();
+
+  const size_t segments = state.range(0);
+  const size_t skip = state.range(1);
+
+  const std::string input = GeneratePath(segments, "/");
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "/";
+  options.reverse = false;
+  options.skip = skip;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    while (tokenizer->next()) {
+      benchmark::DoNotOptimize(tokenizer);
+    }
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+static void BmReverseWithSkip(benchmark::State& state) {
+  InitOnce();
+
+  const size_t segments = state.range(0);
+  const size_t skip = state.range(1);
+
+  const std::string input = GeneratePath(segments, "/");
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "/";
+  options.reverse = true;
+  options.skip = skip;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    while (tokenizer->next()) {
+      benchmark::DoNotOptimize(tokenizer);
+    }
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+// no delimiters
+static void BmForwardNoDelimiters(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GenerateNoDelimiterPath(state.range(0));
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "/";
+  options.reverse = false;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    while (tokenizer->next()) {
+      benchmark::DoNotOptimize(tokenizer);
+    }
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+static void BmReverseNoDelimiters(benchmark::State& state) {
+  InitOnce();
+
+  const std::string input = GenerateNoDelimiterPath(state.range(0));
+
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "/";
+  options.reverse = true;
+
+  auto tokenizer =
+    irs::analysis::PathHierarchyTokenizer::make(Options{options});
+
+  for (auto _ : state) {
+    tokenizer->reset(input);
+
+    while (tokenizer->next()) {
+      benchmark::DoNotOptimize(tokenizer);
+    }
+  }
+
+  state.SetBytesProcessed(state.iterations() * input.size());
+}
+
+}  // namespace
+
+BENCHMARK(BmForwardSingleCharZeroCopy)->Range(8, 256);
+BENCHMARK(BmForwardMultiCharZeroCopy)->Range(8, 256);
+BENCHMARK(BmForwardBuffered)->Range(8, 256);
+
+BENCHMARK(BmReverseSingleCharZeroCopy)->Range(8, 256);
+BENCHMARK(BmReverseMultiCharZeroCopy)->Range(8, 256);
+BENCHMARK(BmReverseBuffered)->Range(8, 256);
+
+BENCHMARK(BmForwardWithSkip)->ArgsProduct({{64}, {0, 4, 8, 16}});
+BENCHMARK(BmReverseWithSkip)->ArgsProduct({{64}, {0, 4, 8, 16}});
+
+BENCHMARK(BmForwardNoDelimiters)->Range(64, 4096);
+BENCHMARK(BmReverseNoDelimiters)->Range(64, 4096);
+
+BENCHMARK_MAIN();

--- a/tests/libs/iresearch/analysis/path_hierarchy_tokenizer_test.cpp
+++ b/tests/libs/iresearch/analysis/path_hierarchy_tokenizer_test.cpp
@@ -364,8 +364,8 @@ TEST_F(PathHierarchyTokenizerTests, test_delimiter_in_replacement) {
   ASSERT_NE(nullptr, stream);
 
   ASSERT_TRUE(stream->reset(data));
-  AssertTokenStreamContents(stream.get(), {"//a", "//a//b", "//a//b//c"}, {0, 0, 0},
-                            {2, 4, 6}, {1, 1, 1});
+  AssertTokenStreamContents(stream.get(), {"//a", "//a//b", "//a//b//c"},
+                            {0, 0, 0}, {2, 4, 6}, {1, 1, 1});
 }
 
 TEST_F(PathHierarchyTokenizerTests, test_forward_basic_skip) {

--- a/tests/libs/iresearch/analysis/path_hierarchy_tokenizer_test.cpp
+++ b/tests/libs/iresearch/analysis/path_hierarchy_tokenizer_test.cpp
@@ -353,6 +353,21 @@ TEST_F(PathHierarchyTokenizerTests, test_only_delimiters) {
   AssertTokenStreamContents(stream.get(), {"/", "//"}, {0, 0}, {1, 2}, {1, 1});
 }
 
+TEST_F(PathHierarchyTokenizerTests, test_delimiter_in_replacement) {
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "//";
+  options.reverse = false;
+
+  std::string_view data = "/a/b/c";
+  auto stream = PathHierarchyTokenizer::make(std::move(options));
+  ASSERT_NE(nullptr, stream);
+
+  ASSERT_TRUE(stream->reset(data));
+  AssertTokenStreamContents(stream.get(), {"//a", "//a//b", "//a//b//c"}, {0, 0, 0},
+                            {2, 4, 6}, {1, 1, 1});
+}
+
 TEST_F(PathHierarchyTokenizerTests, test_forward_basic_skip) {
   Options options;
   options.delimiter = "/";
@@ -567,6 +582,21 @@ TEST_F(PathHierarchyTokenizerTests, test_reverse_only_delimiters) {
   ASSERT_TRUE(stream->reset(data));
 
   AssertTokenStreamContents(stream.get(), {"//", "/"}, {0, 1}, {2, 2}, {1, 1});
+}
+
+TEST_F(PathHierarchyTokenizerTests, test_reverse_delimiter_in_replacement) {
+  Options options;
+  options.delimiter = "/";
+  options.replacement = "//";
+  options.reverse = true;
+
+  std::string_view data = "/a/b/c";
+  auto stream = PathHierarchyTokenizer::make(std::move(options));
+  ASSERT_NE(nullptr, stream);
+  ASSERT_TRUE(stream->reset(data));
+
+  AssertTokenStreamContents(stream.get(), {"//a//b//c", "a//b//c", "b//c", "c"},
+                            {0, 1, 3, 5}, {6, 6, 6, 6}, {1, 1, 1, 1});
 }
 
 TEST_F(PathHierarchyTokenizerTests, test_reverse_end_of_delimiter_skip) {


### PR DESCRIPTION
old implementation
```
❯ ./bin/serenedb-bench-micro-path_hierarchy_tokenizer
2026-04-15T15:00:27+03:00
Running ./bin/serenedb-bench-micro-path_hierarchy_tokenizer
Run on (12 X 3994.74 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 512 KiB (x6)
  L3 Unified 4096 KiB (x2)
Load Average: 1.35, 4.20, 5.61
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
BmForwardSingleCharZeroCopy/8         84.7 ns         84.7 ns      7211005 bytes_per_second=461.681Mi/s
BmForwardSingleCharZeroCopy/64         498 ns          497 ns      1274587 bytes_per_second=719.455Mi/s
BmForwardSingleCharZeroCopy/256       1936 ns         1936 ns       358595 bytes_per_second=828.989Mi/s
BmForwardMultiCharZeroCopy/8          76.1 ns         76.1 ns      8265209 bytes_per_second=626.641Mi/s
BmForwardMultiCharZeroCopy/64          489 ns          489 ns      1221696 bytes_per_second=858.149Mi/s
BmForwardMultiCharZeroCopy/256        1936 ns         1934 ns       324780 bytes_per_second=956.789Mi/s
BmForwardBuffered/8                    221 ns          220 ns      3153017 bytes_per_second=177.468Mi/s
BmForwardBuffered/64                  1579 ns         1578 ns       438255 bytes_per_second=226.563Mi/s
BmForwardBuffered/256                 6100 ns         6099 ns       107163 bytes_per_second=263.142Mi/s
BmReverseSingleCharZeroCopy/8          103 ns          103 ns      6461001 bytes_per_second=378.369Mi/s
BmReverseSingleCharZeroCopy/64         593 ns          593 ns      1207058 bytes_per_second=603.162Mi/s
BmReverseSingleCharZeroCopy/256       2190 ns         2190 ns       296270 bytes_per_second=732.81Mi/s
BmReverseMultiCharZeroCopy/8          94.4 ns         94.4 ns      6919723 bytes_per_second=504.932Mi/s
BmReverseMultiCharZeroCopy/64          638 ns          638 ns      1136977 bytes_per_second=657.744Mi/s
BmReverseMultiCharZeroCopy/256        2376 ns         2375 ns       300243 bytes_per_second=778.902Mi/s
BmReverseBuffered/8                    271 ns          271 ns      2796072 bytes_per_second=144.5Mi/s
BmReverseBuffered/64                  1687 ns         1687 ns       394438 bytes_per_second=212.041Mi/s
BmReverseBuffered/256                 6277 ns         6266 ns        90252 bytes_per_second=256.145Mi/s
BmForwardWithSkip/64/0                 548 ns          547 ns      1100276 bytes_per_second=654.142Mi/s
BmForwardWithSkip/64/4                 542 ns          541 ns      1206967 bytes_per_second=660.767Mi/s
BmForwardWithSkip/64/8                 539 ns          537 ns      1339119 bytes_per_second=665.759Mi/s
BmForwardWithSkip/64/16                507 ns          506 ns      1139853 bytes_per_second=706.998Mi/s
BmReverseWithSkip/64/0                 589 ns          588 ns      1066734 bytes_per_second=607.828Mi/s
BmReverseWithSkip/64/4                1382 ns         1381 ns       468160 bytes_per_second=258.891Mi/s
BmReverseWithSkip/64/8                2099 ns         2095 ns       320721 bytes_per_second=170.69Mi/s
BmReverseWithSkip/64/16               3508 ns         3500 ns       193103 bytes_per_second=102.171Mi/s
BmForwardNoDelimiters/64              20.4 ns         20.3 ns     33827129 bytes_per_second=2.93633Gi/s
BmForwardNoDelimiters/512             24.0 ns         24.0 ns     28736074 bytes_per_second=19.8753Gi/s
BmForwardNoDelimiters/4096            43.8 ns         43.7 ns     13047747 bytes_per_second=87.3475Gi/s
BmReverseNoDelimiters/64              16.6 ns         16.6 ns     37092427 bytes_per_second=3.58891Gi/s
BmReverseNoDelimiters/512             19.7 ns         19.7 ns     32749018 bytes_per_second=24.2111Gi/s
BmReverseNoDelimiters/4096            40.4 ns         40.2 ns     18063599 bytes_per_second=94.8867Gi/s
```

new implementation
```
❯ ./bin/serenedb-bench-micro-path_hierarchy_tokenizer
2026-04-15T14:33:08+03:00
Running ./bin/serenedb-bench-micro-path_hierarchy_tokenizer
Run on (12 X 3992.37 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 512 KiB (x6)
  L3 Unified 4096 KiB (x2)
Load Average: 1.36, 2.83, 4.61
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
BmForwardSingleCharZeroCopy/8         62.5 ns         62.5 ns     10462327 bytes_per_second=625.724Mi/s
BmForwardSingleCharZeroCopy/64         451 ns          450 ns      1551799 bytes_per_second=794.278Mi/s
BmForwardSingleCharZeroCopy/256       1754 ns         1753 ns       397162 bytes_per_second=915.36Mi/s
BmForwardMultiCharZeroCopy/8          73.7 ns         73.7 ns      9059246 bytes_per_second=647.197Mi/s
BmForwardMultiCharZeroCopy/64          506 ns          506 ns      1196381 bytes_per_second=829.616Mi/s
BmForwardMultiCharZeroCopy/256        1951 ns         1951 ns       355934 bytes_per_second=948.513Mi/s
BmForwardBuffered/8                    160 ns          160 ns      4275856 bytes_per_second=244.313Mi/s
BmForwardBuffered/64                  1075 ns         1074 ns       600595 bytes_per_second=333.011Mi/s
BmForwardBuffered/256                 4214 ns         4213 ns       166249 bytes_per_second=380.979Mi/s
BmReverseSingleCharZeroCopy/8         69.3 ns         69.1 ns      9594838 bytes_per_second=565.66Mi/s
BmReverseSingleCharZeroCopy/64         505 ns          504 ns      1336824 bytes_per_second=709.698Mi/s
BmReverseSingleCharZeroCopy/256       1977 ns         1977 ns       351915 bytes_per_second=811.913Mi/s
BmReverseMultiCharZeroCopy/8          76.5 ns         76.5 ns      8042566 bytes_per_second=623.637Mi/s
BmReverseMultiCharZeroCopy/64          530 ns          530 ns      1150534 bytes_per_second=791.542Mi/s
BmReverseMultiCharZeroCopy/256        2063 ns         2062 ns       331103 bytes_per_second=897.374Mi/s
BmReverseBuffered/8                    209 ns          209 ns      3288993 bytes_per_second=186.9Mi/s
BmReverseBuffered/64                  1350 ns         1349 ns       474158 bytes_per_second=265.165Mi/s
BmReverseBuffered/256                 5675 ns         5669 ns       110047 bytes_per_second=283.133Mi/s
BmForwardWithSkip/64/0                 443 ns          442 ns      1350099 bytes_per_second=808.299Mi/s
BmForwardWithSkip/64/4                 440 ns          440 ns      1387832 bytes_per_second=813.085Mi/s
BmForwardWithSkip/64/8                 433 ns          433 ns      1615374 bytes_per_second=826.449Mi/s
BmForwardWithSkip/64/16                418 ns          418 ns      1677575 bytes_per_second=856.308Mi/s
BmReverseWithSkip/64/0                 509 ns          509 ns      1278550 bytes_per_second=702.064Mi/s
BmReverseWithSkip/64/4                 495 ns          495 ns      1304595 bytes_per_second=722.352Mi/s
BmReverseWithSkip/64/8                 482 ns          482 ns      1322042 bytes_per_second=742.098Mi/s
BmReverseWithSkip/64/16                449 ns          449 ns      1564260 bytes_per_second=796.141Mi/s
BmForwardNoDelimiters/64              13.1 ns         13.1 ns     53052513 bytes_per_second=4.55333Gi/s
BmForwardNoDelimiters/512             16.2 ns         16.2 ns     41757262 bytes_per_second=29.4803Gi/s
BmForwardNoDelimiters/4096            34.0 ns         34.0 ns     20731366 bytes_per_second=112.172Gi/s
BmReverseNoDelimiters/64              15.8 ns         15.8 ns     48125114 bytes_per_second=3.77109Gi/s
BmReverseNoDelimiters/512             19.3 ns         19.3 ns     36388640 bytes_per_second=24.7636Gi/s
BmReverseNoDelimiters/4096            37.6 ns         37.6 ns     18427016 bytes_per_second=101.503Gi/s
```