### PR TITLE
feat: More FTS sugar

### DIFF
--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -164,7 +164,6 @@ void RegisterTSQueryTypes(duckdb::ExtensionLoader& loader) {
 }
 
 void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
-  const auto varchar = duckdb::LogicalType::VARCHAR;
   const auto tsquery = MakeTSQueryType();
   const auto tokenized = MakeTokenizedTSQueryType();
   const auto boosted_tsq = MakeBoostedTSQueryType();
@@ -178,9 +177,9 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
   // so a TSQUERY-typed expression always prefers TSQUERY overloads
   // over VARCHAR mirrors when both exist (e.g. `<TSQ> ## 'b'` picks
   // (TSQUERY, TSQUERY) not (VARCHAR, VARCHAR)).
-  loader.RegisterCastFunction(tsquery, varchar,
+  loader.RegisterCastFunction(tsquery, duckdb::LogicalType::VARCHAR,
                               duckdb::DefaultCasts::ReinterpretCast, 100);
-  loader.RegisterCastFunction(varchar, tsquery,
+  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, tsquery,
                               duckdb::DefaultCasts::ReinterpretCast, 0);
 
   // Casts to/from the TOKENIZED_TSQUERY alias. The bind callback for
@@ -202,13 +201,13 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
   // enough that builtin VARCHAR wins for VARCHAR/VARCHAR operands and
   // low enough that STRING_LITERAL (cost 20 to alias) and TSQ-typed
   // (cost 0 via TSQ -> TOK below) operands still prefer ours.
-  loader.RegisterCastFunction(varchar, tokenized,
+  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, tokenized,
                               duckdb::DefaultCasts::ReinterpretCast, 50);
   loader.RegisterCastFunction(tsquery, tokenized,
                               duckdb::DefaultCasts::ReinterpretCast, 0);
   loader.RegisterCastFunction(tokenized, tsquery,
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(tokenized, varchar,
+  loader.RegisterCastFunction(tokenized, duckdb::LogicalType::VARCHAR,
                               duckdb::DefaultCasts::ReinterpretCast, 100);
 
   // BOOSTED <-> {VARCHAR, TSQ, TOK} reinterpret casts. Cost 0 in/out
@@ -220,7 +219,7 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
   //
   // VARCHAR -> BOOSTED at cost 50: same rationale as VARCHAR -> TOK
   // above (keep plain VARCHAR operands out of the TSQ operator set).
-  loader.RegisterCastFunction(varchar, boosted_tsq,
+  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, boosted_tsq,
                               duckdb::DefaultCasts::ReinterpretCast, 50);
   loader.RegisterCastFunction(tsquery, boosted_tsq,
                               duckdb::DefaultCasts::ReinterpretCast, 0);
@@ -230,7 +229,7 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
                               duckdb::DefaultCasts::ReinterpretCast, 0);
   loader.RegisterCastFunction(boosted_tsq, tokenized,
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(boosted_tsq, varchar,
+  loader.RegisterCastFunction(boosted_tsq, duckdb::LogicalType::VARCHAR,
                               duckdb::DefaultCasts::ReinterpretCast, 100);
 }
 
@@ -295,13 +294,11 @@ void RegisterTSQueryBoolCasts(duckdb::ExtensionLoader& loader) {
 }
 
 void RegisterTSQueryListCast(duckdb::ExtensionLoader& loader) {
-  const auto varchar = duckdb::LogicalType::VARCHAR;
   const auto tsquery = MakeTSQueryType();
-  const auto varchar_list = duckdb::LogicalType::LIST(varchar);
   const auto tsq_list = duckdb::LogicalType::LIST(tsquery);
 
   loader.RegisterCastFunction(
-    varchar_list, tsq_list,
+    duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR), tsq_list,
     +[](duckdb::BindCastInput& input, const duckdb::LogicalType& source,
         const duckdb::LogicalType& target) -> duckdb::BoundCastInfo {
       return duckdb::BoundCastInfo(
@@ -314,10 +311,6 @@ void RegisterTSQueryListCast(duckdb::ExtensionLoader& loader) {
 
 void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   const auto tsquery = MakeTSQueryType();
-  const auto varchar = duckdb::LogicalType::VARCHAR;
-  const auto intv = duckdb::LogicalType::INTEGER;
-  const auto dbl = duckdb::LogicalType::DOUBLE;
-  const auto boolv = duckdb::LogicalType::BOOLEAN;
   const auto tsq_list = duckdb::LogicalType::LIST(tsquery);
 
   // ts_phrase(text [, gap, text, gap, text, ...]) -- tokenises each text
@@ -326,7 +319,8 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // INTEGER[] / arrays ([min, max] range). See FromPhrase for the full
   // grammar.
   {
-    duckdb::ScalarFunction fn(std::string{kTSQPhrase}, {varchar}, tsquery,
+    duckdb::ScalarFunction fn(std::string{kTSQPhrase},
+                              {duckdb::LogicalType::VARCHAR}, tsquery,
                               TSQueryStubFn);
     fn.varargs = duckdb::LogicalType::ANY;
     loader.RegisterFunction(std::move(fn));
@@ -335,16 +329,19 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // NGRAM(text [, threshold]) -- tokenises via ambient analyzer.
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQNgram}};
-    set.AddFunction(duckdb::ScalarFunction({varchar}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, dbl}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::DOUBLE}, tsquery,
+      TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
   // ts_like(pattern) / PREFIX(text) -- raw, no tokenisation.
   for (auto name : {kTSQLike, kTSQPrefix}) {
-    loader.RegisterFunction(duckdb::ScalarFunction(std::string{name}, {varchar},
-                                                   tsquery, TSQueryStubFn));
+    loader.RegisterFunction(duckdb::ScalarFunction(
+      std::string{name}, {duckdb::LogicalType::VARCHAR}, tsquery,
+      TSQueryStubFn));
   }
 
   // LESS / LESS_EQ / GREATER / GREATER_EQ -- single-bound range
@@ -371,9 +368,11 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // the pattern is matched directly against terms in the field.
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQRegexp}};
-    set.AddFunction(duckdb::ScalarFunction({varchar}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, varchar}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR}, tsquery,
+      TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -383,12 +382,17 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // in edit-distance computation.
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQLevenshtein}};
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, intv}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, intv, boolv}, tsquery, TSQueryStubFn));
-    set.AddFunction(duckdb::ScalarFunction({varchar, intv, boolv, varchar},
-                                           tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER}, tsquery,
+      TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER,
+       duckdb::LogicalType::BOOLEAN},
+      tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER,
+       duckdb::LogicalType::BOOLEAN, duckdb::LogicalType::VARCHAR},
+      tsquery, TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -414,12 +418,12 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQAnyOf}};
     set.AddFunction(duckdb::ScalarFunction({tsq_list}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({tsq_list, intv}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {tsq_list, duckdb::LogicalType::INTEGER}, tsquery, TSQueryStubFn));
     set.AddFunction(
       duckdb::ScalarFunction({tsq_array}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({tsq_array, intv}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {tsq_array, duckdb::LogicalType::INTEGER}, tsquery, TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
   {
@@ -450,7 +454,7 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
       for (const auto& b : opts) {
         for (const auto& c : opts) {
           register_one({a, b, c});
-          register_one({a, b, c, intv});
+          register_one({a, b, c, duckdb::LogicalType::INTEGER});
         }
       }
     }
@@ -469,21 +473,24 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // Both LIST(VARCHAR) and unsized ARRAY(VARCHAR) input shapes are
   // registered; the filter-builder dispatch handles both.
   {
-    const auto varchar_list = duckdb::LogicalType::LIST(varchar);
-    const auto varchar_array =
-      duckdb::LogicalType::ARRAY(varchar, duckdb::optional_idx{});
+    const auto varchar_list =
+      duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR);
+    const auto varchar_array = duckdb::LogicalType::ARRAY(
+      duckdb::LogicalType::VARCHAR, duckdb::optional_idx{});
     duckdb::ScalarFunctionSet set{std::string{kTSQTokenize}};
-    set.AddFunction(duckdb::ScalarFunction({varchar}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, varchar}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR}, tsquery,
+      TSQueryStubFn));
     set.AddFunction(
       duckdb::ScalarFunction({varchar_list}, tsq_list, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar_list, varchar}, tsq_list, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {varchar_list, duckdb::LogicalType::VARCHAR}, tsq_list, TSQueryStubFn));
     set.AddFunction(
       duckdb::ScalarFunction({varchar_array}, tsq_list, TSQueryStubFn));
-    set.AddFunction(duckdb::ScalarFunction({varchar_array, varchar}, tsq_list,
-                                           TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {varchar_array, duckdb::LogicalType::VARCHAR}, tsq_list, TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -501,7 +508,8 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   {
     duckdb::ScalarFunction fn(
       std::string{kTSQRange},
-      {duckdb::LogicalType::ANY, duckdb::LogicalType::ANY, boolv, boolv},
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::ANY,
+       duckdb::LogicalType::BOOLEAN, duckdb::LogicalType::BOOLEAN},
       tsquery, TSQueryStubFn);
     fn.null_handling = duckdb::FunctionNullHandling::SPECIAL_HANDLING;
     loader.RegisterFunction(std::move(fn));
@@ -513,18 +521,18 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
 // throwing stubs claimed by the filter builder at bind time.
 void RegisterTSQueryParserFunctions(duckdb::ExtensionLoader& loader) {
   const auto tsquery = MakeTSQueryType();
-  const auto varchar = duckdb::LogicalType::VARCHAR;
-  const auto intv = duckdb::LogicalType::INTEGER;
 
   // to_tsquery(VARCHAR) -> TSQUERY -- Lucene parser, wiring deferred.
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kToTsquery}, {varchar}, tsquery, TSQueryStubFn));
+    std::string{kToTsquery}, {duckdb::LogicalType::VARCHAR}, tsquery,
+    TSQueryStubFn));
 
   // plainto_tsquery / phraseto_tsquery / websearch_to_tsquery each take
   // one VARCHAR and produce a TSQUERY via their own semantics.
   for (auto name : {kPlainToTsquery, kPhraseToTsquery, kWebsearchToTsquery}) {
-    loader.RegisterFunction(duckdb::ScalarFunction(std::string{name}, {varchar},
-                                                   tsquery, TSQueryStubFn));
+    loader.RegisterFunction(duckdb::ScalarFunction(
+      std::string{name}, {duckdb::LogicalType::VARCHAR}, tsquery,
+      TSQueryStubFn));
   }
 
   // tsquery_phrase(q1, q2 [, distance]) -- function form of `##`.
@@ -532,8 +540,9 @@ void RegisterTSQueryParserFunctions(duckdb::ExtensionLoader& loader) {
     duckdb::ScalarFunctionSet set{std::string{kTsqueryPhrase}};
     set.AddFunction(
       duckdb::ScalarFunction({tsquery, tsquery}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({tsquery, tsquery, intv}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {tsquery, tsquery, duckdb::LogicalType::INTEGER}, tsquery,
+      TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 }
@@ -541,10 +550,6 @@ void RegisterTSQueryParserFunctions(duckdb::ExtensionLoader& loader) {
 void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
   const auto tsquery = MakeTSQueryType();
   const auto tokenized = MakeTokenizedTSQueryType();
-  const auto varchar = duckdb::LogicalType::VARCHAR;
-  const auto intv = duckdb::LogicalType::INTEGER;
-  const auto dbl = duckdb::LogicalType::DOUBLE;
-  const auto int_list = duckdb::LogicalType::LIST(intv);
 
   // PG-style typed-tsquery binary operators: ||, &&. Registered as
   // (TOKENIZED_TSQUERY, TOKENIZED_TSQUERY) -> TOKENIZED_TSQUERY only.
@@ -571,7 +576,8 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
   // Args stay TOK so per-leg `::tokenize(...)` modifiers on the LHS
   // survive (no TOK->TSQ cast that would fold them away).
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kTSQueryBoost}, {tokenized, dbl}, tsquery, TSQueryStubFn));
+    std::string{kTSQueryBoost}, {tokenized, duckdb::LogicalType::DOUBLE},
+    tsquery, TSQueryStubFn));
 
   // Phrase sequence `a ## b` (strictly adjacent), `a ## N ## b` (gap N),
   // `a ## [lo, hi] ## b` (interval).
@@ -600,12 +606,16 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
     duckdb::ScalarFunctionSet set{std::string{kTSQueryPhraseSeq}};
     set.AddFunction(
       duckdb::ScalarFunction({tsquery, tsquery}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, varchar}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, intv}, tsquery, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar, int_list}, tsquery, TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR}, tsquery,
+      TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER}, tsquery,
+      TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::VARCHAR,
+       duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)},
+      tsquery, TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -627,6 +637,84 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
     duckdb::LogicalType::BOOLEAN, TSQueryStubFn));
 }
 
+// SQL-native predicate sugar: `<name>(col, args...)` -> BOOLEAN.
+// Each is a synonym for `col @@ <inner ts_*(...)>`. The filter
+// builder rewrites the call at bind time and dispatches through the
+// existing @@ handler. First arg is ANY so any indexed column type
+// binds; remaining args mirror the inner ts_* shape.
+void RegisterPredicateFunctions(duckdb::ExtensionLoader& loader) {
+  // phrase_matches(col, text [, gap, text, ...]) -- mirrors ts_phrase.
+  {
+    duckdb::ScalarFunction fn(
+      std::string{kPhraseMatches},
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn);
+    fn.varargs = duckdb::LogicalType::ANY;
+    loader.RegisterFunction(std::move(fn));
+  }
+
+  // ngram_matches(col, text [, threshold]).
+  {
+    duckdb::ScalarFunctionSet set{std::string{kNgramMatches}};
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR,
+       duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    loader.RegisterFunction(std::move(set));
+  }
+
+  // levenshtein_matches(col, term, distance [, transpositions [, prefix]]).
+  {
+    duckdb::ScalarFunctionSet set{std::string{kLevenshteinMatches}};
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR,
+       duckdb::LogicalType::INTEGER},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR,
+       duckdb::LogicalType::INTEGER, duckdb::LogicalType::BOOLEAN},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR,
+       duckdb::LogicalType::INTEGER, duckdb::LogicalType::BOOLEAN,
+       duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    loader.RegisterFunction(std::move(set));
+  }
+
+  // tokens_match_all(col, list).
+  loader.RegisterFunction(duckdb::ScalarFunction(
+    std::string{kTokensMatchAll},
+    {duckdb::LogicalType::ANY,
+     duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR)},
+    duckdb::LogicalType::BOOLEAN, SearchStubFn));
+
+  // tokens_match_any(col, list [, n]) and (col, text [, n]).
+  {
+    duckdb::ScalarFunctionSet set{std::string{kTokensMatchAny}};
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY,
+       duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR)},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY,
+       duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR),
+       duckdb::LogicalType::INTEGER},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR,
+       duckdb::LogicalType::INTEGER},
+      duckdb::LogicalType::BOOLEAN, SearchStubFn));
+    loader.RegisterFunction(std::move(set));
+  }
+}
+
 void RegisterTSQuerySurface(duckdb::ExtensionLoader& loader) {
   RegisterTSQueryTypes(loader);
   RegisterTSQueryAliasCasts(loader);
@@ -635,6 +723,7 @@ void RegisterTSQuerySurface(duckdb::ExtensionLoader& loader) {
   RegisterTSQueryConstructors(loader);
   RegisterTSQueryParserFunctions(loader);
   RegisterTSQueryOperators(loader);
+  RegisterPredicateFunctions(loader);
 }
 
 // Functions normally executed by inverted indexes. If rejected by an index the
@@ -645,21 +734,18 @@ void RegisterTSQuerySurface(duckdb::ExtensionLoader& loader) {
 // claims each call at compile time and threads the scorer into
 // bind_data; the stub fires only if the call escapes the rule.
 void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
-  const auto bigint = duckdb::LogicalType::BIGINT;
-  const auto flt = duckdb::LogicalType::FLOAT;
-  const auto dbl = duckdb::LogicalType::DOUBLE;
-  const auto varchar = duckdb::LogicalType::VARCHAR;
-  const auto boolv = duckdb::LogicalType::BOOLEAN;
-
   // bm25(tableoid) / bm25(tableoid, k1, b) -> DOUBLE -- emits the BM25
   // score per row for the scan identified by tableoid. Parameters are
   // extracted at compile time by the iresearch_plan rule; defaults
   // follow iresearch's Bm25 (k1 = 1.2, b = 0.75).
   {
     duckdb::ScalarFunctionSet set{std::string{kBm25}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({bigint, dbl, dbl}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::DOUBLE,
+       duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -667,8 +753,11 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
   // TF-IDF. `with_norms` toggles length normalisation (default false).
   {
     duckdb::ScalarFunctionSet set{std::string{kTfidf}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
-    set.AddFunction(duckdb::ScalarFunction({bigint, boolv}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::BOOLEAN},
+      duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -677,7 +766,8 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
   // claims the call at compile time and threads the scorer into bind_data.
   {
     duckdb::ScalarFunctionSet set{std::string{kRawTf}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -686,8 +776,11 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
   // lambda in (0, 1]; iresearch default is 0.1.
   {
     duckdb::ScalarFunctionSet set{std::string{kLmJm}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
-    set.AddFunction(duckdb::ScalarFunction({bigint, dbl}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -696,8 +789,11 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
   // iresearch default is 2000.
   {
     duckdb::ScalarFunctionSet set{std::string{kLmDirichlet}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
-    set.AddFunction(duckdb::ScalarFunction({bigint, dbl}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -706,8 +802,11 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
   // floor-at-zero clamp, so scores can be negative when tf < mu*P(t|C).
   {
     duckdb::ScalarFunctionSet set{std::string{kIndriDirichlet}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
-    set.AddFunction(duckdb::ScalarFunction({bigint, dbl}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::DOUBLE},
+      duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -716,9 +815,11 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
   // kernel: 'standardized' (default), 'saturated', or 'chi_squared'.
   {
     duckdb::ScalarFunctionSet set{std::string{kDfi}};
-    set.AddFunction(duckdb::ScalarFunction({bigint}, flt, ScorerStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({bigint, varchar}, flt, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT}, duckdb::LogicalType::FLOAT, ScorerStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::BIGINT, duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::FLOAT, ScorerStubFn));
     loader.RegisterFunction(std::move(set));
   }
 }
@@ -731,15 +832,15 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
 // (or throws a specific error). Wrong arity or a non-integer second
 // arg is rejected at bind time by the function resolver.
 void RegisterPositionFunctions(duckdb::ExtensionLoader& loader) {
-  const auto any = duckdb::LogicalType::ANY;
-  const auto intv = duckdb::LogicalType::INTEGER;
   const auto bigint_list =
     duckdb::LogicalType::LIST(duckdb::LogicalType::BIGINT);
 
   duckdb::ScalarFunctionSet set{std::string{kOffsets}};
-  set.AddFunction(duckdb::ScalarFunction({any}, bigint_list, SearchStubFn));
-  set.AddFunction(
-    duckdb::ScalarFunction({any, intv}, bigint_list, SearchStubFn));
+  set.AddFunction(duckdb::ScalarFunction(
+    {duckdb::LogicalType::ANY}, bigint_list, SearchStubFn));
+  set.AddFunction(duckdb::ScalarFunction(
+    {duckdb::LogicalType::ANY, duckdb::LogicalType::INTEGER}, bigint_list,
+    SearchStubFn));
   loader.RegisterFunction(std::move(set));
 }
 
@@ -850,11 +951,11 @@ void TsLexizeFunction(duckdb::DataChunk& args, duckdb::ExpressionState& state,
 // single token through a named TS dictionary and returns the
 // resulting lexemes (or empty array for stopwords / unmatched).
 void RegisterTextDictionaryHelpers(duckdb::ExtensionLoader& loader) {
-  const auto varchar = duckdb::LogicalType::VARCHAR;
-  duckdb::ScalarFunction fn{"ts_lexize",
-                            {varchar, varchar},
-                            duckdb::LogicalType::LIST(varchar),
-                            TsLexizeFunction};
+  duckdb::ScalarFunction fn{
+    "ts_lexize",
+    {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
+    duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR),
+    TsLexizeFunction};
   fn.null_handling = duckdb::FunctionNullHandling::SPECIAL_HANDLING;
   loader.RegisterFunction(std::move(fn));
 }

--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -646,13 +646,10 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
     duckdb::LogicalType::BOOLEAN, TSQueryStubFn));
 }
 
-// SQL-native predicate sugar: `<name>(col, args...)` -> BOOLEAN.
-// Each is a synonym for `col @@ <inner ts_*(...)>`. The filter
-// builder rewrites the call at bind time and dispatches through the
-// existing @@ handler. First arg is ANY so any indexed column type
-// binds; remaining args mirror the inner ts_* shape.
+// Stub registrations for sugar predicates -- the filter builder
+// rewrites each `<name>(col, args...)` call to `col @@ ts_*(args...)`
+// at bind time, so these never execute as scalar functions.
 void RegisterPredicateFunctions(duckdb::ExtensionLoader& loader) {
-  // phrase_matches(col, text [, gap, text, ...]) -- mirrors ts_phrase.
   {
     duckdb::ScalarFunction fn(
       std::string{kPhraseMatches},
@@ -662,7 +659,6 @@ void RegisterPredicateFunctions(duckdb::ExtensionLoader& loader) {
     loader.RegisterFunction(std::move(fn));
   }
 
-  // ngram_matches(col, text [, threshold]).
   {
     duckdb::ScalarFunctionSet set{std::string{kNgramMatches}};
     set.AddFunction(duckdb::ScalarFunction(
@@ -675,7 +671,6 @@ void RegisterPredicateFunctions(duckdb::ExtensionLoader& loader) {
     loader.RegisterFunction(std::move(set));
   }
 
-  // levenshtein_matches(col, term, distance [, transpositions [, prefix]]).
   {
     duckdb::ScalarFunctionSet set{std::string{kLevenshteinMatches}};
     set.AddFunction(duckdb::ScalarFunction(
@@ -694,14 +689,12 @@ void RegisterPredicateFunctions(duckdb::ExtensionLoader& loader) {
     loader.RegisterFunction(std::move(set));
   }
 
-  // has_all_tokens(col, list).
   loader.RegisterFunction(duckdb::ScalarFunction(
     std::string{kHasAllTokens},
     {duckdb::LogicalType::ANY,
      duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR)},
     duckdb::LogicalType::BOOLEAN, SearchStubFn));
 
-  // has_any_token(col, list [, n]) and (col, text [, n]).
   {
     duckdb::ScalarFunctionSet set{std::string{kHasAnyToken}};
     set.AddFunction(duckdb::ScalarFunction(

--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -694,16 +694,16 @@ void RegisterPredicateFunctions(duckdb::ExtensionLoader& loader) {
     loader.RegisterFunction(std::move(set));
   }
 
-  // tokens_match_all(col, list).
+  // has_all_tokens(col, list).
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kTokensMatchAll},
+    std::string{kHasAllTokens},
     {duckdb::LogicalType::ANY,
      duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR)},
     duckdb::LogicalType::BOOLEAN, SearchStubFn));
 
-  // tokens_match_any(col, list [, n]) and (col, text [, n]).
+  // has_any_token(col, list [, n]) and (col, text [, n]).
   {
-    duckdb::ScalarFunctionSet set{std::string{kTokensMatchAny}};
+    duckdb::ScalarFunctionSet set{std::string{kHasAnyToken}};
     set.AddFunction(duckdb::ScalarFunction(
       {duckdb::LogicalType::ANY,
        duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR)},

--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -82,9 +82,7 @@ void ScorerStubFn(duckdb::DataChunk& /*args*/, duckdb::ExpressionState& state,
 }
 
 void RegisterTSQueryTypes(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-
-  loader.RegisterType(std::string{kTSQueryTypeName}, tsquery);
+  loader.RegisterType(std::string{kTSQueryTypeName}, MakeTSQueryType());
 
   // `tokenize(<analyzer-name>)` is a parameterized type registered as
   // a TSQUERY variant. The bind function consumes a single VARCHAR
@@ -94,7 +92,7 @@ void RegisterTSQueryTypes(duckdb::ExtensionLoader& loader) {
   // existing VARCHAR<->TSQUERY casts apply unchanged; the modifier just
   // travels with the LogicalType into BoundCastExpression.return_type.
   loader.RegisterType(
-    std::string{kTokenizerTypeName}, tsquery,
+    std::string{kTokenizerTypeName}, MakeTSQueryType(),
     +[](duckdb::BindLogicalTypeInput& input) -> duckdb::LogicalType {
       const auto& modifiers = input.modifiers;
       if (modifiers.size() != 1) {
@@ -139,7 +137,7 @@ void RegisterTSQueryTypes(duckdb::ExtensionLoader& loader) {
   // a DOUBLE modifier instead of VARCHAR. Different alias keeps the
   // cast wrapper alive so the walker can read the factor.
   loader.RegisterType(
-    std::string{kBoostTypeName}, tsquery,
+    std::string{kBoostTypeName}, MakeTSQueryType(),
     +[](duckdb::BindLogicalTypeInput& input) -> duckdb::LogicalType {
       const auto& modifiers = input.modifiers;
       if (modifiers.size() != 1) {
@@ -164,10 +162,6 @@ void RegisterTSQueryTypes(duckdb::ExtensionLoader& loader) {
 }
 
 void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-  const auto tokenized = MakeTokenizedTSQueryType();
-  const auto boosted_tsq = MakeBoostedTSQueryType();
-
   // VARCHAR <-> TSQUERY reinterpret casts. Bare string literals in
   // TSQUERY context get tokenised by the filter builder via the
   // ambient (@@ column) analyzer. Asymmetric costs keep typed TSQUERY
@@ -177,9 +171,9 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
   // so a TSQUERY-typed expression always prefers TSQUERY overloads
   // over VARCHAR mirrors when both exist (e.g. `<TSQ> ## 'b'` picks
   // (TSQUERY, TSQUERY) not (VARCHAR, VARCHAR)).
-  loader.RegisterCastFunction(tsquery, duckdb::LogicalType::VARCHAR,
+  loader.RegisterCastFunction(MakeTSQueryType(), duckdb::LogicalType::VARCHAR,
                               duckdb::DefaultCasts::ReinterpretCast, 100);
-  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, tsquery,
+  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, MakeTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
 
   // Casts to/from the TOKENIZED_TSQUERY alias. The bind callback for
@@ -201,13 +195,15 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
   // enough that builtin VARCHAR wins for VARCHAR/VARCHAR operands and
   // low enough that STRING_LITERAL (cost 20 to alias) and TSQ-typed
   // (cost 0 via TSQ -> TOK below) operands still prefer ours.
-  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, tokenized,
+  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR,
+                              MakeTokenizedTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 50);
-  loader.RegisterCastFunction(tsquery, tokenized,
+  loader.RegisterCastFunction(MakeTSQueryType(), MakeTokenizedTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(tokenized, tsquery,
+  loader.RegisterCastFunction(MakeTokenizedTSQueryType(), MakeTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(tokenized, duckdb::LogicalType::VARCHAR,
+  loader.RegisterCastFunction(MakeTokenizedTSQueryType(),
+                              duckdb::LogicalType::VARCHAR,
                               duckdb::DefaultCasts::ReinterpretCast, 100);
 
   // BOOSTED <-> {VARCHAR, TSQ, TOK} reinterpret casts. Cost 0 in/out
@@ -219,25 +215,25 @@ void RegisterTSQueryAliasCasts(duckdb::ExtensionLoader& loader) {
   //
   // VARCHAR -> BOOSTED at cost 50: same rationale as VARCHAR -> TOK
   // above (keep plain VARCHAR operands out of the TSQ operator set).
-  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR, boosted_tsq,
+  loader.RegisterCastFunction(duckdb::LogicalType::VARCHAR,
+                              MakeBoostedTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 50);
-  loader.RegisterCastFunction(tsquery, boosted_tsq,
+  loader.RegisterCastFunction(MakeTSQueryType(), MakeBoostedTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(tokenized, boosted_tsq,
+  loader.RegisterCastFunction(MakeTokenizedTSQueryType(),
+                              MakeBoostedTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(boosted_tsq, tsquery,
+  loader.RegisterCastFunction(MakeBoostedTSQueryType(), MakeTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(boosted_tsq, tokenized,
+  loader.RegisterCastFunction(MakeBoostedTSQueryType(),
+                              MakeTokenizedTSQueryType(),
                               duckdb::DefaultCasts::ReinterpretCast, 0);
-  loader.RegisterCastFunction(boosted_tsq, duckdb::LogicalType::VARCHAR,
+  loader.RegisterCastFunction(MakeBoostedTSQueryType(),
+                              duckdb::LogicalType::VARCHAR,
                               duckdb::DefaultCasts::ReinterpretCast, 100);
 }
 
 void RegisterTSQueryBoolCasts(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-  const auto tokenized = MakeTokenizedTSQueryType();
-  const auto boosted_tsq = MakeBoostedTSQueryType();
-
   // BOOLEAN -> {TSQUERY, TOK}: lets `true` / `false` flow into any
   // TSQUERY position. The runtime function throws -- which makes the
   // cast non-foldable, so the BoundCastExpression survives in the
@@ -255,11 +251,12 @@ void RegisterTSQueryBoolCasts(duckdb::ExtensionLoader& loader) {
         "BOOLEAN -> TSQUERY: only meaningful inside TSQUERY context");
     });
   };
-  loader.RegisterCastFunction(duckdb::LogicalType::BOOLEAN, tsquery,
+  loader.RegisterCastFunction(duckdb::LogicalType::BOOLEAN, MakeTSQueryType(),
                               bool_cast_bind,
                               /*implicit_cast_cost=*/0);
-  loader.RegisterCastFunction(duckdb::LogicalType::BOOLEAN, tokenized,
-                              bool_cast_bind, /*implicit_cast_cost=*/0);
+  loader.RegisterCastFunction(duckdb::LogicalType::BOOLEAN,
+                              MakeTokenizedTSQueryType(), bool_cast_bind,
+                              /*implicit_cast_cost=*/0);
 
   // BOOLEAN <-> BOOSTED_TSQUERY: lets `(predicate)::boost(K)` apply
   // to plain SQL conditions outside `@@`. Both directions throw at
@@ -282,23 +279,22 @@ void RegisterTSQueryBoolCasts(duckdb::ExtensionLoader& loader) {
   // Cost 50 mirrors VARCHAR -> BOOSTED_TSQUERY (above): keeps plain
   // BOOLEAN operands from sweeping into TSQUERY overloads when no
   // boost was actually requested.
-  loader.RegisterCastFunction(duckdb::LogicalType::BOOLEAN, boosted_tsq,
-                              boost_bool_cast_bind,
+  loader.RegisterCastFunction(duckdb::LogicalType::BOOLEAN,
+                              MakeBoostedTSQueryType(), boost_bool_cast_bind,
                               /*implicit_cast_cost=*/50);
   // Cost 0: this is the WHERE-clause coercion DuckDB inserts when a
   // `(predicate)::boost(K)` cast appears at the predicate root (the
   // WhereBinder unconditionally adds a cast to BOOLEAN).
-  loader.RegisterCastFunction(boosted_tsq, duckdb::LogicalType::BOOLEAN,
+  loader.RegisterCastFunction(MakeBoostedTSQueryType(),
+                              duckdb::LogicalType::BOOLEAN,
                               boost_bool_cast_bind,
                               /*implicit_cast_cost=*/0);
 }
 
 void RegisterTSQueryListCast(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-  const auto tsq_list = duckdb::LogicalType::LIST(tsquery);
-
   loader.RegisterCastFunction(
-    duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR), tsq_list,
+    duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR),
+    duckdb::LogicalType::LIST(MakeTSQueryType()),
     +[](duckdb::BindCastInput& input, const duckdb::LogicalType& source,
         const duckdb::LogicalType& target) -> duckdb::BoundCastInfo {
       return duckdb::BoundCastInfo(
@@ -310,9 +306,6 @@ void RegisterTSQueryListCast(duckdb::ExtensionLoader& loader) {
 }
 
 void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-  const auto tsq_list = duckdb::LogicalType::LIST(tsquery);
-
   // ts_phrase(text [, gap, text, gap, text, ...]) -- tokenises each text
   // pattern via the ambient analyzer and chains them into one
   // irs::ByPhrase. Gap args are bare INTEGERs (exact gap N) or 2-element
@@ -320,7 +313,7 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // grammar.
   {
     duckdb::ScalarFunction fn(std::string{kTSQPhrase},
-                              {duckdb::LogicalType::VARCHAR}, tsquery,
+                              {duckdb::LogicalType::VARCHAR}, MakeTSQueryType(),
                               TSQueryStubFn);
     fn.varargs = duckdb::LogicalType::ANY;
     loader.RegisterFunction(std::move(fn));
@@ -329,19 +322,19 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // NGRAM(text [, threshold]) -- tokenises via ambient analyzer.
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQNgram}};
+    set.AddFunction(duckdb::ScalarFunction({duckdb::LogicalType::VARCHAR},
+                                           MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR}, tsquery, TSQueryStubFn));
-    set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::DOUBLE}, tsquery,
-      TSQueryStubFn));
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::DOUBLE},
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
   // ts_like(pattern) / PREFIX(text) -- raw, no tokenisation.
   for (auto name : {kTSQLike, kTSQPrefix}) {
-    loader.RegisterFunction(duckdb::ScalarFunction(
-      std::string{name}, {duckdb::LogicalType::VARCHAR}, tsquery,
-      TSQueryStubFn));
+    loader.RegisterFunction(
+      duckdb::ScalarFunction(std::string{name}, {duckdb::LogicalType::VARCHAR},
+                             MakeTSQueryType(), TSQueryStubFn));
   }
 
   // LESS / LESS_EQ / GREATER / GREATER_EQ -- single-bound range
@@ -358,7 +351,7 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // NULL bound to NULL before the filter builder sees it.
   for (auto name : {kTSQLess, kTSQLessEq, kTSQGreater, kTSQGreaterEq}) {
     duckdb::ScalarFunction fn(std::string{name}, {duckdb::LogicalType::ANY},
-                              tsquery, TSQueryStubFn);
+                              MakeTSQueryType(), TSQueryStubFn);
     fn.null_handling = duckdb::FunctionNullHandling::SPECIAL_HANDLING;
     loader.RegisterFunction(std::move(fn));
   }
@@ -368,11 +361,11 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // the pattern is matched directly against terms in the field.
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQRegexp}};
+    set.AddFunction(duckdb::ScalarFunction({duckdb::LogicalType::VARCHAR},
+                                           MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR}, tsquery, TSQueryStubFn));
-    set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR}, tsquery,
-      TSQueryStubFn));
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -383,16 +376,16 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQLevenshtein}};
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER}, tsquery,
-      TSQueryStubFn));
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER},
+      MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
       {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER,
        duckdb::LogicalType::BOOLEAN},
-      tsquery, TSQueryStubFn));
+      MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
       {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER,
        duckdb::LogicalType::BOOLEAN, duckdb::LogicalType::VARCHAR},
-      tsquery, TSQueryStubFn));
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -413,24 +406,32 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // overloads. DuckDB matches an unsized ARRAY type against any
   // ARRAY(T, N), and the filter-builder dispatch handles ARRAY children
   // alongside LIST.
-  const auto tsq_array =
-    duckdb::LogicalType::ARRAY(tsquery, duckdb::optional_idx{});
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQAnyOf}};
-    set.AddFunction(duckdb::ScalarFunction({tsq_list}, tsquery, TSQueryStubFn));
-    set.AddFunction(duckdb::ScalarFunction(
-      {tsq_list, duckdb::LogicalType::INTEGER}, tsquery, TSQueryStubFn));
     set.AddFunction(
-      duckdb::ScalarFunction({tsq_array}, tsquery, TSQueryStubFn));
+      duckdb::ScalarFunction({duckdb::LogicalType::LIST(MakeTSQueryType())},
+                             MakeTSQueryType(), TSQueryStubFn));
+    set.AddFunction(
+      duckdb::ScalarFunction({duckdb::LogicalType::LIST(MakeTSQueryType()),
+                              duckdb::LogicalType::INTEGER},
+                             MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {tsq_array, duckdb::LogicalType::INTEGER}, tsquery, TSQueryStubFn));
+      {duckdb::LogicalType::ARRAY(MakeTSQueryType(), duckdb::optional_idx{})},
+      MakeTSQueryType(), TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ARRAY(MakeTSQueryType(), duckdb::optional_idx{}),
+       duckdb::LogicalType::INTEGER},
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQAllOf}};
-    set.AddFunction(duckdb::ScalarFunction({tsq_list}, tsquery, TSQueryStubFn));
     set.AddFunction(
-      duckdb::ScalarFunction({tsq_array}, tsquery, TSQueryStubFn));
+      duckdb::ScalarFunction({duckdb::LogicalType::LIST(MakeTSQueryType())},
+                             MakeTSQueryType(), TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ARRAY(MakeTSQueryType(), duckdb::optional_idx{})},
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -441,9 +442,11 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // = 2 (3-arg / 4-arg) * 2^3 (TSQUERY vs TSQUERY[] per arg).
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQCompound}};
-    const std::array<duckdb::LogicalType, 2> opts{tsquery, tsq_list};
+    const std::array<duckdb::LogicalType, 2> opts{
+      MakeTSQueryType(), duckdb::LogicalType::LIST(MakeTSQueryType())};
     auto register_one = [&](std::vector<duckdb::LogicalType> args) {
-      auto fn = duckdb::ScalarFunction(std::move(args), tsquery, TSQueryStubFn);
+      auto fn = duckdb::ScalarFunction(std::move(args), MakeTSQueryType(),
+                                       TSQueryStubFn);
       // Without SPECIAL_HANDLING, DuckDB folds any call with a NULL
       // arg to NULL at bind time; we'd never see the user's bucket
       // structure (e.g. `compound(list, NULL, NULL)` -> NULL).
@@ -473,24 +476,28 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
   // Both LIST(VARCHAR) and unsized ARRAY(VARCHAR) input shapes are
   // registered; the filter-builder dispatch handles both.
   {
-    const auto varchar_list =
-      duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR);
-    const auto varchar_array = duckdb::LogicalType::ARRAY(
-      duckdb::LogicalType::VARCHAR, duckdb::optional_idx{});
     duckdb::ScalarFunctionSet set{std::string{kTSQTokenize}};
+    set.AddFunction(duckdb::ScalarFunction({duckdb::LogicalType::VARCHAR},
+                                           MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR}, tsquery, TSQueryStubFn));
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
+      MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR}, tsquery,
-      TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar_list}, tsq_list, TSQueryStubFn));
+      {duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR)},
+      duckdb::LogicalType::LIST(MakeTSQueryType()), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {varchar_list, duckdb::LogicalType::VARCHAR}, tsq_list, TSQueryStubFn));
-    set.AddFunction(
-      duckdb::ScalarFunction({varchar_array}, tsq_list, TSQueryStubFn));
+      {duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR),
+       duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::LIST(MakeTSQueryType()), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {varchar_array, duckdb::LogicalType::VARCHAR}, tsq_list, TSQueryStubFn));
+      {duckdb::LogicalType::ARRAY(duckdb::LogicalType::VARCHAR,
+                                  duckdb::optional_idx{})},
+      duckdb::LogicalType::LIST(MakeTSQueryType()), TSQueryStubFn));
+    set.AddFunction(duckdb::ScalarFunction(
+      {duckdb::LogicalType::ARRAY(duckdb::LogicalType::VARCHAR,
+                                  duckdb::optional_idx{}),
+       duckdb::LogicalType::VARCHAR},
+      duckdb::LogicalType::LIST(MakeTSQueryType()), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -510,7 +517,7 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
       std::string{kTSQRange},
       {duckdb::LogicalType::ANY, duckdb::LogicalType::ANY,
        duckdb::LogicalType::BOOLEAN, duckdb::LogicalType::BOOLEAN},
-      tsquery, TSQueryStubFn);
+      MakeTSQueryType(), TSQueryStubFn);
     fn.null_handling = duckdb::FunctionNullHandling::SPECIAL_HANDLING;
     loader.RegisterFunction(std::move(fn));
   }
@@ -520,37 +527,33 @@ void RegisterTSQueryConstructors(duckdb::ExtensionLoader& loader) {
 // phraseto_tsquery, websearch_to_tsquery, tsquery_phrase. All
 // throwing stubs claimed by the filter builder at bind time.
 void RegisterTSQueryParserFunctions(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-
   // to_tsquery(VARCHAR) -> TSQUERY -- Lucene parser, wiring deferred.
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kToTsquery}, {duckdb::LogicalType::VARCHAR}, tsquery,
+    std::string{kToTsquery}, {duckdb::LogicalType::VARCHAR}, MakeTSQueryType(),
     TSQueryStubFn));
 
   // plainto_tsquery / phraseto_tsquery / websearch_to_tsquery each take
   // one VARCHAR and produce a TSQUERY via their own semantics.
   for (auto name : {kPlainToTsquery, kPhraseToTsquery, kWebsearchToTsquery}) {
-    loader.RegisterFunction(duckdb::ScalarFunction(
-      std::string{name}, {duckdb::LogicalType::VARCHAR}, tsquery,
-      TSQueryStubFn));
+    loader.RegisterFunction(
+      duckdb::ScalarFunction(std::string{name}, {duckdb::LogicalType::VARCHAR},
+                             MakeTSQueryType(), TSQueryStubFn));
   }
 
   // tsquery_phrase(q1, q2 [, distance]) -- function form of `##`.
   {
     duckdb::ScalarFunctionSet set{std::string{kTsqueryPhrase}};
     set.AddFunction(
-      duckdb::ScalarFunction({tsquery, tsquery}, tsquery, TSQueryStubFn));
+      duckdb::ScalarFunction({MakeTSQueryType(), MakeTSQueryType()},
+                             MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {tsquery, tsquery, duckdb::LogicalType::INTEGER}, tsquery,
-      TSQueryStubFn));
+      {MakeTSQueryType(), MakeTSQueryType(), duckdb::LogicalType::INTEGER},
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 }
 
 void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
-  const auto tsquery = MakeTSQueryType();
-  const auto tokenized = MakeTokenizedTSQueryType();
-
   // PG-style typed-tsquery binary operators: ||, &&. Registered as
   // (TOKENIZED_TSQUERY, TOKENIZED_TSQUERY) -> TOKENIZED_TSQUERY only.
   // TSQUERY operands are auto-cast to TOK at cost 0; the cast wrapper
@@ -564,20 +567,24 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
   // when aliases share the underlying VARCHAR type.
   for (auto name : {kTSQueryOr, kTSQueryAnd}) {
     loader.RegisterFunction(duckdb::ScalarFunction(
-      std::string{name}, {tokenized, tokenized}, tokenized, TSQueryStubFn));
+      std::string{name},
+      {MakeTokenizedTSQueryType(), MakeTokenizedTSQueryType()},
+      MakeTokenizedTSQueryType(), TSQueryStubFn));
   }
 
   // Unary prefix NOT (!!). Single TOK overload (same reasoning).
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kTSQueryNot}, {tokenized}, tokenized, TSQueryStubFn));
+    std::string{kTSQueryNot}, {MakeTokenizedTSQueryType()},
+    MakeTokenizedTSQueryType(), TSQueryStubFn));
 
   // Boost: TOK ^ DOUBLE -> TSQ. Returns plain TSQUERY so the result
   // composes inside TSQUERY[] contexts (e.g. compound([expr ^ K, ...])).
   // Args stay TOK so per-leg `::tokenize(...)` modifiers on the LHS
   // survive (no TOK->TSQ cast that would fold them away).
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kTSQueryBoost}, {tokenized, duckdb::LogicalType::DOUBLE},
-    tsquery, TSQueryStubFn));
+    std::string{kTSQueryBoost},
+    {MakeTokenizedTSQueryType(), duckdb::LogicalType::DOUBLE},
+    MakeTSQueryType(), TSQueryStubFn));
 
   // Phrase sequence `a ## b` (strictly adjacent), `a ## N ## b` (gap N),
   // `a ## [lo, hi] ## b` (interval).
