### PR TITLE
It was very a useful meeting

### DIFF
--- a/libs/iresearch/include/iresearch/CMakeLists.txt
+++ b/libs/iresearch/include/iresearch/CMakeLists.txt
@@ -135,6 +135,10 @@ set(IResearch_core_sources
     ./search/proxy_filter.cpp
     ./search/tfidf.cpp
     ./search/bm25.cpp
+    ./search/raw_tf.cpp
+    ./search/lm_similarity.cpp
+    ./search/lm_jelinek_mercer.cpp
+    ./search/lm_dirichlet.cpp
     ./store/data_input.cpp
     ./store/directory.cpp
     ./store/directory_attributes.cpp

--- a/libs/iresearch/include/iresearch/search/lm_dirichlet.cpp
+++ b/libs/iresearch/include/iresearch/search/lm_dirichlet.cpp
@@ -1,0 +1,298 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lm_dirichlet.hpp"
+
+#include <vpack/common.h>
+#include <vpack/parser.h>
+#include <vpack/serializer.h>
+#include <vpack/slice.h>
+#include <vpack/vpack.h>
+
+#include <cmath>
+
+#include "basics/down_cast.h"
+#include "basics/empty.hpp"
+#include "basics/misc.hpp"
+#include "basics/shared.hpp"
+#include "iresearch/analysis/token_attributes.hpp"
+#include "iresearch/index/field_meta.hpp"
+#include "iresearch/index/index_reader.hpp"
+#include "iresearch/index/norm.hpp"
+#include "iresearch/search/column_collector.hpp"
+#include "iresearch/search/score_function.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorer_impl.hpp"
+#include "iresearch/search/scorers.hpp"
+
+namespace irs {
+namespace {
+
+template<typename T>
+constexpr const T* TryGetValue(const T* value) noexcept {
+  return value;
+}
+
+constexpr std::nullptr_t TryGetValue(utils::Empty /*value*/) noexcept {
+  return nullptr;
+}
+
+struct ObjectParams {
+  score_t mu = LMDirichlet::MU();
+};
+
+Scorer::ptr MakeFromObject(const vpack::Slice slice) {
+  ObjectParams params;
+  auto r = vpack::ReadObjectNothrow(slice, params,
+                                    {
+                                      .skip_unknown = true,
+                                      .strict = false,
+                                    });
+  if (!r.ok()) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Error '", r.errorMessage(),
+              "' while constructing lm_dirichlet scorer from VPack");
+    return {};
+  }
+  if (!std::isfinite(params.mu) || params.mu < 0.f) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "lm_dirichlet mu must be a non-negative finite value");
+    return {};
+  }
+  return std::make_unique<LMDirichlet>(params.mu);
+}
+
+Scorer::ptr MakeFromArray(const vpack::Slice slice) {
+  ObjectParams params;
+  auto r = vpack::ReadTupleNothrow(slice, params);
+  if (!r.ok()) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Error '", r.errorMessage(),
+              "' while constructing lm_dirichlet scorer from VPack array");
+    return {};
+  }
+  if (!std::isfinite(params.mu) || params.mu < 0.f) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "lm_dirichlet mu must be a non-negative finite value");
+    return {};
+  }
+  return std::make_unique<LMDirichlet>(params.mu);
+}
+
+Scorer::ptr MakeVPack(const vpack::Slice slice) {
+  switch (slice.type()) {
+    case vpack::ValueType::Object:
+      return MakeFromObject(slice);
+    case vpack::ValueType::Array:
+      return MakeFromArray(slice);
+    default:
+      SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+                "Invalid VPack arguments for lm_dirichlet scorer");
+      return nullptr;
+  }
+}
+
+Scorer::ptr MakeVPack(std::string_view args) {
+  if (IsNull(args)) {
+    return std::make_unique<LMDirichlet>();
+  }
+  vpack::Slice slice(reinterpret_cast<const uint8_t*>(args.data()));
+  return MakeVPack(slice);
+}
+
+Scorer::ptr MakeJson(std::string_view args) {
+  if (IsNull(args)) {
+    return std::make_unique<LMDirichlet>();
+  }
+  try {
+    auto vpack = vpack::Parser::fromJson(args.data(), args.size());
+    return MakeVPack(vpack->slice());
+  } catch (const vpack::Exception& ex) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Caught error '", ex.what(),
+              "' while constructing VPack from JSON for lm_dirichlet");
+  } catch (...) {
+    SDB_ERROR(
+      "xxxxx", sdb::Logger::IRESEARCH,
+      "Caught error while constructing VPack from JSON for lm_dirichlet");
+  }
+  return nullptr;
+}
+
+template<ScoreMergeType MergeType, bool HasBoost>
+IRS_FORCE_INLINE void LmDirImpl(
+  score_t* IRS_RESTRICT res, scores_size_t n, const uint32_t* IRS_RESTRICT freq,
+  const uint32_t* IRS_RESTRICT norm,
+  [[maybe_unused]] const score_t* IRS_RESTRICT boost, score_t mu_p_inv,
+  score_t mu, score_t const_boost) noexcept {
+  // mu_p_inv = 1 / (mu * collection_prob)
+  // score = log(1 + tf * mu_p_inv) + log(mu / (dl + mu))
+  //       = log(1 + tf * mu_p_inv) - log((dl + mu) / mu)
+  //       = log(1 + tf * mu_p_inv) - log1p(dl / mu)
+  // clamp to 0
+  for (scores_size_t i = 0; i != n; ++i) {
+    const score_t tf = static_cast<score_t>(freq[i]);
+    const score_t dl = static_cast<score_t>(norm[i]);
+    const score_t weight = std::log1p(tf * mu_p_inv);
+    const score_t doc_norm = std::log1p(dl / mu);  // = -log(mu/(dl+mu))
+    score_t r = weight - doc_norm;
+    if (r < 0.f) {
+      r = 0.f;
+    }
+    if constexpr (HasBoost) {
+      r *= const_boost * boost[i];
+    } else {
+      r *= const_boost;
+    }
+    Merge<MergeType>(res[i], r);
+  }
+}
+
+template<bool HasFilterBoost>
+struct LmDirScore : public ScoreOperator {
+  LmDirScore(score_t boost, score_t mu, const LMStats& stats,
+             const FreqBlockAttr* freq, const uint32_t* norm,
+             const score_t* fb) noexcept
+    : freq{freq},
+      norm{norm},
+      filter_boost{fb},
+      boost{boost},
+      mu{mu},
+      mu_p_inv{1.f / (mu * stats.collection_prob)} {}
+
+  template<ScoreMergeType MergeType = ScoreMergeType::Noop>
+  IRS_FORCE_INLINE void ScoreImpl(score_t* res,
+                                  scores_size_t n) const noexcept {
+    LmDirImpl<MergeType, HasFilterBoost>(res, n, freq->value, norm,
+                                         TryGetValue(filter_boost), mu_p_inv,
+                                         mu, boost);
+  }
+
+  score_t Score() const noexcept final {
+    score_t res{};
+    ScoreImpl(&res, 1);
+    return res;
+  }
+
+  void Score(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl(res, n);
+  }
+  void ScoreSum(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, n);
+  }
+  void ScoreMax(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, n);
+  }
+
+  void ScoreBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kScoreBlock);
+  }
+  void ScoreSumBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, kScoreBlock);
+  }
+  void ScoreMaxBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, kScoreBlock);
+  }
+
+  void ScorePostingBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kPostingBlock);
+  }
+
+  const FreqBlockAttr* freq;
+  const uint32_t* norm;
+  [[no_unique_address]] utils::Need<HasFilterBoost, const score_t*>
+    filter_boost;
+  score_t boost;
+  score_t mu;
+  score_t mu_p_inv;  // 1 / (mu * collection_prob)
+};
+
+}  // namespace
+
+void LMDirichlet::collect(byte_type* stats_buf, const FieldCollector* field,
+                          const TermCollector* term) const {
+  auto* stats = stats_cast(stats_buf);
+
+  const auto* field_ptr = sdb::basics::downCast<LMFieldCollector>(field);
+  const auto* term_ptr = sdb::basics::downCast<LMTermCollector>(term);
+
+  const auto ttf_field = field_ptr ? field_ptr->total_term_freq : 0;
+  const auto ttf_term = term_ptr ? term_ptr->total_term_freq : 0;
+
+  const double num = static_cast<double>(ttf_term) + 1.0;
+  const double den = static_cast<double>(ttf_field) + 1.0;
+  stats->collection_prob = static_cast<score_t>(num / den);
+}
+
+FieldCollector::ptr LMDirichlet::PrepareFieldCollector() const {
+  return std::make_unique<LMFieldCollector>();
+}
+
+TermCollector::ptr LMDirichlet::PrepareTermCollector() const {
+  return std::make_unique<LMTermCollector>();
+}
+
+ScoreFunction LMDirichlet::PrepareScorer(const ScoreContext& ctx) const {
+  auto* freq = irs::get<FreqBlockAttr>(ctx.doc_attrs);
+  if (!freq) {
+    return ScoreFunction::Default();
+  }
+
+  auto* stats = stats_cast(ctx.stats);
+  if (stats->collection_prob <= 0.f || _mu <= 0.f) {
+    return ScoreFunction::Default();
+  }
+
+  const uint32_t* norm = [&] {
+    auto* attr = irs::get<Norm>(ctx.doc_attrs);
+    return attr ? &attr->value : nullptr;
+  }();
+
+  if (!norm && ctx.fetcher) {
+    auto* norm_col = ctx.segment.column(ctx.field.norm);
+    norm = ctx.fetcher->AddNorms(norm_col);
+  }
+
+  if (!norm) {
+    return ScoreFunction::Default();
+  }
+
+  auto* filter_boost = [&] {
+    auto* attr = irs::get<BoostBlockAttr>(ctx.doc_attrs);
+    return attr ? attr->value : nullptr;
+  }();
+
+  return ResolveBool(filter_boost != nullptr, [&]<bool HasBoost>() {
+    return ScoreFunction::Make<LmDirScore<HasBoost>>(ctx.boost, _mu, *stats,
+                                                     freq, norm, filter_boost);
+  });
+}
+
+bool LMDirichlet::equals(const Scorer& other) const noexcept {
+  if (!Scorer::equals(other)) {
+    return false;
+  }
+  const auto& p = sdb::basics::downCast<LMDirichlet>(other);
+  return p._mu == _mu;
+}
+
+void LMDirichlet::init() {
+  REGISTER_SCORER_JSON(LMDirichlet, MakeJson);
+  REGISTER_SCORER_VPACK(LMDirichlet, MakeVPack);
+}
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/lm_dirichlet.hpp
+++ b/libs/iresearch/include/iresearch/search/lm_dirichlet.hpp
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "iresearch/index/field_meta.hpp"
+#include "iresearch/search/lm_similarity.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorers.hpp"
+
+namespace irs {
+
+// Language model with Bayesian (Dirichlet) smoothing.
+//
+// LMDirichletSimilarity:
+//   score(doc, term) = boost * (log(1 + tf / (mu * P(t|C))) +
+//                               log(mu / (dl + mu)))
+// clamped to [0, +inf) because the raw formula can yield negative
+// contributions for terms that appear less often than the collection
+// prior predicts.
+//
+// P(t|C) = (ttf_term + 1) / (ttf_field + 1)
+class LMDirichlet final : public irs::ScorerBase<LMDirichlet, LMStats> {
+ public:
+  static constexpr std::string_view type_name() noexcept {
+    return "lm_dirichlet";
+  }
+
+  static constexpr score_t MU() noexcept { return 2000.f; }
+
+  static void init();
+
+  explicit LMDirichlet(score_t mu = MU()) noexcept : _mu{mu} {}
+
+  void collect(byte_type* stats_buf, const irs::FieldCollector* field,
+               const irs::TermCollector* term) const final;
+
+  IndexFeatures GetIndexFeatures() const noexcept final {
+    return IndexFeatures::Freq | IndexFeatures::Norm;
+  }
+
+  FieldCollector::ptr PrepareFieldCollector() const final;
+
+  TermCollector::ptr PrepareTermCollector() const final;
+
+  ScoreFunction PrepareScorer(const ScoreContext& ctx) const final;
+
+  bool equals(const Scorer& other) const noexcept final;
+
+  score_t mu() const noexcept { return _mu; }
+
+ private:
+  score_t _mu;
+};
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/lm_jelinek_mercer.cpp
+++ b/libs/iresearch/include/iresearch/search/lm_jelinek_mercer.cpp
@@ -1,0 +1,306 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lm_jelinek_mercer.hpp"
+
+#include <vpack/common.h>
+#include <vpack/parser.h>
+#include <vpack/serializer.h>
+#include <vpack/slice.h>
+#include <vpack/vpack.h>
+
+#include <cmath>
+
+#include "basics/down_cast.h"
+#include "basics/empty.hpp"
+#include "basics/misc.hpp"
+#include "basics/shared.hpp"
+#include "iresearch/analysis/token_attributes.hpp"
+#include "iresearch/index/field_meta.hpp"
+#include "iresearch/index/index_reader.hpp"
+#include "iresearch/index/norm.hpp"
+#include "iresearch/search/column_collector.hpp"
+#include "iresearch/search/score_function.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorer_impl.hpp"
+#include "iresearch/search/scorers.hpp"
+
+namespace irs {
+namespace {
+
+template<typename T>
+constexpr const T* TryGetValue(const T* value) noexcept {
+  return value;
+}
+
+constexpr std::nullptr_t TryGetValue(utils::Empty /*value*/) noexcept {
+  return nullptr;
+}
+
+struct ObjectParams {
+  score_t lambda = LMJelinekMercer::LAMBDA();
+};
+
+Scorer::ptr MakeFromObject(const vpack::Slice slice) {
+  ObjectParams params;
+  auto r = vpack::ReadObjectNothrow(slice, params,
+                                    {
+                                      .skip_unknown = true,
+                                      .strict = false,
+                                    });
+  if (!r.ok()) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Error '", r.errorMessage(),
+              "' while constructing lm_jm scorer from VPack");
+    return {};
+  }
+  if (params.lambda <= 0.f || params.lambda > 1.f ||
+      !std::isfinite(params.lambda)) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "lm_jm lambda must be in (0, 1]");
+    return {};
+  }
+  return std::make_unique<LMJelinekMercer>(params.lambda);
+}
+
+Scorer::ptr MakeFromArray(const vpack::Slice slice) {
+  ObjectParams params;
+  auto r = vpack::ReadTupleNothrow(slice, params);
+  if (!r.ok()) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Error '", r.errorMessage(),
+              "' while constructing lm_jm scorer from VPack array");
+    return {};
+  }
+  if (params.lambda <= 0.f || params.lambda > 1.f ||
+      !std::isfinite(params.lambda)) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "lm_jm lambda must be in (0, 1]");
+    return {};
+  }
+  return std::make_unique<LMJelinekMercer>(params.lambda);
+}
+
+Scorer::ptr MakeVPack(const vpack::Slice slice) {
+  switch (slice.type()) {
+    case vpack::ValueType::Object:
+      return MakeFromObject(slice);
+    case vpack::ValueType::Array:
+      return MakeFromArray(slice);
+    default:
+      SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+                "Invalid VPack arguments for lm_jm scorer");
+      return nullptr;
+  }
+}
+
+Scorer::ptr MakeVPack(std::string_view args) {
+  if (IsNull(args)) {
+    return std::make_unique<LMJelinekMercer>();
+  }
+  vpack::Slice slice(reinterpret_cast<const uint8_t*>(args.data()));
+  return MakeVPack(slice);
+}
+
+Scorer::ptr MakeJson(std::string_view args) {
+  if (IsNull(args)) {
+    return std::make_unique<LMJelinekMercer>();
+  }
+  try {
+    auto vpack = vpack::Parser::fromJson(args.data(), args.size());
+    return MakeVPack(vpack->slice());
+  } catch (const vpack::Exception& ex) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH, "Caught error '", ex.what(),
+              "' while constructing VPack from JSON for lm_jm");
+  } catch (...) {
+    SDB_ERROR("xxxxx", sdb::Logger::IRESEARCH,
+              "Caught error while constructing VPack from JSON for lm_jm");
+  }
+  return nullptr;
+}
+
+// score(doc, term) = boost * log(1 + ((1 - lambda) * tf / dl) /
+//                                    (lambda * collection_prob))
+// With zero-norm guard: if dl == 0 we treat the doc as unmatched (score 0)
+template<ScoreMergeType MergeType, bool HasBoost>
+IRS_FORCE_INLINE void LmJmImpl(
+  score_t* IRS_RESTRICT res, scores_size_t n, const uint32_t* IRS_RESTRICT freq,
+  const uint32_t* IRS_RESTRICT norm,
+  [[maybe_unused]] const score_t* IRS_RESTRICT boost, score_t num,
+  score_t denom_inv, score_t const_boost) noexcept {
+  // num = 1 - lambda, denom_inv = 1 / (lambda * collection_prob)
+  for (scores_size_t i = 0; i != n; ++i) {
+    const score_t tf = static_cast<score_t>(freq[i]);
+    const score_t dl = static_cast<score_t>(norm[i]);
+    score_t r = 0.f;
+    if (dl > 0.f) {
+      const score_t ratio = (num * tf / dl) * denom_inv;
+      r = std::log1p(ratio);
+    }
+    if constexpr (HasBoost) {
+      r *= const_boost * boost[i];
+    } else {
+      r *= const_boost;
+    }
+    Merge<MergeType>(res[i], r);
+  }
+}
+
+template<bool HasFilterBoost>
+struct LmJmScore : public ScoreOperator {
+  LmJmScore(score_t boost, score_t lambda, const LMStats& stats,
+            const FreqBlockAttr* freq, const uint32_t* norm,
+            const score_t* fb) noexcept
+    : freq{freq},
+      norm{norm},
+      filter_boost{fb},
+      boost{boost},
+      num{1.f - lambda},
+      denom_inv{1.f / (lambda * stats.collection_prob)} {}
+
+  template<ScoreMergeType MergeType = ScoreMergeType::Noop>
+  IRS_FORCE_INLINE void ScoreImpl(score_t* res,
+                                  scores_size_t n) const noexcept {
+    LmJmImpl<MergeType, HasFilterBoost>(res, n, freq->value, norm,
+                                        TryGetValue(filter_boost), num,
+                                        denom_inv, boost);
+  }
+
+  score_t Score() const noexcept final {
+    score_t res{};
+    ScoreImpl(&res, 1);
+    return res;
+  }
+
+  void Score(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl(res, n);
+  }
+  void ScoreSum(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, n);
+  }
+  void ScoreMax(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, n);
+  }
+
+  void ScoreBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kScoreBlock);
+  }
+  void ScoreSumBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, kScoreBlock);
+  }
+  void ScoreMaxBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, kScoreBlock);
+  }
+
+  void ScorePostingBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kPostingBlock);
+  }
+
+  const FreqBlockAttr* freq;
+  const uint32_t* norm;
+  [[no_unique_address]] utils::Need<HasFilterBoost, const score_t*>
+    filter_boost;
+  score_t boost;
+  score_t num;        // 1 - lambda
+  score_t denom_inv;  // 1 / (lambda * collection_prob)
+};
+
+}  // namespace
+
+void LMJelinekMercer::collect(byte_type* stats_buf, const FieldCollector* field,
+                              const TermCollector* term) const {
+  auto* stats = stats_cast(stats_buf);
+
+  const auto* field_ptr = sdb::basics::downCast<LMFieldCollector>(field);
+  const auto* term_ptr = sdb::basics::downCast<LMTermCollector>(term);
+
+  const auto ttf_field = field_ptr ? field_ptr->total_term_freq : 0;
+  const auto ttf_term = term_ptr ? term_ptr->total_term_freq : 0;
+
+  // DefaultCollectionModel: P(t|C) = (ttf_t + 1) / (ttf_field + 1).
+  // Stats are allocated per-term (see TermCollectors::finish), so assignment
+  // is safe; multi-term filters produce one prepared scorer per term with
+  // its own stats buffer.
+  const double num = static_cast<double>(ttf_term) + 1.0;
+  const double den = static_cast<double>(ttf_field) + 1.0;
+  stats->collection_prob = static_cast<score_t>(num / den);
+}
+
+FieldCollector::ptr LMJelinekMercer::PrepareFieldCollector() const {
+  return std::make_unique<LMFieldCollector>();
+}
+
+TermCollector::ptr LMJelinekMercer::PrepareTermCollector() const {
+  return std::make_unique<LMTermCollector>();
+}
+
+ScoreFunction LMJelinekMercer::PrepareScorer(const ScoreContext& ctx) const {
+  auto* freq = irs::get<FreqBlockAttr>(ctx.doc_attrs);
+  if (!freq) {
+    // No frequency (e.g. irs::all filter) -- zero score.
+    return ScoreFunction::Default();
+  }
+
+  // Defensive: guard against a zero/unset collection probability (no stats
+  // collected, e.g. empty index).
+  auto* stats = stats_cast(ctx.stats);
+  if (stats->collection_prob <= 0.f) {
+    return ScoreFunction::Default();
+  }
+
+  const uint32_t* norm = [&] {
+    auto* attr = irs::get<Norm>(ctx.doc_attrs);
+    return attr ? &attr->value : nullptr;
+  }();
+
+  if (!norm && ctx.fetcher) {
+    auto* norm_col = ctx.segment.column(ctx.field.norm);
+    norm = ctx.fetcher->AddNorms(norm_col);
+  }
+
+  if (!norm) {
+    // Without norms we can't compute tf/dl. Fall back to zero scores so the
+    // behaviour degrades gracefully instead of producing NaN.
+    return ScoreFunction::Default();
+  }
+
+  auto* filter_boost = [&] {
+    auto* attr = irs::get<BoostBlockAttr>(ctx.doc_attrs);
+    return attr ? attr->value : nullptr;
+  }();
+
+  return ResolveBool(filter_boost != nullptr, [&]<bool HasBoost>() {
+    return ScoreFunction::Make<LmJmScore<HasBoost>>(ctx.boost, _lambda, *stats,
+                                                    freq, norm, filter_boost);
+  });
+}
+
+bool LMJelinekMercer::equals(const Scorer& other) const noexcept {
+  if (!Scorer::equals(other)) {
+    return false;
+  }
+  const auto& p = sdb::basics::downCast<LMJelinekMercer>(other);
+  return p._lambda == _lambda;
+}
+
+void LMJelinekMercer::init() {
+  REGISTER_SCORER_JSON(LMJelinekMercer, MakeJson);
+  REGISTER_SCORER_VPACK(LMJelinekMercer, MakeVPack);
+}
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/lm_jelinek_mercer.hpp
+++ b/libs/iresearch/include/iresearch/search/lm_jelinek_mercer.hpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "iresearch/index/field_meta.hpp"
+#include "iresearch/search/lm_similarity.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorers.hpp"
+
+namespace irs {
+
+// Language model with Jelinek-Mercer smoothing.
+//
+// LMJelinekMercerSimilarity:
+//   score(doc, term) = boost * log(1 + ((1 - lambda) * tf / dl) /
+//                                      (lambda * P(t | C)))
+// where
+//   P(t | C) = (total_term_freq_of_term + 1) /
+//              (total_term_freq_of_field + 1)
+//
+// Parameters:
+//   lambda in (0, 1]. We recommend ~0.1 for title queries
+//   and ~0.7 for long queries.
+class LMJelinekMercer final : public irs::ScorerBase<LMJelinekMercer, LMStats> {
+ public:
+  static constexpr std::string_view type_name() noexcept { return "lm_jm"; }
+
+  static constexpr score_t LAMBDA() noexcept { return 0.1f; }
+
+  static void init();
+
+  explicit LMJelinekMercer(score_t lambda = LAMBDA()) noexcept
+    : _lambda{lambda} {}
+
+  void collect(byte_type* stats_buf, const irs::FieldCollector* field,
+               const irs::TermCollector* term) const final;
+
+  IndexFeatures GetIndexFeatures() const noexcept final {
+    return IndexFeatures::Freq | IndexFeatures::Norm;
+  }
+
+  FieldCollector::ptr PrepareFieldCollector() const final;
+
+  TermCollector::ptr PrepareTermCollector() const final;
+
+  ScoreFunction PrepareScorer(const ScoreContext& ctx) const final;
+
+  bool equals(const Scorer& other) const noexcept final;
+
+  score_t lambda() const noexcept { return _lambda; }
+
+ private:
+  score_t _lambda;
+};
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/lm_similarity.cpp
+++ b/libs/iresearch/include/iresearch/search/lm_similarity.cpp
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lm_similarity.hpp"
+
+#include "iresearch/analysis/token_attributes.hpp"
+#include "iresearch/error/error.hpp"
+#include "iresearch/formats/formats.hpp"
+#include "iresearch/index/index_reader.hpp"
+#include "iresearch/search/scorer_impl.hpp"
+#include "iresearch/store/data_output.hpp"
+#include "iresearch/utils/string.hpp"
+
+namespace irs {
+
+void LMFieldCollector::collect(const SubReader& /*segment*/,
+                               const TermReader& field) noexcept {
+  docs_with_field += field.docs_count();
+  if (const auto* freq = irs::get<FreqAttr>(field)) {
+    total_term_freq += freq->value;
+  }
+}
+
+void LMFieldCollector::collect(bytes_view in) {
+  ByteRefIterator itr{in};
+  const auto docs_with_field_value = vread<uint64_t>(itr);
+  const auto total_term_freq_value = vread<uint64_t>(itr);
+  if (itr.pos != itr.end) {
+    throw IoError{"input not read fully"};
+  }
+  docs_with_field += docs_with_field_value;
+  total_term_freq += total_term_freq_value;
+}
+
+void LMFieldCollector::write(DataOutput& out) const {
+  out.WriteV64(docs_with_field);
+  out.WriteV64(total_term_freq);
+}
+
+void LMTermCollector::collect(const SubReader& /*segment*/,
+                              const TermReader& /*field*/,
+                              const AttributeProvider& term_attrs) {
+  if (const auto* meta = irs::get<TermMeta>(term_attrs)) {
+    total_term_freq += meta->freq;
+  }
+}
+
+void LMTermCollector::collect(bytes_view in) {
+  ByteRefIterator itr{in};
+  const auto ttf = vread<uint64_t>(itr);
+  if (itr.pos != itr.end) {
+    throw IoError{"input not read fully"};
+  }
+  total_term_freq += ttf;
+}
+
+void LMTermCollector::write(DataOutput& out) const {
+  out.WriteV64(total_term_freq);
+}
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/lm_similarity.hpp
+++ b/libs/iresearch/include/iresearch/search/lm_similarity.hpp
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstdint>
+
+#include "iresearch/index/field_meta.hpp"
+#include "iresearch/search/scorer.hpp"
+
+namespace irs {
+
+// Shared collectors for language-model similarities (LMJelinekMercer,
+// LMDirichlet). Tracks:
+//   - docs_with_field: number of documents indexed in the field,
+//   - total_term_freq: sum of term frequencies across all docs in
+//     the field (i.e. the field's total token count).
+//
+// Used to derive the collection model probability
+//   P(t | C) = (ttf_t + 1) / (sum_ttf + 1)
+struct LMFieldCollector final : FieldCollector {
+  uint64_t docs_with_field = 0;
+  uint64_t total_term_freq = 0;
+
+  void collect(const SubReader& /*segment*/,
+               const TermReader& field) noexcept final;
+
+  void reset() noexcept final {
+    docs_with_field = 0;
+    total_term_freq = 0;
+  }
+
+  void collect(bytes_view in) final;
+
+  void write(DataOutput& out) const final;
+};
+
+// Tracks the collection-wide frequency of a single term (TermMeta::freq),
+// which is what the LM's term weight needs -- not just the doc count.
+struct LMTermCollector final : TermCollector {
+  uint64_t total_term_freq = 0;  // sum of tf across all docs containing term
+
+  void collect(const SubReader& /*segment*/, const TermReader& /*field*/,
+               const AttributeProvider& term_attrs) final;
+
+  void reset() noexcept final { total_term_freq = 0; }
+
+  void collect(bytes_view in) final;
+
+  void write(DataOutput& out) const final;
+};
+
+// Stats persisted per (field,term) and consumed by score().
+// `collection_prob` is DefaultCollectionModel:
+//   (ttf_term + 1) / (ttf_field + 1)
+struct LMStats {
+  score_t collection_prob;
+};
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/raw_tf.cpp
+++ b/libs/iresearch/include/iresearch/search/raw_tf.cpp
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "raw_tf.hpp"
+
+#include "basics/empty.hpp"
+#include "basics/misc.hpp"
+#include "basics/shared.hpp"
+#include "iresearch/analysis/token_attributes.hpp"
+#include "iresearch/search/score_function.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorer_impl.hpp"
+
+namespace irs {
+namespace {
+
+template<typename T>
+constexpr const T* TryGetValue(const T* value) noexcept {
+  return value;
+}
+
+constexpr std::nullptr_t TryGetValue(utils::Empty /*value*/) noexcept {
+  return nullptr;
+}
+
+Scorer::ptr MakeJson(std::string_view /*args*/) {
+  return std::make_unique<RawTF>();
+}
+
+Scorer::ptr MakeVPack(std::string_view /*args*/) {
+  return std::make_unique<RawTF>();
+}
+
+template<ScoreMergeType MergeType, bool HasBoost>
+IRS_FORCE_INLINE void RawTfImpl(
+  score_t* IRS_RESTRICT res, scores_size_t n, const uint32_t* IRS_RESTRICT freq,
+  [[maybe_unused]] const score_t* IRS_RESTRICT boost, score_t num) noexcept {
+  for (scores_size_t i = 0; i != n; ++i) {
+    const auto r = [&] IRS_FORCE_INLINE {
+      if constexpr (HasBoost) {
+        return boost[i] * num * static_cast<score_t>(freq[i]);
+      } else {
+        return num * static_cast<score_t>(freq[i]);
+      }
+    }();
+    Merge<MergeType>(res[i], r);
+  }
+}
+
+template<bool HasFilterBoost>
+struct RawTfScore : public ScoreOperator {
+  RawTfScore(score_t boost, const FreqBlockAttr* freq,
+             const score_t* filter_boost) noexcept
+    : freq{freq}, filter_boost{filter_boost}, boost{boost} {
+    SDB_ASSERT(this->freq);
+  }
+
+  template<ScoreMergeType MergeType = ScoreMergeType::Noop>
+  IRS_FORCE_INLINE void ScoreImpl(score_t* IRS_RESTRICT res,
+                                  scores_size_t n) const noexcept {
+    RawTfImpl<MergeType, HasFilterBoost>(res, n, freq->value,
+                                         TryGetValue(filter_boost), boost);
+  }
+
+  score_t Score() const noexcept final {
+    score_t res{};
+    ScoreImpl(&res, 1);
+    return res;
+  }
+
+  void Score(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl(res, n);
+  }
+  void ScoreSum(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, n);
+  }
+  void ScoreMax(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, n);
+  }
+
+  void ScoreBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kScoreBlock);
+  }
+  void ScoreSumBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, kScoreBlock);
+  }
+  void ScoreMaxBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, kScoreBlock);
+  }
+
+  void ScorePostingBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kPostingBlock);
+  }
+
+  const FreqBlockAttr* freq;
+  [[no_unique_address]] utils::Need<HasFilterBoost, const score_t*>
+    filter_boost;
+  score_t boost;
+};
+
+}  // namespace
+
+ScoreFunction RawTF::PrepareScorer(const ScoreContext& ctx) const {
+  auto* freq = irs::get<FreqBlockAttr>(ctx.doc_attrs);
+  if (!freq) {
+    // No frequency available (e.g. irs::all filter) -- score is 0
+    // per RawTFSimilarity convention; defer to the default
+    // zero scorer.
+    if (0.f == ctx.boost) {
+      return ScoreFunction::Default();
+    }
+    return ScoreFunction::Default();
+  }
+
+  auto* filter_boost = [&] {
+    auto* attr = irs::get<BoostBlockAttr>(ctx.doc_attrs);
+    return attr ? attr->value : nullptr;
+  }();
+
+  return ResolveBool(filter_boost != nullptr, [&]<bool HasBoost>() {
+    return ScoreFunction::Make<RawTfScore<HasBoost>>(ctx.boost, freq,
+                                                     filter_boost);
+  });
+}
+
+void RawTF::init() {
+  REGISTER_SCORER_JSON(RawTF, MakeJson);
+  REGISTER_SCORER_VPACK(RawTF, MakeVPack);
+}
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/raw_tf.hpp
+++ b/libs/iresearch/include/iresearch/search/raw_tf.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "iresearch/index/field_meta.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorers.hpp"
+
+namespace irs {
+
+// RawTF similarity
+//
+// score(doc, term) = boost * freq(doc, term)
+//
+// No IDF, no length normalization. Useful as a debugging / teaching
+// baseline and as a building block for custom scoring pipelines.
+class RawTF final : public irs::ScorerBase<RawTF, void> {
+ public:
+  static constexpr std::string_view type_name() noexcept { return "raw_tf"; }
+
+  static void init();  // trigger registration in static builds
+
+  RawTF() noexcept = default;
+
+  IndexFeatures GetIndexFeatures() const noexcept final {
+    return IndexFeatures::Freq;
+  }
+
+  ScoreFunction PrepareScorer(const ScoreContext& ctx) const final;
+};
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/scorers.cpp
+++ b/libs/iresearch/include/iresearch/search/scorers.cpp
@@ -29,6 +29,9 @@
 #include "bm25.hpp"
 #include "boost_scorer.hpp"
 #include "iresearch/utils/hash_utils.hpp"
+#include "lm_dirichlet.hpp"
+#include "lm_jelinek_mercer.hpp"
+#include "raw_tf.hpp"
 #include "tfidf.hpp"
 
 namespace irs {
@@ -82,6 +85,9 @@ void scorers::Init() {
   BM25::init();
   TFIDF::init();
   BoostScore::init();
+  RawTF::init();
+  LMJelinekMercer::init();
+  LMDirichlet::init();
 }
 
 void scorers::LoadAll(std::string_view path) {

--- a/server/connector/duckdb_external_scan.cpp
+++ b/server/connector/duckdb_external_scan.cpp
@@ -387,7 +387,8 @@ static bool IsSearchFamilyFunction(std::string_view name) {
   return name == kPhrase || name == kTermEq || name == kTermLt ||
          name == kTermLe || name == kTermGe || name == kTermGt ||
          name == kTermIn || name == kTermLike || name == kBoost ||
-         name == kBm25 || name == kTfidf || name == kOffsets;
+         name == kBm25 || name == kTfidf || name == kRawTf || name == kLmJm ||
+         name == kLmDirichlet || name == kOffsets;
 }
 
 static bool ExpressionReferencesSearchFamily(const duckdb::Expression& expr) {

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -26,6 +26,9 @@
 #include <iresearch/formats/formats.hpp>
 #include <iresearch/search/bm25.hpp>
 #include <iresearch/search/doc_collector.hpp>
+#include <iresearch/search/lm_dirichlet.hpp>
+#include <iresearch/search/lm_jelinek_mercer.hpp>
+#include <iresearch/search/raw_tf.hpp>
 #include <iresearch/search/score_function.hpp>
 #include <iresearch/search/scorer.hpp>
 #include <iresearch/search/tfidf.hpp>
@@ -260,12 +263,23 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> SearchFullScanInitGlobal(
   switch (ss.scorer.kind) {
     case SK::Bm25:
       state->scorer_obj =
-        std::make_unique<irs::BM25>(static_cast<float>(ss.scorer.bm25_k1),
-                                    static_cast<float>(ss.scorer.bm25_b));
+        std::make_unique<irs::BM25>(static_cast<float>(ss.scorer.bm25.k1),
+                                    static_cast<float>(ss.scorer.bm25.b));
       break;
     case SK::Tfidf:
       state->scorer_obj =
-        std::make_unique<irs::TFIDF>(ss.scorer.tfidf_with_norms);
+        std::make_unique<irs::TFIDF>(ss.scorer.tfidf.with_norms);
+      break;
+    case SK::RawTf:
+      state->scorer_obj = std::make_unique<irs::RawTF>();
+      break;
+    case SK::LmJm:
+      state->scorer_obj = std::make_unique<irs::LMJelinekMercer>(
+        static_cast<float>(ss.scorer.lm_jm.lambda));
+      break;
+    case SK::LmDirichlet:
+      state->scorer_obj = std::make_unique<irs::LMDirichlet>(
+        static_cast<float>(ss.scorer.lm_dirichlet.mu));
       break;
     case SK::None:
       break;

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -328,13 +328,24 @@ void SearchScan::AppendSummary(
   }
   switch (scorer.kind) {
     case SearchScan::ScorerKind::Bm25:
-      out.insert("Score", absl::StrCat("bm25(k1=", scorer.bm25_k1,
-                                       ", b=", scorer.bm25_b, ")"));
+      out.insert("Score", absl::StrCat("bm25(k1=", scorer.bm25.k1,
+                                       ", b=", scorer.bm25.b, ")"));
       break;
     case SearchScan::ScorerKind::Tfidf:
       out.insert("Score",
                  absl::StrCat("tfidf(with_norms=",
-                              scorer.tfidf_with_norms ? "true" : "false", ")"));
+                              scorer.tfidf.with_norms ? "true" : "false", ")"));
+      break;
+    case SearchScan::ScorerKind::RawTf:
+      out.insert("Score", "raw_tf()");
+      break;
+    case SearchScan::ScorerKind::LmJm:
+      out.insert("Score",
+                 absl::StrCat("lm_jm(lambda=", scorer.lm_jm.lambda, ")"));
+      break;
+    case SearchScan::ScorerKind::LmDirichlet:
+      out.insert("Score",
+                 absl::StrCat("lm_dirichlet(mu=", scorer.lm_dirichlet.mu, ")"));
       break;
     case SearchScan::ScorerKind::None:
       break;

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -160,14 +160,42 @@ struct SearchScan : ScanSource {
   // extracts the scorer kind + parameters from the projection's
   // bm25(...) / tfidf(...) call and stores them here so the runtime
   // executor can build an irs::Scorer without re-parsing expressions.
-  enum class ScorerKind : uint8_t { None, Bm25, Tfidf };
+  enum class ScorerKind : uint8_t {
+    None,
+    Bm25,
+    Tfidf,
+    RawTf,
+    LmJm,
+    LmDirichlet,
+  };
+  // Scorer parameters are tagged by `kind`: only the matching union arm is
+  // live. All variants are trivial types so the union is trivially
+  // constructible; one arm (RawTf -- empty) carries the default-member
+  // initializer so ScorerParams is itself default-constructible.
+  // Writers set `kind` and assign into the matching arm; readers switch on
+  // `kind` before accessing any arm.
   struct ScorerParams {
+    struct Bm25 {
+      double k1 = 1.2;
+      double b = 0.75;
+    };
+    struct Tfidf {
+      bool with_norms = false;
+    };
+    struct LmJm {
+      double lambda = 0.1;
+    };
+    struct LmDirichlet {
+      double mu = 2000.0;
+    };
+
     ScorerKind kind = ScorerKind::None;
-    // bm25(k1, b) -- iresearch defaults per Bm25.
-    double bm25_k1 = 1.2;
-    double bm25_b = 0.75;
-    // tfidf(with_norms) -- default false = no length normalisation.
-    bool tfidf_with_norms = false;
+    union {
+      Bm25 bm25{};
+      Tfidf tfidf;
+      LmJm lm_jm;
+      LmDirichlet lm_dirichlet;
+    };
   };
   ScorerParams scorer;
   std::optional<size_t> score_top_k;

--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -61,6 +61,26 @@ void TfidfStubFn(duckdb::DataChunk& /*args*/,
     "tfidf() requires an inverted index scan in the same sub-query");
 }
 
+void RawTfStubFn(duckdb::DataChunk& /*args*/,
+                 duckdb::ExpressionState& /*state*/,
+                 duckdb::Vector& /*result*/) {
+  throw duckdb::InvalidInputException(
+    "raw_tf() requires an inverted index scan in the same sub-query");
+}
+
+void LmJmStubFn(duckdb::DataChunk& /*args*/, duckdb::ExpressionState& /*state*/,
+                duckdb::Vector& /*result*/) {
+  throw duckdb::InvalidInputException(
+    "lm_jm() requires an inverted index scan in the same sub-query");
+}
+
+void LmDirichletStubFn(duckdb::DataChunk& /*args*/,
+                       duckdb::ExpressionState& /*state*/,
+                       duckdb::Vector& /*result*/) {
+  throw duckdb::InvalidInputException(
+    "lm_dirichlet() requires an inverted index scan in the same sub-query");
+}
+
 // ts_lexize(dict_name VARCHAR, token VARCHAR) -> VARCHAR[]
 // Runs `token` through the named text search dictionary and returns
 // the resulting lexemes as a VARCHAR array. Mirrors pg_catalog.ts_lexize().
@@ -258,6 +278,43 @@ void RegisterSearchFunctions(duckdb::DatabaseInstance& db) {
     set.AddFunction(duckdb::ScalarFunction(
       {duckdb::LogicalType::BIGINT, duckdb::LogicalType::BOOLEAN},
       duckdb::LogicalType::FLOAT, TfidfStubFn));
+    loader.RegisterFunction(std::move(set));
+  }
+
+  // raw_tf(tableoid) -> FLOAT -- emits raw term frequency per matched doc.
+  // Shape mirrors bm25/tfidf: anchor is tableoid; the iresearch_plan rule
+  // claims the call at compile time and threads the scorer into bind_data.
+  {
+    duckdb::ScalarFunctionSet set{std::string{kRawTf}};
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, RawTfStubFn));
+    loader.RegisterFunction(std::move(set));
+  }
+
+  // lm_jm(tableoid) / lm_jm(tableoid, lambda) -> FLOAT.
+  // Language model with Jelinek-Mercer (linear interpolation) smoothing.
+  // lambda in (0, 1]; iresearch default is 0.1.
+  {
+    duckdb::ScalarFunctionSet set{std::string{kLmJm}};
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, LmJmStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::FLOAT, LmJmStubFn));
+    loader.RegisterFunction(std::move(set));
+  }
+
+  // lm_dirichlet(tableoid) / lm_dirichlet(tableoid, mu) -> FLOAT.
+  // Language model with Bayesian (Dirichlet) smoothing. mu >= 0;
+  // iresearch default is 2000.
+  {
+    duckdb::ScalarFunctionSet set{std::string{kLmDirichlet}};
+    set.AddFunction(duckdb::ScalarFunction({duckdb::LogicalType::BIGINT},
+                                           duckdb::LogicalType::FLOAT,
+                                           LmDirichletStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::FLOAT, LmDirichletStubFn));
     loader.RegisterFunction(std::move(set));
   }
 

--- a/server/connector/functions/search.h
+++ b/server/connector/functions/search.h
@@ -54,6 +54,9 @@ inline constexpr std::string_view kBoost = "boost";
 // is enough -- no separate anchor needed).
 inline constexpr std::string_view kBm25 = "bm25";
 inline constexpr std::string_view kTfidf = "tfidf";
+inline constexpr std::string_view kRawTf = "raw_tf";
+inline constexpr std::string_view kLmJm = "lm_jm";
+inline constexpr std::string_view kLmDirichlet = "lm_dirichlet";
 inline constexpr std::string_view kOffsets = "offsets";
 
 void RegisterSearchFunctions(duckdb::DatabaseInstance& db);

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -943,7 +943,6 @@ const duckdb::Value* TryGetConstantValue(const duckdb::Expression& expr) {
   return &expr.Cast<duckdb::BoundConstantExpression>().value;
 }
 
-// Forward declaration (defined after TrySetScorer).
 bool TrySetScorer(connector::SearchScan::ScorerParams& scorer,
                   const duckdb::BoundFunctionExpression& func,
                   std::string_view name);
@@ -1039,6 +1038,8 @@ void RewriteScoreCallInChildren(duckdb::unique_ptr<duckdb::Expression>& expr,
   }
 }
 
