### PR TITLE
fix: Fix config tests

### DIFF
--- a/tests/sqllogic/any/pg/settings/scopes.test
+++ b/tests/sqllogic/any/pg/settings/scopes.test
@@ -185,7 +185,7 @@ statement ok
 BEGIN;
 
 
-skipif postgres # TODO(gnusi) not supported syntax in pg
+skipif postgres # SET GLOBAL is not supported syntax in pg
 statement ok
 SET GLOBAL default_transaction_read_only TO true;
 
@@ -203,7 +203,7 @@ default_transaction_read_only
 on
 
 
-skipif postgres # TODO(gnusi) not supported syntax in pg
+skipif postgres # SET GLOBAL is not supported syntax in pg
 statement ok
 SET GLOBAL default_transaction_read_only TO false;
 

--- a/tests/sqllogic/any/pg/system/functions.test
+++ b/tests/sqllogic/any/pg/system/functions.test
@@ -128,12 +128,215 @@ statement ok
 SET search_path TO 'public,some_schema';
 
 
-skipif postgres # TODO(gnusi) PG format is different
 query
 SHOW search_path;
 ----
 search_path
-public, some_schema
+"public,some_schema"
+
+
+# Single double-quoted identifier with a comma — one atomic entry.
+statement ok
+SET search_path TO "a,b";
+
+
+query
+SHOW search_path;
+----
+search_path
+"a,b"
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."a,b"')::text AS r;
+----
+r
+true
+
+
+# Multi-arg of quoted identifiers, each with a comma — two atomic entries.
+statement ok
+SET search_path TO "a,b", "c,d";
+
+
+query
+SHOW search_path;
+----
+search_path
+"a,b", "c,d"
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."a,b", ' || current_database() || '."c,d"')::text AS r;
+----
+r
+true
+
+
+# Mix of quoted-with-comma and bare — three entries.
+statement ok
+SET search_path TO "a,b", z, "c,d";
+
+
+query
+SHOW search_path;
+----
+search_path
+"a,b", z, "c,d"
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."a,b", ' || current_database() || '.z, ' || current_database() || '."c,d"')::text AS r;
+----
+r
+true
+
+
+# Empty string literal -> empty search_path (no entries).
+statement ok
+SET search_path TO '';
+
+
+query
+SELECT current_schemas(false);
+----
+current_schemas
+{}
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = '')::text AS r;
+----
+r
+true
+
+
+# SET ... TO DEFAULT maps to RESET, restoring the connection default.
+statement ok
+SET search_path TO DEFAULT;
+
+
+query
+SHOW search_path;
+----
+search_path
+"$user", public
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() LIKE current_database() || '.%, ' || current_database() || '.public'
+   AND search_path_canonical() NOT LIKE '%$user%')::text AS r;
+----
+r
+true
+
+
+# Single bare identifier with uppercase needs quoting on display.
+statement ok
+SET search_path TO "A,b";
+
+
+query
+SHOW search_path;
+----
+search_path
+"A,b"
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."A,b"')::text AS r;
+----
+r
+true
+
+
+# Catalog-qualified entries: SHOW strips the current DB prefix, so entries
+# qualified with the current DB show as bare schema names. These tests assume
+# the connection's current_database is `postgres` (the default in both PG
+# and our test harness).
+statement ok
+SET search_path TO postgres.public;
+
+
+query
+SHOW search_path;
+----
+search_path
+public
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '.public')::text AS r;
+----
+r
+true
+
+
+# Catalog-qualified with a quoted schema containing a comma -> one entry.
+statement ok
+SET search_path TO postgres."a,b";
+
+
+query
+SHOW search_path;
+----
+search_path
+"a,b"
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."a,b"')::text AS r;
+----
+r
+true
+
+
+# Two catalog-qualified quoted-comma entries -> two entries.
+statement ok
+SET search_path TO postgres."a,b", postgres."c,d";
+
+
+query
+SHOW search_path;
+----
+search_path
+"a,b", "c,d"
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."a,b", ' || current_database() || '."c,d"')::text AS r;
+----
+r
+true
+
+
+# Mix: qualified-with-comma, bare, qualified -> three entries.
+statement ok
+SET search_path TO postgres."a,b", z, postgres.public;
+
+
+query
+SHOW search_path;
+----
+search_path
+"a,b", z, public
+
+
+onlyif serenedb
+query
+SELECT (search_path_canonical() = current_database() || '."a,b", ' || current_database() || '.z, ' || current_database() || '.public')::text AS r;
+----
+r
+true
 
 
 # Mix of valid and invalid: only valid reported, but invalid kept in path