@@ -605,17 +612,18 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
   {
     duckdb::ScalarFunctionSet set{std::string{kTSQueryPhraseSeq}};
     set.AddFunction(
-      duckdb::ScalarFunction({tsquery, tsquery}, tsquery, TSQueryStubFn));
+      duckdb::ScalarFunction({MakeTSQueryType(), MakeTSQueryType()},
+                             MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR}, tsquery,
-      TSQueryStubFn));
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
+      MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
-      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER}, tsquery,
-      TSQueryStubFn));
+      {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::INTEGER},
+      MakeTSQueryType(), TSQueryStubFn));
     set.AddFunction(duckdb::ScalarFunction(
       {duckdb::LogicalType::VARCHAR,
        duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER)},
-      tsquery, TSQueryStubFn));
+      MakeTSQueryType(), TSQueryStubFn));
     loader.RegisterFunction(std::move(set));
   }
 
@@ -633,7 +641,8 @@ void RegisterTSQueryOperators(duckdb::ExtensionLoader& loader) {
   // (DuckDB ranks `VARCHAR -> TSQUERY` and `VARCHAR -> TOKENIZED_TSQUERY`
   // identically for literals, regardless of registered cast costs).
   loader.RegisterFunction(duckdb::ScalarFunction(
-    std::string{kTSQueryMatch}, {duckdb::LogicalType::ANY, tokenized},
+    std::string{kTSQueryMatch},
+    {duckdb::LogicalType::ANY, MakeTokenizedTSQueryType()},
     duckdb::LogicalType::BOOLEAN, TSQueryStubFn));
 }
 
@@ -832,15 +841,13 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
 // (or throws a specific error). Wrong arity or a non-integer second
 // arg is rejected at bind time by the function resolver.
 void RegisterPositionFunctions(duckdb::ExtensionLoader& loader) {
-  const auto bigint_list =
-    duckdb::LogicalType::LIST(duckdb::LogicalType::BIGINT);
-
   duckdb::ScalarFunctionSet set{std::string{kOffsets}};
   set.AddFunction(duckdb::ScalarFunction(
-    {duckdb::LogicalType::ANY}, bigint_list, SearchStubFn));
+    {duckdb::LogicalType::ANY},
+    duckdb::LogicalType::LIST(duckdb::LogicalType::BIGINT), SearchStubFn));
   set.AddFunction(duckdb::ScalarFunction(
-    {duckdb::LogicalType::ANY, duckdb::LogicalType::INTEGER}, bigint_list,
-    SearchStubFn));
+    {duckdb::LogicalType::ANY, duckdb::LogicalType::INTEGER},
+    duckdb::LogicalType::LIST(duckdb::LogicalType::BIGINT), SearchStubFn));
   loader.RegisterFunction(std::move(set));
 }
 

--- a/server/connector/functions/search.h
+++ b/server/connector/functions/search.h
@@ -102,9 +102,7 @@ inline constexpr std::string_view kTSQueryPhraseSeq = "##";
 // side resolves to a column reference.
 inline constexpr std::string_view kTSQueryMatch = "@@";
 
-// SQL-native predicate sugar. Each rewrites at filter-build time to
-// `col @@ <inner ts_*(...)>` and dispatches through the existing @@
-// handler -- no per-predicate filter logic.
+// Sugar predicates: rewritten to `col @@ ts_*(...)` at filter-build time.
 inline constexpr std::string_view kPhraseMatches = "phrase_matches";
 inline constexpr std::string_view kNgramMatches = "ngram_matches";
 inline constexpr std::string_view kLevenshteinMatches = "levenshtein_matches";

--- a/server/connector/functions/search.h
+++ b/server/connector/functions/search.h
@@ -108,8 +108,8 @@ inline constexpr std::string_view kTSQueryMatch = "@@";
 inline constexpr std::string_view kPhraseMatches = "phrase_matches";
 inline constexpr std::string_view kNgramMatches = "ngram_matches";
 inline constexpr std::string_view kLevenshteinMatches = "levenshtein_matches";
-inline constexpr std::string_view kTokensMatchAll = "tokens_match_all";
-inline constexpr std::string_view kTokensMatchAny = "tokens_match_any";
+inline constexpr std::string_view kHasAllTokens = "has_all_tokens";
+inline constexpr std::string_view kHasAnyToken = "has_any_token";
 
 // Opaque logical type backing TSQUERY. Represented as VARCHAR+alias so
 // storage/IO paths stay standard; the stubs never run so the byte slot is

--- a/server/connector/functions/search.h
+++ b/server/connector/functions/search.h
@@ -102,6 +102,15 @@ inline constexpr std::string_view kTSQueryPhraseSeq = "##";
 // side resolves to a column reference.
 inline constexpr std::string_view kTSQueryMatch = "@@";
 
+// SQL-native predicate sugar. Each rewrites at filter-build time to
+// `col @@ <inner ts_*(...)>` and dispatches through the existing @@
+// handler -- no per-predicate filter logic.
+inline constexpr std::string_view kPhraseMatches = "phrase_matches";
+inline constexpr std::string_view kNgramMatches = "ngram_matches";
+inline constexpr std::string_view kLevenshteinMatches = "levenshtein_matches";
+inline constexpr std::string_view kTokensMatchAll = "tokens_match_all";
+inline constexpr std::string_view kTokensMatchAny = "tokens_match_any";
+
 // Opaque logical type backing TSQUERY. Represented as VARCHAR+alias so
 // storage/IO paths stay standard; the stubs never run so the byte slot is
 // unused in practice. Mirrors the JSON type convention in DuckDB.

--- a/server/connector/functions/string.cpp
+++ b/server/connector/functions/string.cpp
@@ -769,81 +769,6 @@ void LikeEscapeFunction(duckdb::DataChunk& args, duckdb::ExpressionState&,
     });
 }
 
-// similar_to_escape(pattern[, escape]) -> varchar
-// Converts a SQL SIMILAR TO pattern into a POSIX regex.
-// Ported from PG's similar_escape in regexp.c.
-std::string SimilarToEscapePattern(std::string_view pattern, char escape_char) {
-  std::string result;
-  result.reserve(pattern.size() + 6);
-
-  bool afterescape = false;
-  int nquotes = 0;
-  int bracket_depth = 0;
-  int charclass_pos = 0;
-
-  result += "^(?:";
-
-  for (size_t i = 0; i < pattern.size(); ++i) {
-    char pchar = pattern[i];
-
-    if (afterescape) {
-      if (pchar == '"' && bracket_depth < 1) {
-        if (nquotes == 0) {
-          result += "){1,1}?(";
-        } else if (nquotes == 1) {
-          result += "){1,1}(?:";
-        } else {
-          THROW_SQL_ERROR(
-            ERR_CODE(ERRCODE_INVALID_USE_OF_ESCAPE_CHARACTER),
-            ERR_MSG("SQL regular expression may not contain more than "
-                    "two escape-double-quote separators"));
-        }
-        nquotes++;
-      } else {
-        result += '\\';
-        result += pchar;
-        charclass_pos = 3;
-      }
-      afterescape = false;
-    } else if (pchar == escape_char) {
-      afterescape = true;
-    } else if (bracket_depth > 0) {
-      if (pchar == '\\') {
-        result += '\\';
-      }
-      result += pchar;
-      if (pchar == ']' && charclass_pos > 2) {
-        bracket_depth--;
-      } else if (pchar == '[') {
-        bracket_depth++;
-        charclass_pos = 3;
-      } else if (pchar == '^') {
-        charclass_pos++;
-      } else {
-        charclass_pos = 3;
-      }
-    } else if (pchar == '[') {
-      result += pchar;
-      bracket_depth = 1;
-      charclass_pos = 1;
-    } else if (pchar == '%') {
-      result += ".*";
-    } else if (pchar == '_') {
-      result += '.';
-    } else if (pchar == '(') {
-      result += "(?:";
-    } else if (pchar == '\\' || pchar == '.' || pchar == '^' || pchar == '$') {
-      result += '\\';
-      result += pchar;
-    } else {
-      result += pchar;
-    }
-  }
-
-  result += ")$";
-  return result;
-}
-
 void SimilarToEscapeFunction2(duckdb::DataChunk& args, duckdb::ExpressionState&,
                               duckdb::Vector& result) {
   duckdb::BinaryExecutor::Execute<duckdb::string_t, duckdb::string_t,
@@ -1112,14 +1037,6 @@ void RegexpMatchFunction(duckdb::DataChunk& args, duckdb::ExpressionState&,
 
 }  // namespace
 
-// like_escape(pattern, escape) -> varchar
-// Normalizes a LIKE pattern's escape character to backslash.
-// If escape is already '\', returns pattern unchanged.
-// Otherwise replaces escape_char sequences with '\' sequences and escapes
-// literal backslashes. A doubled escape char (e.g. "!!") in the source
-// pattern becomes "\!" in the output -- semantically equivalent to a plain
-// "!" as far as iresearch's wildcard filter is concerned (see
-// ComputeWildcardType / FromWildcard / Unescape).
 std::string LikeEscapePattern(std::string_view pattern, char escape_char) {
   if (escape_char == '\\') {
     return std::string{pattern};
@@ -1138,6 +1055,78 @@ std::string LikeEscapePattern(std::string_view pattern, char escape_char) {
     result += c;
     afterescape = false;
   }
+  return result;
+}
+
+std::string SimilarToEscapePattern(std::string_view pattern, char escape_char) {
+  std::string result;
+  result.reserve(pattern.size() + 6);
+
+  bool afterescape = false;
+  int nquotes = 0;
+  int bracket_depth = 0;
+  int charclass_pos = 0;
+
+  result += "^(?:";
+
+  for (size_t i = 0; i < pattern.size(); ++i) {
+    char pchar = pattern[i];
+
+    if (afterescape) {
+      if (pchar == '"' && bracket_depth < 1) {
+        if (nquotes == 0) {
+          result += "){1,1}?(";
+        } else if (nquotes == 1) {
+          result += "){1,1}(?:";
+        } else {
+          THROW_SQL_ERROR(
+            ERR_CODE(ERRCODE_INVALID_USE_OF_ESCAPE_CHARACTER),
+            ERR_MSG("SQL regular expression may not contain more than "
+                    "two escape-double-quote separators"));
+        }
+        nquotes++;
+      } else {
+        result += '\\';
+        result += pchar;
+        charclass_pos = 3;
+      }
+      afterescape = false;
+    } else if (pchar == escape_char) {
+      afterescape = true;
+    } else if (bracket_depth > 0) {
+      if (pchar == '\\') {
+        result += '\\';
+      }
+      result += pchar;
+      if (pchar == ']' && charclass_pos > 2) {
+        bracket_depth--;
+      } else if (pchar == '[') {
+        bracket_depth++;
+        charclass_pos = 3;
+      } else if (pchar == '^') {
+        charclass_pos++;
+      } else {
+        charclass_pos = 3;
+      }
+    } else if (pchar == '[') {
+      result += pchar;
+      bracket_depth = 1;
+      charclass_pos = 1;
+    } else if (pchar == '%') {
+      result += ".*";
+    } else if (pchar == '_') {
+      result += '.';
+    } else if (pchar == '(') {
+      result += "(?:";
+    } else if (pchar == '\\' || pchar == '.' || pchar == '^' || pchar == '$') {
+      result += '\\';
+      result += pchar;
+    } else {
+      result += pchar;
+    }
+  }
+
+  result += ")$";
   return result;
 }
 

--- a/server/connector/functions/string.h
+++ b/server/connector/functions/string.h
@@ -34,7 +34,6 @@ void RegisterPgStringFunctions(duckdb::DatabaseInstance& db);
 // builder when it translates `LIKE ... ESCAPE` predicates.
 std::string LikeEscapePattern(std::string_view pattern, char escape_char);
 
-// similar_to_escape(pattern[, escape]) -> varchar
 // Converts a SQL SIMILAR TO pattern into a POSIX regex.
 // Ported from PG's similar_escape in regexp.c.
 std::string SimilarToEscapePattern(std::string_view pattern, char escape_char);

--- a/server/connector/functions/string.h
+++ b/server/connector/functions/string.h
@@ -34,4 +34,9 @@ void RegisterPgStringFunctions(duckdb::DatabaseInstance& db);
 // builder when it translates `LIKE ... ESCAPE` predicates.
 std::string LikeEscapePattern(std::string_view pattern, char escape_char);
 
+// similar_to_escape(pattern[, escape]) -> varchar
+// Converts a SQL SIMILAR TO pattern into a POSIX regex.
+// Ported from PG's similar_escape in regexp.c.
+std::string SimilarToEscapePattern(std::string_view pattern, char escape_char);
+
 }  // namespace sdb::connector

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -134,8 +134,95 @@ customize::enum_name<sdb::connector::TSQueryOp>(
 }
 
 }  // namespace magic_enum