+bool IsScorerFunctionName(std::string_view name);
+
 duckdb::unique_ptr<duckdb::Expression> RewriteScoreCallInExpr(
   duckdb::unique_ptr<duckdb::Expression>& expr, duckdb::LogicalOperator& root,
   bool& changed, bool set_scorer) {
@@ -1059,7 +1060,7 @@ duckdb::unique_ptr<duckdb::Expression> RewriteScoreCallInExpr(
   }
   auto& func = expr->Cast<duckdb::BoundFunctionExpression>();
   const auto& name = func.function.name;
-  if (name != connector::kBm25 && name != connector::kTfidf) {
+  if (!IsScorerFunctionName(name)) {
     RewriteScoreCallInChildren(expr, root, changed, set_scorer);
     return nullptr;
   }
@@ -1166,51 +1167,115 @@ catalog::Column::Id ResolveColumnId(
   return bind_data.column_ids[phys];
 }
 
-// Parse bm25/tfidf parameters from `func` into `scorer`. Returns false if
-// the parameters are non-constant (rule refuses to claim; stub raises).
+// True iff `name` is one of the supported scorer function names.
+bool IsScorerFunctionName(std::string_view name) {
+  return name == connector::kBm25 || name == connector::kTfidf ||
+         name == connector::kRawTf || name == connector::kLmJm ||
+         name == connector::kLmDirichlet;
+}
+
+// Parse scorer parameters from `func` into `scorer`. Returns false if the
+// parameters are non-constant (rule refuses to claim; stub raises).
 // Also validates scorer kind conflicts: same kind+params is idempotent,
 // different kind/params throws.
 bool TrySetScorer(connector::SearchScan::ScorerParams& scorer,
                   const duckdb::BoundFunctionExpression& func,
                   std::string_view name) {
+  using ScorerParams = connector::SearchScan::ScorerParams;
   using ScorerKind = connector::SearchScan::ScorerKind;
-  ScorerKind new_kind;
-  double new_k1 = 1.2, new_b = 0.75;
-  bool new_with_norms = false;
+  ScorerParams candidate;
 
   if (name == connector::kBm25) {
-    new_kind = ScorerKind::Bm25;
+    candidate.kind = ScorerKind::Bm25;
+    candidate.bm25 = ScorerParams::Bm25{};
     if (func.children.size() == 3) {
       auto* k1v = TryGetConstantValue(*func.children[1]);
       auto* bv = TryGetConstantValue(*func.children[2]);
       if (!k1v || !bv) {
-        return false;  // Non-constant params -- don't claim.
+        return false;
       }
-      new_k1 = k1v->GetValue<double>();
-      new_b = bv->GetValue<double>();
+      candidate.bm25.k1 = k1v->GetValue<double>();
+      candidate.bm25.b = bv->GetValue<double>();
     }
-  } else {
-    new_kind = ScorerKind::Tfidf;
+  } else if (name == connector::kTfidf) {
+    candidate.kind = ScorerKind::Tfidf;
+    candidate.tfidf = ScorerParams::Tfidf{};
     if (func.children.size() == 2) {
       auto* cv = TryGetConstantValue(*func.children[1]);
       if (!cv) {
         return false;
       }
-      new_with_norms = cv->GetValue<bool>();
+      candidate.tfidf.with_norms = cv->GetValue<bool>();
     }
+  } else if (name == connector::kRawTf) {
+    candidate.kind = ScorerKind::RawTf;
+    // raw_tf has no parameters; `raw_tf` arm already default-constructed.
+  } else if (name == connector::kLmJm) {
+    candidate.kind = ScorerKind::LmJm;
+    candidate.lm_jm = ScorerParams::LmJm{};
+    if (func.children.size() == 2) {
+      auto* lv = TryGetConstantValue(*func.children[1]);
+      if (!lv) {
+        return false;
+      }
+      candidate.lm_jm.lambda = lv->GetValue<double>();
+      if (!(candidate.lm_jm.lambda > 0.0 && candidate.lm_jm.lambda <= 1.0)) {
+        throw duckdb::InvalidInputException(
+          "lm_jm lambda must be in (0, 1], got " +
+          std::to_string(candidate.lm_jm.lambda));
+      }
+    }
+  } else if (name == connector::kLmDirichlet) {
+    candidate.kind = ScorerKind::LmDirichlet;
+    candidate.lm_dirichlet = ScorerParams::LmDirichlet{};
+    if (func.children.size() == 2) {
+      auto* mv = TryGetConstantValue(*func.children[1]);
+      if (!mv) {
+        return false;
+      }
+      candidate.lm_dirichlet.mu = mv->GetValue<double>();
+      if (candidate.lm_dirichlet.mu < 0.0 ||
+          !std::isfinite(candidate.lm_dirichlet.mu)) {
+        throw duckdb::InvalidInputException(
+          "lm_dirichlet mu must be a non-negative finite value, got " +
+          std::to_string(candidate.lm_dirichlet.mu));
+      }
+    }
+  } else {
+    return false;  // Unreachable -- caller filters on IsScorerFunctionName.
   }
 
   if (scorer.kind == ScorerKind::None) {
-    scorer.kind = new_kind;
-    scorer.bm25_k1 = new_k1;
-    scorer.bm25_b = new_b;
-    scorer.tfidf_with_norms = new_with_norms;
+    scorer = candidate;
     return true;
   }
-  // Already set -- check for conflict.
-  if (scorer.kind == new_kind && scorer.bm25_k1 == new_k1 &&
-      scorer.bm25_b == new_b && scorer.tfidf_with_norms == new_with_norms) {
-    return true;  // Idempotent (same scorer in multiple expressions).
+  // Already set -- check for conflict. Compare only the live arm; other
+  // arms of the union may be uninitialized.
+  if (scorer.kind == candidate.kind) {
+    bool same = false;
+    switch (scorer.kind) {
+      case ScorerKind::Bm25:
+        same = scorer.bm25.k1 == candidate.bm25.k1 &&
+               scorer.bm25.b == candidate.bm25.b;
+        break;
+      case ScorerKind::Tfidf:
+        same = scorer.tfidf.with_norms == candidate.tfidf.with_norms;
+        break;
+      case ScorerKind::RawTf:
+        same = true;
+        break;
+      case ScorerKind::LmJm:
+        same = scorer.lm_jm.lambda == candidate.lm_jm.lambda;
+        break;
+      case ScorerKind::LmDirichlet:
+        same = scorer.lm_dirichlet.mu == candidate.lm_dirichlet.mu;
+        break;
+      case ScorerKind::None:
+        break;  // unreachable -- covered by outer if above
+    }
+    if (same) {
+      return true;  // Idempotent.
+    }
   }
   throw duckdb::InvalidInputException(
     "Only one scorer function is allowed per inverted index\n"
@@ -1227,7 +1292,7 @@ bool IsScorerCallAnchoredOnSearchScan(duckdb::LogicalOperator& root,
   }
   const auto& func = expr.Cast<duckdb::BoundFunctionExpression>();
   const auto& name = func.function.name;
-  if (name != connector::kBm25 && name != connector::kTfidf) {
+  if (!IsScorerFunctionName(name)) {
     return false;
   }
   if (func.children.empty() || func.children[0]->expression_class !=

--- a/tests/libs/iresearch/CMakeLists.txt
+++ b/tests/libs/iresearch/CMakeLists.txt
@@ -58,6 +58,8 @@ set(iresearch-tests_sources
     ./search/tfidf_test.cpp
     ./search/wand_test.cpp
     ./search/bm25_test.cpp
+    ./search/raw_tf_test.cpp
+    ./search/lm_test.cpp
     ./search/cost_attribute_test.cpp
     ./search/boost_attribute_test.cpp
     ./search/filter_test_case_base.cpp

--- a/tests/libs/iresearch/search/lm_test.cpp
+++ b/tests/libs/iresearch/search/lm_test.cpp
@@ -1,0 +1,295 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+// Tests for both language-model similarities. They share stats collectors
+// (LMFieldCollector / LMTermCollector) and the LMStats layout, so they're
+// co-located here.
+
+#include <algorithm>
+#include <map>
+
+#include "index/index_tests.hpp"
+#include "iresearch/index/index_features.hpp"
+#include "iresearch/index/norm.hpp"
+#include "iresearch/search/lm_dirichlet.hpp"
+#include "iresearch/search/lm_jelinek_mercer.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorers.hpp"
+#include "iresearch/search/term_filter.hpp"
+#include "iresearch/utils/lz4compression.hpp"
+#include "tests_shared.hpp"
+
+namespace {
+
+using namespace tests;
+
+// ---------------------------------------------------------------------------
+// LM Jelinek-Mercer factory tests.
+// ---------------------------------------------------------------------------
+
+TEST(lm_test, jm_consts) {
+  static_assert("lm_jm" == irs::Type<irs::LMJelinekMercer>::name());
+}
+
+TEST(lm_test, jm_load_default) {
+  auto scorer = irs::scorers::Get(
+    "lm_jm", irs::Type<irs::text_format::Json>::get(), std::string_view{});
+  ASSERT_NE(nullptr, scorer);
+  ASSERT_EQ(irs::Type<irs::LMJelinekMercer>::id(), scorer->type());
+  auto& lm = dynamic_cast<irs::LMJelinekMercer&>(*scorer);
+  ASSERT_EQ(irs::LMJelinekMercer::LAMBDA(), lm.lambda());
+  ASSERT_EQ(irs::IndexFeatures::Freq | irs::IndexFeatures::Norm,
+            scorer->GetIndexFeatures());
+}
+
+TEST(lm_test, jm_load_object) {
+  auto scorer =
+    irs::scorers::Get("lm_jm", irs::Type<irs::text_format::Json>::get(),
+                      "{ \"lambda\": 0.7 }");
+  ASSERT_NE(nullptr, scorer);
+  auto& lm = dynamic_cast<irs::LMJelinekMercer&>(*scorer);
+  ASSERT_FLOAT_EQ(0.7f, lm.lambda());
+}
+
+TEST(lm_test, jm_load_array) {
+  auto scorer = irs::scorers::Get(
+    "lm_jm", irs::Type<irs::text_format::Json>::get(), "[ 0.3 ]");
+  ASSERT_NE(nullptr, scorer);
+  auto& lm = dynamic_cast<irs::LMJelinekMercer&>(*scorer);
+  ASSERT_FLOAT_EQ(0.3f, lm.lambda());
+}
+
+TEST(lm_test, jm_load_invalid) {
+  // lambda must be in (0, 1].
+  ASSERT_EQ(nullptr,
+            irs::scorers::Get("lm_jm", irs::Type<irs::text_format::Json>::get(),
+                              "{ \"lambda\": 0 }"));
+  ASSERT_EQ(nullptr,
+            irs::scorers::Get("lm_jm", irs::Type<irs::text_format::Json>::get(),
+                              "{ \"lambda\": -0.1 }"));
+  ASSERT_EQ(nullptr,
+            irs::scorers::Get("lm_jm", irs::Type<irs::text_format::Json>::get(),
+                              "{ \"lambda\": 1.5 }"));
+}
+
+TEST(lm_test, jm_equals) {
+  auto a = std::make_unique<irs::LMJelinekMercer>(0.5f);
+  auto b = std::make_unique<irs::LMJelinekMercer>(0.5f);
+  auto c = std::make_unique<irs::LMJelinekMercer>(0.7f);
+  ASSERT_TRUE(a->equals(*b));
+  ASSERT_FALSE(a->equals(*c));
+}
+
+// ---------------------------------------------------------------------------
+// LM Dirichlet factory tests.
+// ---------------------------------------------------------------------------
+
+TEST(lm_test, dirichlet_consts) {
+  static_assert("lm_dirichlet" == irs::Type<irs::LMDirichlet>::name());
+}
+
+TEST(lm_test, dirichlet_load_default) {
+  auto scorer = irs::scorers::Get("lm_dirichlet",
+                                  irs::Type<irs::text_format::Json>::get(),
+                                  std::string_view{});
+  ASSERT_NE(nullptr, scorer);
+  ASSERT_EQ(irs::Type<irs::LMDirichlet>::id(), scorer->type());
+  auto& lm = dynamic_cast<irs::LMDirichlet&>(*scorer);
+  ASSERT_FLOAT_EQ(irs::LMDirichlet::MU(), lm.mu());
+  ASSERT_EQ(irs::IndexFeatures::Freq | irs::IndexFeatures::Norm,
+            scorer->GetIndexFeatures());
+}
+
+TEST(lm_test, dirichlet_load_object) {
+  auto scorer = irs::scorers::Get("lm_dirichlet",
+                                  irs::Type<irs::text_format::Json>::get(),
+                                  "{ \"mu\": 500.0 }");
+  ASSERT_NE(nullptr, scorer);
+  auto& lm = dynamic_cast<irs::LMDirichlet&>(*scorer);
+  ASSERT_FLOAT_EQ(500.f, lm.mu());
+}
+
+TEST(lm_test, dirichlet_load_invalid) {
+  ASSERT_EQ(nullptr, irs::scorers::Get("lm_dirichlet",
+                                       irs::Type<irs::text_format::Json>::get(),
+                                       "{ \"mu\": -1.0 }"));
+}
+
+TEST(lm_test, dirichlet_equals) {
+  auto a = std::make_unique<irs::LMDirichlet>(1000.f);
+  auto b = std::make_unique<irs::LMDirichlet>(1000.f);
+  auto c = std::make_unique<irs::LMDirichlet>(2000.f);
+  ASSERT_TRUE(a->equals(*b));
+  ASSERT_FALSE(a->equals(*c));
+}
+
+TEST(lm_test, jm_vs_dirichlet_not_equal) {
+  auto jm = std::make_unique<irs::LMJelinekMercer>();
+  auto dir = std::make_unique<irs::LMDirichlet>();
+  ASSERT_FALSE(jm->equals(*dir));
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end scoring on a tiny fixture index.
+//
+// Fixture:
+//   doc1: "fox fox dog"       -- freq(fox)=2, dl=3
+//   doc2: "fox cat"           -- freq(fox)=1, dl=2
+//   doc3: "dog rabbit fox"    -- freq(fox)=1, dl=3
+//
+// For term "fox":
+//   ttf(fox) = 4   (total fox across docs)
+//   docs_with_term(fox) = 3
+// Field-wide:
+//   sum_ttf = 8    (3 + 2 + 3)
+//   docs_with_field = 3
+//   P(fox|C) = (4 + 1) / (8 + 1) = 5/9
+// ---------------------------------------------------------------------------
+
+class LMIndexTest : public IndexTestBase {
+ protected:
+  void BuildFixture();
+};
+
+void LMIndexTest::BuildFixture() {
+  using TextField = tests::TextField<std::string>;
+  const auto extra = irs::IndexFeatures::Norm;
+
+  tests::Document doc1;
+  doc1.insert(std::make_shared<TextField>("body", std::string{"fox fox dog"},
+                                          /*payload=*/false, extra),
+              true, false);
+  tests::Document doc2;
+  doc2.insert(std::make_shared<TextField>("body", std::string{"fox cat"},
+                                          /*payload=*/false, extra),
+              true, false);
+  tests::Document doc3;
+  doc3.insert(std::make_shared<TextField>("body", std::string{"dog rabbit fox"},
+                                          /*payload=*/false, extra),
+              true, false);
+
+  irs::IndexWriterOptions opts;
+  opts.features = [&](irs::IndexFeatures id) {
+    irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
+    if (id == irs::IndexFeatures::Norm) {
+      return std::make_pair(info,
+                            irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
+    }
+    return std::make_pair(info, irs::FeatureWriterFactory{});
+  };
+
+  auto writer = open_writer(irs::kOmCreate, opts);
+  ASSERT_NE(nullptr, writer);
+  ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
+  writer->Commit();
+}
+
+namespace {
+
+// Helper: run a filter with the given scorer and return {doc_id -> score}.
+std::map<irs::doc_id_t, irs::score_t> RunQuery(irs::IndexReader& index,
+                                               irs::Scorer& scorer) {
+  auto& segment = *(index.begin());
+
+  irs::ByTerm filter;
+  *filter.mutable_field() = "body";
+  filter.mutable_options()->term =
+    irs::ViewCast<irs::byte_type>(std::string_view("fox"));
+
+  MaxMemoryCounter counter;
+  auto prepared = filter.prepare({
+    .index = index,
+    .memory = counter,
+    .scorer = &scorer,
+  });
+
+  irs::ColumnArgsFetcher fetcher;
+  auto docs = prepared->execute({
+    .segment = segment,
+    .scorer = &scorer,
+  });
+  auto score = docs->PrepareScore({
+    .scorer = &scorer,
+    .segment = &segment,
+    .fetcher = &fetcher,
+  });
+
+  std::map<irs::doc_id_t, irs::score_t> seen;
+  while (docs->next()) {
+    fetcher.Fetch(docs->value());
+    docs->FetchScoreArgs(0);
+    irs::score_t s{};
+    score.Score(&s, 1);
+    seen.emplace(docs->value(), s);
+  }
+  return seen;
+}
+
+}  // namespace
+
+TEST_P(LMIndexTest, jm_scores_positive_and_ordered) {
+  BuildFixture();
+
+  auto impl = std::make_unique<irs::LMJelinekMercer>(0.1f);
+  auto index = open_reader();
+  ASSERT_EQ(1, index->size());
+
+  auto seen = RunQuery(*index, *impl);
+  ASSERT_EQ(3u, seen.size());
+  for (auto& [_, s] : seen) {
+    ASSERT_GT(s, 0.f) << "LM JM should produce positive scores for matches";
+  }
+
+  std::vector<irs::score_t> values;
+  for (auto& [_, s] : seen) {
+    values.push_back(s);
+  }
+  std::sort(values.begin(), values.end(), std::greater<>{});
+  // The doc with freq=2, dl=3 has the highest freq/dl ratio (0.667).
+  // The other two have ratio 0.5 (1/2) and 0.333 (1/3).
+  ASSERT_GT(values[0], values[1]);
+  ASSERT_GE(values[1], values[2]);
+}
+
+TEST_P(LMIndexTest, dirichlet_scores_nonnegative) {
+  BuildFixture();
+
+  // Small mu for sharper separation on this toy corpus.
+  auto impl = std::make_unique<irs::LMDirichlet>(10.f);
+  auto index = open_reader();
+  ASSERT_EQ(1, index->size());
+
+  auto seen = RunQuery(*index, *impl);
+  ASSERT_EQ(3u, seen.size());
+  for (auto& [_, s] : seen) {
+    ASSERT_GE(s, 0.f) << "LM Dirichlet floors at 0 per Lucene";
+  }
+}
+
+static constexpr auto kTestDirs = tests::GetDirectories<tests::kTypesDefault>();
+
+INSTANTIATE_TEST_SUITE_P(lm_test, LMIndexTest,
+                         ::testing::Combine(::testing::ValuesIn(kTestDirs),
+                                            ::testing::Values("1_5simd")),
+                         LMIndexTest::to_string);
+
+}  // namespace

--- a/tests/libs/iresearch/search/lm_test.cpp
+++ b/tests/libs/iresearch/search/lm_test.cpp
@@ -60,9 +60,8 @@ TEST(lm_test, jm_load_default) {
 }
 
 TEST(lm_test, jm_load_object) {
-  auto scorer =
-    irs::scorers::Get("lm_jm", irs::Type<irs::text_format::Json>::get(),
-                      "{ \"lambda\": 0.7 }");
+  auto scorer = irs::scorers::Get(
+    "lm_jm", irs::Type<irs::text_format::Json>::get(), "{ \"lambda\": 0.7 }");
   ASSERT_NE(nullptr, scorer);
   auto& lm = dynamic_cast<irs::LMJelinekMercer&>(*scorer);
   ASSERT_FLOAT_EQ(0.7f, lm.lambda());
@@ -106,9 +105,9 @@ TEST(lm_test, dirichlet_consts) {
 }
 
 TEST(lm_test, dirichlet_load_default) {
-  auto scorer = irs::scorers::Get("lm_dirichlet",
-                                  irs::Type<irs::text_format::Json>::get(),
-                                  std::string_view{});
+  auto scorer =
+    irs::scorers::Get("lm_dirichlet", irs::Type<irs::text_format::Json>::get(),
+                      std::string_view{});
   ASSERT_NE(nullptr, scorer);
   ASSERT_EQ(irs::Type<irs::LMDirichlet>::id(), scorer->type());
   auto& lm = dynamic_cast<irs::LMDirichlet&>(*scorer);
@@ -118,9 +117,9 @@ TEST(lm_test, dirichlet_load_default) {
 }
 
 TEST(lm_test, dirichlet_load_object) {
-  auto scorer = irs::scorers::Get("lm_dirichlet",
-                                  irs::Type<irs::text_format::Json>::get(),
-                                  "{ \"mu\": 500.0 }");
+  auto scorer =
+    irs::scorers::Get("lm_dirichlet", irs::Type<irs::text_format::Json>::get(),
+                      "{ \"mu\": 500.0 }");
   ASSERT_NE(nullptr, scorer);
   auto& lm = dynamic_cast<irs::LMDirichlet&>(*scorer);
   ASSERT_FLOAT_EQ(500.f, lm.mu());

--- a/tests/libs/iresearch/search/raw_tf_test.cpp
+++ b/tests/libs/iresearch/search/raw_tf_test.cpp
@@ -1,0 +1,166 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>
+#include <map>
+
+#include "index/index_tests.hpp"
+#include "iresearch/index/index_features.hpp"
+#include "iresearch/index/norm.hpp"
+#include "iresearch/search/raw_tf.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/scorers.hpp"
+#include "iresearch/search/term_filter.hpp"
+#include "iresearch/utils/lz4compression.hpp"
+#include "tests_shared.hpp"
+
+namespace {
+
+using namespace tests;
+
+// Factory / registration tests.
+
+TEST(raw_tf_test, consts) {
+  static_assert("raw_tf" == irs::Type<irs::RawTF>::name());
+}
+
+TEST(raw_tf_test, load) {
+  auto scorer = irs::scorers::Get(
+    "raw_tf", irs::Type<irs::text_format::Json>::get(), std::string_view{});
+  ASSERT_NE(nullptr, scorer);
+  ASSERT_EQ(irs::Type<irs::RawTF>::id(), scorer->type());
+  ASSERT_EQ(irs::IndexFeatures::Freq, scorer->GetIndexFeatures());
+}
+
+TEST(raw_tf_test, equals) {
+  // RawTF has no params -- any two instances are equal.
+  auto a = std::make_unique<irs::RawTF>();
+  auto b = std::make_unique<irs::RawTF>();
+  ASSERT_TRUE(a->equals(*b));
+}
+
+// End-to-end scoring on a tiny fixture index.
+//
+// Fixture:
+//   doc1: "fox fox dog"       -- freq(fox)=2, dl=3
+//   doc2: "fox cat"           -- freq(fox)=1, dl=2
+//   doc3: "dog rabbit fox"    -- freq(fox)=1, dl=3
+
+class RawTfIndexTest : public IndexTestBase {
+ protected:
+  void BuildFixture();
+};
+
+void RawTfIndexTest::BuildFixture() {
+  using TextField = tests::TextField<std::string>;
+  const auto extra = irs::IndexFeatures::Norm;
+
+  tests::Document doc1;
+  doc1.insert(std::make_shared<TextField>("body", std::string{"fox fox dog"},
+                                          /*payload=*/false, extra),
+              true, false);
+  tests::Document doc2;
+  doc2.insert(std::make_shared<TextField>("body", std::string{"fox cat"},
+                                          /*payload=*/false, extra),
+              true, false);
+  tests::Document doc3;
+  doc3.insert(std::make_shared<TextField>("body", std::string{"dog rabbit fox"},
+                                          /*payload=*/false, extra),
+              true, false);
+
+  irs::IndexWriterOptions opts;
+  opts.features = [&](irs::IndexFeatures id) {
+    irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
+    if (id == irs::IndexFeatures::Norm) {
+      return std::make_pair(info,
+                            irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
+    }
+    return std::make_pair(info, irs::FeatureWriterFactory{});
+  };
+
+  auto writer = open_writer(irs::kOmCreate, opts);
+  ASSERT_NE(nullptr, writer);
+  ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
+  writer->Commit();
+}
+
+TEST_P(RawTfIndexTest, scores_match_freq) {
+  BuildFixture();
+
+  auto impl = std::make_unique<irs::RawTF>();
+
+  auto index = open_reader();
+  ASSERT_EQ(1, index->size());
+  auto& segment = *(index.begin());
+
+  irs::ByTerm filter;
+  *filter.mutable_field() = "body";
+  filter.mutable_options()->term =
+    irs::ViewCast<irs::byte_type>(std::string_view("fox"));
+
+  MaxMemoryCounter counter;
+  auto prepared = filter.prepare({
+    .index = *index,
+    .memory = counter,
+    .scorer = impl.get(),
+  });
+
+  irs::ColumnArgsFetcher fetcher;
+  auto docs = prepared->execute({
+    .segment = segment,
+    .scorer = impl.get(),
+  });
+  auto score = docs->PrepareScore({
+    .scorer = impl.get(),
+    .segment = &segment,
+    .fetcher = &fetcher,
+  });
+
+  std::map<irs::doc_id_t, irs::score_t> seen;
+  while (docs->next()) {
+    fetcher.Fetch(docs->value());
+    docs->FetchScoreArgs(0);
+    irs::score_t s{};
+    score.Score(&s, 1);
+    seen.emplace(docs->value(), s);
+  }
+  ASSERT_EQ(3u, seen.size());
+
+  // The doc with freq=2 must outrank docs with freq=1.
+  std::vector<irs::score_t> values;
+  for (auto& [_, s] : seen) {
+    values.push_back(s);
+  }
+  std::sort(values.begin(), values.end(), std::greater<>{});
+  ASSERT_FLOAT_EQ(2.f, values[0]);
+  ASSERT_FLOAT_EQ(1.f, values[1]);
+  ASSERT_FLOAT_EQ(1.f, values[2]);
+}
+
+static constexpr auto kTestDirs = tests::GetDirectories<tests::kTypesDefault>();
+
+INSTANTIATE_TEST_SUITE_P(raw_tf_test, RawTfIndexTest,
+                         ::testing::Combine(::testing::ValuesIn(kTestDirs),
+                                            ::testing::Values("1_5simd")),
+                         RawTfIndexTest::to_string);
+
+}  // namespace

--- a/tests/sqllogic/sdb/pg/index/inverted_index_lm.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_lm.test
@@ -1,0 +1,149 @@
+hash-threshold 100
+
+statement ok
+CREATE TABLE docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+INSERT INTO docs VALUES (1, 'the quick brown fox jumps over the lazy dog');
+
+
+statement count 1
+INSERT INTO docs VALUES (2, 'the quick fox');
+
+
+statement count 1
+INSERT INTO docs VALUES (3, 'the lazy dog');
+
+
+statement count 1
+INSERT INTO docs VALUES (4, 'the fox runs fast');
+
+
+statement count 1
+INSERT INTO docs VALUES (5, 'a quick brown rabbit and a fox');
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true,
+    norm = true
+);
+
+
+statement ok
+CREATE INDEX docs_idx ON docs USING inverted(id, body en);
+
+
+statement ok
+VACUUM (UPDATE_INDEXES) docs;
+
+
+# LM Jelinek-Mercer with default lambda (0.1): strictly positive for matches.
+query
+SELECT id, lm_jm(docs_idx.tableoid) > 0 AS has_score
+  FROM docs_idx WHERE PHRASE(body, 'fox') ORDER BY id;
+----
+id	has_score
+1	t
+2	t
+4	t
+5	t
+
+
+# LM Jelinek-Mercer with explicit lambda (must be in (0, 1]).
+query
+SELECT id, lm_jm(docs_idx.tableoid, 0.7) > 0 AS has_score
+  FROM docs_idx WHERE PHRASE(body, 'fox') ORDER BY id;
+----
+id	has_score
+1	t
+2	t
+4	t
+5	t
+
+
+# LM Dirichlet with default mu (2000) -- on a tiny corpus this typically floors
+# to 0 because log(mu / (dl + mu)) dominates. Use a small mu to get positive
+# scores and verify the floor never goes below zero.
+query
+SELECT id, lm_dirichlet(docs_idx.tableoid, 5.0) >= 0 AS nonneg
+  FROM docs_idx WHERE PHRASE(body, 'fox') ORDER BY id;
+----
+id	nonneg
+1	t
+2	t
+4	t
+5	t
+
+
+# LM JM ordering: 'lazy' appears in doc 1 (dl=9) and doc 3 (dl=3).
+# Higher tf/dl ratio -> higher score, so doc 3 must outrank doc 1.
+query
+SELECT id FROM docs_idx WHERE PHRASE(body, 'lazy')
+  ORDER BY lm_jm(docs_idx.tableoid) DESC, id;
+----
+id
+3
+1
+
+
+# Invalid params should raise. lambda must be in (0, 1].
+statement error
+SELECT id FROM docs_idx WHERE PHRASE(body, 'fox')
+  ORDER BY lm_jm(docs_idx.tableoid, 0) DESC, id;
+
+
+statement error
+SELECT id FROM docs_idx WHERE PHRASE(body, 'fox')
+  ORDER BY lm_jm(docs_idx.tableoid, 1.5) DESC, id;
+
+
+# mu must be non-negative.
+statement error
+SELECT id FROM docs_idx WHERE PHRASE(body, 'fox')
+  ORDER BY lm_dirichlet(docs_idx.tableoid, -1.0) DESC, id;
+
+
+# Mixing scorers on the same scan -- the optimizer should reject it.
+statement error
+SELECT id, bm25(docs_idx.tableoid) AS a, lm_jm(docs_idx.tableoid) AS b
+  FROM docs_idx WHERE PHRASE(body, 'fox') ORDER BY id;
+
+
+# Calling LM scorers without an inverted-index scan should surface stub errors.
+statement error
+SELECT lm_jm(42::BIGINT);
+
+
+statement error
+SELECT lm_dirichlet(42::BIGINT);
+
+
+# Second segment: reinvoke after more data to exercise multi-segment scoring.
+statement count 1
+INSERT INTO docs VALUES (6, 'another fox entered the room');
+
+
+statement count 1
+INSERT INTO docs VALUES (7, 'fox runs fast fox');
+
+
+statement ok
+VACUUM (UPDATE_INDEXES) docs;
+
+
+# LM JM across segments: positive for every match, doc 7 (higher tf) strictly
+# outranks its siblings with tf=1 on comparable dl.
+query
+SELECT id FROM docs_idx WHERE PHRASE(body, 'fox')
+  ORDER BY lm_jm(docs_idx.tableoid) DESC, id LIMIT 1;
+----
+id
+7

--- a/tests/sqllogic/sdb/pg/index/inverted_index_raw_tf.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_raw_tf.test
@@ -1,0 +1,114 @@
+hash-threshold 100
+
+statement ok
+CREATE TABLE docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+INSERT INTO docs VALUES (1, 'the quick brown fox jumps over the lazy dog');
+
+
+statement count 1
+INSERT INTO docs VALUES (2, 'the quick fox');
+
+
+statement count 1
+INSERT INTO docs VALUES (3, 'the lazy dog');
+
+
+statement count 1
+INSERT INTO docs VALUES (4, 'the fox runs fast');
+
+
+statement count 1
+INSERT INTO docs VALUES (5, 'a quick brown rabbit and a fox');
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true,
+    norm = true
+);
+
+
+statement ok
+CREATE INDEX docs_idx ON docs USING inverted(id, body en);
+
+
+statement ok
+VACUUM (UPDATE_INDEXES) docs;
+
+
+# raw_tf: per-doc score is just the term frequency. All matching docs have
+# freq('fox') == 1, so every score equals 1.
+query
+SELECT id, raw_tf(docs_idx.tableoid) AS s FROM docs_idx
+  WHERE PHRASE(body, 'fox') ORDER BY id;
+----
+id	s
+1	1
+2	1
+4	1
+5	1
+
+
+# Only doc 1 has two 'the' occurrences. raw_tf must separate by raw count:
+# doc 1 scores 2, every other matching doc scores 1.
+query
+SELECT id, raw_tf(docs_idx.tableoid) AS s FROM docs_idx
+  WHERE PHRASE(body, 'the') ORDER BY id;
+----
+id	s
+1	2
+2	1
+3	1
+4	1
+
+
+# Ordering with raw_tf: for 'lazy' both docs have freq 1 so ordering falls
+# back to id ASC tiebreak.
+query
+SELECT id FROM docs_idx WHERE PHRASE(body, 'lazy')
+  ORDER BY raw_tf(docs_idx.tableoid) DESC, id;
+----
+id
+1
+3
+
+
+# Calling raw_tf without an inverted-index scan should surface the stub error.
+statement error
+SELECT raw_tf(42::BIGINT);
+
+
+# Second segment: reinvoke after more data to exercise multi-segment scoring.
+statement count 1
+INSERT INTO docs VALUES (6, 'another fox entered the room');
+
+
+statement count 1
+INSERT INTO docs VALUES (7, 'fox runs fast fox');
+
+
+statement ok
+VACUUM (UPDATE_INDEXES) docs;
+
+
+# raw_tf across segments: doc 7 has two 'fox' occurrences.
+query
+SELECT id, raw_tf(docs_idx.tableoid) AS s FROM docs_idx
+  WHERE PHRASE(body, 'fox') ORDER BY id;
+----
+id	s
+1	1
+2	1
+4	1
+5	1
+6	1
+7	2


### PR DESCRIPTION
Add RawTF and language-model similarities

Adds three scorers — raw_tf, lm_jm (Jelinek-Mercer), lm_dirichlet — to iresearch and exposes them as SQL functions alongside the existing bm25()/tfidf(). The two LM variants share collectors and a DefaultCollectionModel P(t|C) = (ttf_t + 1)/(ttf_field + 1).

SearchScan::ScorerParams refactored to nested per-variant structs in an anonymous union tagged by ScorerKind (48 → 16 bytes, explicit live arm). Param validation at plan time (λ ∈ (0, 1], μ ≥ 0 finite); mixing scorers on one scan is rejected.