@@ -166,11 +369,8 @@ true
 
 # Explicit catalog.schema with unknown catalog still errors (avoids
 # the lookup short-circuit bug for unqualified names)
-skipif postgres # TODO(gnusi) PG is works!
-statement error
+statement ok
 SET search_path TO 'badcat.public';
-----
-db error: ERROR: SET search_path: No catalog + schema named "badcat.public" found.
 
 
 # Reset for cleanup
@@ -241,3 +441,96 @@ SELECT current_schema = 'public';
 ----
 ?column?
 t
+
+
+# ----------------------------------------------------------------------
+# $user combined with explicit database qualification
+# ----------------------------------------------------------------------
+
+# Explicit DB on the $user entry only.
+skipif postgres
+statement ok
+SET search_path TO postgres."$user", public;
+
+
+skipif postgres
+query
+SHOW search_path;
+----
+search_path
+"$user", public
+
+
+# Canonical expands $user for the postgres-qualified entry too; still no
+# "$user" literal in the resolved form, public remains current-DB qualified.
+skipif postgres
+query
+SELECT (search_path_canonical() LIKE current_database() || '.%, ' || current_database() || '.public'
+   AND search_path_canonical() NOT LIKE '%$user%')::text AS r;
+----
+r
+true
+
+
+# Explicit DB on both entries — SHOW strips current-DB prefix consistently.
+skipif postgres
+statement ok
+SET search_path TO postgres."$user", postgres.public;
+
+
+skipif postgres
+query
+SHOW search_path;
+----
+search_path
+"$user", public
+
+
+# Sole entry is DB-qualified $user.
+skipif postgres
+statement ok
+SET search_path TO postgres."$user";
+
+
+skipif postgres
+query
+SHOW search_path;
+----
+search_path
+"$user"
+
+
+skipif postgres
+query
+SELECT (search_path_canonical() LIKE current_database() || '.%'
+   AND search_path_canonical() NOT LIKE '%$user%')::text AS r;
+----
+r
+true
+
+
+# Schema named after the session user (created under explicit DB) is
+# picked up by current_schema via $user resolution.
+skipif postgres
+statement ok
+CREATE SCHEMA some_user_schema;
+
+
+skipif postgres
+statement ok
+SET search_path TO postgres."$user", some_user_schema;
+
+
+# $user doesn't match any real schema (no schema named after the session
+# user) -> current_schema falls through to the next entry.
+skipif postgres
+query
+SELECT current_schema = 'some_user_schema';
+----
+?column?
+t
+
+
+skipif postgres
+statement ok
+DROP SCHEMA some_user_schema;

--- a/tests/sqllogic/any/pg/system/functions.test
+++ b/tests/sqllogic/any/pg/system/functions.test
@@ -260,10 +260,12 @@ true
 # qualified with the current DB show as bare schema names. These tests assume
 # the connection's current_database is `postgres` (the default in both PG
 # and our test harness).
+onlyif serenedb
 statement ok
 SET search_path TO postgres.public;
 
 
+onlyif serenedb
 query
 SHOW search_path;
 ----
@@ -280,10 +282,12 @@ true
 
 
 # Catalog-qualified with a quoted schema containing a comma -> one entry.
+onlyif serenedb
 statement ok
 SET search_path TO postgres."a,b";
 
 
+onlyif serenedb
 query
 SHOW search_path;
 ----
@@ -300,10 +304,12 @@ true
 
 
 # Two catalog-qualified quoted-comma entries -> two entries.