+
 namespace sdb::connector {
 namespace {
+
+// Returns the raw byte content of a Value whose physical type is
+// VARCHAR (covers both LogicalType::VARCHAR and LogicalType::BLOB) as
+// an irs::bytes_view ready for term-dictionary use. Use this instead
+// of GetValue<std::string>() at sites where the constant may arrive
+// as BLOB: DuckDB's regex_range_filter optimizer rewrites
+// regexp_full_match(col, pat) into
+//   col >= BLOB_RAW(min) AND col <= BLOB_RAW(max)
+// so the comparison constant against a VARCHAR column may be BLOB
+// even though the column is VARCHAR. GetValue<std::string>() on a
+// BLOB returns the textual display form (e.g. "\xF4\xBF\xBF\xC0" as
+// 24 ASCII chars), which is wrong as a byte-wise term-dictionary
+// bound. StringValue::Get returns the raw stored bytes for both
+// types because they share PhysicalType::VARCHAR.
+irs::bytes_view AsRawBytes(const duckdb::Value& value) {
+  return irs::ViewCast<irs::byte_type>(
+    std::string_view{duckdb::StringValue::Get(value)});
+}
+
+}  // namespace
+
+Result SetupTermFilter(irs::ByTerm& filter, std::string& field_name,
+                       const SearchColumnInfo& column_info,
+                       const duckdb::Value& value) {
+  SDB_ASSERT(!value.IsNull(),
+             "UNKNOWN and Nulls should be handled as part of IS NULL operator. "
+             "For regular filter it should be just irs::Empty!");
+
+  auto type_id = column_info.logical_type.id();
+
+  if (auto r = MangleForType(type_id, field_name); !r.ok()) {
+    return r;
+  }
+
+  if (type_id == duckdb::LogicalTypeId::VARCHAR) {
+    filter.mutable_options()->term.assign(AsRawBytes(value));
+  } else if (type_id == duckdb::LogicalTypeId::BOOLEAN) {
+    filter.mutable_options()->term.assign(irs::ViewCast<irs::byte_type>(
+      irs::BooleanTokenizer::value(value.GetValue<bool>())));
+  } else if (IsNumericTypeId(type_id)) {
+    irs::NumericTokenizer stream;
+    const irs::TermAttr* token = irs::get<irs::TermAttr>(stream);
+    ResetNumericStream(stream, type_id, value);
+    stream.next();
+    filter.mutable_options()->term.assign(token->value);
+  } else {
+    return {ERROR_NOT_IMPLEMENTED,
+            "Unsupported type for term filter: ", static_cast<int>(type_id)};
+  }
+
+  *filter.mutable_field() = field_name;
+  return {};
+}
+
+namespace {
+
+ComparisonOp InvertComparisonOp(ComparisonOp op) {
+  switch (op) {
+    case ComparisonOp::Le:
+      return ComparisonOp::Gt;
+    case ComparisonOp::Ge:
+      return ComparisonOp::Lt;
+    case ComparisonOp::Gt:
+      return ComparisonOp::Le;
+    case ComparisonOp::Lt:
+      return ComparisonOp::Ge;
+    case ComparisonOp::None:
+      return ComparisonOp::None;
+  }
+  SDB_UNREACHABLE();
+}
+
+ComparisonOp GetComparisonOp(duckdb::ExpressionType type) {
+  switch (type) {
+    case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+      return ComparisonOp::Le;
+    case duckdb::ExpressionType::COMPARE_LESSTHAN:
+      return ComparisonOp::Lt;
+    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+      return ComparisonOp::Ge;
+    case duckdb::ExpressionType::COMPARE_GREATERTHAN:
+      return ComparisonOp::Gt;
+    default:
+      return ComparisonOp::None;
+  }
+}
 
 template<typename... Args>
 std::vector<duckdb::unique_ptr<duckdb::Expression>> MakeChildren(
@@ -145,8 +232,6 @@ std::vector<duckdb::unique_ptr<duckdb::Expression>> MakeChildren(
   (v.emplace_back(std::forward<Args>(children)), ...);
   return v;
 }
-
-}  // namespace
 
 // True iff `type` is one of TSQUERY / TOKENIZED_TSQUERY /
 // BOOSTED_TSQUERY -- all valid carriers of TSQUERY-shaped values
@@ -195,218 +280,6 @@ std::optional<double> TryGetBoostModifier(const duckdb::LogicalType& type) {
   return mods[0].value.GetValue<double>();
 }
 
-const duckdb::BoundColumnRefExpression* TryGetColumnRef(
-  const duckdb::Expression& expr) {
-  if (expr.expression_class != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
-    return nullptr;
-  }
-  return &expr.Cast<duckdb::BoundColumnRefExpression>();
-}
-
-const duckdb::Value* TryGetConstant(const duckdb::Expression& expr) {
-  if (expr.expression_class != duckdb::ExpressionClass::BOUND_CONSTANT) {
-    return nullptr;
-  }
-  return &expr.Cast<duckdb::BoundConstantExpression>().value;
-}
-
-const SearchColumnInfo* FindColumnInfo(
-  const FilterContext& ctx, const duckdb::BoundColumnRefExpression& ref) {
-  // Try cache first -- keyed on column_id from a previous resolution.
-  // We do a two-step lookup: first resolve via column_getter to get the
-  // column_id, then check cache.  The column_getter itself may be cheap
-  // (just a span lookup), but caching avoids repeated analyzer copies.
-
-  // We cannot cache by binding alone (table_index + column_index) because
-  // different bindings may map to the same catalog column_id.  Instead
-  // we resolve first, then cache by column_id.
-
-  auto info = ctx.column_getter(ref);
-  if (!info) {
-    return nullptr;
-  }
-
-  auto cache_it = ctx.column_cache.find(info->column_id);
-  if (cache_it != ctx.column_cache.end()) {
-    SDB_ASSERT(cache_it->second.logical_type.id() !=
-                 duckdb::LogicalTypeId::VARCHAR ||
-               cache_it->second.tokenizer.analyzer);
-    return &cache_it->second;
-  }
-
-  auto column_id = info->column_id;
-  return &ctx.column_cache.emplace(column_id, std::move(info.value()))
-            .first->second;
-}
-
-void MakeFieldName(catalog::Column::Id column_id, std::string& field_name) {
-  basics::StrResize(field_name, sizeof(column_id));
-  absl::big_endian::Store(field_name.data(), column_id);
-}
-
-Result MangleForType(duckdb::LogicalTypeId type_id, std::string& field_name) {
-  switch (type_id) {
-    case duckdb::LogicalTypeId::VARCHAR:
-      search::mangling::MangleString(field_name);
-      return {};
-    case duckdb::LogicalTypeId::BOOLEAN:
-      search::mangling::MangleBool(field_name);
-      return {};
-    case duckdb::LogicalTypeId::TINYINT:
-    case duckdb::LogicalTypeId::SMALLINT:
-    case duckdb::LogicalTypeId::INTEGER:
-    case duckdb::LogicalTypeId::BIGINT:
-    case duckdb::LogicalTypeId::FLOAT:
-    case duckdb::LogicalTypeId::DOUBLE:
-    case duckdb::LogicalTypeId::DATE:
-    case duckdb::LogicalTypeId::TIMESTAMP:
-    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
-      search::mangling::MangleNumeric(field_name);
-      return {};
-    default:
-      return {ERROR_NOT_IMPLEMENTED, "Unsupported type id ",
-              static_cast<int>(type_id), " for field mangling"};
-  }
-}
-
-void ResetNumericStream(irs::NumericTokenizer& stream,
-                        duckdb::LogicalTypeId type_id,
-                        const duckdb::Value& value) {
-  switch (type_id) {
-    case duckdb::LogicalTypeId::TINYINT:
-    case duckdb::LogicalTypeId::SMALLINT:
-    case duckdb::LogicalTypeId::INTEGER:
-    case duckdb::LogicalTypeId::DATE:
-      stream.reset(value.GetValue<int32_t>());
-      break;
-    case duckdb::LogicalTypeId::BIGINT:
-    case duckdb::LogicalTypeId::TIMESTAMP:
-    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
-      stream.reset(value.GetValue<int64_t>());
-      break;
-    case duckdb::LogicalTypeId::FLOAT:
-      stream.reset(value.GetValue<float>());
-      break;
-    case duckdb::LogicalTypeId::DOUBLE:
-      stream.reset(value.GetValue<double>());
-      break;
-    default:
-      SDB_ASSERT(false, "ResetNumericStream called with non-numeric type");
-  }
-}
-
-bool IsNumericTypeId(duckdb::LogicalTypeId id) {
-  switch (id) {
-    case duckdb::LogicalTypeId::TINYINT:
-    case duckdb::LogicalTypeId::SMALLINT:
-    case duckdb::LogicalTypeId::INTEGER:
-    case duckdb::LogicalTypeId::BIGINT:
-    case duckdb::LogicalTypeId::FLOAT:
-    case duckdb::LogicalTypeId::DOUBLE:
-    case duckdb::LogicalTypeId::DATE:
-    case duckdb::LogicalTypeId::TIMESTAMP:
-    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
-      return true;
-    default:
-      return false;
-  }
-}
-
-// Looser numeric check used by RANGE / LESS / LESS_EQ / GREATER /
-// GREATER_EQ bound validation: accepts the same set as
-// IsNumericTypeId plus DECIMAL. The TSQUERY range constructors cast
-// bound values to the column's logical type before tokenising, so
-// DECIMAL bounds on a DOUBLE/INT/BIGINT column work as expected. We
-// don't fold DECIMAL into IsNumericTypeId itself because the legacy
-// FromComparison / SetupTermFilter paths feed `type_id` directly into
-// ResetNumericStream, which doesn't handle DECIMAL.
-bool IsRangeNumericValueType(duckdb::LogicalTypeId id) {
-  return IsNumericTypeId(id) || id == duckdb::LogicalTypeId::DECIMAL;
-}
-
-// Returns the raw byte content of a Value whose physical type is
-// VARCHAR (covers both LogicalType::VARCHAR and LogicalType::BLOB) as
-// an irs::bytes_view ready for term-dictionary use. Use this instead
-// of GetValue<std::string>() at sites where the constant may arrive
-// as BLOB: DuckDB's regex_range_filter optimizer rewrites
-// regexp_full_match(col, pat) into
-//   col >= BLOB_RAW(min) AND col <= BLOB_RAW(max)
-// so the comparison constant against a VARCHAR column may be BLOB
-// even though the column is VARCHAR. GetValue<std::string>() on a
-// BLOB returns the textual display form (e.g. "\xF4\xBF\xBF\xC0" as
-// 24 ASCII chars), which is wrong as a byte-wise term-dictionary
-// bound. StringValue::Get returns the raw stored bytes for both
-// types because they share PhysicalType::VARCHAR.
-irs::bytes_view AsRawBytes(const duckdb::Value& value) {
-  return irs::ViewCast<irs::byte_type>(
-    std::string_view{duckdb::StringValue::Get(value)});
-}
-
-// Sets up a ByTerm filter for a single constant value against a column.
-Result SetupTermFilter(irs::ByTerm& filter, std::string& field_name,
-                       const SearchColumnInfo& column_info,
-                       const duckdb::Value& value) {
-  SDB_ASSERT(!value.IsNull(),
-             "UNKNOWN and Nulls should be handled as part of IS NULL operator. "
-             "For regular filter it should be just irs::Empty!");
-
-  auto type_id = column_info.logical_type.id();
-
-  if (auto r = MangleForType(type_id, field_name); !r.ok()) {
-    return r;
-  }
-
-  if (type_id == duckdb::LogicalTypeId::VARCHAR) {
-    filter.mutable_options()->term.assign(AsRawBytes(value));
-  } else if (type_id == duckdb::LogicalTypeId::BOOLEAN) {
-    filter.mutable_options()->term.assign(irs::ViewCast<irs::byte_type>(
-      irs::BooleanTokenizer::value(value.GetValue<bool>())));
-  } else if (IsNumericTypeId(type_id)) {
-    irs::NumericTokenizer stream;
-    const irs::TermAttr* token = irs::get<irs::TermAttr>(stream);
-    ResetNumericStream(stream, type_id, value);
-    stream.next();
-    filter.mutable_options()->term.assign(token->value);
-  } else {
-    return {ERROR_NOT_IMPLEMENTED,
-            "Unsupported type for term filter: ", static_cast<int>(type_id)};
-  }
-
-  *filter.mutable_field() = field_name;
-  return {};
-}
-
-ComparisonOp GetComparisonOp(duckdb::ExpressionType type) {
-  switch (type) {
-    case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
-      return ComparisonOp::Le;
-    case duckdb::ExpressionType::COMPARE_LESSTHAN:
-      return ComparisonOp::Lt;
-    case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-      return ComparisonOp::Ge;
-    case duckdb::ExpressionType::COMPARE_GREATERTHAN:
-      return ComparisonOp::Gt;
-    default:
-      return ComparisonOp::None;
-  }
-}
-
-ComparisonOp InvertComparisonOp(ComparisonOp op) {
-  switch (op) {
-    case ComparisonOp::Le:
-      return ComparisonOp::Gt;
-    case ComparisonOp::Ge:
-      return ComparisonOp::Lt;
-    case ComparisonOp::Gt:
-      return ComparisonOp::Le;
-    case ComparisonOp::Lt:
-      return ComparisonOp::Ge;
-    case ComparisonOp::None:
-      return ComparisonOp::None;
-  }
-  SDB_UNREACHABLE();
-}
-
 bool IsComparisonExpr(const duckdb::Expression& expr) {
   return expr.expression_class == duckdb::ExpressionClass::BOUND_COMPARISON &&
          GetComparisonOp(expr.type) != ComparisonOp::None;
@@ -447,106 +320,6 @@ const duckdb::Expression& UnwrapBoostBoolCoercion(
     return expr;
   }
   return *cast.child;
-}
-
-const duckdb::Expression& UnwrapTSQueryCast(const duckdb::Expression& expr) {
-  const duckdb::Expression* cur = &expr;
-  while (cur->expression_class == duckdb::ExpressionClass::BOUND_CAST) {
-    const auto& cast = cur->Cast<duckdb::BoundCastExpression>();
-    if (!cast.child) {
-      break;
-    }
-    const auto& target = cast.return_type;
-    const auto& source = cast.child->return_type;
-    // Stop at modifier-bearing casts; the walker needs to see them.
-    if (!TryGetTokenizerModifier(target).empty() ||
-        TryGetBoostModifier(target)) {
-      break;
-    }
-    // Peel only transit casts within the {VARCHAR, TSQUERY,
-    // TOKENIZED_TSQUERY} family: both sides VARCHAR-backed, with at
-    // least one carrying a TSQUERY alias (otherwise it's a plain
-    // VARCHAR->VARCHAR cast we shouldn't strip).
-    if (target.id() != duckdb::LogicalTypeId::VARCHAR ||
-        source.id() != duckdb::LogicalTypeId::VARCHAR) {
-      break;
-    }
-    if (!IsAnyTSQueryType(target) && !IsAnyTSQueryType(source)) {
-      break;
-    }
-    cur = cast.child.get();
-  }
-  return *cur;
-}
-
-Result GetVarcharArg(const duckdb::Expression& expr, std::string_view label,
-                     std::string& out) {
-  const auto& unwrapped = UnwrapTSQueryCast(expr);
-  const auto* val = TryGetConstant(unwrapped);
-  if (!val || val->IsNull()) {
-    return {ERROR_BAD_PARAMETER, label, " must be a non-null VARCHAR constant"};
-  }
-  if (val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
-    return {ERROR_BAD_PARAMETER, label, " must be a VARCHAR constant"};
-  }
-  out = val->GetValue<std::string>();
-  return {};
-}
-
-Result GetIntArg(const duckdb::Expression& expr, std::string_view label,
-                 int64_t& out) {
-  const auto* val = TryGetConstant(expr);
-  if (!val || val->IsNull()) {
-    return {ERROR_BAD_PARAMETER, label, " must be a non-null INTEGER constant"};
-  }
-  switch (val->type().id()) {
-    case duckdb::LogicalTypeId::TINYINT:
-    case duckdb::LogicalTypeId::SMALLINT:
-    case duckdb::LogicalTypeId::INTEGER:
-    case duckdb::LogicalTypeId::BIGINT:
-    case duckdb::LogicalTypeId::UTINYINT:
-    case duckdb::LogicalTypeId::USMALLINT:
-    case duckdb::LogicalTypeId::UINTEGER:
-    case duckdb::LogicalTypeId::UBIGINT:
-      out = val->GetValue<int64_t>();
-      return {};
-    default:
-      return {ERROR_BAD_PARAMETER, label, " must be an INTEGER constant"};
-  }
-}
-
-Result GetBoolArg(const duckdb::Expression& expr, std::string_view label,
-                  bool& out) {
-  const auto* val = TryGetConstant(expr);
-  if (!val || val->IsNull()) {
-    return {ERROR_BAD_PARAMETER, label, " must be a non-null BOOLEAN constant"};
-  }
-  if (val->type().id() != duckdb::LogicalTypeId::BOOLEAN) {
-    return {ERROR_BAD_PARAMETER, label, " must be a BOOLEAN constant"};
-  }
-  out = val->GetValue<bool>();
-  return {};
-}
-
-Result GetDoubleArg(const duckdb::Expression& expr, std::string_view label,
-                    double& out) {
-  const auto* val = TryGetConstant(expr);
-  if (!val || val->IsNull()) {
-    return {ERROR_BAD_PARAMETER, label, " must be a non-null numeric constant"};
-  }
-  switch (val->type().id()) {
-    case duckdb::LogicalTypeId::FLOAT:
-    case duckdb::LogicalTypeId::DOUBLE:
-    case duckdb::LogicalTypeId::DECIMAL:
-    case duckdb::LogicalTypeId::TINYINT:
-    case duckdb::LogicalTypeId::SMALLINT:
-    case duckdb::LogicalTypeId::INTEGER:
-    case duckdb::LogicalTypeId::BIGINT:
-      out = val->GetValue<double>();
-      return {};
-    default:
-      return {ERROR_BAD_PARAMETER, label, " must be a numeric constant"};
-  }
 }
 
 Result FromExpression(irs::BooleanFilter& filter, const FilterContext& ctx,
@@ -955,38 +728,6 @@ Result FromLike(irs::BooleanFilter& filter, const FilterContext& ctx,
   return {};
 }
 
-// Picks ByWildcardNgram for WildcardAnalyzer-indexed columns -- those
-// columns ngram-tokenise terms at index time, so the pattern matches
-// through the inverted index instead of a brute-force term-dictionary
-// scan -- and ByWildcard otherwise.
-void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
-                    const SearchColumnInfo& column_info, std::string field_name,
-                    std::string_view raw_pattern, char escape_char) {
-  auto pattern = LikeEscapePattern(raw_pattern, escape_char);
-  if (column_info.tokenizer.analyzer->type() ==
-      irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
-    auto& wf = ctx.negated ? Negate<irs::ByWildcardNgram>(parent)
-                           : AddFilter<irs::ByWildcardNgram>(parent);
-    wf.boost(ctx.boost);
-    *wf.mutable_field() = std::move(field_name);
-    *wf.mutable_options() = {
-      pattern,
-      basics::downCast<irs::analysis::WildcardAnalyzer>(
-        *column_info.tokenizer.analyzer.get()),
-      (column_info.tokenizer.features & irs::IndexFeatures::Pos) ==
-        irs::IndexFeatures::Pos};
-    return;
-  }
-  auto& wild = ctx.negated ? Negate<irs::ByWildcard>(parent)
-                           : AddFilter<irs::ByWildcard>(parent);
-  wild.boost(ctx.boost);
-  *wild.mutable_field() = std::move(field_name);
-  auto& wild_opts = *wild.mutable_options();
-  wild_opts.scored_terms_limit = ctx.scored_terms_limit;
-  wild_opts.term.assign(
-    irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
-}
-
 duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryCall(
   std::string_view ts_name, duckdb::LogicalType return_type,
   std::vector<duckdb::unique_ptr<duckdb::Expression>> children) {
@@ -1163,67 +904,6 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
   }
 
   return {ERROR_NOT_IMPLEMENTED, "Unsupported function: ", name};
-}
-
-// Per-type TSQUERY entry points -- each defined in ts_<name>.cpp and
-// dispatched to from BuildTSQuery's switch below. All throw
-// THROW_SQL_ERROR on any failure (with operator-specific hints).
-void FromPhrase(irs::BooleanFilter&, const FilterContext&,
-                const SearchColumnInfo&,
-                const duckdb::BoundFunctionExpression&);
-void FromNgram(irs::BooleanFilter&, const FilterContext&,
-               const SearchColumnInfo&, const duckdb::BoundFunctionExpression&);
-void FromLevenshtein(irs::BooleanFilter&, const FilterContext&,
-                     const SearchColumnInfo&,
-                     const duckdb::BoundFunctionExpression&);
-void FromTerm(irs::BooleanFilter&, const FilterContext&,
-              const SearchColumnInfo&, const duckdb::BoundFunctionExpression&);
-void FromTSQLike(irs::BooleanFilter&, const FilterContext&,
-                 const SearchColumnInfo&,
-                 const duckdb::BoundFunctionExpression&);
-void FromPrefix(irs::BooleanFilter&, const FilterContext&,
-                const SearchColumnInfo&,
-                const duckdb::BoundFunctionExpression&);
-void FromTokenize(irs::BooleanFilter&, const FilterContext&,
-                  const SearchColumnInfo&,
-                  const duckdb::BoundFunctionExpression&);
-void FromHalfRange(irs::BooleanFilter&, const FilterContext&,
-                   const SearchColumnInfo&,
-                   const duckdb::BoundFunctionExpression&,
-                   std::string_view label, bool is_lower, bool inclusive);
-void FromRegexp(irs::BooleanFilter&, const FilterContext&,
-                const SearchColumnInfo&,
-                const duckdb::BoundFunctionExpression&);
-void FromBetween(irs::BooleanFilter&, const FilterContext&,
-                 const SearchColumnInfo&,
-                 const duckdb::BoundFunctionExpression&);
-void FromCompound(irs::BooleanFilter&, const FilterContext&,
-                  const SearchColumnInfo&,
-                  const duckdb::BoundFunctionExpression&);
-void FromAnyAllOf(irs::BooleanFilter&, const FilterContext&,
-                  const SearchColumnInfo&,
-                  const duckdb::BoundFunctionExpression&, bool is_any);
-void FromPlainToTsquery(irs::BooleanFilter&, const FilterContext&,
-                        const SearchColumnInfo&,
-                        const duckdb::BoundFunctionExpression&);
-void FromPhraseToTsquery(irs::BooleanFilter&, const FilterContext&,
-                         const SearchColumnInfo&,
-                         const duckdb::BoundFunctionExpression&);
-void FromTsqueryPhrase(irs::BooleanFilter&, const FilterContext&,
-                       const SearchColumnInfo&,
-                       const duckdb::BoundFunctionExpression&);
-void FromToTsquery(irs::BooleanFilter&, const FilterContext&,
-                   const SearchColumnInfo&,
-                   const duckdb::BoundFunctionExpression&);
-void FromWebsearchToTsquery(irs::BooleanFilter&, const FilterContext&,
-                            const SearchColumnInfo&,
-                            const duckdb::BoundFunctionExpression&);
-void FromTSQueryPhraseSeq(irs::BooleanFilter&, const FilterContext&,
-                          const SearchColumnInfo&,
-                          const duckdb::BoundFunctionExpression&);
-
-TSQueryOp ClassifyTSQueryFunction(std::string_view name) {
-  return magic_enum::enum_cast<TSQueryOp>(name).value_or(TSQueryOp::Unknown);
 }
 
 void FromTSQueryConjunction(irs::BooleanFilter& parent,
@@ -1431,146 +1111,6 @@ bool TryDispatchTokenizeCast(irs::BooleanFilter& parent,
   return true;
 }
 
-void BuildTSQuery(irs::BooleanFilter& parent, const FilterContext& ctx,
-                  const SearchColumnInfo& column_info,
-                  const duckdb::Expression& expr) {
-  const duckdb::Expression& unwrapped = UnwrapTSQueryCast(expr);
-
-  // Trivial-constant short-circuit: NULL -> Empty, true -> All,
-  // false -> Empty. Surfaces as either a NULL TSQUERY constant or a
-  // BoundCast<TSQUERY> wrapping a BOOLEAN constant. Works at any
-  // TSQUERY position thanks to the recursive walker.
-  if (unwrapped.expression_class == duckdb::ExpressionClass::BOUND_CAST) {
-    const auto& cast = unwrapped.Cast<duckdb::BoundCastExpression>();
-    if (cast.child &&
-        cast.child->return_type.id() == duckdb::LogicalTypeId::BOOLEAN) {
-      const auto* val = TryGetConstant(*cast.child);
-      if (!val) {
-        THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                        ERR_MSG("BOOLEAN inside TSQUERY must be a constant"),
-                        ERR_HINT("Use a literal true / false / NULL."));
-      }
-      if (val->IsNull() || !val->GetValue<bool>()) {
-        AddFilter<irs::Empty>(parent);
-      } else {
-        AddFilter<irs::All>(parent);
-      }
-      return;
-    }
-  }
-  if (const auto* val = TryGetConstant(unwrapped); val && val->IsNull()) {
-    AddFilter<irs::Empty>(parent);
-    return;
-  }
-
-  if (TryDispatchBoostCast(parent, ctx, column_info, unwrapped)) {
-    return;
-  }
-
-  if (TryDispatchTokenizeCast(parent, ctx, column_info, unwrapped)) {
-    return;
-  }
-
-  // Bare string (promoted via VARCHAR -> TSQUERY cast) -> tokenize via
-  // the ambient (column) analyzer. Multi-token input composes with OR
-  // (min_match=1) per the plan's "col @@ 'Quick Fox' ≡ ANY_OF(tokens)"
-  // rule. Non-VARCHAR / analyzer-less paths fall back to raw ByTerm.
-  if (unwrapped.expression_class == duckdb::ExpressionClass::BOUND_CONSTANT) {
-    const auto& val = unwrapped.Cast<duckdb::BoundConstantExpression>().value;
-    if (val.IsNull()) {
-      AddFilter<irs::Empty>(parent);
-      return;
-    }
-    if (val.type().id() == duckdb::LogicalTypeId::VARCHAR) {
-      BuildFtsTokens(parent, ctx, column_info, val.GetValue<std::string>(),
-                     /*require_all=*/false);
-      return;
-    }
-    BuildFtsTerm(parent, ctx, column_info, val);
-    return;
-  }
-
-  if (unwrapped.expression_class != duckdb::ExpressionClass::BOUND_FUNCTION) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("Unsupported TSQUERY expression class: ",
-                            static_cast<int>(unwrapped.expression_class)),
-                    ERR_HINT("Use a TSQUERY constructor (ts_phrase, ts_like, "
-                             "...) or 'literal'::TSQUERY."));
-  }
-
-  const auto& func = unwrapped.Cast<duckdb::BoundFunctionExpression>();
-  const auto op = ClassifyTSQueryFunction(func.function.name);
-
-  switch (op) {
-    case TSQueryOp::Phrase:
-      return FromPhrase(parent, ctx, column_info, func);
-    case TSQueryOp::Term:
-      return FromTerm(parent, ctx, column_info, func);
-    case TSQueryOp::Like:
-      return FromTSQLike(parent, ctx, column_info, func);
-    case TSQueryOp::Prefix:
-      return FromPrefix(parent, ctx, column_info, func);
-    case TSQueryOp::Ngram:
-      return FromNgram(parent, ctx, column_info, func);
-    case TSQueryOp::Fuzzy:
-      return FromLevenshtein(parent, ctx, column_info, func);
-    case TSQueryOp::Or:
-      return FromTSQueryConjunction(parent, ctx, column_info, func,
-                                    /*is_and=*/false);
-    case TSQueryOp::And:
-      return FromTSQueryConjunction(parent, ctx, column_info, func,
-                                    /*is_and=*/true);
-    case TSQueryOp::Not:
-      return FromTSQueryNot(parent, ctx, column_info, func);
-    case TSQueryOp::Boost:
-      return FromTSQueryBoost(parent, ctx, column_info, func);
-    case TSQueryOp::PhraseSeq:
-      return FromTSQueryPhraseSeq(parent, ctx, column_info, func);
-    case TSQueryOp::PhraseToTsquery:
-      return FromPhraseToTsquery(parent, ctx, column_info, func);
-    case TSQueryOp::Any:
-      return FromAnyAllOf(parent, ctx, column_info, func, /*is_any=*/true);
-    case TSQueryOp::All:
-      return FromAnyAllOf(parent, ctx, column_info, func, /*is_any=*/false);
-    case TSQueryOp::Compound:
-      return FromCompound(parent, ctx, column_info, func);
-    case TSQueryOp::Between:
-      return FromBetween(parent, ctx, column_info, func);
-    case TSQueryOp::Regexp:
-      return FromRegexp(parent, ctx, column_info, func);
-    case TSQueryOp::Less:
-      return FromHalfRange(parent, ctx, column_info, func, "ts_lt",
-                           /*is_lower=*/false, /*inclusive=*/false);
-    case TSQueryOp::LessEq:
-      return FromHalfRange(parent, ctx, column_info, func, "ts_le",
-                           /*is_lower=*/false, /*inclusive=*/true);
-    case TSQueryOp::Greater:
-      return FromHalfRange(parent, ctx, column_info, func, "ts_gt",
-                           /*is_lower=*/true, /*inclusive=*/false);
-    case TSQueryOp::GreaterEq:
-      return FromHalfRange(parent, ctx, column_info, func, "ts_ge",
-                           /*is_lower=*/true, /*inclusive=*/true);
-    case TSQueryOp::Tokenize:
-      return FromTokenize(parent, ctx, column_info, func);
-    case TSQueryOp::PlainToTsquery:
-      return FromPlainToTsquery(parent, ctx, column_info, func);
-    case TSQueryOp::WebsearchToTsquery:
-      return FromWebsearchToTsquery(parent, ctx, column_info, func);
-    case TSQueryOp::TsqueryPhrase:
-      return FromTsqueryPhrase(parent, ctx, column_info, func);
-    case TSQueryOp::ToTSQuery:
-      return FromToTsquery(parent, ctx, column_info, func);
-    case TSQueryOp::Unknown:
-      THROW_SQL_ERROR(
-        ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-        ERR_MSG("Not a TSQUERY-producing function: ", func.function.name),
-        ERR_HINT("Use a TSQUERY constructor (ts_phrase, ts_like, ts_between, "
-                 "ts_ngram, ts_levenshtein, ts_regexp, ts_any, ts_all, "
-                 "ts_compound, ...) or 'literal'::TSQUERY."));
-  }
-  SDB_UNREACHABLE();
-}
-
 void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
                       const duckdb::BoundFunctionExpression& func) {
   SDB_ASSERT(func.children.size() == 2);
@@ -1710,6 +1250,470 @@ Result FromExpression(irs::BooleanFilter& filter, const FilterContext& ctx,
       return {ERROR_NOT_IMPLEMENTED, "Unsupported expression class: ",
               static_cast<int>(expr.expression_class)};
   }
+}
+
+}  // namespace
+
+const duckdb::BoundColumnRefExpression* TryGetColumnRef(
+  const duckdb::Expression& expr) {
+  if (expr.expression_class != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+    return nullptr;
+  }
+  return &expr.Cast<duckdb::BoundColumnRefExpression>();
+}
+
+const duckdb::Value* TryGetConstant(const duckdb::Expression& expr) {
+  if (expr.expression_class != duckdb::ExpressionClass::BOUND_CONSTANT) {
+    return nullptr;
+  }
+  return &expr.Cast<duckdb::BoundConstantExpression>().value;
+}
+
+const SearchColumnInfo* FindColumnInfo(
+  const FilterContext& ctx, const duckdb::BoundColumnRefExpression& ref) {
+  // Try cache first -- keyed on column_id from a previous resolution.
+  // We do a two-step lookup: first resolve via column_getter to get the
+  // column_id, then check cache.  The column_getter itself may be cheap
+  // (just a span lookup), but caching avoids repeated analyzer copies.
+
+  // We cannot cache by binding alone (table_index + column_index) because
+  // different bindings may map to the same catalog column_id.  Instead
+  // we resolve first, then cache by column_id.
+
+  auto info = ctx.column_getter(ref);
+  if (!info) {
+    return nullptr;
+  }
+
+  auto cache_it = ctx.column_cache.find(info->column_id);
+  if (cache_it != ctx.column_cache.end()) {
+    SDB_ASSERT(cache_it->second.logical_type.id() !=
+                 duckdb::LogicalTypeId::VARCHAR ||
+               cache_it->second.tokenizer.analyzer);
+    return &cache_it->second;
+  }
+
+  auto column_id = info->column_id;
+  return &ctx.column_cache.emplace(column_id, std::move(info.value()))
+            .first->second;
+}
+
+void MakeFieldName(catalog::Column::Id column_id, std::string& field_name) {
+  basics::StrResize(field_name, sizeof(column_id));
+  absl::big_endian::Store(field_name.data(), column_id);
+}
+
+Result MangleForType(duckdb::LogicalTypeId type_id, std::string& field_name) {
+  switch (type_id) {
+    case duckdb::LogicalTypeId::VARCHAR:
+      search::mangling::MangleString(field_name);
+      return {};
+    case duckdb::LogicalTypeId::BOOLEAN:
+      search::mangling::MangleBool(field_name);
+      return {};
+    case duckdb::LogicalTypeId::TINYINT:
+    case duckdb::LogicalTypeId::SMALLINT:
+    case duckdb::LogicalTypeId::INTEGER:
+    case duckdb::LogicalTypeId::BIGINT:
+    case duckdb::LogicalTypeId::FLOAT:
+    case duckdb::LogicalTypeId::DOUBLE:
+    case duckdb::LogicalTypeId::DATE:
+    case duckdb::LogicalTypeId::TIMESTAMP:
+    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
+      search::mangling::MangleNumeric(field_name);
+      return {};
+    default:
+      return {ERROR_NOT_IMPLEMENTED, "Unsupported type id ",
+              static_cast<int>(type_id), " for field mangling"};
+  }
+}
+
+void ResetNumericStream(irs::NumericTokenizer& stream,
+                        duckdb::LogicalTypeId type_id,
+                        const duckdb::Value& value) {
+  switch (type_id) {
+    case duckdb::LogicalTypeId::TINYINT:
+    case duckdb::LogicalTypeId::SMALLINT:
+    case duckdb::LogicalTypeId::INTEGER:
+    case duckdb::LogicalTypeId::DATE:
+      stream.reset(value.GetValue<int32_t>());
+      break;
+    case duckdb::LogicalTypeId::BIGINT:
+    case duckdb::LogicalTypeId::TIMESTAMP:
+    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
+      stream.reset(value.GetValue<int64_t>());
+      break;
+    case duckdb::LogicalTypeId::FLOAT:
+      stream.reset(value.GetValue<float>());
+      break;
+    case duckdb::LogicalTypeId::DOUBLE:
+      stream.reset(value.GetValue<double>());
+      break;
+    default:
+      SDB_ASSERT(false, "ResetNumericStream called with non-numeric type");
+  }
+}
+
+bool IsNumericTypeId(duckdb::LogicalTypeId id) {
+  switch (id) {
+    case duckdb::LogicalTypeId::TINYINT:
+    case duckdb::LogicalTypeId::SMALLINT:
+    case duckdb::LogicalTypeId::INTEGER:
+    case duckdb::LogicalTypeId::BIGINT:
+    case duckdb::LogicalTypeId::FLOAT:
+    case duckdb::LogicalTypeId::DOUBLE:
+    case duckdb::LogicalTypeId::DATE:
+    case duckdb::LogicalTypeId::TIMESTAMP:
+    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Looser numeric check used by RANGE / LESS / LESS_EQ / GREATER /
+// GREATER_EQ bound validation: accepts the same set as
+// IsNumericTypeId plus DECIMAL. The TSQUERY range constructors cast
+// bound values to the column's logical type before tokenising, so
+// DECIMAL bounds on a DOUBLE/INT/BIGINT column work as expected. We
+// don't fold DECIMAL into IsNumericTypeId itself because the legacy
+// FromComparison / SetupTermFilter paths feed `type_id` directly into
+// ResetNumericStream, which doesn't handle DECIMAL.
+bool IsRangeNumericValueType(duckdb::LogicalTypeId id) {
+  return IsNumericTypeId(id) || id == duckdb::LogicalTypeId::DECIMAL;
+}
+
+const duckdb::Expression& UnwrapTSQueryCast(const duckdb::Expression& expr) {
+  const duckdb::Expression* cur = &expr;
+  while (cur->expression_class == duckdb::ExpressionClass::BOUND_CAST) {
+    const auto& cast = cur->Cast<duckdb::BoundCastExpression>();
+    if (!cast.child) {
+      break;
+    }
+    const auto& target = cast.return_type;
+    const auto& source = cast.child->return_type;
+    // Stop at modifier-bearing casts; the walker needs to see them.
+    if (!TryGetTokenizerModifier(target).empty() ||
+        TryGetBoostModifier(target)) {
+      break;
+    }
+    // Peel only transit casts within the {VARCHAR, TSQUERY,
+    // TOKENIZED_TSQUERY} family: both sides VARCHAR-backed, with at
+    // least one carrying a TSQUERY alias (otherwise it's a plain
+    // VARCHAR->VARCHAR cast we shouldn't strip).
+    if (target.id() != duckdb::LogicalTypeId::VARCHAR ||
+        source.id() != duckdb::LogicalTypeId::VARCHAR) {
+      break;
+    }
+    if (!IsAnyTSQueryType(target) && !IsAnyTSQueryType(source)) {
+      break;
+    }
+    cur = cast.child.get();
+  }
+  return *cur;
+}
+
+Result GetVarcharArg(const duckdb::Expression& expr, std::string_view label,
+                     std::string& out) {
+  const auto& unwrapped = UnwrapTSQueryCast(expr);
+  const auto* val = TryGetConstant(unwrapped);
+  if (!val || val->IsNull()) {
+    return {ERROR_BAD_PARAMETER, label, " must be a non-null VARCHAR constant"};
+  }
+  if (val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
+    return {ERROR_BAD_PARAMETER, label, " must be a VARCHAR constant"};
+  }
+  out = val->GetValue<std::string>();
+  return {};
+}
+
+Result GetIntArg(const duckdb::Expression& expr, std::string_view label,
+                 int64_t& out) {
+  const auto* val = TryGetConstant(expr);
+  if (!val || val->IsNull()) {
+    return {ERROR_BAD_PARAMETER, label, " must be a non-null INTEGER constant"};
+  }
+  switch (val->type().id()) {
+    case duckdb::LogicalTypeId::TINYINT:
+    case duckdb::LogicalTypeId::SMALLINT:
+    case duckdb::LogicalTypeId::INTEGER:
+    case duckdb::LogicalTypeId::BIGINT:
+    case duckdb::LogicalTypeId::UTINYINT:
+    case duckdb::LogicalTypeId::USMALLINT:
+    case duckdb::LogicalTypeId::UINTEGER:
+    case duckdb::LogicalTypeId::UBIGINT:
+      out = val->GetValue<int64_t>();
+      return {};
+    default:
+      return {ERROR_BAD_PARAMETER, label, " must be an INTEGER constant"};
+  }
+}
+
+Result GetBoolArg(const duckdb::Expression& expr, std::string_view label,
+                  bool& out) {
+  const auto* val = TryGetConstant(expr);
+  if (!val || val->IsNull()) {
+    return {ERROR_BAD_PARAMETER, label, " must be a non-null BOOLEAN constant"};
+  }
+  if (val->type().id() != duckdb::LogicalTypeId::BOOLEAN) {
+    return {ERROR_BAD_PARAMETER, label, " must be a BOOLEAN constant"};
+  }
+  out = val->GetValue<bool>();
+  return {};
+}
+
+Result GetDoubleArg(const duckdb::Expression& expr, std::string_view label,
+                    double& out) {
+  const auto* val = TryGetConstant(expr);
+  if (!val || val->IsNull()) {
+    return {ERROR_BAD_PARAMETER, label, " must be a non-null numeric constant"};
+  }
+  switch (val->type().id()) {
+    case duckdb::LogicalTypeId::FLOAT:
+    case duckdb::LogicalTypeId::DOUBLE:
+    case duckdb::LogicalTypeId::DECIMAL:
+    case duckdb::LogicalTypeId::TINYINT:
+    case duckdb::LogicalTypeId::SMALLINT:
+    case duckdb::LogicalTypeId::INTEGER:
+    case duckdb::LogicalTypeId::BIGINT:
+      out = val->GetValue<double>();
+      return {};
+    default:
+      return {ERROR_BAD_PARAMETER, label, " must be a numeric constant"};
+  }
+}
+
+// Picks ByWildcardNgram for WildcardAnalyzer-indexed columns -- those
+// columns ngram-tokenise terms at index time, so the pattern matches
+// through the inverted index instead of a brute-force term-dictionary
+// scan -- and ByWildcard otherwise.
+void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
+                    const SearchColumnInfo& column_info, std::string field_name,
+                    std::string_view raw_pattern, char escape_char) {
+  auto pattern = LikeEscapePattern(raw_pattern, escape_char);
+  if (column_info.tokenizer.analyzer->type() ==
+      irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
+    auto& wf = ctx.negated ? Negate<irs::ByWildcardNgram>(parent)
+                           : AddFilter<irs::ByWildcardNgram>(parent);
+    wf.boost(ctx.boost);
+    *wf.mutable_field() = std::move(field_name);
+    *wf.mutable_options() = {
+      pattern,
+      basics::downCast<irs::analysis::WildcardAnalyzer>(
+        *column_info.tokenizer.analyzer.get()),
+      (column_info.tokenizer.features & irs::IndexFeatures::Pos) ==
+        irs::IndexFeatures::Pos};
+    return;
+  }
+  auto& wild = ctx.negated ? Negate<irs::ByWildcard>(parent)
+                           : AddFilter<irs::ByWildcard>(parent);
+  wild.boost(ctx.boost);
+  *wild.mutable_field() = std::move(field_name);
+  auto& wild_opts = *wild.mutable_options();
+  wild_opts.scored_terms_limit = ctx.scored_terms_limit;
+  wild_opts.term.assign(
+    irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
+}
+
+// Per-type TSQUERY entry points -- each defined in ts_<name>.cpp and
+// dispatched to from BuildTSQuery's switch below. All throw
+// THROW_SQL_ERROR on any failure (with operator-specific hints).
+void FromPhrase(irs::BooleanFilter&, const FilterContext&,
+                const SearchColumnInfo&,
+                const duckdb::BoundFunctionExpression&);
+void FromNgram(irs::BooleanFilter&, const FilterContext&,
+               const SearchColumnInfo&, const duckdb::BoundFunctionExpression&);
+void FromLevenshtein(irs::BooleanFilter&, const FilterContext&,
+                     const SearchColumnInfo&,
+                     const duckdb::BoundFunctionExpression&);
+void FromTerm(irs::BooleanFilter&, const FilterContext&,
+              const SearchColumnInfo&, const duckdb::BoundFunctionExpression&);
+void FromTSQLike(irs::BooleanFilter&, const FilterContext&,
+                 const SearchColumnInfo&,
+                 const duckdb::BoundFunctionExpression&);
+void FromPrefix(irs::BooleanFilter&, const FilterContext&,
+                const SearchColumnInfo&,
+                const duckdb::BoundFunctionExpression&);
+void FromTokenize(irs::BooleanFilter&, const FilterContext&,
+                  const SearchColumnInfo&,
+                  const duckdb::BoundFunctionExpression&);
+void FromHalfRange(irs::BooleanFilter&, const FilterContext&,
+                   const SearchColumnInfo&,
+                   const duckdb::BoundFunctionExpression&,
+                   std::string_view label, bool is_lower, bool inclusive);
+void FromRegexp(irs::BooleanFilter&, const FilterContext&,
+                const SearchColumnInfo&,
+                const duckdb::BoundFunctionExpression&);
+void FromBetween(irs::BooleanFilter&, const FilterContext&,
+                 const SearchColumnInfo&,
+                 const duckdb::BoundFunctionExpression&);
+void FromCompound(irs::BooleanFilter&, const FilterContext&,
+                  const SearchColumnInfo&,
+                  const duckdb::BoundFunctionExpression&);
+void FromAnyAllOf(irs::BooleanFilter&, const FilterContext&,
+                  const SearchColumnInfo&,
+                  const duckdb::BoundFunctionExpression&, bool is_any);
+void FromPlainToTsquery(irs::BooleanFilter&, const FilterContext&,
+                        const SearchColumnInfo&,
+                        const duckdb::BoundFunctionExpression&);
+void FromPhraseToTsquery(irs::BooleanFilter&, const FilterContext&,
+                         const SearchColumnInfo&,
+                         const duckdb::BoundFunctionExpression&);
+void FromTsqueryPhrase(irs::BooleanFilter&, const FilterContext&,
+                       const SearchColumnInfo&,
+                       const duckdb::BoundFunctionExpression&);
+void FromToTsquery(irs::BooleanFilter&, const FilterContext&,
+                   const SearchColumnInfo&,
+                   const duckdb::BoundFunctionExpression&);
+void FromWebsearchToTsquery(irs::BooleanFilter&, const FilterContext&,
+                            const SearchColumnInfo&,
+                            const duckdb::BoundFunctionExpression&);
+void FromTSQueryPhraseSeq(irs::BooleanFilter&, const FilterContext&,
+                          const SearchColumnInfo&,
+                          const duckdb::BoundFunctionExpression&);
+
+TSQueryOp ClassifyTSQueryFunction(std::string_view name) {
+  return magic_enum::enum_cast<TSQueryOp>(name).value_or(TSQueryOp::Unknown);
+}
+
+void BuildTSQuery(irs::BooleanFilter& parent, const FilterContext& ctx,
+                  const SearchColumnInfo& column_info,
+                  const duckdb::Expression& expr) {
+  const duckdb::Expression& unwrapped = UnwrapTSQueryCast(expr);
+
+  // Trivial-constant short-circuit: NULL -> Empty, true -> All,
+  // false -> Empty. Surfaces as either a NULL TSQUERY constant or a
+  // BoundCast<TSQUERY> wrapping a BOOLEAN constant. Works at any
+  // TSQUERY position thanks to the recursive walker.
+  if (unwrapped.expression_class == duckdb::ExpressionClass::BOUND_CAST) {
+    const auto& cast = unwrapped.Cast<duckdb::BoundCastExpression>();
+    if (cast.child &&
+        cast.child->return_type.id() == duckdb::LogicalTypeId::BOOLEAN) {
+      const auto* val = TryGetConstant(*cast.child);
+      if (!val) {
+        THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                        ERR_MSG("BOOLEAN inside TSQUERY must be a constant"),
+                        ERR_HINT("Use a literal true / false / NULL."));
+      }
+      if (val->IsNull() || !val->GetValue<bool>()) {
+        AddFilter<irs::Empty>(parent);
+      } else {
+        AddFilter<irs::All>(parent);
+      }
+      return;
+    }
+  }
+  if (const auto* val = TryGetConstant(unwrapped); val && val->IsNull()) {
+    AddFilter<irs::Empty>(parent);
+    return;
+  }
+
+  if (TryDispatchBoostCast(parent, ctx, column_info, unwrapped)) {
+    return;
+  }
+
+  if (TryDispatchTokenizeCast(parent, ctx, column_info, unwrapped)) {
+    return;
+  }
+
+  // Bare string (promoted via VARCHAR -> TSQUERY cast) -> tokenize via
+  // the ambient (column) analyzer. Multi-token input composes with OR
+  // (min_match=1) per the plan's "col @@ 'Quick Fox' ≡ ANY_OF(tokens)"
+  // rule. Non-VARCHAR / analyzer-less paths fall back to raw ByTerm.
+  if (unwrapped.expression_class == duckdb::ExpressionClass::BOUND_CONSTANT) {
+    const auto& val = unwrapped.Cast<duckdb::BoundConstantExpression>().value;
+    if (val.IsNull()) {
+      AddFilter<irs::Empty>(parent);
+      return;
+    }
+    if (val.type().id() == duckdb::LogicalTypeId::VARCHAR) {
+      BuildFtsTokens(parent, ctx, column_info, val.GetValue<std::string>(),
+                     /*require_all=*/false);
+      return;
+    }
+    BuildFtsTerm(parent, ctx, column_info, val);
+    return;
+  }
+
+  if (unwrapped.expression_class != duckdb::ExpressionClass::BOUND_FUNCTION) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG("Unsupported TSQUERY expression class: ",
+                            static_cast<int>(unwrapped.expression_class)),
+                    ERR_HINT("Use a TSQUERY constructor (ts_phrase, ts_like, "
+                             "...) or 'literal'::TSQUERY."));
+  }
+
+  const auto& func = unwrapped.Cast<duckdb::BoundFunctionExpression>();
+  const auto op = ClassifyTSQueryFunction(func.function.name);
+
+  switch (op) {
+    case TSQueryOp::Phrase:
+      return FromPhrase(parent, ctx, column_info, func);
+    case TSQueryOp::Term:
+      return FromTerm(parent, ctx, column_info, func);
+    case TSQueryOp::Like:
+      return FromTSQLike(parent, ctx, column_info, func);
+    case TSQueryOp::Prefix:
+      return FromPrefix(parent, ctx, column_info, func);
+    case TSQueryOp::Ngram:
+      return FromNgram(parent, ctx, column_info, func);
+    case TSQueryOp::Fuzzy:
+      return FromLevenshtein(parent, ctx, column_info, func);
+    case TSQueryOp::Or:
+      return FromTSQueryConjunction(parent, ctx, column_info, func,
+                                    /*is_and=*/false);
+    case TSQueryOp::And:
+      return FromTSQueryConjunction(parent, ctx, column_info, func,
+                                    /*is_and=*/true);
+    case TSQueryOp::Not:
+      return FromTSQueryNot(parent, ctx, column_info, func);
+    case TSQueryOp::Boost:
+      return FromTSQueryBoost(parent, ctx, column_info, func);
+    case TSQueryOp::PhraseSeq:
+      return FromTSQueryPhraseSeq(parent, ctx, column_info, func);
+    case TSQueryOp::PhraseToTsquery:
+      return FromPhraseToTsquery(parent, ctx, column_info, func);
+    case TSQueryOp::Any:
+      return FromAnyAllOf(parent, ctx, column_info, func, /*is_any=*/true);
+    case TSQueryOp::All:
+      return FromAnyAllOf(parent, ctx, column_info, func, /*is_any=*/false);
+    case TSQueryOp::Compound:
+      return FromCompound(parent, ctx, column_info, func);
+    case TSQueryOp::Between:
+      return FromBetween(parent, ctx, column_info, func);
+    case TSQueryOp::Regexp:
+      return FromRegexp(parent, ctx, column_info, func);
+    case TSQueryOp::Less:
+      return FromHalfRange(parent, ctx, column_info, func, "ts_lt",
+                           /*is_lower=*/false, /*inclusive=*/false);
+    case TSQueryOp::LessEq:
+      return FromHalfRange(parent, ctx, column_info, func, "ts_le",
+                           /*is_lower=*/false, /*inclusive=*/true);
+    case TSQueryOp::Greater:
+      return FromHalfRange(parent, ctx, column_info, func, "ts_gt",
+                           /*is_lower=*/true, /*inclusive=*/false);
+    case TSQueryOp::GreaterEq:
+      return FromHalfRange(parent, ctx, column_info, func, "ts_ge",
+                           /*is_lower=*/true, /*inclusive=*/true);
+    case TSQueryOp::Tokenize:
+      return FromTokenize(parent, ctx, column_info, func);
+    case TSQueryOp::PlainToTsquery:
+      return FromPlainToTsquery(parent, ctx, column_info, func);
+    case TSQueryOp::WebsearchToTsquery:
+      return FromWebsearchToTsquery(parent, ctx, column_info, func);
+    case TSQueryOp::TsqueryPhrase:
+      return FromTsqueryPhrase(parent, ctx, column_info, func);
+    case TSQueryOp::ToTSQuery:
+      return FromToTsquery(parent, ctx, column_info, func);
+    case TSQueryOp::Unknown:
+      THROW_SQL_ERROR(
+        ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+        ERR_MSG("Not a TSQUERY-producing function: ", func.function.name),
+        ERR_HINT("Use a TSQUERY constructor (ts_phrase, ts_like, ts_between, "
+                 "ts_ngram, ts_levenshtein, ts_regexp, ts_any, ts_all, "
+                 "ts_compound, ...) or 'literal'::TSQUERY."));
+  }
+  SDB_UNREACHABLE();
 }
 
 Result MakeSearchFilter(

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -57,6 +57,7 @@
 #include <magic_enum/magic_enum.hpp>
 
 #include "basics/assert.h"
+#include "basics/containers/trivial_map.h"
 #include "basics/down_cast.h"
 #include "basics/string_utils.h"
 #include "catalog/mangling.h"
@@ -134,6 +135,18 @@ customize::enum_name<sdb::connector::TSQueryOp>(
 
 }  // namespace magic_enum
 namespace sdb::connector {
+namespace {
+
+template<typename... Args>
+std::vector<duckdb::unique_ptr<duckdb::Expression>> MakeChildren(
+  Args&&... children) {
+  std::vector<duckdb::unique_ptr<duckdb::Expression>> v;
+  v.reserve(sizeof...(children));
+  (v.emplace_back(std::forward<Args>(children)), ...);
+  return v;
+}
+
+}  // namespace
 
 // True iff `type` is one of TSQUERY / TOKENIZED_TSQUERY /
 // BOOSTED_TSQUERY -- all valid carriers of TSQUERY-shaped values
@@ -974,6 +987,129 @@ void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
     irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
 }
 
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryCall(
+  std::string_view ts_name, duckdb::LogicalType return_type,
+  std::vector<duckdb::unique_ptr<duckdb::Expression>> children) {
+  duckdb::ScalarFunction fn(std::string{ts_name}, {}, return_type, nullptr);
+  auto expr = duckdb::make_uniq<duckdb::BoundFunctionExpression>(
+    return_type, std::move(fn), std::move(children), nullptr);
+  expr->function.name = std::string{ts_name};
+  return expr;
+}
+
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryCall(
+  std::string_view ts_name,
+  std::vector<duckdb::unique_ptr<duckdb::Expression>> children) {
+  return MakeTSQueryCall(ts_name, MakeTSQueryType(), std::move(children));
+}
+
+// ts_tokenize taking a list returns LIST(TSQUERY); the array-form
+// dispatch (FromTokenizeListInAnyAllOf) keys on this via
+// IsTokenizeListCall.
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryTokenizeList(
+  duckdb::unique_ptr<duckdb::Expression> list) {
+  return MakeTSQueryCall(kTSQTokenize,
+                         duckdb::LogicalType::LIST(MakeTSQueryType()),
+                         MakeChildren(std::move(list)));
+}
+
+template<const std::string_view& kTsName>
+duckdb::unique_ptr<duckdb::Expression> BuildPassthrough(
+  std::vector<duckdb::unique_ptr<duckdb::Expression>>&& args) {
+  return MakeTSQueryCall(kTsName, std::move(args));
+}
+
+duckdb::unique_ptr<duckdb::Expression> BuildAllTokens(
+  std::vector<duckdb::unique_ptr<duckdb::Expression>>&& args) {
+  return MakeTSQueryCall(
+    kTSQAllOf, MakeChildren(MakeTSQueryTokenizeList(std::move(args.at(0)))));
+}
+
+// Wraps a single VARCHAR expression in a constant LIST(VARCHAR) so it
+// flows through ts_tokenize array form. The text must be a constant;
+// non-constant text is rejected (matches the existing ts_tokenize
+// array-form constraint).
+duckdb::unique_ptr<duckdb::Expression> WrapTextAsConstantList(
+  duckdb::unique_ptr<duckdb::Expression> text) {
+  const auto* val = TryGetConstant(*text);
+  if (!val || val->IsNull()) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG(kTokensMatchAny,
+              "(col, text, min_match) requires a constant non-NULL text"),
+      ERR_HINT("Pass a literal string or a list-form: ", kTokensMatchAny,
+               "(col, ['text'], n)."));
+  }
+  duckdb::vector<duckdb::Value> elems;
+  elems.emplace_back(*val);
+  return duckdb::make_uniq<duckdb::BoundConstantExpression>(
+    duckdb::Value::LIST(duckdb::LogicalType::VARCHAR, std::move(elems)));
+}
+
+duckdb::unique_ptr<duckdb::Expression> BuildAnyToken(
+  std::vector<duckdb::unique_ptr<duckdb::Expression>>&& args) {
+  const bool is_text =
+    args.at(0)->return_type.id() == duckdb::LogicalTypeId::VARCHAR;
+  const bool has_min_match = args.size() >= 2;
+
+  if (!is_text) {
+    auto tokenize = MakeTSQueryTokenizeList(std::move(args[0]));
+    return MakeTSQueryCall(
+      kTSQAnyOf, has_min_match
+                   ? MakeChildren(std::move(tokenize), std::move(args[1]))
+                   : MakeChildren(std::move(tokenize)));
+  }
+  if (!has_min_match) {
+    return std::move(args[0]);
+  }
+  auto list = WrapTextAsConstantList(std::move(args[0]));
+  auto tokenize = MakeTSQueryTokenizeList(std::move(list));
+  return MakeTSQueryCall(kTSQAnyOf,
+                         MakeChildren(std::move(tokenize), std::move(args[1])));
+}
+
+using PredicateInnerBuilder = duckdb::unique_ptr<duckdb::Expression> (*)(
+  std::vector<duckdb::unique_ptr<duckdb::Expression>>&& args);
+
+constexpr containers::TrivialBiMap kPredicateBuilders = [](auto selector) {
+  return selector()
+    .Case(kPhraseMatches, PredicateInnerBuilder{&BuildPassthrough<kTSQPhrase>})
+    .Case(kNgramMatches, PredicateInnerBuilder{&BuildPassthrough<kTSQNgram>})
+    .Case(kLevenshteinMatches,
+          PredicateInnerBuilder{&BuildPassthrough<kTSQLevenshtein>})
+    .Case(kTokensMatchAll, PredicateInnerBuilder{&BuildAllTokens})
+    .Case(kTokensMatchAny, PredicateInnerBuilder{&BuildAnyToken});
+};
+
+Result FromPredicate(irs::BooleanFilter& filter, const FilterContext& ctx,
+                     PredicateInnerBuilder build_inner,
+                     const duckdb::BoundFunctionExpression& func) {
+  if (func.children.empty()) {
+    return {ERROR_BAD_PARAMETER, func.function.name,
+            " requires a column reference as the first argument"};
+  }
+  auto column = func.children[0]->Copy();
+  std::vector<duckdb::unique_ptr<duckdb::Expression>> tail;
+  tail.reserve(func.children.size() - 1);
+  for (size_t i = 1; i < func.children.size(); ++i) {
+    tail.emplace_back(func.children[i]->Copy());
+  }
+  auto inner = build_inner(std::move(tail));
+
+  // Synthesise `column @@ inner` and reuse FromTSQueryMatch -- it
+  // resolves the column, sets up the tokenizer ctx, and dispatches
+  // the inner ts_* via BuildTSQuery's name switch.
+  duckdb::ScalarFunction match_fn(std::string{kTSQueryMatch}, {},
+                                  duckdb::LogicalType::BOOLEAN, nullptr);
+  duckdb::BoundFunctionExpression at_at(
+    duckdb::LogicalType::BOOLEAN, std::move(match_fn),
+    MakeChildren(std::move(column), std::move(inner)), nullptr);
+  at_at.function.name = std::string{kTSQueryMatch};
+
+  FromTSQueryMatch(filter, ctx, at_at);
+  return {};
+}
+
 Result FromFunctionExpression(irs::BooleanFilter& filter,
                               const FilterContext& ctx,
                               const duckdb::BoundFunctionExpression& func) {
@@ -1024,6 +1160,10 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
 
   if (name == "prefix") {
     return FromFuncPrefix(filter, ctx, func);
+  }
+
+  if (auto build = kPredicateBuilders.TryFindByFirst(name)) {
+    return FromPredicate(filter, ctx, *build, func);
   }
 
   return {ERROR_NOT_IMPLEMENTED, "Unsupported function: ", name};

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -33,6 +33,7 @@
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <expected>
 #include <iresearch/analysis/tokenizers.hpp>
 #include <iresearch/analysis/wildcard_analyzer.hpp>
 #include <iresearch/search/all_filter.hpp>
@@ -58,7 +59,7 @@
 
 #include "basics/assert.h"
 #include "basics/containers/trivial_map.h"
-#include "basics/down_cast.h"
+#include "basics/errors.h"
 #include "basics/string_utils.h"
 #include "catalog/mangling.h"
 #include "functions/search.h"
@@ -191,6 +192,15 @@ Result SetupTermFilter(irs::ByTerm& filter, std::string& field_name,
 }
 
 namespace {
+
+ResultOr<std::string> TryGetString(const duckdb::Expression& expr) {
+  const auto* value = TryGetConstant(expr);
+  if (!value || value->IsNull() ||
+      value->type().id() != duckdb::LogicalTypeId::VARCHAR) {
+    return std::unexpected{ERROR_BAD_PARAMETER};
+  }
+  return value->GetValue<std::string>();
+}
 
 ComparisonOp InvertComparisonOp(ComparisonOp op) {
   switch (op) {
@@ -670,64 +680,6 @@ Result FromIn(irs::BooleanFilter& filter, const FilterContext& ctx,
   return {};
 }
 
-// `generic_version` selects the call-site contract:
-//  - true: SQL `b LIKE 'pat'` operator -- the column may be any
-//    indexed type; the function returns a Result so the optimizer
-//    can leave the filter unclaimed when the column rejects the
-//    LIKE shape (non-VARCHAR, non-keyword / non-wildcard analyzer).
-//  - false: TSQUERY-surface entry where the binder has already
-//    constrained the column to VARCHAR. Validate via SDB_ASSERT
-//    instead of returning a Result -- the failure mode is a bind-
-//    time programmer error, not a user-recoverable predicate
-//    mismatch.
-Result FromLike(irs::BooleanFilter& filter, const FilterContext& ctx,
-                const duckdb::Expression& field_expr,
-                const duckdb::Expression& pattern_expr, bool generic_version,
-                char escape_char = '\\') {
-  const auto* column_ref = TryGetColumnRef(field_expr);
-  if (!column_ref) {
-    return {ERROR_BAD_PARAMETER, "Input is not a column reference"};
-  }
-
-  const auto* const_val = TryGetConstant(pattern_expr);
-  if (!const_val) {
-    return {ERROR_BAD_PARAMETER, "Failed to evaluate LIKE pattern as constant"};
-  }
-
-  if (const_val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
-    return {ERROR_BAD_PARAMETER, "Failed to evaluate LIKE pattern as VARCHAR"};
-  }
-
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
-  if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column is not indexed"};
-  }
-
-  std::string field_name;
-  MakeFieldName(column_info->column_id, field_name);
-
-  if (generic_version) {
-    if (column_info->logical_type.id() != duckdb::LogicalTypeId::VARCHAR) {
-      return {ERROR_BAD_PARAMETER, "LIKE field is not VARCHAR"};
-    }
-    const auto analyzer_type = column_info->tokenizer.analyzer->type();
-    if (analyzer_type != irs::Type<irs::StringTokenizer>::id() &&
-        analyzer_type != irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
-      return {ERROR_BAD_PARAMETER,
-              "Field is not indexed by identity or wildcard analyzer. Use "
-              "`col @@ ts_like('pattern')`."};
-    }
-  } else {
-    SDB_ASSERT(column_info->logical_type.id() == duckdb::LogicalTypeId::VARCHAR,
-               ERROR_BAD_PARAMETER, "LIKE field is not VARCHAR");
-  }
-
-  search::mangling::MangleString(field_name);
-  EmitLikeFilter(filter, ctx, *column_info, std::move(field_name),
-                 const_val->GetValue<std::string>(), escape_char);
-  return {};
-}
-
 // Appends `s` to `out` with `\`, `%`, `_` backslash-escaped so the
 // result is a LIKE pattern that matches `s` literally. Caller reserves
 // up front (worst-case +1 char per input byte). Used by the `contains`
@@ -823,7 +775,7 @@ duckdb::unique_ptr<duckdb::Expression> BuildAnyToken(
 using PredicateInnerBuilder = duckdb::unique_ptr<duckdb::Expression> (*)(
   std::vector<duckdb::unique_ptr<duckdb::Expression>>&& args);
 
-constexpr containers::TrivialBiMap kPredicateBuilders = [](auto selector) {
+constexpr containers::TrivialBiMap kSugarBuilders = [](auto selector) {
   return selector()
     .Case(kPhraseMatches, BuildPassthrough<kTSQPhrase>)
     .Case(kNgramMatches, BuildPassthrough<kTSQNgram>)
@@ -835,10 +787,8 @@ constexpr containers::TrivialBiMap kPredicateBuilders = [](auto selector) {
 Result FromPredicate(irs::BooleanFilter& filter, const FilterContext& ctx,
                      PredicateInnerBuilder build_inner,
                      const duckdb::BoundFunctionExpression& func) {
-  if (func.children.empty()) {
-    return {ERROR_BAD_PARAMETER, func.function.name,
-            " requires a column reference as the first argument"};
-  }
+  SDB_ASSERT(!func.children.empty());
+
   // Tail must be copied because the builder takes ownership (it splices
   // the args into a synthesised ts_* call).
   auto tail = func.children | std::views::drop(1) |
@@ -890,123 +840,125 @@ duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSRegexp(
                   duckdb::Value(std::string{literal}))));
 }
 
-// `<builtin>(col, literal)` -> `col @@ <inner>(literal)` for keyword-
-// analyzed columns. Decline (no claim) when the call shape doesn't
-// match: wrong arity, non-VARCHAR column type, non-column LHS, non-
-// constant or NULL pattern. Throw with a helpful hint when the column
-// is indexed but uses a non-keyword analyzer (semantics would diverge
-// from DuckDB's whole-string predicate).
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSLike(
+  std::string_view literal) {
+  return MakeTSQueryCall(
+    kTSQLike, MakeChildren(duckdb::make_uniq<duckdb::BoundConstantExpression>(
+                duckdb::Value(std::string{literal}))));
+}
+
+using AnalyzerPredicate = bool (*)(irs::TypeInfo::type_id);
+
+bool IsKeywordAnalyzer(irs::TypeInfo::type_id t) {
+  return t == irs::Type<irs::StringTokenizer>::id();
+}
+
+bool IsLikeCompatibleAnalyzer(irs::TypeInfo::type_id t) {
+  return t == irs::Type<irs::StringTokenizer>::id() ||
+         t == irs::Type<irs::analysis::WildcardAnalyzer>::id();
+}
+
+constexpr containers::TrivialBiMap kBuiltinBuilder = [](auto selector) {
+  return selector()
+    .Case("contains", &BuildTSContainsLike)
+    .Case("^@", &BuildTSStartsWith)
+    .Case("starts_with", &BuildTSStartsWith)
+    .Case("prefix", &BuildTSStartsWith)
+    .Case("suffix", &BuildTSEndsWithLike)
+    .Case("ends_with", &BuildTSEndsWithLike)
+    .Case("regexp_matches", &BuildTSRegexp)
+    .Case("regexp_like", &BuildTSRegexp)
+    .Case("~~", &BuildTSLike);
+};
+
+// Pre-extracted variant: validates column ref + indexed + analyzer
+// predicate, then synthesises `col @@ build_inner(pattern)` and
+// dispatches via FromTSQueryMatch. Used by callers that already
+// extracted the literal pattern (e.g. LIKE which also needs to
+// normalise via LikeEscapePattern).
 Result RewriteAsTSQueryMatch(irs::BooleanFilter& filter,
                              const FilterContext& ctx,
-                             const duckdb::BoundFunctionExpression& func,
+                             const duckdb::Expression& column_expr,
+                             std::string_view pattern,
                              StringBuiltinBuilder build_inner,
-                             std::string_view ts_form_hint) {
-  if (func.children.size() != 2) {
-    return {ERROR_NOT_IMPLEMENTED, func.function.name,
-            ": expected 2 args, got ", func.children.size()};
-  }
-  if (func.children[0]->return_type.id() != duckdb::LogicalTypeId::VARCHAR) {
-    return {ERROR_NOT_IMPLEMENTED, func.function.name,
-            ": VARCHAR overload only -- declined for ",
-            func.children[0]->return_type.ToString()};
-  }
-  const auto* column_ref = TryGetColumnRef(*func.children[0]);
+                             AnalyzerPredicate analyzer_ok,
+                             std::string_view func_name) {
+  const auto* column_ref = TryGetColumnRef(column_expr);
   if (!column_ref) {
-    return {ERROR_NOT_IMPLEMENTED, func.function.name,
+    return {ERROR_NOT_IMPLEMENTED, func_name,
             ": first arg is not a column reference"};
-  }
-  const auto* literal_val = TryGetConstant(*func.children[1]);
-  if (!literal_val || literal_val->IsNull() ||
-      literal_val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
-    return {ERROR_NOT_IMPLEMENTED, func.function.name,
-            ": pattern must be a non-NULL VARCHAR constant"};
   }
   const auto* column_info = FindColumnInfo(ctx, *column_ref);
   if (!column_info) {
     return {ERROR_BAD_PARAMETER, "Column is not indexed"};
   }
-  if (column_info->tokenizer.analyzer->type() !=
-      irs::Type<irs::StringTokenizer>::id()) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG(func.function.name,
-              " requires a keyword-analyzed column on inverted-indexed "
-              "inputs"),
-      ERR_HINT("Use `", ts_form_hint, "` for non-keyword analyzers."));
+  if (!analyzer_ok(column_info->tokenizer.analyzer->type())) {
+    return {ERROR_BAD_PARAMETER, func_name, ": column analyzer not supported"};
   }
-  auto inner = build_inner(literal_val->GetValue<std::string>());
-  FromTSQueryMatch(filter, ctx, *func.children[0], *inner);
+  auto inner = build_inner(pattern);
+  FromTSQueryMatch(filter, ctx, column_expr, *inner);
   return {};
 }
 
 Result FromFunctionExpression(irs::BooleanFilter& filter,
                               const FilterContext& ctx,
                               const duckdb::BoundFunctionExpression& func) {
-  const auto& name = func.function.name;
+  std::string_view name = func.function.name;
+  std::span args = func.children;
+
   if (name == kTSQueryMatch) {
     // Anything that fails inside `@@` would otherwise fall through to
     // the runtime stub and surface the generic "TSQUERY expression
     // evaluated outside @@" error -- losing the specific cause. Throw
     // at this boundary so users see the actual reason + a hint.
-    SDB_ASSERT(func.children.size() == 2);
-    FromTSQueryMatch(filter, ctx, *func.children[0], *func.children[1]);
+    SDB_ASSERT(args.size() == 2);
+    FromTSQueryMatch(filter, ctx, *args[0], *args[1]);
     return {};
   }
 
-  // DuckDB turns LIKE into a BoundFunctionExpression with function.name
-  // "~~" or "like_escape".  Handle it as generic LIKE.
-  //
-  // We deliberately do NOT add a `regexp_full_match` claimer here even
-  // though Postgres `~ / ~* / !~ / !~*` rewrite to it. DuckDB's own
-  // regex_range_filter optimizer runs first and wraps any
-  // `regexp_full_match(col, pat)` call in a sibling LogicalFilter that
-  // adds `col >= range_min AND col <= range_max` (computed from the
-  // pattern's literal prefix). After our walker recursively claims
-  // the inner range filter and rewrites the LogicalGet into an
-  // iresearch scan, the outer filter (still holding the original
-  // regexp_full_match) no longer matches our claim shape -- the Get
-  // has scan_source.Kind() != FullTable -- so the regexp_full_match
-  // would silently fall back to the DuckDB regex executor anyway.
-  if (name == "~~" || name == "like_escape") {
-    if (func.children.size() < 2) {
-      return {ERROR_BAD_PARAMETER, "LIKE has ", func.children.size(),
-              " inputs but at least 2 expected"};
+  char escape_char = '\\';
+  if (name == "like_escape") {
+    SDB_ASSERT(args.size() == 3);
+    auto escape_str = TryGetString(*args[2]);
+    if (!escape_str) {
+      return std::move(escape_str).error();
     }
-    char escape_char = '\\';
-    if (name == "like_escape" && func.children.size() >= 3) {
-      const auto* esc_val = TryGetConstant(*func.children[2]);
-      if (!esc_val || esc_val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
-        return {ERROR_BAD_PARAMETER, "LIKE ESCAPE must be a VARCHAR constant"};
-      }
-      auto esc_str = esc_val->GetValue<std::string>();
-      if (esc_str.size() != 1) {
-        return {ERROR_BAD_PARAMETER, "LIKE ESCAPE must be a single character"};
-      }
-      escape_char = esc_str[0];
+    if (escape_str->size() != 1) {
+      return {ERROR_BAD_PARAMETER, "LIKE ESCAPE must be a single character"};
     }
-    return FromLike(filter, ctx, *func.children[0], *func.children[1],
-                    /*generic_version=*/true, escape_char);
+    escape_char = escape_str->front();
+    args = args.subspan(0, 2);
+    name = "~~";
   }
 
-  if (name == "contains") {
-    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSContainsLike,
-                                 "col @@ ts_like('%pattern%')");
-  }
-  if (name == "^@" || name == "starts_with" || name == "prefix") {
-    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSStartsWith,
-                                 "col @@ ts_starts_with('p')");
-  }
-  if (name == "suffix" || name == "ends_with") {
-    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSEndsWithLike,
-                                 "col @@ ts_like('%suffix')");
-  }
-  if (name == "regexp_matches" || name == "regexp_like") {
-    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSRegexp,
-                                 "col @@ ts_regexp('re')");
+  if (args.size() == 2) {
+    // some functions like regexp_matches/regexp_like have optional third args
+    // for flags; ignore those here since we don't support
+    if (auto builder = kBuiltinBuilder.TryFindByFirst(name).value_or(nullptr)) {
+      SDB_ASSERT(args.size() == 2);
+      if (args[0]->return_type.id() != duckdb::LogicalTypeId::VARCHAR) {
+        return {ERROR_NOT_IMPLEMENTED, func.function.name,
+                ": VARCHAR overload only -- declined for ",
+                args[0]->return_type.ToString()};
+      }
+      auto pattern = TryGetString(*args[1]);
+      if (!pattern) {
+        return std::move(pattern).error();
+      }
+      auto validator = &IsKeywordAnalyzer;
+
+      if (builder == &BuildTSLike) {
+        *pattern = LikeEscapePattern(*pattern, escape_char);
+        validator = &IsLikeCompatibleAnalyzer;
+      }
+
+      return RewriteAsTSQueryMatch(filter, ctx, *args[0], *pattern, builder,
+                                   validator, name);
+    }
   }
 
-  if (auto build = kPredicateBuilders.TryFindByFirst(name)) {
-    return FromPredicate(filter, ctx, *build, func);
+  if (auto builder = kSugarBuilders.TryFindByFirst(name)) {
+    return FromPredicate(filter, ctx, *builder, func);
   }
 
   return {ERROR_NOT_IMPLEMENTED, "Unsupported function: ", name};
@@ -1590,38 +1542,6 @@ Result GetDoubleArg(const duckdb::Expression& expr, std::string_view label,
     default:
       return {ERROR_BAD_PARAMETER, label, " must be a numeric constant"};
   }
-}
-
-// Picks ByWildcardNgram for WildcardAnalyzer-indexed columns -- those
-// columns ngram-tokenise terms at index time, so the pattern matches
-// through the inverted index instead of a brute-force term-dictionary
-// scan -- and ByWildcard otherwise.
-void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
-                    const SearchColumnInfo& column_info, std::string field_name,
-                    std::string_view raw_pattern, char escape_char) {
-  auto pattern = LikeEscapePattern(raw_pattern, escape_char);
-  if (column_info.tokenizer.analyzer->type() ==
-      irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
-    auto& wf = ctx.negated ? Negate<irs::ByWildcardNgram>(parent)
-                           : AddFilter<irs::ByWildcardNgram>(parent);
-    wf.boost(ctx.boost);
-    *wf.mutable_field() = std::move(field_name);
-    *wf.mutable_options() = {
-      pattern,
-      basics::downCast<irs::analysis::WildcardAnalyzer>(
-        *column_info.tokenizer.analyzer.get()),
-      (column_info.tokenizer.features & irs::IndexFeatures::Pos) ==
-        irs::IndexFeatures::Pos};
-    return;
-  }
-  auto& wild = ctx.negated ? Negate<irs::ByWildcard>(parent)
-                           : AddFilter<irs::ByWildcard>(parent);
-  wild.boost(ctx.boost);
-  *wild.mutable_field() = std::move(field_name);
-  auto& wild_opts = *wild.mutable_options();
-  wild_opts.scored_terms_limit = ctx.scored_terms_limit;
-  wild_opts.term.assign(
-    irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
 }
 
 // Per-type TSQUERY entry points -- each defined in ts_<name>.cpp and

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -33,7 +33,6 @@
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
-#include <expected>
 #include <iresearch/analysis/tokenizers.hpp>
 #include <iresearch/analysis/wildcard_analyzer.hpp>
 #include <iresearch/search/all_filter.hpp>
@@ -192,15 +191,6 @@ Result SetupTermFilter(irs::ByTerm& filter, std::string& field_name,
 }
 
 namespace {
-
-ResultOr<std::string> TryGetString(const duckdb::Expression& expr) {
-  const auto* value = TryGetConstant(expr);
-  if (!value || value->IsNull() ||
-      value->type().id() != duckdb::LogicalTypeId::VARCHAR) {
-    return std::unexpected{ERROR_BAD_PARAMETER};
-  }
-  return value->GetValue<std::string>();
-}
 
 ComparisonOp InvertComparisonOp(ComparisonOp op) {
   switch (op) {
@@ -844,14 +834,14 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
   char escape_char = '\\';
   if (name == "like_escape") {
     SDB_ASSERT(args.size() == 3);
-    auto escape_str = TryGetString(*args[2]);
-    if (!escape_str) {
-      return std::move(escape_str).error();
+    std::string escape_str;
+    if (auto r = GetVarcharArg(*args[2], "LIKE ESCAPE", escape_str); !r.ok()) {
+      return r;
     }
-    if (escape_str->size() != 1) {
+    if (escape_str.size() != 1) {
       return {ERROR_BAD_PARAMETER, "LIKE ESCAPE must be a single character"};
     }
-    escape_char = escape_str->front();
+    escape_char = escape_str.front();
     args = args.subspan(0, 2);
     name = "~~";
   }
@@ -864,14 +854,14 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
                 ": VARCHAR overload only -- declined for ",
                 args[0]->return_type.ToString()};
       }
-      auto pattern = TryGetString(*args[1]);
-      if (!pattern) {
-        return std::move(pattern).error();
+      std::string pattern;
+      if (auto r = GetVarcharArg(*args[1], name, pattern); !r.ok()) {
+        return r;
       }
       auto validator = &IsKeywordAnalyzer;
 
       if (builder == &BuildTSLike) {
-        *pattern = LikeEscapePattern(*pattern, escape_char);
+        pattern = LikeEscapePattern(pattern, escape_char);
         validator = &IsLikeCompatibleAnalyzer;
       }
 
@@ -883,7 +873,7 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
       if (!validator(column_info->tokenizer.analyzer->type())) {
         return {ERROR_BAD_PARAMETER, name, ": column analyzer not supported"};
       }
-      auto inner = builder(*pattern);
+      auto inner = builder(pattern);
       FromTSQueryMatch(filter, ctx, *args[0], *inner);
       return {};
     }

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -1035,9 +1035,9 @@ duckdb::unique_ptr<duckdb::Expression> WrapTextAsConstantList(
   if (!val || val->IsNull()) {
     THROW_SQL_ERROR(
       ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG(kTokensMatchAny,
+      ERR_MSG(kHasAnyToken,
               "(col, text, min_match) requires a constant non-NULL text"),
-      ERR_HINT("Pass a literal string or a list-form: ", kTokensMatchAny,
+      ERR_HINT("Pass a literal string or a list-form: ", kHasAnyToken,
                "(col, ['text'], n)."));
   }
   duckdb::vector<duckdb::Value> elems;
@@ -1077,8 +1077,8 @@ constexpr containers::TrivialBiMap kPredicateBuilders = [](auto selector) {
     .Case(kNgramMatches, PredicateInnerBuilder{&BuildPassthrough<kTSQNgram>})
     .Case(kLevenshteinMatches,
           PredicateInnerBuilder{&BuildPassthrough<kTSQLevenshtein>})
-    .Case(kTokensMatchAll, PredicateInnerBuilder{&BuildAllTokens})
-    .Case(kTokensMatchAny, PredicateInnerBuilder{&BuildAnyToken});
+    .Case(kHasAllTokens, PredicateInnerBuilder{&BuildAllTokens})
+    .Case(kHasAnyToken, PredicateInnerBuilder{&BuildAnyToken});
 };
 
 Result FromPredicate(irs::BooleanFilter& filter, const FilterContext& ctx,

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -1003,9 +1003,6 @@ duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryCall(
   return MakeTSQueryCall(ts_name, MakeTSQueryType(), std::move(children));
 }
 
-// ts_tokenize taking a list returns LIST(TSQUERY); the array-form
-// dispatch (FromTokenizeListInAnyAllOf) keys on this via
-// IsTokenizeListCall.
 duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryTokenizeList(
   duckdb::unique_ptr<duckdb::Expression> list) {
   return MakeTSQueryCall(kTSQTokenize,
@@ -1013,10 +1010,10 @@ duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryTokenizeList(
                          MakeChildren(std::move(list)));
 }
 
-template<const std::string_view& kTsName>
+template<const std::string_view& Name>
 duckdb::unique_ptr<duckdb::Expression> BuildPassthrough(
   std::vector<duckdb::unique_ptr<duckdb::Expression>>&& args) {
-  return MakeTSQueryCall(kTsName, std::move(args));
+  return MakeTSQueryCall(Name, std::move(args));
 }
 
 duckdb::unique_ptr<duckdb::Expression> BuildAllTokens(
@@ -1073,12 +1070,11 @@ using PredicateInnerBuilder = duckdb::unique_ptr<duckdb::Expression> (*)(
 
 constexpr containers::TrivialBiMap kPredicateBuilders = [](auto selector) {
   return selector()
-    .Case(kPhraseMatches, PredicateInnerBuilder{&BuildPassthrough<kTSQPhrase>})
-    .Case(kNgramMatches, PredicateInnerBuilder{&BuildPassthrough<kTSQNgram>})
-    .Case(kLevenshteinMatches,
-          PredicateInnerBuilder{&BuildPassthrough<kTSQLevenshtein>})
-    .Case(kHasAllTokens, PredicateInnerBuilder{&BuildAllTokens})
-    .Case(kHasAnyToken, PredicateInnerBuilder{&BuildAnyToken});
+    .Case(kPhraseMatches, BuildPassthrough<kTSQPhrase>)
+    .Case(kNgramMatches, BuildPassthrough<kTSQNgram>)
+    .Case(kLevenshteinMatches, BuildPassthrough<kTSQLevenshtein>)
+    .Case(kHasAllTokens, BuildAllTokens)
+    .Case(kHasAnyToken, BuildAnyToken);
 };
 
 Result FromPredicate(irs::BooleanFilter& filter, const FilterContext& ctx,

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -372,10 +372,8 @@ Result MakeGroup(irs::BooleanFilter& parent, const FilterContext& ctx,
 
 Result FromIsNull(irs::BooleanFilter& filter, const FilterContext& ctx,
                   const duckdb::BoundOperatorExpression& op_expr) {
-  if (op_expr.children.size() != 1) {
-    return {ERROR_NOT_IMPLEMENTED, "IS NULL has ", op_expr.children.size(),
-            " inputs but 1 expected"};
-  }
+  // OPERATOR_IS_NULL / IS_NOT_NULL are unary by construction.
+  SDB_ASSERT(op_expr.children.size() == 1);
   const auto* column_ref = TryGetColumnRef(*op_expr.children[0]);
   if (!column_ref) {
     return {ERROR_BAD_PARAMETER, "Input is not a column reference"};
@@ -601,10 +599,7 @@ Result FromBetween(irs::BooleanFilter& filter, const FilterContext& ctx,
 template<bool GenericVersion>
 Result FromIn(irs::BooleanFilter& filter, const FilterContext& ctx,
               const duckdb::BoundOperatorExpression& op_expr) {
-  if (op_expr.children.size() < 2) {
-    return {ERROR_NOT_IMPLEMENTED, "IN has ", op_expr.children.size(),
-            " inputs but at least 2 expected"};
-  }
+  SDB_ASSERT(op_expr.children.size() >= 2);
 
   const auto* column_ref = TryGetColumnRef(*op_expr.children[0]);
   if (!column_ref) {
@@ -969,12 +964,8 @@ void FromTSQueryConjunction(irs::BooleanFilter& parent,
                             const SearchColumnInfo& column_info,
                             const duckdb::BoundFunctionExpression& func,
                             bool is_and) {
-  if (func.children.size() != 2) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("TSQUERY ", is_and ? "&&" : "||",
-                            " expects 2 operands, got ", func.children.size()),
-                    ERR_HINT("Example: ts_phrase('a') && 'b'."));
-  }
+  // `||` / `&&` registered as (TOK, TOK) -> TOK; binder enforces arity.
+  SDB_ASSERT(func.children.size() == 2);
   irs::BooleanFilter* group;
   if (is_and) {
     group =
@@ -998,12 +989,8 @@ void FromTSQueryConjunction(irs::BooleanFilter& parent,
 void FromTSQueryNot(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info,
                     const duckdb::BoundFunctionExpression& func) {
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("TSQUERY !! expects 1 operand, got ", func.children.size()),
-      ERR_HINT("Example: !!ts_phrase('text')."));
-  }
+  // `!!` registered as (TOK) -> TOK; binder enforces arity.
+  SDB_ASSERT(func.children.size() == 1);
   auto neg = ctx;
   neg.negated = !ctx.negated;
   BuildTSQuery(parent, neg, column_info, *func.children[0]);
@@ -1017,13 +1004,8 @@ void FromTSQueryBoost(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_phrase('text') ^ 2.0. Factor must be >= 0; "
     "for composable boost use ::boost(K).";
-  if (func.children.size() != 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("TSQUERY ^ expects 2 operands (query ^ factor), got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  // `^` registered as (TOK, DOUBLE) -> TSQ; binder enforces arity.
+  SDB_ASSERT(func.children.size() == 2);
   double factor_d;
   if (auto r = GetDoubleArg(*func.children[1], "boost factor", factor_d);
       !r.ok()) {
@@ -1557,9 +1539,8 @@ void FromLevenshtein(irs::BooleanFilter&, const FilterContext&,
                      const duckdb::BoundFunctionExpression&);
 void FromTerm(irs::BooleanFilter&, const FilterContext&,
               const SearchColumnInfo&, const duckdb::BoundFunctionExpression&);
-void FromTSQLike(irs::BooleanFilter&, const FilterContext&,
-                 const SearchColumnInfo&,
-                 const duckdb::BoundFunctionExpression&);
+void FromLike(irs::BooleanFilter&, const FilterContext&,
+              const SearchColumnInfo&, const duckdb::BoundFunctionExpression&);
 void FromPrefix(irs::BooleanFilter&, const FilterContext&,
                 const SearchColumnInfo&,
                 const duckdb::BoundFunctionExpression&);
@@ -1585,9 +1566,6 @@ void FromAnyAllOf(irs::BooleanFilter&, const FilterContext&,
 void FromPlainToTsquery(irs::BooleanFilter&, const FilterContext&,
                         const SearchColumnInfo&,
                         const duckdb::BoundFunctionExpression&);
-void FromPhraseToTsquery(irs::BooleanFilter&, const FilterContext&,
-                         const SearchColumnInfo&,
-                         const duckdb::BoundFunctionExpression&);
 void FromTsqueryPhrase(irs::BooleanFilter&, const FilterContext&,
                        const SearchColumnInfo&,
                        const duckdb::BoundFunctionExpression&);
@@ -1681,7 +1659,7 @@ void BuildTSQuery(irs::BooleanFilter& parent, const FilterContext& ctx,
     case TSQueryOp::Term:
       return FromTerm(parent, ctx, column_info, func);
     case TSQueryOp::Like:
-      return FromTSQLike(parent, ctx, column_info, func);
+      return FromLike(parent, ctx, column_info, func);
     case TSQueryOp::Prefix:
       return FromPrefix(parent, ctx, column_info, func);
     case TSQueryOp::Ngram:
@@ -1701,7 +1679,7 @@ void BuildTSQuery(irs::BooleanFilter& parent, const FilterContext& ctx,
     case TSQueryOp::PhraseSeq:
       return FromTSQueryPhraseSeq(parent, ctx, column_info, func);
     case TSQueryOp::PhraseToTsquery:
-      return FromPhraseToTsquery(parent, ctx, column_info, func);
+      return FromPhrase(parent, ctx, column_info, func);
     case TSQueryOp::Any:
       return FromAnyAllOf(parent, ctx, column_info, func, /*is_any=*/true);
     case TSQueryOp::All:

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -134,7 +134,6 @@ customize::enum_name<sdb::connector::TSQueryOp>(
 }
 
 }  // namespace magic_enum
-
 namespace sdb::connector {
 namespace {
 

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -1289,9 +1289,6 @@ bool IsNumericTypeId(duckdb::LogicalTypeId id) {
     case duckdb::LogicalTypeId::BIGINT:
     case duckdb::LogicalTypeId::FLOAT:
     case duckdb::LogicalTypeId::DOUBLE:
-    case duckdb::LogicalTypeId::DATE:
-    case duckdb::LogicalTypeId::TIMESTAMP:
-    case duckdb::LogicalTypeId::TIMESTAMP_TZ:
       return true;
     default:
       return false;

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -374,14 +374,10 @@ Result FromIsNull(irs::BooleanFilter& filter, const FilterContext& ctx,
                   const duckdb::BoundOperatorExpression& op_expr) {
   // OPERATOR_IS_NULL / IS_NOT_NULL are unary by construction.
   SDB_ASSERT(op_expr.children.size() == 1);
-  const auto* column_ref = TryGetColumnRef(*op_expr.children[0]);
-  if (!column_ref) {
-    return {ERROR_BAD_PARAMETER, "Input is not a column reference"};
-  }
-
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
+  const auto* column_info = TryFindColumnInfo(ctx, *op_expr.children[0]);
   if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column was not found"};
+    return {ERROR_BAD_PARAMETER,
+            "IS NULL input is not a reference to an indexed column"};
   }
   std::string field_name;
   MakeFieldName(column_info->column_id, field_name);
@@ -399,23 +395,19 @@ template<bool GenericVersion>
 Result FromBinaryEq(irs::BooleanFilter& filter, const FilterContext& ctx,
                     const duckdb::Expression& left_expr,
                     const duckdb::Expression& right_expr, bool not_equal) {
-  const auto* column_ref = TryGetColumnRef(left_expr);
+  const auto* column_info = TryFindColumnInfo(ctx, left_expr);
   const auto* const_val = TryGetConstant(right_expr);
 
-  if (!column_ref || !const_val) {
+  if (!column_info || !const_val) {
     return {ERROR_BAD_PARAMETER,
-            "Expected column reference on the left and constant on the right"};
+            "Expected indexed column reference on the left and constant on "
+            "the right"};
   }
 
   if (const_val->IsNull()) {
     // foo == NULL is always false and foo != NULL is false too.
     AddFilter<irs::Empty>(filter);
     return {};
-  }
-
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
-  if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column was not found"};
   }
   if constexpr (GenericVersion) {
     if (column_info->logical_type.id() == duckdb::LogicalTypeId::VARCHAR &&
@@ -446,22 +438,17 @@ Result FromComparison(irs::BooleanFilter& filter, const FilterContext& ctx,
     op = InvertComparisonOp(op);
   }
 
-  const auto* column_ref = TryGetColumnRef(field_expr);
+  const auto* column_info = TryFindColumnInfo(ctx, field_expr);
   const auto* const_val = TryGetConstant(value_expr);
 
-  if (!column_ref || !const_val) {
+  if (!column_info || !const_val) {
     return {ERROR_BAD_PARAMETER,
-            "Expected column reference and constant for comparison"};
+            "Expected indexed column reference and constant for comparison"};
   }
 
   if (const_val->IsNull()) {
     AddFilter<irs::Empty>(filter);
     return {};
-  }
-
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
-  if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column was not found"};
   }
   if constexpr (GenericVersion) {
     if (column_info->logical_type.id() == duckdb::LogicalTypeId::VARCHAR &&
@@ -543,11 +530,6 @@ Result FromBetween(irs::BooleanFilter& filter, const FilterContext& ctx,
   // Decompose BETWEEN into conjunction of two range comparisons.
   // BETWEEN a AND b  =>  field >= a (or >) AND field <= b (or <)
   // NOT BETWEEN       =>  field < a (or <=) OR field > b (or >=)
-
-  const auto* column_ref = TryGetColumnRef(*between.input);
-  if (!column_ref) {
-    return {ERROR_BAD_PARAMETER, "BETWEEN input is not a column reference"};
-  }
   const auto* lower_val = TryGetConstant(*between.lower);
   const auto* upper_val = TryGetConstant(*between.upper);
   if (!lower_val || !upper_val) {
@@ -601,14 +583,10 @@ Result FromIn(irs::BooleanFilter& filter, const FilterContext& ctx,
               const duckdb::BoundOperatorExpression& op_expr) {
   SDB_ASSERT(op_expr.children.size() >= 2);
 
-  const auto* column_ref = TryGetColumnRef(*op_expr.children[0]);
-  if (!column_ref) {
-    return {ERROR_BAD_PARAMETER, "Input is not a column reference"};
-  }
-
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
+  const auto* column_info = TryFindColumnInfo(ctx, *op_expr.children[0]);
   if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column was not found"};
+    return {ERROR_BAD_PARAMETER,
+            "IN input is not a reference to an indexed column"};
   }
 
   if constexpr (GenericVersion) {
@@ -866,35 +844,6 @@ constexpr containers::TrivialBiMap kBuiltinBuilder = [](auto selector) {
     .Case("~~", &BuildTSLike);
 };
 
-// Pre-extracted variant: validates column ref + indexed + analyzer
-// predicate, then synthesises `col @@ build_inner(pattern)` and
-// dispatches via FromTSQueryMatch. Used by callers that already
-// extracted the literal pattern (e.g. LIKE which also needs to
-// normalise via LikeEscapePattern).
-Result RewriteAsTSQueryMatch(irs::BooleanFilter& filter,
-                             const FilterContext& ctx,
-                             const duckdb::Expression& column_expr,
-                             std::string_view pattern,
-                             StringBuiltinBuilder build_inner,
-                             AnalyzerPredicate analyzer_ok,
-                             std::string_view func_name) {
-  const auto* column_ref = TryGetColumnRef(column_expr);
-  if (!column_ref) {
-    return {ERROR_NOT_IMPLEMENTED, func_name,
-            ": first arg is not a column reference"};
-  }
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
-  if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column is not indexed"};
-  }
-  if (!analyzer_ok(column_info->tokenizer.analyzer->type())) {
-    return {ERROR_BAD_PARAMETER, func_name, ": column analyzer not supported"};
-  }
-  auto inner = build_inner(pattern);
-  FromTSQueryMatch(filter, ctx, column_expr, *inner);
-  return {};
-}
-
 Result FromFunctionExpression(irs::BooleanFilter& filter,
                               const FilterContext& ctx,
                               const duckdb::BoundFunctionExpression& func) {
@@ -947,8 +896,17 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
         validator = &IsLikeCompatibleAnalyzer;
       }
 
-      return RewriteAsTSQueryMatch(filter, ctx, *args[0], *pattern, builder,
-                                   validator, name);
+      const auto* column_info = TryFindColumnInfo(ctx, *args[0]);
+      if (!column_info) {
+        return {ERROR_NOT_IMPLEMENTED, name,
+                ": first arg is not a reference to an indexed column"};
+      }
+      if (!validator(column_info->tokenizer.analyzer->type())) {
+        return {ERROR_BAD_PARAMETER, name, ": column analyzer not supported"};
+      }
+      auto inner = builder(*pattern);
+      FromTSQueryMatch(filter, ctx, *args[0], *inner);
+      return {};
     }
   }
 
@@ -1159,39 +1117,24 @@ bool TryDispatchTokenizeCast(irs::BooleanFilter& parent,
 void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
                       const duckdb::Expression& lhs,
                       const duckdb::Expression& rhs) {
-  const auto* left_col = TryGetColumnRef(UnwrapTSQueryCast(lhs));
-  const auto* right_col = TryGetColumnRef(UnwrapTSQueryCast(rhs));
-  const duckdb::BoundColumnRefExpression* column = nullptr;
-  const duckdb::Expression* expr = nullptr;
-  if (left_col && right_col) {
-    const auto* left_info = FindColumnInfo(ctx, *left_col);
-    const auto* right_info = FindColumnInfo(ctx, *right_col);
-    if (left_info && right_info) {
-      THROW_SQL_ERROR(
-        ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-        ERR_MSG("@@ has column references on both sides"),
-        ERR_HINT("Wrap one side in 'word'::TSQUERY or a constructor "
-                 "(ts_phrase, ts_like, ...)."));
-    }
-    column = left_info ? left_col : right_col;
-    expr = left_info ? &rhs : &lhs;
-  } else if (left_col) {
-    column = left_col;
-    expr = &rhs;
-  } else if (right_col) {
-    column = right_col;
-    expr = &lhs;
-  } else {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("@@ requires a column reference on one side"),
-                    ERR_HINT("Use: <col> @@ <tsquery_expr>."));
+  const auto* left_info = TryFindColumnInfo(ctx, UnwrapTSQueryCast(lhs));
+  const auto* right_info = TryFindColumnInfo(ctx, UnwrapTSQueryCast(rhs));
+  if (left_info && right_info) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG("@@ has column references on both sides"),
+      ERR_HINT("Wrap one side in 'word'::TSQUERY or a constructor "
+               "(ts_phrase, ts_like, ...)."));
   }
-  const auto* column_info = FindColumnInfo(ctx, *column);
+  const auto* column_info = left_info ? left_info : right_info;
   if (!column_info) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("@@ column not found in inverted index"),
-                    ERR_HINT("CREATE INDEX ... USING inverted(<col>)."));
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG("@@ requires an inverted-indexed column on one side"),
+      ERR_HINT("Use: <indexed_col> @@ <tsquery_expr>. CREATE INDEX ... "
+               "USING inverted(<col>) if missing."));
   }
+  const auto& expr = left_info ? rhs : lhs;
   auto* tokenizer = column_info->tokenizer.analyzer.get();
   if (!tokenizer) {
     THROW_SQL_ERROR(
@@ -1202,7 +1145,7 @@ void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
   auto sub_ctx = ctx.WithTokenizer(*tokenizer);
   // BuildTSQuery throws THROW_SQL_ERROR with the standard hint on any
   // dispatch failure, so we don't wrap its result here.
-  BuildTSQuery(filter, sub_ctx, *column_info, *expr);
+  BuildTSQuery(filter, sub_ctx, *column_info, expr);
 }
 
 Result FromComparisonExpression(irs::BooleanFilter& filter,
@@ -1297,14 +1240,6 @@ Result FromExpression(irs::BooleanFilter& filter, const FilterContext& ctx,
 
 }  // namespace
 
-const duckdb::BoundColumnRefExpression* TryGetColumnRef(
-  const duckdb::Expression& expr) {
-  if (expr.expression_class != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
-    return nullptr;
-  }
-  return &expr.Cast<duckdb::BoundColumnRefExpression>();
-}
-
 const duckdb::Value* TryGetConstant(const duckdb::Expression& expr) {
   if (expr.expression_class != duckdb::ExpressionClass::BOUND_CONSTANT) {
     return nullptr;
@@ -1312,30 +1247,26 @@ const duckdb::Value* TryGetConstant(const duckdb::Expression& expr) {
   return &expr.Cast<duckdb::BoundConstantExpression>().value;
 }
 
-const SearchColumnInfo* FindColumnInfo(
-  const FilterContext& ctx, const duckdb::BoundColumnRefExpression& ref) {
-  // Try cache first -- keyed on column_id from a previous resolution.
-  // We do a two-step lookup: first resolve via column_getter to get the
-  // column_id, then check cache.  The column_getter itself may be cheap
+const SearchColumnInfo* TryFindColumnInfo(const FilterContext& ctx,
+                                          const duckdb::Expression& expr) {
+  if (expr.expression_class != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+    return nullptr;
+  }
+  // Two-step lookup: first resolve via column_getter to get the
+  // column_id, then check cache. The column_getter itself may be cheap
   // (just a span lookup), but caching avoids repeated analyzer copies.
-
-  // We cannot cache by binding alone (table_index + column_index) because
-  // different bindings may map to the same catalog column_id.  Instead
-  // we resolve first, then cache by column_id.
-
-  auto info = ctx.column_getter(ref);
+  // We cannot cache by binding alone (table_index + column_index)
+  // because different bindings may map to the same catalog column_id.
+  auto info = ctx.column_getter(expr.Cast<duckdb::BoundColumnRefExpression>());
   if (!info) {
     return nullptr;
   }
-
-  auto cache_it = ctx.column_cache.find(info->column_id);
-  if (cache_it != ctx.column_cache.end()) {
-    SDB_ASSERT(cache_it->second.logical_type.id() !=
-                 duckdb::LogicalTypeId::VARCHAR ||
-               cache_it->second.tokenizer.analyzer);
-    return &cache_it->second;
+  if (auto it = ctx.column_cache.find(info->column_id);
+      it != ctx.column_cache.end()) {
+    SDB_ASSERT(it->second.logical_type.id() != duckdb::LogicalTypeId::VARCHAR ||
+               it->second.tokenizer.analyzer);
+    return &it->second;
   }
-
   auto column_id = info->column_id;
   return &ctx.column_cache.emplace(column_id, std::move(info.value()))
             .first->second;

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -653,20 +653,6 @@ Result FromIn(irs::BooleanFilter& filter, const FilterContext& ctx,
   return {};
 }
 
-// Appends `s` to `out` with `\`, `%`, `_` backslash-escaped so the
-// result is a LIKE pattern that matches `s` literally. Caller reserves
-// up front (worst-case +1 char per input byte). Used by the `contains`
-// / `ends_with` claim paths to splice user input safely into a LIKE
-// pattern without leaking wildcards.
-void AppendEscapedLikePattern(std::string_view s, std::string& out) {
-  for (char c : s) {
-    if (c == '\\' || c == '%' || c == '_') {
-      out.push_back('\\');
-    }
-    out.push_back(c);
-  }
-}
-
 duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryCall(
   std::string_view ts_name, duckdb::LogicalType return_type,
   std::vector<duckdb::unique_ptr<duckdb::Expression>> children) {
@@ -781,6 +767,20 @@ duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSStartsWith(
   return MakeTSQueryCall(
     kTSQPrefix, MakeChildren(duckdb::make_uniq<duckdb::BoundConstantExpression>(
                   duckdb::Value(std::string{literal}))));
+}
+
+// Appends `s` to `out` with `\`, `%`, `_` backslash-escaped so the
+// result is a LIKE pattern that matches `s` literally. Caller reserves
+// up front (worst-case +1 char per input byte). Used by the `contains`
+// / `ends_with` claim paths to splice user input safely into a LIKE
+// pattern without leaking wildcards.
+void AppendEscapedLikePattern(std::string_view s, std::string& out) {
+  for (char c : s) {
+    if (c == '\\' || c == '%' || c == '_') {
+      out.push_back('\\');
+    }
+    out.push_back(c);
+  }
 }
 
 duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSContainsLike(
@@ -1143,8 +1143,6 @@ void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
       ERR_HINT("Reindex the VARCHAR column with a text-search analyzer."));
   }
   auto sub_ctx = ctx.WithTokenizer(*tokenizer);
-  // BuildTSQuery throws THROW_SQL_ERROR with the standard hint on any
-  // dispatch failure, so we don't wrap its result here.
   BuildTSQuery(filter, sub_ctx, *column_info, expr);
 }
 

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -325,7 +325,8 @@ const duckdb::Expression& UnwrapBoostBoolCoercion(
 Result FromExpression(irs::BooleanFilter& filter, const FilterContext& ctx,
                       const duckdb::Expression& expr);
 void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
-                      const duckdb::BoundFunctionExpression& func);
+                      const duckdb::Expression& lhs,
+                      const duckdb::Expression& rhs);
 
 template<typename Filter>
 Result MakeGroup(irs::BooleanFilter& parent, const FilterContext& ctx,
@@ -728,6 +729,20 @@ Result FromLike(irs::BooleanFilter& filter, const FilterContext& ctx,
   return {};
 }
 
+// Appends `s` to `out` with `\`, `%`, `_` backslash-escaped so the
+// result is a LIKE pattern that matches `s` literally. Caller reserves
+// up front (worst-case +1 char per input byte). Used by the `contains`
+// / `ends_with` claim paths to splice user input safely into a LIKE
+// pattern without leaking wildcards.
+void AppendEscapedLikePattern(std::string_view s, std::string& out) {
+  for (char c : s) {
+    if (c == '\\' || c == '%' || c == '_') {
+      out.push_back('\\');
+    }
+    out.push_back(c);
+  }
+}
+
 duckdb::unique_ptr<duckdb::BoundFunctionExpression> MakeTSQueryCall(
   std::string_view ts_name, duckdb::LogicalType return_type,
   std::vector<duckdb::unique_ptr<duckdb::Expression>> children) {
@@ -825,25 +840,103 @@ Result FromPredicate(irs::BooleanFilter& filter, const FilterContext& ctx,
     return {ERROR_BAD_PARAMETER, func.function.name,
             " requires a column reference as the first argument"};
   }
-  auto column = func.children[0]->Copy();
-  std::vector<duckdb::unique_ptr<duckdb::Expression>> tail;
-  tail.reserve(func.children.size() - 1);
-  for (size_t i = 1; i < func.children.size(); ++i) {
-    tail.emplace_back(func.children[i]->Copy());
-  }
+  // Tail must be copied because the builder takes ownership (it splices
+  // the args into a synthesised ts_* call).
+  auto tail = func.children | std::views::drop(1) |
+              std::views::transform([](const auto& e) { return e->Copy(); }) |
+              std::ranges::to<std::vector>();
   auto inner = build_inner(std::move(tail));
+  FromTSQueryMatch(filter, ctx, *func.children[0], *inner);
+  return {};
+}
 
-  // Synthesise `column @@ inner` and reuse FromTSQueryMatch -- it
-  // resolves the column, sets up the tokenizer ctx, and dispatches
-  // the inner ts_* via BuildTSQuery's name switch.
-  duckdb::ScalarFunction match_fn(std::string{kTSQueryMatch}, {},
-                                  duckdb::LogicalType::BOOLEAN, nullptr);
-  duckdb::BoundFunctionExpression at_at(
-    duckdb::LogicalType::BOOLEAN, std::move(match_fn),
-    MakeChildren(std::move(column), std::move(inner)), nullptr);
-  at_at.function.name = std::string{kTSQueryMatch};
+using StringBuiltinBuilder =
+  duckdb::unique_ptr<duckdb::BoundFunctionExpression> (*)(
+    std::string_view literal);
 
-  FromTSQueryMatch(filter, ctx, at_at);
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSStartsWith(
+  std::string_view literal) {
+  return MakeTSQueryCall(
+    kTSQPrefix, MakeChildren(duckdb::make_uniq<duckdb::BoundConstantExpression>(
+                  duckdb::Value(std::string{literal}))));
+}
+
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSContainsLike(
+  std::string_view literal) {
+  std::string pattern;
+  pattern.reserve(literal.size() * 2 + 2);
+  pattern.push_back('%');
+  AppendEscapedLikePattern(literal, pattern);
+  pattern.push_back('%');
+  return MakeTSQueryCall(
+    kTSQLike, MakeChildren(duckdb::make_uniq<duckdb::BoundConstantExpression>(
+                duckdb::Value(std::move(pattern)))));
+}
+
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSEndsWithLike(
+  std::string_view literal) {
+  std::string pattern;
+  pattern.reserve(literal.size() * 2 + 1);
+  pattern.push_back('%');
+  AppendEscapedLikePattern(literal, pattern);
+  return MakeTSQueryCall(
+    kTSQLike, MakeChildren(duckdb::make_uniq<duckdb::BoundConstantExpression>(
+                duckdb::Value(std::move(pattern)))));
+}
+
+duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSRegexp(
+  std::string_view literal) {
+  return MakeTSQueryCall(
+    kTSQRegexp, MakeChildren(duckdb::make_uniq<duckdb::BoundConstantExpression>(
+                  duckdb::Value(std::string{literal}))));
+}
+
+// `<builtin>(col, literal)` -> `col @@ <inner>(literal)` for keyword-
+// analyzed columns. Decline (no claim) when the call shape doesn't
+// match: wrong arity, non-VARCHAR column type, non-column LHS, non-
+// constant or NULL pattern. Throw with a helpful hint when the column
+// is indexed but uses a non-keyword analyzer (semantics would diverge
+// from DuckDB's whole-string predicate).
+Result RewriteAsTSQueryMatch(irs::BooleanFilter& filter,
+                             const FilterContext& ctx,
+                             const duckdb::BoundFunctionExpression& func,
+                             StringBuiltinBuilder build_inner,
+                             std::string_view ts_form_hint) {
+  if (func.children.size() != 2) {
+    return {ERROR_NOT_IMPLEMENTED, func.function.name,
+            ": expected 2 args, got ", func.children.size()};
+  }
+  if (func.children[0]->return_type.id() != duckdb::LogicalTypeId::VARCHAR) {
+    return {ERROR_NOT_IMPLEMENTED, func.function.name,
+            ": VARCHAR overload only -- declined for ",
+            func.children[0]->return_type.ToString()};
+  }
+  const auto* column_ref = TryGetColumnRef(*func.children[0]);
+  if (!column_ref) {
+    return {ERROR_NOT_IMPLEMENTED, func.function.name,
+            ": first arg is not a column reference"};
+  }
+  const auto* literal_val = TryGetConstant(*func.children[1]);
+  if (!literal_val || literal_val->IsNull() ||
+      literal_val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
+    return {ERROR_NOT_IMPLEMENTED, func.function.name,
+            ": pattern must be a non-NULL VARCHAR constant"};
+  }
+  const auto* column_info = FindColumnInfo(ctx, *column_ref);
+  if (!column_info) {
+    return {ERROR_BAD_PARAMETER, "Column is not indexed"};
+  }
+  if (column_info->tokenizer.analyzer->type() !=
+      irs::Type<irs::StringTokenizer>::id()) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG(func.function.name,
+              " requires a keyword-analyzed column on inverted-indexed "
+              "inputs"),
+      ERR_HINT("Use `", ts_form_hint, "` for non-keyword analyzers."));
+  }
+  auto inner = build_inner(literal_val->GetValue<std::string>());
+  FromTSQueryMatch(filter, ctx, *func.children[0], *inner);
   return {};
 }
 
@@ -856,7 +949,8 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
     // the runtime stub and surface the generic "TSQUERY expression
     // evaluated outside @@" error -- losing the specific cause. Throw
     // at this boundary so users see the actual reason + a hint.
-    FromTSQueryMatch(filter, ctx, func);
+    SDB_ASSERT(func.children.size() == 2);
+    FromTSQueryMatch(filter, ctx, *func.children[0], *func.children[1]);
     return {};
   }
 
@@ -895,8 +989,21 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
                     /*generic_version=*/true, escape_char);
   }
 
-  if (name == "prefix") {
-    return FromFuncPrefix(filter, ctx, func);
+  if (name == "contains") {
+    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSContainsLike,
+                                 "col @@ ts_like('%pattern%')");
+  }
+  if (name == "^@" || name == "starts_with" || name == "prefix") {
+    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSStartsWith,
+                                 "col @@ ts_starts_with('p')");
+  }
+  if (name == "suffix" || name == "ends_with") {
+    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSEndsWithLike,
+                                 "col @@ ts_like('%suffix')");
+  }
+  if (name == "regexp_matches" || name == "regexp_like") {
+    return RewriteAsTSQueryMatch(filter, ctx, func, &BuildTSRegexp,
+                                 "col @@ ts_regexp('re')");
   }
 
   if (auto build = kPredicateBuilders.TryFindByFirst(name)) {
@@ -1111,13 +1218,16 @@ bool TryDispatchTokenizeCast(irs::BooleanFilter& parent,
   return true;
 }
 
+// Resolves an `@@` match against its two operand expressions. Called
+// directly with the bound `@@` function's two children, and from the
+// predicate-sugar / built-in claim paths with one column expression
+// and a computed inner. `@@` is commutative -- either side may be
+// the column.
 void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
-                      const duckdb::BoundFunctionExpression& func) {
-  SDB_ASSERT(func.children.size() == 2);
-  // @@ is commutative: either side can be the column. Try LHS first,
-  // then the cast-stripped RHS. Matches PG `doc @@ q` / `q @@ doc`.
-  const auto* left_col = TryGetColumnRef(UnwrapTSQueryCast(*func.children[0]));
-  const auto* right_col = TryGetColumnRef(UnwrapTSQueryCast(*func.children[1]));
+                      const duckdb::Expression& lhs,
+                      const duckdb::Expression& rhs) {
+  const auto* left_col = TryGetColumnRef(UnwrapTSQueryCast(lhs));
+  const auto* right_col = TryGetColumnRef(UnwrapTSQueryCast(rhs));
   const duckdb::BoundColumnRefExpression* column = nullptr;
   const duckdb::Expression* expr = nullptr;
   if (left_col && right_col) {
@@ -1131,13 +1241,13 @@ void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
                  "(ts_phrase, ts_like, ...)."));
     }
     column = left_info ? left_col : right_col;
-    expr = left_info ? func.children[1].get() : func.children[0].get();
+    expr = left_info ? &rhs : &lhs;
   } else if (left_col) {
     column = left_col;
-    expr = func.children[1].get();
+    expr = &rhs;
   } else if (right_col) {
     column = right_col;
-    expr = func.children[0].get();
+    expr = &lhs;
   } else {
     THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                     ERR_MSG("@@ requires a column reference on one side"),

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -242,9 +242,6 @@ std::vector<duckdb::unique_ptr<duckdb::Expression>> MakeChildren(
   return v;
 }
 
-// True iff `type` is one of TSQUERY / TOKENIZED_TSQUERY /
-// BOOSTED_TSQUERY -- all valid carriers of TSQUERY-shaped values
-// inside the filter builder.
 bool IsAnyTSQueryType(const duckdb::LogicalType& type) {
   if (type.id() != duckdb::LogicalTypeId::VARCHAR) {
     return false;
@@ -254,12 +251,9 @@ bool IsAnyTSQueryType(const duckdb::LogicalType& type) {
          alias == kBoostedTSQueryTypeName;
 }
 
-// If `type` is a TSQUERY annotated with a `tokenize(name)` modifier,
-// returns the tokenizer name. Resolution to a live analyzer happens
-// at filter-build time via ResolveTokenizerAnalyzer below -- the bind
-// callback intentionally does NOT pre-resolve, because the analyzer
-// is stateful (one tokenization stream per use) and shouldn't be
-// shared across queries.
+// Bind does NOT pre-resolve the tokenizer name to a live analyzer
+// because the analyzer is stateful (one tokenization stream per use)
+// and can't be shared across queries.
 std::string_view TryGetTokenizerModifier(const duckdb::LogicalType& type) {
   if (!IsAnyTSQueryType(type) || !type.HasExtensionInfo()) {
     return {};
@@ -273,8 +267,7 @@ std::string_view TryGetTokenizerModifier(const duckdb::LogicalType& type) {
   return duckdb::StringValue::Get(mods[0].value);
 }
 
-// If `type` carries a `boost(K)` modifier, returns the factor.
-// Distinguished from TokenizerModifier by the modifier's value type
+// Boost and tokenizer modifiers are distinguished by value type
 // (DOUBLE vs VARCHAR) so the two never alias each other.
 std::optional<double> TryGetBoostModifier(const duckdb::LogicalType& type) {
   if (!IsAnyTSQueryType(type) || !type.HasExtensionInfo()) {
@@ -372,7 +365,6 @@ Result MakeGroup(irs::BooleanFilter& parent, const FilterContext& ctx,
 
 Result FromIsNull(irs::BooleanFilter& filter, const FilterContext& ctx,
                   const duckdb::BoundOperatorExpression& op_expr) {
-  // OPERATOR_IS_NULL / IS_NOT_NULL are unary by construction.
   SDB_ASSERT(op_expr.children.size() == 1);
   const auto* column_info = TryFindColumnInfo(ctx, *op_expr.children[0]);
   if (!column_info) {
@@ -688,10 +680,6 @@ duckdb::unique_ptr<duckdb::Expression> BuildAllTokens(
     kTSQAllOf, MakeChildren(MakeTSQueryTokenizeList(std::move(args.at(0)))));
 }
 
-// Wraps a single VARCHAR expression in a constant LIST(VARCHAR) so it
-// flows through ts_tokenize array form. The text must be a constant;
-// non-constant text is rejected (matches the existing ts_tokenize
-// array-form constraint).
 duckdb::unique_ptr<duckdb::Expression> WrapTextAsConstantList(
   duckdb::unique_ptr<duckdb::Expression> text) {
   const auto* val = TryGetConstant(*text);
@@ -748,8 +736,6 @@ Result FromPredicate(irs::BooleanFilter& filter, const FilterContext& ctx,
                      const duckdb::BoundFunctionExpression& func) {
   SDB_ASSERT(!func.children.empty());
 
-  // Tail must be copied because the builder takes ownership (it splices
-  // the args into a synthesised ts_* call).
   auto tail = func.children | std::views::drop(1) |
               std::views::transform([](const auto& e) { return e->Copy(); }) |
               std::ranges::to<std::vector>();
@@ -769,11 +755,6 @@ duckdb::unique_ptr<duckdb::BoundFunctionExpression> BuildTSStartsWith(
                   duckdb::Value(std::string{literal}))));
 }
 
-// Appends `s` to `out` with `\`, `%`, `_` backslash-escaped so the
-// result is a LIKE pattern that matches `s` literally. Caller reserves
-// up front (worst-case +1 char per input byte). Used by the `contains`
-// / `ends_with` claim paths to splice user input safely into a LIKE
-// pattern without leaking wildcards.
 void AppendEscapedLikePattern(std::string_view s, std::string& out) {
   for (char c : s) {
     if (c == '\\' || c == '%' || c == '_') {
@@ -876,8 +857,6 @@ Result FromFunctionExpression(irs::BooleanFilter& filter,
   }
 
   if (args.size() == 2) {
-    // some functions like regexp_matches/regexp_like have optional third args
-    // for flags; ignore those here since we don't support
     if (auto builder = kBuiltinBuilder.TryFindByFirst(name).value_or(nullptr)) {
       SDB_ASSERT(args.size() == 2);
       if (args[0]->return_type.id() != duckdb::LogicalTypeId::VARCHAR) {
@@ -922,7 +901,6 @@ void FromTSQueryConjunction(irs::BooleanFilter& parent,
                             const SearchColumnInfo& column_info,
                             const duckdb::BoundFunctionExpression& func,
                             bool is_and) {
-  // `||` / `&&` registered as (TOK, TOK) -> TOK; binder enforces arity.
   SDB_ASSERT(func.children.size() == 2);
   irs::BooleanFilter* group;
   if (is_and) {
@@ -947,7 +925,6 @@ void FromTSQueryConjunction(irs::BooleanFilter& parent,
 void FromTSQueryNot(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info,
                     const duckdb::BoundFunctionExpression& func) {
-  // `!!` registered as (TOK) -> TOK; binder enforces arity.
   SDB_ASSERT(func.children.size() == 1);
   auto neg = ctx;
   neg.negated = !ctx.negated;
@@ -962,7 +939,6 @@ void FromTSQueryBoost(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_phrase('text') ^ 2.0. Factor must be >= 0; "
     "for composable boost use ::boost(K).";
-  // `^` registered as (TOK, DOUBLE) -> TSQ; binder enforces arity.
   SDB_ASSERT(func.children.size() == 2);
   double factor_d;
   if (auto r = GetDoubleArg(*func.children[1], "boost factor", factor_d);
@@ -1082,8 +1058,6 @@ bool TryDispatchTokenizeCast(irs::BooleanFilter& parent,
       ERR_MSG("::tokenize('keyword'): inner expression has unsupported "
               "shape"));
   }
-  // Wrapper lives on this stack frame; releases the analyzer back to
-  // the Tokenizer's pool when the scope exits.
   auto wrapper = ResolveTokenizerAnalyzer(ctx.client_context, tokenizer);
   if (!wrapper) {
     THROW_SQL_ERROR(
@@ -1094,8 +1068,8 @@ bool TryDispatchTokenizeCast(irs::BooleanFilter& parent,
   }
   auto sub_ctx = ctx.WithTokenizer(*wrapper);
   if (val) {
-    // Cannot recurse on a folded constant -- its type still carries
-    // the modifier and would re-enter this branch.
+    // Don't recurse on a folded constant: its type still carries the
+    // modifier and would re-enter this branch.
     if (val->IsNull() || val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
       THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                       ERR_MSG("::tokenize(<name>): inner value must be "
@@ -1109,11 +1083,7 @@ bool TryDispatchTokenizeCast(irs::BooleanFilter& parent,
   return true;
 }
 
-// Resolves an `@@` match against its two operand expressions. Called
-// directly with the bound `@@` function's two children, and from the
-// predicate-sugar / built-in claim paths with one column expression
-// and a computed inner. `@@` is commutative -- either side may be
-// the column.
+// `@@` is commutative -- either side may be the column.
 void FromTSQueryMatch(irs::BooleanFilter& filter, const FilterContext& ctx,
                       const duckdb::Expression& lhs,
                       const duckdb::Expression& rhs) {
@@ -1199,10 +1169,8 @@ Result FromOperatorExpression(irs::BooleanFilter& filter,
 
 Result FromExpression(irs::BooleanFilter& filter, const FilterContext& ctx,
                       const duckdb::Expression& expr) {
-  // Peel the BOOSTED_TSQUERY -> BOOLEAN coercion the WHERE-binder
-  // inserts when a `(predicate)::boost(K)` cast appears at the
-  // predicate root, then dispatch the boost cast itself. If the
-  // inner predicate can't be claimed, this throws.
+  // Peel the BOOSTED_TSQUERY -> BOOLEAN coercion that the WHERE-binder
+  // inserts around `(predicate)::boost(K)` at the predicate root.
   if (TryDispatchSqlBoostCast(filter, ctx, UnwrapBoostBoolCoercion(expr))) {
     return {};
   }
@@ -1250,11 +1218,8 @@ const SearchColumnInfo* TryFindColumnInfo(const FilterContext& ctx,
   if (expr.expression_class != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
     return nullptr;
   }
-  // Two-step lookup: first resolve via column_getter to get the
-  // column_id, then check cache. The column_getter itself may be cheap
-  // (just a span lookup), but caching avoids repeated analyzer copies.
-  // We cannot cache by binding alone (table_index + column_index)
-  // because different bindings may map to the same catalog column_id.
+  // Cache by catalog column_id, not by binding (table_index +
+  // column_index): different bindings may map to the same column_id.
   auto info = ctx.column_getter(expr.Cast<duckdb::BoundColumnRefExpression>());
   if (!info) {
     return nullptr;
@@ -1343,14 +1308,10 @@ bool IsNumericTypeId(duckdb::LogicalTypeId id) {
   }
 }
 
-// Looser numeric check used by RANGE / LESS / LESS_EQ / GREATER /
-// GREATER_EQ bound validation: accepts the same set as
-// IsNumericTypeId plus DECIMAL. The TSQUERY range constructors cast
-// bound values to the column's logical type before tokenising, so
-// DECIMAL bounds on a DOUBLE/INT/BIGINT column work as expected. We
-// don't fold DECIMAL into IsNumericTypeId itself because the legacy
-// FromComparison / SetupTermFilter paths feed `type_id` directly into
-// ResetNumericStream, which doesn't handle DECIMAL.
+// Accepts numeric + DECIMAL. Range constructors cast DECIMAL bounds
+// to the column's logical type before tokenising; the comparison/term
+// paths can't because they feed `type_id` straight into
+// ResetNumericStream which doesn't handle DECIMAL.
 bool IsRangeNumericValueType(duckdb::LogicalTypeId id) {
   return IsNumericTypeId(id) || id == duckdb::LogicalTypeId::DECIMAL;
 }
@@ -1364,15 +1325,13 @@ const duckdb::Expression& UnwrapTSQueryCast(const duckdb::Expression& expr) {
     }
     const auto& target = cast.return_type;
     const auto& source = cast.child->return_type;
-    // Stop at modifier-bearing casts; the walker needs to see them.
+    // Modifier-bearing casts must be preserved so the walker sees them.
     if (!TryGetTokenizerModifier(target).empty() ||
         TryGetBoostModifier(target)) {
       break;
     }
-    // Peel only transit casts within the {VARCHAR, TSQUERY,
-    // TOKENIZED_TSQUERY} family: both sides VARCHAR-backed, with at
-    // least one carrying a TSQUERY alias (otherwise it's a plain
-    // VARCHAR->VARCHAR cast we shouldn't strip).
+    // Peel transit casts within {VARCHAR, TSQUERY, TOKENIZED_TSQUERY}
+    // only -- a plain VARCHAR->VARCHAR cast must stay.
     if (target.id() != duckdb::LogicalTypeId::VARCHAR ||
         source.id() != duckdb::LogicalTypeId::VARCHAR) {
       break;
@@ -1455,9 +1414,7 @@ Result GetDoubleArg(const duckdb::Expression& expr, std::string_view label,
   }
 }
 
-// Per-type TSQUERY entry points -- each defined in ts_<name>.cpp and
-// dispatched to from BuildTSQuery's switch below. All throw
-// THROW_SQL_ERROR on any failure (with operator-specific hints).
+// All From* entry points throw THROW_SQL_ERROR on failure.
 void FromPhrase(irs::BooleanFilter&, const FilterContext&,
                 const SearchColumnInfo&,
                 const duckdb::BoundFunctionExpression&);

--- a/server/connector/ts_anyall.cpp
+++ b/server/connector/ts_anyall.cpp
@@ -57,11 +57,7 @@ void FromTokenizeListInAnyAllOf(
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_any(ts_tokenize(['quick', 'brown'])). Tokenises each list "
     "element through the column analyzer.";
-  if (!is_any && outer.children.size() != 1) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("ts_all takes a single argument"),
-                    ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(is_any || outer.children.size() == 1);
   std::optional<size_t> min_match;
   if (is_any && outer.children.size() == 2) {
     int64_t m;
@@ -77,14 +73,9 @@ void FromTokenizeListInAnyAllOf(
     }
     min_match = static_cast<size_t>(m);
   }
-  if (tokenize_call.children.empty() || tokenize_call.children.size() > 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_tokenize(text_array[, analyzer]) expects 1 or 2 arguments, "
-              "got ",
-              tokenize_call.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+
+  SDB_ASSERT(tokenize_call.children.size() >= 1 &&
+             tokenize_call.children.size() <= 2);
   // Inner list -- v1 requires a constant LIST(VARCHAR).
   const auto* list_const = TryGetConstant(*tokenize_call.children[0]);
   if (!list_const) {
@@ -210,18 +201,18 @@ void FromTokenizeListInAnyAllOf(
   //   ts_any without min_match -> 1
   //   ts_any(min_match=N) -> N (capped at tokens.size())
   //   ts_all -> tokens.size()
-  size_t mm = 1;
+  size_t min_match_value = 1;
   if (!is_any) {
-    mm = tokens.size();
+    min_match_value = tokens.size();
   } else if (min_match) {
-    mm = std::min<size_t>(*min_match, tokens.size());
+    min_match_value = std::min<size_t>(*min_match, tokens.size());
   }
   auto& terms = ctx.negated ? Negate<irs::ByTerms>(parent)
                             : AddFilter<irs::ByTerms>(parent);
   terms.boost(ctx.boost);
   *terms.mutable_field() = std::move(field_name);
   auto& opts = *terms.mutable_options();
-  opts.min_match = mm;
+  opts.min_match = min_match_value;
   for (auto& t : tokens) {
     opts.terms.emplace(std::move(t));
   }
@@ -240,18 +231,8 @@ void ExtractAnyAllOfArgs(
   std::optional<size_t>& min_match) {
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_any(['a', 'b'], 1) (OR), ts_all(['a', 'b']) (AND).";
-  if (func.children.empty() || func.children.size() > 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG(is_any ? "ts_any takes ([list]) or ([list], min_match)"
-                     : "ts_all takes ([list])"),
-      ERR_HINT(kSyntaxHint));
-  }
-  if (!is_any && func.children.size() != 1) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("ts_all takes a single list argument"),
-                    ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() >= 1 && func.children.size() <= 2);
+  SDB_ASSERT(is_any || func.children.size() == 1);
 
   // DuckDB constant-folds `['a', 'b']` into a BOUND_CONSTANT holding a
   // LIST/ARRAY Value rather than a `list_value`/`array_value` function

--- a/server/connector/ts_between.cpp
+++ b/server/connector/ts_between.cpp
@@ -91,8 +91,6 @@ void FromHalfRange(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_lt('m') or ts_ge(42). Bound must be non-null; "
     "use ts_between(NULL, ...) for unbounded.";
-  // ts_lt / ts_le / ts_gt / ts_ge registered as single-bound ANY;
-  // binder enforces arity.
   SDB_ASSERT(func.children.size() == 1);
   const auto* bound_val = TryGetConstant(*func.children[0]);
   if (!bound_val) {

--- a/server/connector/ts_between.cpp
+++ b/server/connector/ts_between.cpp
@@ -33,14 +33,7 @@ namespace sdb::connector {
 RangeArgs ParseRangeArgs(const duckdb::BoundFunctionExpression& func) {
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_between('a', 'z', true, false). NULL bound = unbounded.";
-  if (func.children.size() != 4) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_between expects 4 arguments (min, max, min_incl, max_incl), "
-              "got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() == 4);
   RangeArgs out;
   for (size_t i = 0; i < 2; ++i) {
     const auto* val = TryGetConstant(*func.children[i]);
@@ -98,12 +91,9 @@ void FromHalfRange(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_lt('m') or ts_ge(42). Bound must be non-null; "
     "use ts_between(NULL, ...) for unbounded.";
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG(label, " expects 1 argument (bound), got ", func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  // ts_lt / ts_le / ts_gt / ts_ge registered as single-bound ANY;
+  // binder enforces arity.
+  SDB_ASSERT(func.children.size() == 1);
   const auto* bound_val = TryGetConstant(*func.children[0]);
   if (!bound_val) {
     THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/server/connector/ts_common.hpp
+++ b/server/connector/ts_common.hpp
@@ -136,9 +136,11 @@ void BuildFtsTerm(irs::BooleanFilter& parent, const FilterContext& ctx,
 void BuildFtsTokens(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info, std::string_view text,
                     bool require_all);
+// `pattern` must already be normalised to `\`-escape form (callers
+// can use LikeEscapePattern() to normalise from a custom escape char).
 void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info, std::string field_name,
-                    std::string_view raw_pattern, char escape_char = '\\');
+                    std::string_view pattern);
 
 // SQL-surface helpers shared with cross-TU claimers.
 const duckdb::BoundColumnRefExpression* TryGetColumnRef(

--- a/server/connector/ts_common.hpp
+++ b/server/connector/ts_common.hpp
@@ -136,8 +136,6 @@ void BuildFtsTerm(irs::BooleanFilter& parent, const FilterContext& ctx,
 void BuildFtsTokens(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info, std::string_view text,
                     bool require_all);
-// Returns the indexed column info if `expr` is a BoundColumnRef to an
-// indexed column, nullptr otherwise.
 const SearchColumnInfo* TryFindColumnInfo(const FilterContext& ctx,
                                           const duckdb::Expression& expr);
 

--- a/server/connector/ts_common.hpp
+++ b/server/connector/ts_common.hpp
@@ -146,8 +146,6 @@ const duckdb::BoundColumnRefExpression* TryGetColumnRef(
 const SearchColumnInfo* FindColumnInfo(
   const FilterContext& ctx, const duckdb::BoundColumnRefExpression& column_ref);
 
-Result FromFuncPrefix(irs::BooleanFilter& filter, const FilterContext& ctx,
-                      const duckdb::BoundFunctionExpression& func);
 
 // Pointers reference constants in the bound expression tree;
 // nullptr means an unbounded side (NULL).

--- a/server/connector/ts_common.hpp
+++ b/server/connector/ts_common.hpp
@@ -136,11 +136,10 @@ void BuildFtsTerm(irs::BooleanFilter& parent, const FilterContext& ctx,
 void BuildFtsTokens(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info, std::string_view text,
                     bool require_all);
-// SQL-surface helpers shared with cross-TU claimers.
-const duckdb::BoundColumnRefExpression* TryGetColumnRef(
-  const duckdb::Expression& expr);
-const SearchColumnInfo* FindColumnInfo(
-  const FilterContext& ctx, const duckdb::BoundColumnRefExpression& column_ref);
+// Returns the indexed column info if `expr` is a BoundColumnRef to an
+// indexed column, nullptr otherwise.
+const SearchColumnInfo* TryFindColumnInfo(const FilterContext& ctx,
+                                          const duckdb::Expression& expr);
 
 // Pointers reference constants in the bound expression tree;
 // nullptr means an unbounded side (NULL).

--- a/server/connector/ts_common.hpp
+++ b/server/connector/ts_common.hpp
@@ -136,12 +136,6 @@ void BuildFtsTerm(irs::BooleanFilter& parent, const FilterContext& ctx,
 void BuildFtsTokens(irs::BooleanFilter& parent, const FilterContext& ctx,
                     const SearchColumnInfo& column_info, std::string_view text,
                     bool require_all);
-// `pattern` must already be normalised to `\`-escape form (callers
-// can use LikeEscapePattern() to normalise from a custom escape char).
-void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
-                    const SearchColumnInfo& column_info, std::string field_name,
-                    std::string_view pattern);
-
 // SQL-surface helpers shared with cross-TU claimers.
 const duckdb::BoundColumnRefExpression* TryGetColumnRef(
   const duckdb::Expression& expr);

--- a/server/connector/ts_common.hpp
+++ b/server/connector/ts_common.hpp
@@ -146,7 +146,6 @@ const duckdb::BoundColumnRefExpression* TryGetColumnRef(
 const SearchColumnInfo* FindColumnInfo(
   const FilterContext& ctx, const duckdb::BoundColumnRefExpression& column_ref);
 
-
 // Pointers reference constants in the bound expression tree;
 // nullptr means an unbounded side (NULL).
 struct RangeArgs {

--- a/server/connector/ts_compound.cpp
+++ b/server/connector/ts_compound.cpp
@@ -34,13 +34,7 @@ void FromCompound(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_compound([ts_phrase('a')], [], ['b','c'], 1). "
     "Buckets are TSQUERY[] or NULL; min_should_match defaults to 1.";
-  if (func.children.size() < 3 || func.children.size() > 4) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("ts_compound expects (must, must_not, should [, "
-                            "min_should_match]), got ",
-                            func.children.size(), " args"),
-                    ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() >= 3 && func.children.size() <= 4);
 
   auto extract =
     [](const duckdb::Expression& arg, std::string_view label,

--- a/server/connector/ts_levenshtein.cpp
+++ b/server/connector/ts_levenshtein.cpp
@@ -35,13 +35,7 @@ LevenshteinArgs ParseLevenshteinArgs(
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_levenshtein('test', 1, true, 'pre'). Distance must be 0-4 "
     "(0-3 with transpositions). Optional `prefix` matches exactly.";
-  if (func.children.empty() || func.children.size() > 4) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("ts_levenshtein expects 1 to 4 arguments "
-                            "(text, distance?, transpositions?, prefix?), got ",
-                            func.children.size()),
-                    ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() >= 2 && func.children.size() <= 4);
   LevenshteinArgs out;
   if (auto r =
         GetVarcharArg(*func.children[0], "ts_levenshtein text", out.text);
@@ -117,14 +111,7 @@ void FromLevenshtein(irs::BooleanFilter& filter, const FilterContext& ctx,
                     ERR_MSG("ts_levenshtein field is not VARCHAR"),
                     ERR_HINT(kSyntaxHint));
   }
-  if (func.children.empty() || func.children.size() > 4) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("ts_levenshtein expects 1 to 4 arguments "
-                            "(text, distance?, transpositions?, prefix?), got ",
-                            func.children.size()),
-                    ERR_HINT(kSyntaxHint));
-  }
-
+  // Arity already enforced by ParseLevenshteinArgs's assertion.
   auto args = ParseLevenshteinArgs(func);
 
   std::string field_name;

--- a/server/connector/ts_levenshtein.cpp
+++ b/server/connector/ts_levenshtein.cpp
@@ -111,7 +111,6 @@ void FromLevenshtein(irs::BooleanFilter& filter, const FilterContext& ctx,
                     ERR_MSG("ts_levenshtein field is not VARCHAR"),
                     ERR_HINT(kSyntaxHint));
   }
-  // Arity already enforced by ParseLevenshteinArgs's assertion.
   auto args = ParseLevenshteinArgs(func);
 
   std::string field_name;

--- a/server/connector/ts_like.cpp
+++ b/server/connector/ts_like.cpp
@@ -33,13 +33,29 @@
 
 namespace sdb::connector {
 
-// Picks ByWildcardNgram for WildcardAnalyzer-indexed columns -- those
-// columns ngram-tokenise terms at index time, so the pattern matches
-// through the inverted index instead of a brute-force term-dictionary
-// scan -- and ByWildcard otherwise.
-void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
-                    const SearchColumnInfo& column_info, std::string field_name,
-                    std::string_view pattern) {
+void FromLike(irs::BooleanFilter& parent, const FilterContext& ctx,
+              const SearchColumnInfo& column_info,
+              const duckdb::BoundFunctionExpression& func) {
+  SDB_ASSERT(func.children.size() == 1);
+
+  std::string pattern;
+  if (auto r = GetVarcharArg(*func.children[0], "ts_like pattern", pattern);
+      !r.ok()) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG(r.errorMessage()),
+                    ERR_HINT("Example: ts_like('foo%bar')."));
+  }
+  if (column_info.logical_type.id() != duckdb::LogicalTypeId::VARCHAR) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG("ts_like field is not VARCHAR"),
+      ERR_HINT("ts_like requires a VARCHAR column with identity or wildcard "
+               "analyzer."));
+  }
+  std::string field_name;
+  MakeFieldName(column_info.column_id, field_name);
+  search::mangling::MangleString(field_name);
+
   if (column_info.tokenizer.analyzer->type() ==
       irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
     auto& wf = ctx.negated ? Negate<irs::ByWildcardNgram>(parent)
@@ -62,47 +78,6 @@ void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
   wild_opts.scored_terms_limit = ctx.scored_terms_limit;
   wild_opts.term.assign(
     irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
-}
-
-namespace {
-
-void BuildFtsLike(irs::BooleanFilter& parent, const FilterContext& ctx,
-                  const SearchColumnInfo& column_info,
-                  std::string_view like_pattern) {
-  if (column_info.logical_type.id() != duckdb::LogicalTypeId::VARCHAR) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_like field is not VARCHAR"),
-      ERR_HINT("ts_like requires a VARCHAR column with identity or wildcard "
-               "analyzer."));
-  }
-  std::string field_name;
-  MakeFieldName(column_info.column_id, field_name);
-  search::mangling::MangleString(field_name);
-  EmitLikeFilter(parent, ctx, column_info, std::move(field_name), like_pattern);
-}
-
-}  // namespace
-
-void FromTSQLike(irs::BooleanFilter& parent, const FilterContext& ctx,
-                 const SearchColumnInfo& column_info,
-                 const duckdb::BoundFunctionExpression& func) {
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_like expects 1 argument (pattern), got ",
-              func.children.size()),
-      ERR_HINT("Example: ts_like('foo%bar'). `%` = any sequence, `_` = one "
-               "char."));
-  }
-  std::string pat;
-  if (auto r = GetVarcharArg(*func.children[0], "ts_like pattern", pat);
-      !r.ok()) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG(r.errorMessage()),
-                    ERR_HINT("Example: ts_like('foo%bar')."));
-  }
-  BuildFtsLike(parent, ctx, column_info, pat);
 }
 
 }  // namespace sdb::connector

--- a/server/connector/ts_like.cpp
+++ b/server/connector/ts_like.cpp
@@ -20,14 +20,50 @@
 
 #include <duckdb/planner/expression/bound_cast_expression.hpp>
 #include <iresearch/analysis/token_attributes.hpp>
+#include <iresearch/analysis/wildcard_analyzer.hpp>
+#include <iresearch/search/wildcard_filter.hpp>
+#include <iresearch/search/wildcard_ngram_filter.hpp>
 #include <iresearch/utils/string.hpp>
 
+#include "basics/down_cast.h"
 #include "catalog/mangling.h"
 #include "pg/errcodes.h"
 #include "pg/sql_exception_macro.h"
 #include "ts_common.hpp"
 
 namespace sdb::connector {
+
+// Picks ByWildcardNgram for WildcardAnalyzer-indexed columns -- those
+// columns ngram-tokenise terms at index time, so the pattern matches
+// through the inverted index instead of a brute-force term-dictionary
+// scan -- and ByWildcard otherwise.
+void EmitLikeFilter(irs::BooleanFilter& parent, const FilterContext& ctx,
+                    const SearchColumnInfo& column_info, std::string field_name,
+                    std::string_view pattern) {
+  if (column_info.tokenizer.analyzer->type() ==
+      irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
+    auto& wf = ctx.negated ? Negate<irs::ByWildcardNgram>(parent)
+                           : AddFilter<irs::ByWildcardNgram>(parent);
+    wf.boost(ctx.boost);
+    *wf.mutable_field() = std::move(field_name);
+    *wf.mutable_options() = {
+      pattern,
+      basics::downCast<irs::analysis::WildcardAnalyzer>(
+        *column_info.tokenizer.analyzer.get()),
+      (column_info.tokenizer.features & irs::IndexFeatures::Pos) ==
+        irs::IndexFeatures::Pos};
+    return;
+  }
+  auto& filter = ctx.negated ? Negate<irs::ByWildcard>(parent)
+                             : AddFilter<irs::ByWildcard>(parent);
+  filter.boost(ctx.boost);
+  *filter.mutable_field() = std::move(field_name);
+  auto& wild_opts = *filter.mutable_options();
+  wild_opts.scored_terms_limit = ctx.scored_terms_limit;
+  wild_opts.term.assign(
+    irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
+}
+
 namespace {
 
 void BuildFtsLike(irs::BooleanFilter& parent, const FilterContext& ctx,

--- a/server/connector/ts_ngram.cpp
+++ b/server/connector/ts_ngram.cpp
@@ -41,13 +41,7 @@ void FromNgram(irs::BooleanFilter& filter, const FilterContext& ctx,
                     ERR_MSG("ts_ngram field is not VARCHAR"),
                     ERR_HINT(kSyntaxHint));
   }
-  if (func.children.empty() || func.children.size() > 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_ngram expects 1 or 2 arguments (text[, threshold]), got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() >= 1 && func.children.size() <= 2);
 
   std::string target;
   if (auto r = GetVarcharArg(*func.children[0], "ts_ngram text", target);

--- a/server/connector/ts_phrase.cpp
+++ b/server/connector/ts_phrase.cpp
@@ -328,16 +328,10 @@ void FlattenPhraseSeq(const duckdb::Expression& expr, PhraseSeq& seq) {
     seq.parts.push_back(&unwrapped);
     return;
   }
-  const auto& f = unwrapped.Cast<duckdb::BoundFunctionExpression>();
-  if (f.children.size() != 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("## expects 2 arguments (lhs ## rhs), got ", f.children.size()),
-      ERR_HINT("Example: ts_phrase('a') ## 'b' (adjacent), or with a gap: "
-               "ts_phrase('a') ## 1 ## 'b'."));
-  }
-  FlattenPhraseSeq(*f.children[0], seq);
-  const auto& right = *f.children[1];
+  const auto& func = unwrapped.Cast<duckdb::BoundFunctionExpression>();
+  SDB_ASSERT(func.children.size() == 2);
+  FlattenPhraseSeq(*func.children[0], seq);
+  const auto& right = *func.children[1];
   if (IsPhraseSeqGapType(right)) {
     if (seq.pending) {
       THROW_SQL_ERROR(

--- a/server/connector/ts_prefix.cpp
+++ b/server/connector/ts_prefix.cpp
@@ -29,11 +29,18 @@
 #include "ts_common.hpp"
 
 namespace sdb::connector {
-namespace {
 
-void BuildFtsPrefix(irs::BooleanFilter& parent, const FilterContext& ctx,
-                    const SearchColumnInfo& column_info,
-                    std::string_view prefix) {
+void FromPrefix(irs::BooleanFilter& parent, const FilterContext& ctx,
+                const SearchColumnInfo& column_info,
+                const duckdb::BoundFunctionExpression& func) {
+  SDB_ASSERT(func.children.size() == 1);
+  std::string prefix;
+  if (auto r = GetVarcharArg(*func.children[0], "ts_starts_with text", prefix);
+      !r.ok()) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG(r.errorMessage()),
+                    ERR_HINT("Example: ts_starts_with('pre')."));
+  }
   if (column_info.logical_type.id() != duckdb::LogicalTypeId::VARCHAR) {
     THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                     ERR_MSG("ts_starts_with field is not VARCHAR"),
@@ -46,33 +53,10 @@ void BuildFtsPrefix(irs::BooleanFilter& parent, const FilterContext& ctx,
   auto& filter = ctx.negated ? Negate<irs::ByPrefix>(parent)
                              : AddFilter<irs::ByPrefix>(parent);
   filter.boost(ctx.boost);
-  *filter.mutable_field() = field_name;
+  *filter.mutable_field() = std::move(field_name);
   auto& pf_opts = *filter.mutable_options();
   pf_opts.scored_terms_limit = ctx.scored_terms_limit;
-  pf_opts.term.assign(irs::ViewCast<irs::byte_type>(prefix));
-}
-
-}  // namespace
-
-void FromPrefix(irs::BooleanFilter& parent, const FilterContext& ctx,
-                const SearchColumnInfo& column_info,
-                const duckdb::BoundFunctionExpression& func) {
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_starts_with expects 1 argument (text), got ",
-              func.children.size()),
-      ERR_HINT("Example: ts_starts_with('pre'). For mid-string wildcards use "
-               "ts_like('foo%bar')."));
-  }
-  std::string prefix;
-  if (auto r = GetVarcharArg(*func.children[0], "ts_starts_with text", prefix);
-      !r.ok()) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG(r.errorMessage()),
-                    ERR_HINT("Example: ts_starts_with('pre')."));
-  }
-  BuildFtsPrefix(parent, ctx, column_info, prefix);
+  pf_opts.term.assign(irs::ViewCast<irs::byte_type>(std::string_view{prefix}));
 }
 
 }  // namespace sdb::connector

--- a/server/connector/ts_prefix.cpp
+++ b/server/connector/ts_prefix.cpp
@@ -75,34 +75,4 @@ void FromPrefix(irs::BooleanFilter& parent, const FilterContext& ctx,
   BuildFtsPrefix(parent, ctx, column_info, prefix);
 }
 
-Result FromFuncPrefix(irs::BooleanFilter& filter, const FilterContext& ctx,
-                      const duckdb::BoundFunctionExpression& func) {
-  if (func.children.size() != 2) {
-    return {ERROR_BAD_PARAMETER, "prefix expects 2 arguments, got ",
-            func.children.size()};
-  }
-  const auto* column_ref = TryGetColumnRef(*func.children[0]);
-  if (!column_ref) {
-    return {ERROR_BAD_PARAMETER, "prefix input is not a column reference"};
-  }
-  const auto* literal_val = TryGetConstant(*func.children[1]);
-  if (!literal_val ||
-      literal_val->type().id() != duckdb::LogicalTypeId::VARCHAR) {
-    return {ERROR_BAD_PARAMETER, "prefix literal must be a VARCHAR constant"};
-  }
-  const auto* column_info = FindColumnInfo(ctx, *column_ref);
-  if (!column_info) {
-    return {ERROR_BAD_PARAMETER, "Column is not indexed"};
-  }
-  if (column_info->tokenizer.analyzer->type() !=
-      irs::Type<irs::StringTokenizer>::id()) {
-    return {ERROR_BAD_PARAMETER,
-            "prefix requires an keyword-analyzed column. Use "
-            "`col @@ ts_starts_with('pre')` for non-keyword analyzers."};
-  }
-  BuildFtsPrefix(filter, ctx, *column_info,
-                 literal_val->GetValue<std::string>());
-  return {};
-}
-
 }  // namespace sdb::connector

--- a/server/connector/ts_regexp.cpp
+++ b/server/connector/ts_regexp.cpp
@@ -53,8 +53,6 @@ void FromRegexp(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_regexp('abc.*') or ts_regexp('foo', 'posix'). "
     "Syntax is 'perl' (default) or 'posix'.";
-  // ts_regexp registered as (VARCHAR) and (VARCHAR, VARCHAR); binder
-  // enforces arity.
   SDB_ASSERT(func.children.size() >= 1 && func.children.size() <= 2);
   std::string pattern;
   if (auto r = GetVarcharArg(*func.children[0], "ts_regexp pattern", pattern);

--- a/server/connector/ts_regexp.cpp
+++ b/server/connector/ts_regexp.cpp
@@ -98,7 +98,8 @@ void FromRegexp(irs::BooleanFilter& parent, const FilterContext& ctx,
   *filter.mutable_field() = std::move(field_name);
   auto* opts = filter.mutable_options();
   opts->scored_terms_limit = ctx.scored_terms_limit;
-  opts->pattern.assign(irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
+  opts->pattern.assign(
+    irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
   opts->syntax = syntax;
 }
 

--- a/server/connector/ts_regexp.cpp
+++ b/server/connector/ts_regexp.cpp
@@ -28,11 +28,6 @@
 #include "pg/sql_exception_macro.h"
 #include "ts_common.hpp"
 
-// magic_enum customisation for irs::RegexpSyntax: maps the surface
-// names accepted by ts_regexp(pattern, syntax) ('perl', 'posix') to the
-// underlying enum values. The specialisation must be visible at
-// every enum_cast / enum_names<irs::RegexpSyntax> instantiation; only
-// this TU calls them, so the customisation lives here.
 namespace magic_enum {
 
 template<>
@@ -51,28 +46,6 @@ customize::enum_name<irs::RegexpSyntax>(irs::RegexpSyntax value) noexcept {
 
 }  // namespace magic_enum
 namespace sdb::connector {
-namespace {
-
-void BuildFtsRegexp(irs::BooleanFilter& parent, const FilterContext& ctx,
-                    const SearchColumnInfo& column_info,
-                    std::string_view pattern, irs::RegexpSyntax syntax) {
-  if (column_info.logical_type.id() != duckdb::LogicalTypeId::VARCHAR) {
-    throw duckdb::InvalidInputException("ts_regexp field is not VARCHAR");
-  }
-  std::string field_name;
-  MakeFieldName(column_info.column_id, field_name);
-  search::mangling::MangleString(field_name);
-  auto& filter = ctx.negated ? Negate<irs::ByRegexp>(parent)
-                             : AddFilter<irs::ByRegexp>(parent);
-  filter.boost(ctx.boost);
-  *filter.mutable_field() = field_name;
-  auto* opts = filter.mutable_options();
-  opts->scored_terms_limit = ctx.scored_terms_limit;
-  opts->pattern.assign(irs::ViewCast<irs::byte_type>(pattern));
-  opts->syntax = syntax;
-}
-
-}  // namespace
 
 void FromRegexp(irs::BooleanFilter& parent, const FilterContext& ctx,
                 const SearchColumnInfo& column_info,
@@ -80,13 +53,9 @@ void FromRegexp(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_regexp('abc.*') or ts_regexp('foo', 'posix'). "
     "Syntax is 'perl' (default) or 'posix'.";
-  if (func.children.empty() || func.children.size() > 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_regexp expects 1 or 2 arguments (pattern[, syntax]), got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  // ts_regexp registered as (VARCHAR) and (VARCHAR, VARCHAR); binder
+  // enforces arity.
+  SDB_ASSERT(func.children.size() >= 1 && func.children.size() <= 2);
   std::string pattern;
   if (auto r = GetVarcharArg(*func.children[0], "ts_regexp pattern", pattern);
       !r.ok()) {
@@ -117,7 +86,20 @@ void FromRegexp(irs::BooleanFilter& parent, const FilterContext& ctx,
     }
     syntax = *parsed;
   }
-  BuildFtsRegexp(parent, ctx, column_info, pattern, syntax);
+  if (column_info.logical_type.id() != duckdb::LogicalTypeId::VARCHAR) {
+    throw duckdb::InvalidInputException("ts_regexp field is not VARCHAR");
+  }
+  std::string field_name;
+  MakeFieldName(column_info.column_id, field_name);
+  search::mangling::MangleString(field_name);
+  auto& filter = ctx.negated ? Negate<irs::ByRegexp>(parent)
+                             : AddFilter<irs::ByRegexp>(parent);
+  filter.boost(ctx.boost);
+  *filter.mutable_field() = std::move(field_name);
+  auto* opts = filter.mutable_options();
+  opts->scored_terms_limit = ctx.scored_terms_limit;
+  opts->pattern.assign(irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
+  opts->syntax = syntax;
 }
 
 }  // namespace sdb::connector

--- a/server/connector/ts_to_tsquery.cpp
+++ b/server/connector/ts_to_tsquery.cpp
@@ -184,36 +184,12 @@ void ParseWebsearchQuery(std::string_view text,
 
 }  // namespace
 
-void FromPhrase(irs::BooleanFilter&, const FilterContext&,
-                const SearchColumnInfo&,
-                const duckdb::BoundFunctionExpression&);
-
-void FromPhraseToTsquery(irs::BooleanFilter& parent, const FilterContext& ctx,
-                         const SearchColumnInfo& column_info,
-                         const duckdb::BoundFunctionExpression& func) {
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("phraseto_tsquery expects 1 argument (text), got ",
-              func.children.size()),
-      ERR_HINT("Example: phraseto_tsquery('quick fox'). The text is "
-               "tokenised through the column analyzer and emitted as a "
-               "phrase."));
-  }
-  FromPhrase(parent, ctx, column_info, func);
-}
-
 void FromPlainToTsquery(irs::BooleanFilter& parent, const FilterContext& ctx,
                         const SearchColumnInfo& column_info,
                         const duckdb::BoundFunctionExpression& func) {
   static constexpr std::string_view kSyntaxHint =
     "Example: plainto_tsquery('quick fox'). AND-semantics over tokens.";
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("plainto_tsquery expects 1 argument (text), got ",
-                            func.children.size()),
-                    ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() == 1);
   std::string text;
   if (auto r = GetVarcharArg(*func.children[0], "plainto_tsquery text", text);
       !r.ok()) {
@@ -231,13 +207,7 @@ void FromWebsearchToTsquery(irs::BooleanFilter& parent,
                             const duckdb::BoundFunctionExpression& func) {
   static constexpr std::string_view kSyntaxHint =
     "Example: websearch_to_tsquery('\"quick fox\" -slow OR fast').";
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("websearch_to_tsquery expects 1 argument (text), got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() == 1);
   std::string text;
   if (auto r =
         GetVarcharArg(*func.children[0], "websearch_to_tsquery text", text);
@@ -254,16 +224,7 @@ void FromWebsearchToTsquery(irs::BooleanFilter& parent,
 void FromTsqueryPhrase(irs::BooleanFilter& parent, const FilterContext& ctx,
                        const SearchColumnInfo& column_info,
                        const duckdb::BoundFunctionExpression& func) {
-  static constexpr std::string_view kSyntaxHint =
-    "Example: tsquery_phrase(ts_phrase('hello'), 'world', 1). Same as "
-    "ts_phrase('hello') ## 1 ## 'world'.";
-  if (func.children.size() < 2 || func.children.size() > 3) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-                    ERR_MSG("tsquery_phrase expects 2 or 3 arguments "
-                            "(q1, q2[, distance]), got ",
-                            func.children.size()),
-                    ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() >= 2 && func.children.size() <= 3);
   PhraseSeq seq;
   FlattenPhraseSeq(*func.children[0], seq);
   if (func.children.size() == 3) {
@@ -279,13 +240,8 @@ void FromToTsquery(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: to_tsquery('field:foo AND bar*'). Lucene syntax: "
     "AND/OR/NOT, +/-, prefix/wildcard/regex, ranges, ^N, ~N.";
-  if (func.children.size() != 1) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("to_tsquery expects 1 argument (lucene-string), got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  // to_tsquery registred as (VARCHAR); binder enforces arity.
+  SDB_ASSERT(func.children.size() == 1);
   std::string text;
   if (auto r = GetVarcharArg(*func.children[0], "to_tsquery text", text);
       !r.ok()) {

--- a/server/connector/ts_to_tsquery.cpp
+++ b/server/connector/ts_to_tsquery.cpp
@@ -240,7 +240,6 @@ void FromToTsquery(irs::BooleanFilter& parent, const FilterContext& ctx,
   static constexpr std::string_view kSyntaxHint =
     "Example: to_tsquery('field:foo AND bar*'). Lucene syntax: "
     "AND/OR/NOT, +/-, prefix/wildcard/regex, ranges, ^N, ~N.";
-  // to_tsquery registred as (VARCHAR); binder enforces arity.
   SDB_ASSERT(func.children.size() == 1);
   std::string text;
   if (auto r = GetVarcharArg(*func.children[0], "to_tsquery text", text);

--- a/server/connector/ts_tokenize.cpp
+++ b/server/connector/ts_tokenize.cpp
@@ -34,13 +34,7 @@ void FromTokenize(irs::BooleanFilter& parent, const FilterContext& ctx,
                   const duckdb::BoundFunctionExpression& func) {
   static constexpr std::string_view kSyntaxHint =
     "Example: ts_tokenize('quick fox') or ts_tokenize('foo', 'keyword').";
-  if (func.children.empty() || func.children.size() > 2) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
-      ERR_MSG("ts_tokenize expects 1 or 2 arguments (text[, analyzer]), got ",
-              func.children.size()),
-      ERR_HINT(kSyntaxHint));
-  }
+  SDB_ASSERT(func.children.size() >= 1 && func.children.size() <= 2);
   std::string text;
   if (auto r = GetVarcharArg(*func.children[0], "ts_tokenize text", text);
       !r.ok()) {

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -4602,4 +4602,172 @@ TEST_F(SearchFilterBuilderTest, test_TSQueryMatch_WebsearchEmpty) {
                true, SegmentationAnalyzerProvider);
 }
 
+// ===========================================================================
+// SQL-native predicate sugar -- `<name>(col, args...)` rewrites at
+// filter-build time to `col @@ <inner ts_*(...)>`. Each test asserts
+// the predicate produces the exact same filter as the @@ equivalent.
+// ===========================================================================
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_eq_AtAtTsPhrase) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"quick", "brown", "fox"});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown fox')",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_WithGap_eq_AtAtTsPhrase) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<std::string_view>(1);
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(3, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick', 2, 'fox')",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_eq_AtAtTsNgram) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddNgramSimilarityFilter(expected, 1, {"he", "el", "ll", "lo"});
+  AssertFilter(expected, "SELECT * FROM foo WHERE ngram_matches(b, 'hello')",
+               columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_WithThreshold_eq_AtAtTsNgram) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddNgramSimilarityFilter(expected, 1, {"he", "el", "ll", "lo"}, 0.5f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE ngram_matches(b, 'hello', 0.5)",
+               columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_eq_AtAtTsLevenshtein) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "test", 2, false);
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE levenshtein_matches(b, 'test', 2, false)", columns,
+    true);
+}
+
+TEST_F(SearchFilterBuilderTest,
+       test_LevenshteinMatches_WithPrefix_eq_AtAtTsLevenshtein) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "roximate", 1,
+                        /*with_transpositions=*/true,
+                        /*max_terms=*/1024, /*prefix=*/"app");
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE levenshtein_matches(b, 'roximate', 1, "
+               "true, 'app')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_TokensMatchAll_eq_AtAtTsAllTsTokenize) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+  }
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE tokens_match_all(b, ['Foo', 'Bar'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_TokensMatchAny_List_eq_AtAtTsAnyTsTokenize) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE tokens_match_any(b, ['Foo', 'Bar'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest,
+       test_TokensMatchAny_ListWithMinMatch_eq_AtAtTsAnyTsTokenizeMinMatch) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"baz"}));
+  }
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE tokens_match_any(b, ['Foo', 'Bar', 'Baz'], 2)",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_TokensMatchAny_Text_eq_AtAtBareString) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermFilter<std::string_view>(expected, 1, std::string_view{"foo"});
+  AssertFilter(expected, "SELECT * FROM foo WHERE tokens_match_any(b, 'Foo')",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest,
+       test_TokensMatchAny_TextWithMinMatch_eq_AtAtTsAnyListValueTokenize) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  // 'foo bar' tokenises to two tokens through the segmentation
+  // analyzer -- both must match (min_match=2).
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+  }
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE tokens_match_any(b, 'Foo Bar', 2)", columns,
+    true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_BoostCastWraps) {
+  // Predicates return BOOLEAN, so the SQL `::boost(K)` cast composes
+  // through the same machinery as direct `@@` results.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"quick", "brown", "fox"}).boost(2.0f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (phrase_matches(category, 'quick "
+               "brown fox'))::boost(2.0)",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
 }  // namespace

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -4771,4 +4771,643 @@ TEST_F(SearchFilterBuilderTest, test_PhraseMatches_BoostCastWraps) {
                columns, true, SegmentationAnalyzerProvider);
 }
 
+// ===========================================================================
+// Predicate-sugar comprehensive coverage. Each block exercises a single
+// predicate across argument shapes, boolean composition, negation, and
+// boost. Cross-cutting tests at the end mix predicates and verify
+// error paths.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// phrase_matches
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_SingleToken) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"foo"});
+  AssertFilter(expected, "SELECT * FROM foo WHERE phrase_matches(b, 'foo')",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_MultipleGaps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<std::string_view>(1);
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(2, 2).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"brown"});
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(3, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE phrase_matches(category, 'quick', 1, "
+               "'brown', 2, 'fox')",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_RangeGap) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& phrase = AddFilter<irs::ByPhrase>(expected);
+  *phrase.mutable_field() = MakeFieldName<std::string_view>(1);
+  phrase.mutable_options()->push_back<irs::ByTermOptions>().term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"quick"});
+  phrase.mutable_options()->push_back<irs::ByTermOptions>(2, 3).term =
+    irs::ViewCast<irs::byte_type>(std::string_view{"fox"});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE phrase_matches(category, 'quick', "
+               "ARRAY[1,2], 'fox')",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"quick", "brown", "fox"});
+  AddPhraseFilter(expected, 1, {"quick", "lazy", "fox"});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown fox') "
+    "AND phrase_matches(category, 'quick lazy fox')",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_OredWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddPhraseFilter(or_filter, 1, {"quick", "brown", "fox"});
+  AddPhraseFilter(or_filter, 1, {"quick", "lazy", "fox"});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown fox') "
+    "OR phrase_matches(category, 'quick lazy fox')",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddPhraseFilter(not_filter, 1, {"quick", "brown", "fox"});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE NOT phrase_matches(category, 'quick brown fox')",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_AndedWithNumericRange) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"},
+    {.id = 2, .type = duckdb::LogicalType::INTEGER, .name = "n"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"quick", "brown", "fox"});
+  AddRangeFilter<int32_t>(expected, 2, 10, true, std::nullopt, false);
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown fox') "
+    "AND n >= 10",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PhraseMatches_GapEndingError) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  // ts_phrase ends with a gap -- error message preserved through the
+  // sugar rewrite (FromPredicate dispatches to FromTSQueryMatch which
+  // dispatches to FromPhrase, where the validation lives).
+  AssertFilter(irs::And{},
+               "SELECT * FROM foo WHERE phrase_matches(category, 'quick', 2)",
+               columns, false, SegmentationAnalyzerProvider, "ts_phrase");
+}
+
+// ---------------------------------------------------------------------------
+// ngram_matches
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_DefaultThreshold) {
+  // Default threshold = 0.7 (matches AddNgramSimilarityFilter default).
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddNgramSimilarityFilter(expected, 1, {"he", "el", "ll", "lo"});
+  AssertFilter(expected, "SELECT * FROM foo WHERE ngram_matches(b, 'hello')",
+               columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddNgramSimilarityFilter(not_filter, 1, {"he", "el", "ll", "lo"});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE NOT ngram_matches(b, 'hello')",
+               columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddNgramSimilarityFilter(expected, 1, {"he", "el", "ll", "lo"});
+  AddNgramSimilarityFilter(expected, 1, {"wo", "or", "rl", "ld"}, 0.5f);
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE ngram_matches(b, 'hello') AND "
+    "ngram_matches(b, 'world', 0.5)",
+    columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_OredWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddNgramSimilarityFilter(or_filter, 1, {"he", "el", "ll", "lo"}, 0.5f);
+  AddNgramSimilarityFilter(or_filter, 1, {"wo", "or", "rl", "ld"}, 0.5f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE ngram_matches(b, 'hello', 0.5) OR "
+               "ngram_matches(b, 'world', 0.5)",
+               columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddNgramSimilarityFilter(expected, 1, {"he", "el", "ll", "lo"}, 0.5f)
+    .boost(3.5f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (ngram_matches(b, 'hello', "
+               "0.5))::boost(3.5)",
+               columns, true, NgramAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_NgramMatches_NoFeaturesError) {
+  // Default keyword analyzer lacks Pos+Freq features required for
+  // ngram. Error surfaces through the sugar rewrite.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{}, "SELECT * FROM foo WHERE ngram_matches(b, 'hello')",
+               columns, false, IdentityAnalyzerProvider, "ts_ngram");
+}
+
+// ---------------------------------------------------------------------------
+// levenshtein_matches
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_3Arg) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "test", 2);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE levenshtein_matches(b, 'test', 2)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_5Arg_EmptyPrefix) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "test", 2, /*with_transpositions=*/false);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE levenshtein_matches(b, 'test', 2, "
+               "false, '')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddEditDistanceFilter(not_filter, 1, "test", 2);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE NOT levenshtein_matches(b, 'test', 2)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "test", 1);
+  AddEditDistanceFilter(expected, 1, "best", 1);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE levenshtein_matches(b, 'test', 1) AND "
+               "levenshtein_matches(b, 'best', 1)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_OredWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddEditDistanceFilter(or_filter, 1, "test", 1);
+  AddEditDistanceFilter(or_filter, 1, "best", 1);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE levenshtein_matches(b, 'test', 1) OR "
+               "levenshtein_matches(b, 'best', 1)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "test", 2).boost(1.5f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (levenshtein_matches(b, 'test', "
+               "2))::boost(1.5)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_LevenshteinMatches_AndedWithRange) {
+  // `n > 0 AND n < 100` produces two separate GranularRange filters at
+  // the AND root (DuckDB doesn't fuse the bounds).
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"},
+    {.id = 2, .type = duckdb::LogicalType::INTEGER, .name = "n"}};
+  irs::And expected;
+  AddEditDistanceFilter(expected, 1, "test", 2);
+  AddRangeFilter<int32_t>(expected, 2, 0, false, std::nullopt, false);
+  AddRangeFilter<int32_t>(expected, 2, std::nullopt, false, 100, false);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE levenshtein_matches(b, 'test', 2) "
+               "AND n > 0 AND n < 100",
+               columns, true);
+}
+
+// ---------------------------------------------------------------------------
+// has_all_tokens
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_SingleElementList) {
+  // Single-element list with single-token element collapses to ByTerm
+  // (FromTokenizeListInAnyAllOf single-token short-circuit).
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermFilter<std::string_view>(expected, 1, std::string_view{"foo"});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_MultiTokenElement) {
+  // 'foo bar' tokenises to ['foo', 'bar'] under segmentation; combined
+  // with 'baz' the flattened list is [foo, bar, baz] under min_match=3
+  // (ALL_OF semantics).
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 3;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"baz"}));
+  }
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo Bar', 'Baz'])", columns,
+    true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  {
+    auto& terms = AddFilter<irs::ByTerms>(not_filter);
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+  }
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE NOT has_all_tokens(b, ['Foo', 'Bar'])", columns,
+    true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+  }
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"baz"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"qux"}));
+  }
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo', 'Bar']) "
+               "AND has_all_tokens(b, ['Baz', 'Qux'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_OredWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  {
+    auto& terms = or_filter.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+  }
+  {
+    auto& terms = or_filter.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"baz"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"qux"}));
+  }
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo', 'Bar']) "
+               "OR has_all_tokens(b, ['Baz', 'Qux'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+    static_cast<irs::FilterWithBoost&>(terms).boost(2.5f);
+  }
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (has_all_tokens(b, ['Foo', "
+               "'Bar']))::boost(2.5)",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_IdentityAnalyzer) {
+  // With identity analyzer: each list element becomes one raw term.
+  // 'Foo Bar' stays as a single ByTerm("Foo Bar") because the identity
+  // analyzer does not split on whitespace -- but list path doesn't
+  // accept analyzer override and uses ambient (identity here), so
+  // each element is preserved verbatim with min_match = list size.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"Foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"Bar"}));
+  }
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo', 'Bar'])",
+               columns, true, IdentityAnalyzerProvider);
+}
+
+// ---------------------------------------------------------------------------
+// has_any_token
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_List_MinMatch1Default) {
+  // Default min_match for ts_any is 1 -- equivalent to no min_match arg.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'], 1)", columns,
+    true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_List_MinMatchEqualsSize) {
+  // min_match = list size -- behaves like has_all_tokens.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+  }
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'], 2)", columns,
+    true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_SingleToken) {
+  // Single-token text via segmentation -> bare-string @@ produces a ByTerm.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermFilter<std::string_view>(expected, 1, std::string_view{"foo"});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_any_token(b, 'Foo')", columns,
+               true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_MultiToken) {
+  // Multi-token text via segmentation -> bare-string @@ produces ByTerms
+  // with min_match=1 (OR semantics).
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_any_token(b, 'Foo Bar')", columns,
+               true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddTermsFilter<std::string_view>(
+    not_filter, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE NOT has_any_token(b, ['Foo', 'Bar'])", columns,
+    true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"baz"}, std::string_view{"qux"}});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar']) AND "
+               "has_any_token(b, ['Baz', 'Qux'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_OredWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddTermsFilter<std::string_view>(
+    or_filter, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AddTermsFilter<std::string_view>(
+    or_filter, 1, {std::string_view{"baz"}, std::string_view{"qux"}});
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar']) OR "
+               "has_any_token(b, ['Baz', 'Qux'])",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}})
+    .boost(0.5f);
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE (has_any_token(b, ['Foo', 'Bar']))::boost(0.5)",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_TextWithMinMatch_BoostCast) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  {
+    auto& terms = expected.add<irs::ByTerms>();
+    *terms.mutable_field() = MakeFieldName<std::string_view>(1);
+    auto& opts = *terms.mutable_options();
+    opts.min_match = 2;
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
+    opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
+    static_cast<irs::FilterWithBoost&>(terms).boost(4.0f);
+  }
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (has_any_token(b, 'Foo Bar', "
+               "2))::boost(4.0)",
+               columns, true, SegmentationAnalyzerProvider);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: mixed predicates, complex composition, error paths
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_PredicateMix_PhraseAndLevenshtein) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"quick", "brown"});
+  AddEditDistanceFilter(expected, 1, "test", 2);
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown') AND "
+    "levenshtein_matches(category, 'test', 2)",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PredicateMix_OrOfDifferentPredicates) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddPhraseFilter(or_filter, 1, {"quick", "brown"});
+  AddTermsFilter<std::string_view>(
+    or_filter, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown') OR "
+    "has_any_token(category, ['Foo', 'Bar'])",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PredicateMix_NotOfAnd) {
+  // DuckDB does not apply De Morgan here -- the bound expression
+  // arrives as `NOT (A AND B)` and the filter builder mirrors that
+  // shape with a Not over an And.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  auto& inner_and = AddFilter<irs::And>(not_filter);
+  AddPhraseFilter(inner_and, 1, {"quick", "brown"});
+  AddPhraseFilter(inner_and, 1, {"red", "fox"});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE NOT (phrase_matches(category, 'quick brown') "
+    "AND phrase_matches(category, 'red fox'))",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_PredicateMix_AndOfThree) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "category"}};
+  irs::And expected;
+  AddPhraseFilter(expected, 1, {"quick", "brown"});
+  AddEditDistanceFilter(expected, 1, "test", 2);
+  AddTermsFilter<std::string_view>(
+    expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE phrase_matches(category, 'quick brown') AND "
+    "levenshtein_matches(category, 'test', 2) AND "
+    "has_any_token(category, ['Foo', 'Bar'])",
+    columns, true, SegmentationAnalyzerProvider);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Predicate_NonColumnFirstArg) {
+  // First arg is a constant, not a column ref -- the @@ handler rejects
+  // it via "@@ requires a column reference on one side".
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{},
+               "SELECT * FROM foo WHERE phrase_matches('not a column', 'foo')",
+               columns, false, SegmentationAnalyzerProvider, "@@");
+}
+
 }  // namespace

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -4697,8 +4697,7 @@ TEST_F(SearchFilterBuilderTest, test_HasAllTokens_eq_AtAtTsAllTsTokenize) {
                columns, true, SegmentationAnalyzerProvider);
 }
 
-TEST_F(SearchFilterBuilderTest,
-       test_HasAnyToken_List_eq_AtAtTsAnyTsTokenize) {
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_List_eq_AtAtTsAnyTsTokenize) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
@@ -4910,8 +4909,8 @@ TEST_F(SearchFilterBuilderTest, test_NgramMatches_Negated) {
   auto& not_filter = expected.add<irs::Not>();
   AddNgramSimilarityFilter(not_filter, 1, {"he", "el", "ll", "lo"});
   AssertFilter(expected,
-               "SELECT * FROM foo WHERE NOT ngram_matches(b, 'hello')",
-               columns, true, NgramAnalyzerProvider);
+               "SELECT * FROM foo WHERE NOT ngram_matches(b, 'hello')", columns,
+               true, NgramAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_NgramMatches_AndedWithSelf) {
@@ -4920,11 +4919,10 @@ TEST_F(SearchFilterBuilderTest, test_NgramMatches_AndedWithSelf) {
   irs::And expected;
   AddNgramSimilarityFilter(expected, 1, {"he", "el", "ll", "lo"});
   AddNgramSimilarityFilter(expected, 1, {"wo", "or", "rl", "ld"}, 0.5f);
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE ngram_matches(b, 'hello') AND "
-    "ngram_matches(b, 'world', 0.5)",
-    columns, true, NgramAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE ngram_matches(b, 'hello') AND "
+               "ngram_matches(b, 'world', 0.5)",
+               columns, true, NgramAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_NgramMatches_OredWithSelf) {
@@ -5060,8 +5058,7 @@ TEST_F(SearchFilterBuilderTest, test_HasAllTokens_SingleElementList) {
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
   AddTermFilter<std::string_view>(expected, 1, std::string_view{"foo"});
-  AssertFilter(expected,
-               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo'])",
+  AssertFilter(expected, "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo'])",
                columns, true, SegmentationAnalyzerProvider);
 }
 
@@ -5081,10 +5078,9 @@ TEST_F(SearchFilterBuilderTest, test_HasAllTokens_MultiTokenElement) {
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"baz"}));
   }
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo Bar', 'Baz'])", columns,
-    true, SegmentationAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo Bar', 'Baz'])",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAllTokens_Negated) {
@@ -5100,10 +5096,9 @@ TEST_F(SearchFilterBuilderTest, test_HasAllTokens_Negated) {
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
   }
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE NOT has_all_tokens(b, ['Foo', 'Bar'])", columns,
-    true, SegmentationAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE NOT has_all_tokens(b, ['Foo', 'Bar'])",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAllTokens_AndedWithSelf) {
@@ -5211,10 +5206,9 @@ TEST_F(SearchFilterBuilderTest, test_HasAnyToken_List_MinMatch1Default) {
   irs::And expected;
   AddTermsFilter<std::string_view>(
     expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'], 1)", columns,
-    true, SegmentationAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'], 1)",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAnyToken_List_MinMatchEqualsSize) {
@@ -5230,10 +5224,9 @@ TEST_F(SearchFilterBuilderTest, test_HasAnyToken_List_MinMatchEqualsSize) {
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
   }
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'], 2)", columns,
-    true, SegmentationAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'], 2)",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_SingleToken) {
@@ -5242,9 +5235,8 @@ TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_SingleToken) {
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
   AddTermFilter<std::string_view>(expected, 1, std::string_view{"foo"});
-  AssertFilter(expected,
-               "SELECT * FROM foo WHERE has_any_token(b, 'Foo')", columns,
-               true, SegmentationAnalyzerProvider);
+  AssertFilter(expected, "SELECT * FROM foo WHERE has_any_token(b, 'Foo')",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_MultiToken) {
@@ -5255,9 +5247,8 @@ TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_MultiToken) {
   irs::And expected;
   AddTermsFilter<std::string_view>(
     expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
-  AssertFilter(expected,
-               "SELECT * FROM foo WHERE has_any_token(b, 'Foo Bar')", columns,
-               true, SegmentationAnalyzerProvider);
+  AssertFilter(expected, "SELECT * FROM foo WHERE has_any_token(b, 'Foo Bar')",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Negated) {
@@ -5267,10 +5258,9 @@ TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Negated) {
   auto& not_filter = expected.add<irs::Not>();
   AddTermsFilter<std::string_view>(
     not_filter, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE NOT has_any_token(b, ['Foo', 'Bar'])", columns,
-    true, SegmentationAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE NOT has_any_token(b, ['Foo', 'Bar'])",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_HasAnyToken_AndedWithSelf) {

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -4644,7 +4644,8 @@ TEST_F(SearchFilterBuilderTest, test_NgramMatches_eq_AtAtTsNgram) {
                columns, true, NgramAnalyzerProvider);
 }
 
-TEST_F(SearchFilterBuilderTest, test_NgramMatches_WithThreshold_eq_AtAtTsNgram) {
+TEST_F(SearchFilterBuilderTest,
+       test_NgramMatches_WithThreshold_eq_AtAtTsNgram) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
@@ -4696,7 +4697,8 @@ TEST_F(SearchFilterBuilderTest, test_TokensMatchAll_eq_AtAtTsAllTsTokenize) {
                columns, true, SegmentationAnalyzerProvider);
 }
 
-TEST_F(SearchFilterBuilderTest, test_TokensMatchAny_List_eq_AtAtTsAnyTsTokenize) {
+TEST_F(SearchFilterBuilderTest,
+       test_TokensMatchAny_List_eq_AtAtTsAnyTsTokenize) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
@@ -4751,10 +4753,9 @@ TEST_F(SearchFilterBuilderTest,
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"foo"}));
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
   }
-  AssertFilter(
-    expected,
-    "SELECT * FROM foo WHERE tokens_match_any(b, 'Foo Bar', 2)", columns,
-    true, SegmentationAnalyzerProvider);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE tokens_match_any(b, 'Foo Bar', 2)",
+               columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_PhraseMatches_BoostCastWraps) {

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -4680,7 +4680,7 @@ TEST_F(SearchFilterBuilderTest,
                columns, true);
 }
 
-TEST_F(SearchFilterBuilderTest, test_TokensMatchAll_eq_AtAtTsAllTsTokenize) {
+TEST_F(SearchFilterBuilderTest, test_HasAllTokens_eq_AtAtTsAllTsTokenize) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
@@ -4693,24 +4693,24 @@ TEST_F(SearchFilterBuilderTest, test_TokensMatchAll_eq_AtAtTsAllTsTokenize) {
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
   }
   AssertFilter(expected,
-               "SELECT * FROM foo WHERE tokens_match_all(b, ['Foo', 'Bar'])",
+               "SELECT * FROM foo WHERE has_all_tokens(b, ['Foo', 'Bar'])",
                columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest,
-       test_TokensMatchAny_List_eq_AtAtTsAnyTsTokenize) {
+       test_HasAnyToken_List_eq_AtAtTsAnyTsTokenize) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
   AddTermsFilter<std::string_view>(
     expected, 1, {std::string_view{"foo"}, std::string_view{"bar"}});
   AssertFilter(expected,
-               "SELECT * FROM foo WHERE tokens_match_any(b, ['Foo', 'Bar'])",
+               "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar'])",
                columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest,
-       test_TokensMatchAny_ListWithMinMatch_eq_AtAtTsAnyTsTokenizeMinMatch) {
+       test_HasAnyToken_ListWithMinMatch_eq_AtAtTsAnyTsTokenizeMinMatch) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
@@ -4725,21 +4725,21 @@ TEST_F(SearchFilterBuilderTest,
   }
   AssertFilter(
     expected,
-    "SELECT * FROM foo WHERE tokens_match_any(b, ['Foo', 'Bar', 'Baz'], 2)",
+    "SELECT * FROM foo WHERE has_any_token(b, ['Foo', 'Bar', 'Baz'], 2)",
     columns, true, SegmentationAnalyzerProvider);
 }
 
-TEST_F(SearchFilterBuilderTest, test_TokensMatchAny_Text_eq_AtAtBareString) {
+TEST_F(SearchFilterBuilderTest, test_HasAnyToken_Text_eq_AtAtBareString) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
   AddTermFilter<std::string_view>(expected, 1, std::string_view{"foo"});
-  AssertFilter(expected, "SELECT * FROM foo WHERE tokens_match_any(b, 'Foo')",
+  AssertFilter(expected, "SELECT * FROM foo WHERE has_any_token(b, 'Foo')",
                columns, true, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest,
-       test_TokensMatchAny_TextWithMinMatch_eq_AtAtTsAnyListValueTokenize) {
+       test_HasAnyToken_TextWithMinMatch_eq_AtAtTsAnyListValueTokenize) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   irs::And expected;
@@ -4754,7 +4754,7 @@ TEST_F(SearchFilterBuilderTest,
     opts.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view{"bar"}));
   }
   AssertFilter(expected,
-               "SELECT * FROM foo WHERE tokens_match_any(b, 'Foo Bar', 2)",
+               "SELECT * FROM foo WHERE has_any_token(b, 'Foo Bar', 2)",
                columns, true, SegmentationAnalyzerProvider);
 }
 

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -5476,12 +5476,13 @@ TEST_F(SearchFilterBuilderTest, test_Contains_BoostCastWraps) {
                columns, true);
 }
 
-TEST_F(SearchFilterBuilderTest, test_Contains_RejectsNonKeywordAnalyzer) {
+TEST_F(SearchFilterBuilderTest, test_Contains_DeclinesNonKeywordAnalyzer) {
+  // Non-keyword analyzer -> claim silently declines so DuckDB evaluates
+  // the predicate per row.
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   AssertFilter(irs::And{}, "SELECT * FROM foo WHERE contains(b, 'foo')",
-               columns, false, SegmentationAnalyzerProvider,
-               "requires a keyword-analyzed column");
+               columns, false, SegmentationAnalyzerProvider);
 }
 
 TEST_F(SearchFilterBuilderTest, test_Contains_DeclinesListShape) {
@@ -5556,12 +5557,11 @@ TEST_F(SearchFilterBuilderTest, test_StartsWith_BoostCastWraps) {
                columns, true);
 }
 
-TEST_F(SearchFilterBuilderTest, test_StartsWith_RejectsNonKeywordAnalyzer) {
+TEST_F(SearchFilterBuilderTest, test_StartsWith_DeclinesNonKeywordAnalyzer) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   AssertFilter(irs::And{}, "SELECT * FROM foo WHERE starts_with(b, 'foo')",
-               columns, false, SegmentationAnalyzerProvider,
-               "requires a keyword-analyzed column");
+               columns, false, SegmentationAnalyzerProvider);
 }
 
 // ---------------------------------------------------------------------------
@@ -5605,12 +5605,11 @@ TEST_F(SearchFilterBuilderTest, test_EndsWith_Negated) {
                columns, true);
 }
 
-TEST_F(SearchFilterBuilderTest, test_EndsWith_RejectsNonKeywordAnalyzer) {
+TEST_F(SearchFilterBuilderTest, test_EndsWith_DeclinesNonKeywordAnalyzer) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   AssertFilter(irs::And{}, "SELECT * FROM foo WHERE ends_with(b, 'foo')",
-               columns, false, SegmentationAnalyzerProvider,
-               "requires a keyword-analyzed column");
+               columns, false, SegmentationAnalyzerProvider);
 }
 
 // ---------------------------------------------------------------------------
@@ -5684,13 +5683,12 @@ TEST_F(SearchFilterBuilderTest, test_RegexpMatches_DeclinesThreeArg) {
                columns, false);
 }
 
-TEST_F(SearchFilterBuilderTest, test_RegexpMatches_RejectsNonKeywordAnalyzer) {
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_DeclinesNonKeywordAnalyzer) {
   std::vector<ColumnSpec> columns{
     {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
   AssertFilter(irs::And{},
                "SELECT * FROM foo WHERE regexp_matches(b, '[a-z]+[0-9]+')",
-               columns, false, SegmentationAnalyzerProvider,
-               "requires a keyword-analyzed column");
+               columns, false, SegmentationAnalyzerProvider);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -5410,4 +5410,326 @@ TEST_F(SearchFilterBuilderTest, test_Predicate_NonColumnFirstArg) {
                columns, false, SegmentationAnalyzerProvider, "@@");
 }
 
+// ===========================================================================
+// DuckDB built-in claims (contains / starts_with / ^@ / ends_with /
+// suffix / regexp_matches / regexp_like). All require a keyword-
+// analyzed column; lower to `col @@ ts_*(...)`. Each asserts the
+// produced filter equals what `col @@ ts_*` would build directly.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// contains
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_Contains_eq_AtAtTsLikeWrapped) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%foo%");
+  AssertFilter(expected, "SELECT * FROM foo WHERE contains(b, 'foo')", columns,
+               true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_EscapesSpecialChars) {
+  // '50%' should become LIKE '%50\%%' so the user-literal `%` is
+  // matched, not interpreted as a wildcard.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%50\\%%");
+  AssertFilter(expected, "SELECT * FROM foo WHERE contains(b, '50%')", columns,
+               true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%foo%");
+  AddLikeFilter(expected, 1, "%bar%");
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE contains(b, 'foo') AND contains(b, 'bar')",
+    columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_OredWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddLikeFilter(or_filter, 1, "%foo%");
+  AddLikeFilter(or_filter, 1, "%bar%");
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE contains(b, 'foo') OR contains(b, 'bar')", columns,
+    true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddLikeFilter(not_filter, 1, "%foo%");
+  AssertFilter(expected, "SELECT * FROM foo WHERE NOT contains(b, 'foo')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%foo%").boost(2.0f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (contains(b, 'foo'))::boost(2.0)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_RejectsNonKeywordAnalyzer) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{}, "SELECT * FROM foo WHERE contains(b, 'foo')",
+               columns, false, SegmentationAnalyzerProvider,
+               "requires a keyword-analyzed column");
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_DeclinesListShape) {
+  // contains([1,2,3]::INT[], 2) -- LIST shape; our claim declines.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE contains([1, 2, 3]::INT[], 2)", columns,
+               false);
+}
+
+TEST_F(SearchFilterBuilderTest, test_Contains_DeclinesNonConstant) {
+  // contains(b, b) -- pattern is a column ref, not constant; declines.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{}, "SELECT * FROM foo WHERE contains(b, b)", columns,
+               false);
+}
+
+// ---------------------------------------------------------------------------
+// starts_with / ^@
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_StartsWith_eq_AtAtTsStartsWith) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddPrefixFilter(expected, 1, "foo");
+  AssertFilter(expected, "SELECT * FROM foo WHERE starts_with(b, 'foo')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_StartsWith_OperatorAlias) {
+  // `b ^@ 'foo'` lowers to the same function as `starts_with`.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddPrefixFilter(expected, 1, "foo");
+  AssertFilter(expected, "SELECT * FROM foo WHERE b ^@ 'foo'", columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_StartsWith_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddPrefixFilter(expected, 1, "foo");
+  AddPrefixFilter(expected, 1, "ba");
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE starts_with(b, 'foo') AND starts_with(b, 'ba')",
+    columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_StartsWith_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddPrefixFilter(not_filter, 1, "foo");
+  AssertFilter(expected, "SELECT * FROM foo WHERE NOT starts_with(b, 'foo')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_StartsWith_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddPrefixFilter(expected, 1, "foo").boost(3.0f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (starts_with(b, 'foo'))::boost(3.0)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_StartsWith_RejectsNonKeywordAnalyzer) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{}, "SELECT * FROM foo WHERE starts_with(b, 'foo')",
+               columns, false, SegmentationAnalyzerProvider,
+               "requires a keyword-analyzed column");
+}
+
+// ---------------------------------------------------------------------------
+// ends_with / suffix
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_EndsWith_eq_AtAtTsLikeAnchored) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%foo");
+  AssertFilter(expected, "SELECT * FROM foo WHERE ends_with(b, 'foo')", columns,
+               true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_EndsWith_AliasSuffix) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%foo");
+  AssertFilter(expected, "SELECT * FROM foo WHERE suffix(b, 'foo')", columns,
+               true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_EndsWith_EscapesSpecialChars) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%a\\_b");
+  AssertFilter(expected, "SELECT * FROM foo WHERE ends_with(b, 'a_b')", columns,
+               true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_EndsWith_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddLikeFilter(not_filter, 1, "%foo");
+  AssertFilter(expected, "SELECT * FROM foo WHERE NOT ends_with(b, 'foo')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_EndsWith_RejectsNonKeywordAnalyzer) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{}, "SELECT * FROM foo WHERE ends_with(b, 'foo')",
+               columns, false, SegmentationAnalyzerProvider,
+               "requires a keyword-analyzed column");
+}
+
+// ---------------------------------------------------------------------------
+// regexp_matches / regexp_like
+// ---------------------------------------------------------------------------
+
+// DuckDB's regex_range_filter optimizer rewrites simple regex patterns
+// (like `^foo`, `bar$`) into starts_with / LIKE before our claim sees
+// them. Use patterns with character classes / quantifiers that survive
+// the optimizer so we test the real ts_regexp claim path.
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_eq_AtAtTsRegexp) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddRegexpFilter(expected, 1, "[a-z]+[0-9]+");
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE regexp_matches(b, '[a-z]+[0-9]+')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_AliasRegexpLike) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddRegexpFilter(expected, 1, "[a-z]+[0-9]+");
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE regexp_like(b, '[a-z]+[0-9]+')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_AndedWithSelf) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddRegexpFilter(expected, 1, "[a-z]+");
+  AddRegexpFilter(expected, 1, "[0-9]+");
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE regexp_matches(b, '[a-z]+') AND "
+               "regexp_matches(b, '[0-9]+')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_Negated) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& not_filter = expected.add<irs::Not>();
+  AddRegexpFilter(not_filter, 1, "[a-z]+[0-9]+");
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE NOT regexp_matches(b, '[a-z]+[0-9]+')",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_BoostCastWraps) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddRegexpFilter(expected, 1, "[a-z]+[0-9]+").boost(1.5f);
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE (regexp_matches(b, "
+               "'[a-z]+[0-9]+'))::boost(1.5)",
+               columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_DeclinesThreeArg) {
+  // 3-arg form (with options) -- not claimed.
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{},
+               "SELECT * FROM foo WHERE regexp_matches(b, '[a-z]+', 'i')",
+               columns, false);
+}
+
+TEST_F(SearchFilterBuilderTest, test_RegexpMatches_RejectsNonKeywordAnalyzer) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  AssertFilter(irs::And{},
+               "SELECT * FROM foo WHERE regexp_matches(b, '[a-z]+[0-9]+')",
+               columns, false, SegmentationAnalyzerProvider,
+               "requires a keyword-analyzed column");
+}
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: mixing built-ins with each other and with sugar
+// ---------------------------------------------------------------------------
+
+TEST_F(SearchFilterBuilderTest, test_BuiltinMix_ContainsAndStartsWith) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  AddLikeFilter(expected, 1, "%bar%");
+  AddPrefixFilter(expected, 1, "foo");
+  AssertFilter(
+    expected,
+    "SELECT * FROM foo WHERE contains(b, 'bar') AND starts_with(b, 'foo')",
+    columns, true);
+}
+
+TEST_F(SearchFilterBuilderTest, test_BuiltinMix_OrEndsWithRegexp) {
+  std::vector<ColumnSpec> columns{
+    {.id = 1, .type = duckdb::LogicalType::VARCHAR, .name = "b"}};
+  irs::And expected;
+  auto& or_filter = expected.add<irs::Or>();
+  AddLikeFilter(or_filter, 1, "%bar");
+  AddRegexpFilter(or_filter, 1, "[a-z]+[0-9]+");
+  AssertFilter(expected,
+               "SELECT * FROM foo WHERE ends_with(b, 'bar') OR "
+               "regexp_matches(b, '[a-z]+[0-9]+')",
+               columns, true);
+}
+
 }  // namespace

--- a/tests/sqllogic/sdb/pg/index/tsquery_match.test
+++ b/tests/sqllogic/sdb/pg/index/tsquery_match.test
@@ -1897,9 +1897,9 @@ a
 1
 2
 
-# tokens_match_all
+# has_all_tokens
 query
-SELECT a FROM tsq_idx WHERE tokens_match_all(b, ['quick', 'fox']) ORDER BY a;
+SELECT a FROM tsq_idx WHERE has_all_tokens(b, ['quick', 'fox']) ORDER BY a;
 ----
 a
 1
@@ -1912,9 +1912,9 @@ a
 1
 2
 
-# tokens_match_any list-form.
+# has_any_token list-form.
 query
-SELECT a FROM tsq_idx WHERE tokens_match_any(b, ['turtle', 'fox']) ORDER BY a;
+SELECT a FROM tsq_idx WHERE has_any_token(b, ['turtle', 'fox']) ORDER BY a;
 ----
 a
 1
@@ -1929,9 +1929,9 @@ a
 2
 3
 
-# tokens_match_any list-form with min_match.
+# has_any_token list-form with min_match.
 query
-SELECT a FROM tsq_idx WHERE tokens_match_any(b, ['quick', 'fox', 'lazy'], 2) ORDER BY a;
+SELECT a FROM tsq_idx WHERE has_any_token(b, ['quick', 'fox', 'lazy'], 2) ORDER BY a;
 ----
 a
 1
@@ -1944,9 +1944,9 @@ a
 1
 2
 
-# tokens_match_any single-string form (no min_match -> bare-string @@).
+# has_any_token single-string form (no min_match -> bare-string @@).
 query
-SELECT a FROM tsq_idx WHERE tokens_match_any(b, 'Quick Turtle') ORDER BY a;
+SELECT a FROM tsq_idx WHERE has_any_token(b, 'Quick Turtle') ORDER BY a;
 ----
 a
 1
@@ -1961,10 +1961,10 @@ a
 2
 3
 
-# tokens_match_any single-string form with min_match -- both tokens
+# has_any_token single-string form with min_match -- both tokens
 # of 'quick fox' must match.
 query
-SELECT a FROM tsq_idx WHERE tokens_match_any(b, 'quick fox', 2) ORDER BY a;
+SELECT a FROM tsq_idx WHERE has_any_token(b, 'quick fox', 2) ORDER BY a;
 ----
 a
 1

--- a/tests/sqllogic/sdb/pg/index/tsquery_match.test
+++ b/tests/sqllogic/sdb/pg/index/tsquery_match.test
@@ -1808,6 +1808,169 @@ a
 2
 
 # ----------------------------------------------------------------------
+# SQL-native predicate sugar: <name>(col, args...) is sugar for
+# `col @@ <inner ts_*>`. Each block is a row-equivalence pair against
+# the canonical @@ form.
+# ----------------------------------------------------------------------
+
+# phrase_matches
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'over lazy dog') ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_idx WHERE b @@ ts_phrase('over lazy dog') ORDER BY a;
+----
+a
+1
+2
+
+# phrase_matches with gap.
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick', 1, 'fox') ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_idx WHERE b @@ ts_phrase('quick', 1, 'fox') ORDER BY a;
+----
+a
+1
+2
+
+# ngram_matches needs an ngram-tokenised column -- separate fixture.
+statement ok
+CREATE TABLE tsq_ngram (a INTEGER PRIMARY KEY, b VARCHAR);
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY tsq_ngram_dict(
+    template = 'ngram',
+    mingram = 2,
+    maxgram = 2,
+    preserveoriginal = false,
+    frequency = true,
+    position = true
+);
+
+statement ok
+CREATE INDEX tsq_ngram_idx ON tsq_ngram USING inverted(a, b tsq_ngram_dict);
+
+statement ok
+INSERT INTO tsq_ngram values (1, 'hello'), (2, 'help'), (3, 'held');
+
+statement ok
+VACUUM (UPDATE_INDEXES) tsq_ngram;
+
+query
+SELECT a FROM tsq_ngram_idx WHERE ngram_matches(b, 'hello', 0.3) ORDER BY a;
+----
+a
+1
+2
+3
+
+query
+SELECT a FROM tsq_ngram_idx WHERE b @@ ts_ngram('hello', 0.3) ORDER BY a;
+----
+a
+1
+2
+3
+
+# levenshtein_matches
+query
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'quikc', 2) ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_idx WHERE b @@ ts_levenshtein('quikc', 2) ORDER BY a;
+----
+a
+1
+2
+
+# tokens_match_all
+query
+SELECT a FROM tsq_idx WHERE tokens_match_all(b, ['quick', 'fox']) ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_idx WHERE b @@ ts_all(ts_tokenize(['quick', 'fox'])) ORDER BY a;
+----
+a
+1
+2
+
+# tokens_match_any list-form.
+query
+SELECT a FROM tsq_idx WHERE tokens_match_any(b, ['turtle', 'fox']) ORDER BY a;
+----
+a
+1
+2
+3
+
+query
+SELECT a FROM tsq_idx WHERE b @@ ts_any(ts_tokenize(['turtle', 'fox'])) ORDER BY a;
+----
+a
+1
+2
+3
+
+# tokens_match_any list-form with min_match.
+query
+SELECT a FROM tsq_idx WHERE tokens_match_any(b, ['quick', 'fox', 'lazy'], 2) ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_idx WHERE b @@ ts_any(ts_tokenize(['quick', 'fox', 'lazy']), 2) ORDER BY a;
+----
+a
+1
+2
+
+# tokens_match_any single-string form (no min_match -> bare-string @@).
+query
+SELECT a FROM tsq_idx WHERE tokens_match_any(b, 'Quick Turtle') ORDER BY a;
+----
+a
+1
+2
+3
+
+query
+SELECT a FROM tsq_idx WHERE b @@ 'Quick Turtle' ORDER BY a;
+----
+a
+1
+2
+3
+
+# tokens_match_any single-string form with min_match -- both tokens
+# of 'quick fox' must match.
+query
+SELECT a FROM tsq_idx WHERE tokens_match_any(b, 'quick fox', 2) ORDER BY a;
+----
+a
+1
+2
+
+# ----------------------------------------------------------------------
 # Non-FTS expressions unchanged.
 # ----------------------------------------------------------------------
 

--- a/tests/sqllogic/sdb/pg/index/tsquery_match.test
+++ b/tests/sqllogic/sdb/pg/index/tsquery_match.test
@@ -2296,6 +2296,145 @@ a
 # 4
 
 # ----------------------------------------------------------------------
+# DuckDB built-in claims (contains / starts_with / ^@ / ends_with /
+# suffix / regexp_matches / regexp_like) -- require a keyword-
+# analyzed column. Each pair below is a row-equivalence check vs the
+# canonical `col @@ ts_*` form on a keyword-only fixture.
+# ----------------------------------------------------------------------
+
+statement ok
+CREATE TABLE tsq_kw (a INTEGER PRIMARY KEY, b VARCHAR);
+
+statement ok
+CREATE INDEX tsq_kw_idx ON tsq_kw USING inverted(a, b);
+
+statement ok
+INSERT INTO tsq_kw VALUES (1, 'foo'), (2, 'foobar'), (3, 'bar'), (4, ''), (5, '50%'), (6, 'abc123');
+
+statement ok
+VACUUM (UPDATE_INDEXES) tsq_kw;
+
+# contains
+query
+SELECT a FROM tsq_kw_idx WHERE contains(b, 'oo') ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_kw_idx WHERE b @@ ts_like('%oo%') ORDER BY a;
+----
+a
+1
+2
+
+# contains -- literal '%' must not behave as a wildcard.
+query
+SELECT a FROM tsq_kw_idx WHERE contains(b, '50%') ORDER BY a;
+----
+a
+5
+
+# starts_with
+query
+SELECT a FROM tsq_kw_idx WHERE starts_with(b, 'foo') ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_kw_idx WHERE b @@ ts_starts_with('foo') ORDER BY a;
+----
+a
+1
+2
+
+# ^@ operator (alias for starts_with).
+query
+SELECT a FROM tsq_kw_idx WHERE b ^@ 'foo' ORDER BY a;
+----
+a
+1
+2
+
+# ends_with
+query
+SELECT a FROM tsq_kw_idx WHERE ends_with(b, 'bar') ORDER BY a;
+----
+a
+2
+3
+
+query
+SELECT a FROM tsq_kw_idx WHERE b @@ ts_like('%bar') ORDER BY a;
+----
+a
+2
+3
+
+# suffix (alias for ends_with).
+query
+SELECT a FROM tsq_kw_idx WHERE suffix(b, 'bar') ORDER BY a;
+----
+a
+2
+3
+
+# regexp_matches -- use a pattern complex enough that DuckDB's
+# regex_range_filter optimizer doesn't pre-rewrite it to
+# starts_with / LIKE.
+query
+SELECT a FROM tsq_kw_idx WHERE regexp_matches(b, '[a-z]+[0-9]+') ORDER BY a;
+----
+a
+6
+
+query
+SELECT a FROM tsq_kw_idx WHERE b @@ ts_regexp('[a-z]+[0-9]+') ORDER BY a;
+----
+a
+6
+
+# regexp_like (alias for regexp_matches).
+query
+SELECT a FROM tsq_kw_idx WHERE regexp_like(b, '[a-z]+[0-9]+') ORDER BY a;
+----
+a
+6
+
+# Non-keyword analyzer rejected: the same call against the segmenting
+# `tsq_idx.b` errors with the documented hint.
+statement error
+SELECT a FROM tsq_idx WHERE contains(b, 'foo');
+
+statement error
+SELECT a FROM tsq_idx WHERE starts_with(b, 'foo');
+
+statement error
+SELECT a FROM tsq_idx WHERE ends_with(b, 'foo');
+
+statement error
+SELECT a FROM tsq_idx WHERE regexp_matches(b, '[a-z]+[0-9]+');
+
+# Mixing built-ins.
+query
+SELECT a FROM tsq_kw_idx WHERE contains(b, 'oo') AND starts_with(b, 'foo') ORDER BY a;
+----
+a
+1
+2
+
+query
+SELECT a FROM tsq_kw_idx WHERE ends_with(b, 'bar') OR regexp_matches(b, '[a-z]+[0-9]+') ORDER BY a;
+----
+a
+2
+3
+6
+
+# ----------------------------------------------------------------------
 # Non-FTS expressions unchanged.
 # ----------------------------------------------------------------------
 

--- a/tests/sqllogic/sdb/pg/index/tsquery_match.test
+++ b/tests/sqllogic/sdb/pg/index/tsquery_match.test
@@ -2404,19 +2404,36 @@ SELECT a FROM tsq_kw_idx WHERE regexp_like(b, '[a-z]+[0-9]+') ORDER BY a;
 a
 6
 
-# Non-keyword analyzer rejected: the same call against the segmenting
-# `tsq_idx.b` errors with the documented hint.
-statement error
-SELECT a FROM tsq_idx WHERE contains(b, 'foo');
+# Non-keyword analyzer: the claim path silently declines and DuckDB
+# evaluates the predicate per-row against the column projection. The
+# query still works (just without index acceleration); these checks
+# confirm the fallback returns the correct row set.
+query
+SELECT a FROM tsq_idx WHERE contains(b, 'quick') ORDER BY a;
+----
+a
+1
+2
 
-statement error
-SELECT a FROM tsq_idx WHERE starts_with(b, 'foo');
+query
+SELECT a FROM tsq_idx WHERE starts_with(b, 'quick') ORDER BY a;
+----
+a
+1
+2
 
-statement error
-SELECT a FROM tsq_idx WHERE ends_with(b, 'foo');
+query
+SELECT a FROM tsq_idx WHERE ends_with(b, 'dog') ORDER BY a;
+----
+a
+1
+2
 
-statement error
-SELECT a FROM tsq_idx WHERE regexp_matches(b, '[a-z]+[0-9]+');
+query
+SELECT a FROM tsq_idx WHERE regexp_matches(b, 'sl[a-z]+') ORDER BY a;
+----
+a
+3
 
 # Mixing built-ins.
 query

--- a/tests/sqllogic/sdb/pg/index/tsquery_match.test
+++ b/tests/sqllogic/sdb/pg/index/tsquery_match.test
@@ -1971,6 +1971,331 @@ a
 2
 
 # ----------------------------------------------------------------------
+# Predicate sugar -- broader coverage: boolean composition (AND / OR /
+# NOT), boost cast, mixed predicates, single/multi-token edges, error
+# paths.
+# ----------------------------------------------------------------------
+
+# phrase_matches with multiple gaps. quick (gap 1) fox (adjacent) jumps
+# matches `quick X fox jumps` -- rows 1 and 2.
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick', 1, 'fox', 0, 'jumps') ORDER BY a;
+----
+a
+1
+2
+
+# phrase_matches with range gap [min,max].
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick', ARRAY[1,2], 'fox') ORDER BY a;
+----
+a
+1
+2
+
+# phrase_matches AND another phrase_matches (intersection).
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick brown') AND phrase_matches(b, 'lazy dog') ORDER BY a;
+----
+a
+1
+
+# phrase_matches OR another phrase_matches (union).
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'red fox') OR phrase_matches(b, 'grey turtle') ORDER BY a;
+----
+a
+2
+3
+
+# NOT phrase_matches (complement).
+# TODO: re-enable once the pre-existing `NOT (col @@ ts_*(...))` crash
+# against a real inverted index is fixed. Reproduces with the
+# canonical form too (NOT (b @@ ts_phrase('quick brown'))) -- not a
+# sugar-specific issue. The corresponding unit test passes (filter
+# build is correct); the crash is downstream of MakeSearchFilter.
+# query
+# SELECT a FROM tsq_idx WHERE NOT phrase_matches(b, 'quick brown') ORDER BY a;
+# ----
+# a
+# 2
+# 3
+# 4
+
+# phrase_matches::boost(K) -- predicates return BOOLEAN, so the SQL
+# boost cast composes through the @@ machinery.
+query
+SELECT a FROM tsq_idx WHERE (phrase_matches(b, 'quick brown'))::boost(2.0) ORDER BY a;
+----
+a
+1
+
+# phrase_matches mixed with an int-range predicate on `a`.
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick brown') AND a >= 1 ORDER BY a;
+----
+a
+1
+
+# phrase_matches end-with-gap -- bind/build error.
+statement error
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick', 2);
+
+# levenshtein_matches with explicit transpositions=true.
+query
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'quikc', 1, true) ORDER BY a;
+----
+a
+1
+2
+
+# levenshtein_matches with prefix arg -- only the suffix participates
+# in distance.
+query
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'uikc', 1, true, 'q') ORDER BY a;
+----
+a
+1
+2
+
+# levenshtein_matches AND another levenshtein_matches.
+query
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'quikc', 2) AND levenshtein_matches(b, 'browb', 2) ORDER BY a;
+----
+a
+1
+
+# levenshtein_matches OR levenshtein_matches.
+query
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'redx', 2) OR levenshtein_matches(b, 'turtl', 1) ORDER BY a;
+----
+a
+2
+3
+
+# NOT levenshtein_matches.
+query
+SELECT a FROM tsq_idx WHERE NOT levenshtein_matches(b, 'quikc', 2) ORDER BY a;
+----
+a
+3
+4
+
+# levenshtein_matches::boost(K).
+query
+SELECT a FROM tsq_idx WHERE (levenshtein_matches(b, 'quikc', 2))::boost(1.5) ORDER BY a;
+----
+a
+1
+2
+
+# levenshtein_matches with too-large distance is rejected at bind.
+statement error
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'test', 5);
+
+# ngram_matches with default threshold (0.7).
+query
+SELECT a FROM tsq_ngram_idx WHERE ngram_matches(b, 'hello') ORDER BY a;
+----
+a
+1
+
+# ngram_matches AND ngram_matches.
+query
+SELECT a FROM tsq_ngram_idx WHERE ngram_matches(b, 'hello', 0.3) AND ngram_matches(b, 'help', 0.3) ORDER BY a;
+----
+a
+1
+2
+3
+
+# ngram_matches OR ngram_matches (single column).
+query
+SELECT a FROM tsq_ngram_idx WHERE ngram_matches(b, 'hello', 0.5) OR ngram_matches(b, 'held', 0.5) ORDER BY a;
+----
+a
+1
+2
+3
+
+# NOT ngram_matches.
+# TODO: re-enable once the pre-existing crash in
+# NGramSimilarityDocIterator under a NOT scope is fixed. Same
+# pre-existing issue as NOT phrase_matches (also blocked).
+# query
+# SELECT a FROM tsq_ngram_idx WHERE NOT ngram_matches(b, 'hello', 0.7) ORDER BY a;
+# ----
+# a
+# 2
+# 3
+
+# ngram_matches::boost(K).
+query
+SELECT a FROM tsq_ngram_idx WHERE (ngram_matches(b, 'hello', 0.3))::boost(2.0) ORDER BY a;
+----
+a
+1
+2
+3
+
+# has_all_tokens single-element list.
+query
+SELECT a FROM tsq_idx WHERE has_all_tokens(b, ['quick']) ORDER BY a;
+----
+a
+1
+2
+
+# has_all_tokens with multi-token element ('quick fox' tokenises to
+# ['quick','fox']) plus another single-token element.
+query
+SELECT a FROM tsq_idx WHERE has_all_tokens(b, ['quick fox', 'lazy']) ORDER BY a;
+----
+a
+1
+2
+
+# has_all_tokens AND has_all_tokens.
+query
+SELECT a FROM tsq_idx WHERE has_all_tokens(b, ['quick', 'fox']) AND has_all_tokens(b, ['lazy', 'dog']) ORDER BY a;
+----
+a
+1
+2
+
+# has_all_tokens OR has_all_tokens.
+query
+SELECT a FROM tsq_idx WHERE has_all_tokens(b, ['quick', 'fox']) OR has_all_tokens(b, ['grey', 'turtle']) ORDER BY a;
+----
+a
+1
+2
+3
+
+# NOT has_all_tokens.
+query
+SELECT a FROM tsq_idx WHERE NOT has_all_tokens(b, ['quick', 'fox']) ORDER BY a;
+----
+a
+3
+4
+
+# has_all_tokens::boost(K).
+query
+SELECT a FROM tsq_idx WHERE (has_all_tokens(b, ['quick', 'fox']))::boost(2.5) ORDER BY a;
+----
+a
+1
+2
+
+# has_any_token list with min_match equal to list size = has_all_tokens.
+query
+SELECT a FROM tsq_idx WHERE has_any_token(b, ['quick', 'fox'], 2) ORDER BY a;
+----
+a
+1
+2
+
+# has_any_token single-token text -> bare-string @@ -> ByTerm.
+query
+SELECT a FROM tsq_idx WHERE has_any_token(b, 'quick') ORDER BY a;
+----
+a
+1
+2
+
+# has_any_token AND has_any_token.
+query
+SELECT a FROM tsq_idx WHERE has_any_token(b, ['quick', 'red']) AND has_any_token(b, ['fox', 'turtle']) ORDER BY a;
+----
+a
+1
+2
+
+# has_any_token OR has_any_token.
+query
+SELECT a FROM tsq_idx WHERE has_any_token(b, ['turtle']) OR has_any_token(b, ['something']) ORDER BY a;
+----
+a
+3
+4
+
+# NOT has_any_token.
+query
+SELECT a FROM tsq_idx WHERE NOT has_any_token(b, ['quick', 'red']) ORDER BY a;
+----
+a
+3
+4
+
+# has_any_token::boost(K) on the list form.
+query
+SELECT a FROM tsq_idx WHERE (has_any_token(b, ['turtle', 'fox']))::boost(0.5) ORDER BY a;
+----
+a
+1
+2
+3
+
+# has_any_token::boost(K) on the single-string form (no min_match
+# lowers to bare `col @@ text`, which wraps cleanly).
+query
+SELECT a FROM tsq_idx WHERE (has_any_token(b, 'turtle fox'))::boost(0.5) ORDER BY a;
+----
+a
+1
+2
+3
+
+# Mixed predicates: phrase_matches AND has_any_token.
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'lazy dog') AND has_any_token(b, ['quick', 'red']) ORDER BY a;
+----
+a
+1
+2
+
+# Mixed predicates: levenshtein_matches OR has_all_tokens.
+query
+SELECT a FROM tsq_idx WHERE levenshtein_matches(b, 'turtl', 1) OR has_all_tokens(b, ['quick', 'fox']) ORDER BY a;
+----
+a
+1
+2
+3
+
+# Mixed: phrase_matches on column b, has_any_token on column c.
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'quick brown') OR has_any_token(c, 'goodbye') ORDER BY a;
+----
+a
+1
+3
+
+# Predicate with non-column first arg -- bind/build error surfaced
+# from the @@ handler.
+statement error
+SELECT a FROM tsq_idx WHERE phrase_matches('not a column', 'foo');
+
+# ts_phrase composes as the inner of @@; this checks that the sugar
+# rewrite produces an equivalent filter for the same row-set.
+query
+SELECT a FROM tsq_idx WHERE phrase_matches(b, 'over lazy dog') AND b @@ ts_phrase('quick brown') ORDER BY a;
+----
+a
+1
+
+# Predicates compose under DeMorgan-style queries.
+# TODO: re-enable once `NOT (col @@ ts_*(...))` against a real index
+# is fixed (same pre-existing crash as NOT phrase_matches above).
+# query
+# SELECT a FROM tsq_idx WHERE NOT (phrase_matches(b, 'quick brown') OR phrase_matches(b, 'red fox')) ORDER BY a;
+# ----
+# a
+# 3
+# 4
+
+# ----------------------------------------------------------------------
 # Non-FTS expressions unchanged.
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two-phase expansion of FTS surface area on top of the existing `col @@ ts_*(...)` machinery.

### 1. SQL-native sugar predicates

New top-level predicate functions that rewrite at filter-build time to `col @@ ts_*(...)`. Same lowering, friendlier surface for users who haven't discovered the `@@` constructors.

| Predicate | Lowers to |
|---|---|
| `phrase_matches(col, text)` | `col @@ ts_phrase(text)` |
| `ngram_matches(col, text [, threshold])` | `col @@ ts_ngram(text, threshold)` |
| `levenshtein_matches(col, text [, distance, with_transpositions, prefix])` | `col @@ ts_levenshtein(...)` |
| `has_any_token(col, ARRAY[...])` | `col @@ ts_any_of(...)` |
| `has_all_tokens(col, ARRAY[...])` | `col @@ ts_all_of(...)` |

### 2. DuckDB built-in claims

Recognised by name in the filter builder and rewritten to `col @@ ts_*(...)`. Each claim requires the column to be inverted-indexed with the **keyword analyzer** (`irs::StringTokenizer`) so the indexed term equals the column value byte-for-byte and predicate semantics map exactly to per-row evaluation. On a segmenting analyzer the claim is silently declined (returns `Result` error) and DuckDB evaluates per-row with a hint pointing to the equivalent `ts_*` form.

| DuckDB built-in | Lowers to |
|---|---|
| `contains(col, s)` | `col @@ ts_like('%' \|\| escape(s) \|\| '%')` |
| `starts_with` / `^@` / `prefix` | `col @@ ts_starts_with(p)` |
| `ends_with` / `suffix` | `col @@ ts_like('%' \|\| escape(s))` |
| `regexp_matches` / `regexp_like` (2-arg) | `col @@ ts_regexp(re)` |
| `~~` / `like_escape` | `col @@ ts_like(pattern)` (3-arg form normalised by extracting `escape_char`) |

