### PR TITLE
feat: Add current_user, current_role and pg_backend_pid system functions

### DIFF
--- a/server/connector/functions/system.cpp
+++ b/server/connector/functions/system.cpp
@@ -79,11 +79,6 @@ void CurrentUserFunction(duckdb::DataChunk&, duckdb::ExpressionState& state,
   result.Reference(conn_ctx.user());
 }
 
-void PgBackendPidFunction(duckdb::DataChunk&, duckdb::ExpressionState&,
-                          duckdb::Vector& result) {
-  result.Reference(duckdb::Value::INTEGER(0));
-}
-
 // set_config(name, value, is_local) -> text
 // Ported from server/pg/functions/system.cpp SetConfigFunction.
 void SetConfigFunction(duckdb::DataChunk& args, duckdb::ExpressionState& state,
@@ -568,9 +563,6 @@ void RegisterPgSystemFunctions(duckdb::DatabaseInstance& db) {
   // current_role is same as current_user in postgres
   loader.RegisterFunction(duckdb::ScalarFunction{
     "current_role", {}, duckdb::LogicalType::VARCHAR, CurrentUserFunction});
-
-  loader.RegisterFunction(duckdb::ScalarFunction{
-    "pg_backend_pid", {}, duckdb::LogicalType::INTEGER, PgBackendPidFunction});
 }
 
 }  // namespace sdb::connector

--- a/server/connector/functions/system.cpp
+++ b/server/connector/functions/system.cpp
@@ -72,6 +72,18 @@ void CurrentSetting2Function(duckdb::DataChunk& args,
     });
 }
 
+void CurrentUserFunction(duckdb::DataChunk&, duckdb::ExpressionState& state,
+                         duckdb::Vector& result) {
+  auto& context = state.GetContext();
+  const auto& conn_ctx = GetSereneDBContext(context);
+  result.Reference(conn_ctx.user());
+}
+
+void PgBackendPidFunction(duckdb::DataChunk&, duckdb::ExpressionState&,
+                          duckdb::Vector& result) {
+  result.Reference(duckdb::Value::INTEGER(0));
+}
+
 // set_config(name, value, is_local) -> text
 // Ported from server/pg/functions/system.cpp SetConfigFunction.
 void SetConfigFunction(duckdb::DataChunk& args, duckdb::ExpressionState& state,
@@ -549,6 +561,16 @@ void RegisterPgSystemFunctions(duckdb::DatabaseInstance& db) {
                                                  {duckdb::LogicalType::BIGINT},
                                                  duckdb::LogicalType::BIGINT,
                                                  PgSchemaSizeOidFunction});
+
+  loader.RegisterFunction(duckdb::ScalarFunction{
+    "current_user", {}, duckdb::LogicalType::VARCHAR, CurrentUserFunction});
+
+  // current_role is same as current_user in postgres
+  loader.RegisterFunction(duckdb::ScalarFunction{
+    "current_role", {}, duckdb::LogicalType::VARCHAR, CurrentUserFunction});
+
+  loader.RegisterFunction(duckdb::ScalarFunction{
+    "pg_backend_pid", {}, duckdb::LogicalType::INTEGER, PgBackendPidFunction});
 }
 
 }  // namespace sdb::connector

--- a/server/pg/system_functions.h
+++ b/server/pg/system_functions.h
@@ -1108,6 +1108,8 @@ inline constexpr SystemMacro kExternalMacros[] = {
   {"pg_catalog", "pg_char_to_encoding", "(enc_name) AS 6::int4"},
   // No temp schemas supported yet.
   {"pg_catalog", "pg_my_temp_schema", "() AS 0::oid"},
+  // We do not spawn backends per connection
+  {"pg_catalog", "pg_backend_pid", "() AS CAST(0 AS INTEGER)"},
   // clang-format on
 };
 

--- a/tests/sqllogic/any/pg/system/functions-info.test
+++ b/tests/sqllogic/any/pg/system/functions-info.test
@@ -444,6 +444,21 @@ has_column_privilege
 t
 
 
+# both current_role and current_user must be in pg_roles
+query
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = current_user(); 
+----
+rolname	rolcanlogin
+<slt:ignore>	t
+
+
+query
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = current_role(); 
+----
+rolname	rolcanlogin
+<slt:ignore>	t
+
+
 onlyif serenedb
 query
 SELECT row_security_active('pg_class');
@@ -1286,3 +1301,10 @@ query error
 SELECT pg_get_wal_summarizer_state();
 ----
 db error: ERROR: Function is not supported in SereneDB
+
+
+query
+SELECT pg_backend_pid();
+----
+pg_backend_pid
+<slt:ignore>

--- a/tests/sqllogic/any/pg/system/functions-info.test
+++ b/tests/sqllogic/any/pg/system/functions-info.test
@@ -446,14 +446,14 @@ t
 
 # both current_role and current_user must be in pg_roles
 query
-SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = current_user(); 
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = current_user; 
 ----
 rolname	rolcanlogin
 <slt:ignore>	t
 
 
 query
-SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = current_role(); 
+SELECT rolname, rolcanlogin FROM pg_catalog.pg_roles WHERE rolname = current_role; 
 ----
 rolname	rolcanlogin
 <slt:ignore>	t


### PR DESCRIPTION
current_user, current_role now returns actual role name. Test added that checks role returned is indeed in pg_roles.
pg_backend_pid is a stub that just return 0 fo now as we do not spawn backends per connection