+onlyif serenedb
 statement ok
 SET search_path TO postgres."a,b", postgres."c,d";
 
 
+onlyif serenedb
 query
 SHOW search_path;
 ----
@@ -320,10 +326,12 @@ true
 
 
 # Mix: qualified-with-comma, bare, qualified -> three entries.
+onlyif serenedb
 statement ok
 SET search_path TO postgres."a,b", z, postgres.public;
 
 
+onlyif serenedb
 query
 SHOW search_path;
 ----

--- a/tests/sqllogic/any/pg/txn/variables.test
+++ b/tests/sqllogic/any/pg/txn/variables.test
@@ -659,9 +659,21 @@ statement ok
 BEGIN;
 
 
-onlyif serenedb # TODO(gnusi) PG doesn't support such syntax
+statement ok
+SET extra_float_digits = 2;
+
+
+onlyif serenedb # PG doesn't support RESET LOCAL
 statement ok
 RESET LOCAL ALL;
+
+
+onlyif serenedb # PG doesn't support RESET LOCAL
+query
+SHOW extra_float_digits;
+----
+extra_float_digits
+1
 
 
 statement ok

--- a/tests/sqllogic/any/pg/txn/variables.test
+++ b/tests/sqllogic/any/pg/txn/variables.test
@@ -5,7 +5,6 @@
 #         SHOW transaction_isolation, SHOW default_transaction_isolation
 ###############################################################################
 
-skipif serenedb
 statement ok
 SET default_transaction_isolation = "repeatable read";
 
@@ -625,12 +624,17 @@ statement ok
 BEGIN;
 
 
-skipif postgres # TODO(gnusi) Maybe disable in duckdb grammar?
+query
+SHOW extra_float_digits;
+----
+extra_float_digits
+3
+
+
 statement ok
-RESET LOCAL ALL;
+RESET ALL;
 
 
-skipif postgres # TODO(gnusi) Different default in postgres, fix?
 query
 SHOW extra_float_digits;
 ----
@@ -639,10 +643,11 @@ extra_float_digits
 
 
 statement ok
-COMMIT;
+ROLLBACK;
 
 
-# Session value restored even after COMMIT (SET LOCAL semantics)
+# ROLLBACK reverts the RESET ALL along with the rest of the transaction,
+# so the pre-txn session value (3) comes back.
 query
 SHOW extra_float_digits;
 ----


### PR DESCRIPTION
Make SET search_path behave like PostgreSQL

### What changed

**Parser / transformer**
- Carved out a dedicated path for `SET search_path` because it's special (GUC_LIST_INPUT in PG terms): it accepts a comma-separated list, but a single quoted string is *not* split.
- Now handles correctly:
  - `SET search_path TO a, b` → two entries.
  - `SET search_path TO "a,b"` → one entry literally named `a,b`.
  - `SET search_path TO 'a,b'` → one entry literally named `a,b` (PG treats a quoted string as a scalar name).
  - `SET search_path TO "a,b", "c,d"` → two entries, commas inside names preserved.
  - `SET search_path TO DEFAULT` → `RESET`.
  - `SET search_path TO ''` → empty path.
  - `SET search_path TO postgres.public` (and mixes) — catalog-qualified works.

**Catalog layer**
- `SET search_path TO validdb.some_schema` no longer errors when the schema doesn't exist but the database does. PG never validates search_path entries at SET time — unresolved entries are just skipped at lookup. We now match that, still erroring only if the catalog itself is bogus.

**Internal plumbing cleanup**
- Added an overload for the "resolve effective scope" helper so we don't write `scope == AUTOMATIC ? default : scope` in multiple places.
- `RESET` helpers now take the resolved scope as a parameter (computed once at the call site) instead of recomputing; dropped some indirect lambda wrappers.

### Tests
- New `search_path` test cases covering every form above.
- Each SHOW assertion paired with an equivalent `search_path_canonical()` check to verify the raw stored form, not just the display form.
- Added tests for `$user` combined with explicit database qualification.
- Fixed a couple of older test expectations that were wrong against PG semantics (boolean rendering, RESET ALL vs ROLLBACK interaction).
