### PR TITLE
refactor(iresearch): inline norm handling, drop FeatureInfoProvider

### DIFF
--- a/libs/iresearch/examples/basic.cpp
+++ b/libs/iresearch/examples/basic.cpp
@@ -70,20 +70,6 @@ struct TextField {
   }
 };
 
-// Configure the index writer to handle Norm features (needed for BM25).
-irs::IndexWriterOptions MakeWriterOptions() {
-  irs::IndexWriterOptions opts;
-  opts.features = [](irs::IndexFeatures id) {
-    const irs::ColumnInfo info{
-      irs::Type<irs::compression::None>::get(), {}, false};
-    if (irs::IndexFeatures::Norm == id) {
-      return std::make_pair(info, &irs::Norm::MakeWriter);
-    }
-    return std::make_pair(info, irs::FeatureWriterFactory{});
-  };
-  return opts;
-}
-
 // Helper: index a single document with two text fields.
 void IndexDocument(irs::IndexWriter::Transaction& ctx, TextField& title_field,
                    TextField& body_field, std::string_view title,
@@ -352,8 +338,7 @@ int main() {
     "segmentation", irs::Type<irs::text_format::Json>::get(), "{}");
 
   irs::MemoryDirectory dir;
-  auto writer =
-    irs::IndexWriter::Make(dir, format, irs::kOmCreate, MakeWriterOptions());
+  auto writer = irs::IndexWriter::Make(dir, format, irs::kOmCreate, {});
 
   BuildIndex(*writer);
 

--- a/libs/iresearch/include/iresearch/formats/column/hnsw_index.hpp
+++ b/libs/iresearch/include/iresearch/formats/column/hnsw_index.hpp
@@ -28,6 +28,7 @@
 
 #include "basics/errors.h"
 #include "basics/exceptions.h"
+#include "iresearch/index/column_info.hpp"
 #include "iresearch/index/iterators.hpp"
 #include "iresearch/store/data_output.hpp"
 

--- a/libs/iresearch/include/iresearch/formats/formats.hpp
+++ b/libs/iresearch/include/iresearch/formats/formats.hpp
@@ -63,7 +63,6 @@ struct IteratorOptions : WandContext {};
 
 struct SegmentWriterOptions {
   const ColumnInfoProvider& column_info;
-  const FeatureInfoProvider& feature_info;
   const IndexFeatures scorers_features;
   ScorerPtr scorer = nullptr;
   const Comparer* const comparator{};

--- a/libs/iresearch/include/iresearch/index/field_data.cpp
+++ b/libs/iresearch/include/iresearch/index/field_data.cpp
@@ -623,9 +623,7 @@ NormReader::ptr CachedColumn::norms() const {
   return MakeNormReader(payload(), _stream.Index(), _stream.Data());
 }
 
-FieldData::FieldData(std::string_view name,
-                     const FeatureInfoProvider& feature_columns,
-                     CachedColumns& cached_columns,
+FieldData::FieldData(std::string_view name, CachedColumns& cached_columns,
                      IndexFeatures cached_features, ColumnstoreWriter& columns,
                      byte_block_pool::inserter& byte_writer,
                      int_block_pool::inserter& int_writer,
@@ -638,42 +636,28 @@ FieldData::FieldData(std::string_view name,
     _proc_table{kTermProcessingTables[size_t(random_access)]},
     _requested_features{index_features},
     _last_doc{doc_limits::invalid()} {
-  auto& rm = cached_columns.get_allocator().Manager();
-
-  auto write_feature = [&](IndexFeatures feature, field_id* id) {
-    if (!IsSubsetOf(feature, index_features)) {
-      return;
-    }
-
-    SDB_ASSERT(feature_columns);
-    auto [feature_column_info, feature_writer_factory] =
-      feature_columns(feature);
-
-    auto feature_writer =
-      feature_writer_factory ? (*feature_writer_factory)({}) : nullptr;
-    *id = field_limits::invalid();
-    if (!feature_writer) {
-      return;
-    }
-    ColumnFinalizer finalizer = ColumnFinalizer{
+  if (IsSubsetOf(IndexFeatures::Norm, index_features)) {
+    // no compression, no encryption
+    const ColumnInfo info{Type<compression::None>::get(), {}, false};
+    auto feature_writer = Norm::MakeWriter({});
+    SDB_ASSERT(feature_writer);
+    ColumnFinalizer finalizer{
       [writer = feature_writer.get()](DataOutput& out) { writer->finish(out); },
       [] { return std::string_view{}; },
     };
 
     // sorted index case or the feature is required for wand
-    if (random_access || IsSubsetOf(feature, cached_features)) {
-      auto& column = cached_columns.emplace_back(id, feature_column_info,
+    if (random_access || IsSubsetOf(IndexFeatures::Norm, cached_features)) {
+      auto& rm = cached_columns.get_allocator().Manager();
+      auto& column = cached_columns.emplace_back(&_meta.norm, info,
                                                  std::move(finalizer), rm);
       _features.emplace_back(std::move(feature_writer), column.Stream());
     } else {
-      auto [column, out] =
-        columns.push_column(feature_column_info, std::move(finalizer));
+      auto [column, out] = columns.push_column(info, std::move(finalizer));
       _features.emplace_back(std::move(feature_writer), out);
-      *id = column;
+      _meta.norm = column;
     }
-  };
-
-  write_feature(IndexFeatures::Norm, &_meta.norm);
+  }
 
   SDB_ASSERT(!field_limits::valid(_meta.norm) ||
              IsSubsetOf(IndexFeatures::Norm, _meta.index_features));
@@ -1020,12 +1004,10 @@ bool FieldData::invert(Tokenizer& stream, doc_id_t id) {
   return true;
 }
 
-FieldsData::FieldsData(const FeatureInfoProvider& feature_info,
-                       FieldData::CachedColumns& cached_columns,
+FieldsData::FieldsData(FieldData::CachedColumns& cached_columns,
                        IndexFeatures cached_features,
                        const Comparer* comparator)
   : _comparator{comparator},
-    _feature_info{&feature_info},
     _fields{cached_columns.get_allocator()},
     _cached_columns{&cached_columns},
     _byte_pool{cached_columns.get_allocator()},
@@ -1045,8 +1027,8 @@ FieldData* FieldsData::emplace(const hashed_string_view& name,
   if (!it->ref) {
     try {
       const_cast<FieldData*&>(it->ref) = &_fields.emplace_back(
-        name, *_feature_info, *_cached_columns, _cached_features, columns,
-        _byte_writer, _int_writer, index_features, (nullptr != _comparator));
+        name, *_cached_columns, _cached_features, columns, _byte_writer,
+        _int_writer, index_features, (nullptr != _comparator));
     } catch (...) {
       _fields_map.erase(it);
       throw;

--- a/libs/iresearch/include/iresearch/index/field_data.hpp
+++ b/libs/iresearch/include/iresearch/index/field_data.hpp
@@ -114,9 +114,9 @@ class FieldData : util::Noncopyable {
   using CachedColumns =
     std::deque<CachedColumn, ManagedTypedAllocator<CachedColumn>>;
 
-  FieldData(std::string_view name, const FeatureInfoProvider& feature_columns,
-            CachedColumns& cached_columns, IndexFeatures cached_features,
-            ColumnstoreWriter& columns, byte_block_pool::inserter& byte_writer,
+  FieldData(std::string_view name, CachedColumns& cached_columns,
+            IndexFeatures cached_features, ColumnstoreWriter& columns,
+            byte_block_pool::inserter& byte_writer,
             int_block_pool::inserter& int_writer, IndexFeatures index_features,
             bool random_access);
 
@@ -221,8 +221,7 @@ class FieldsData : util::Noncopyable {
  public:
   using postings_ref_t = std::vector<const Posting*>;
 
-  explicit FieldsData(const FeatureInfoProvider& feature_info,
-                      FieldData::CachedColumns& cached_columns,
+  explicit FieldsData(FieldData::CachedColumns& cached_columns,
                       IndexFeatures cached_features,
                       const Comparer* comparator);
 
@@ -247,7 +246,6 @@ class FieldsData : util::Noncopyable {
 
  private:
   const Comparer* _comparator;
-  const FeatureInfoProvider* _feature_info;
   Fields _fields;                             // pointers remain valid
   FieldData::CachedColumns* _cached_columns;  // pointers remain valid
   FieldsMap _fields_map;

--- a/libs/iresearch/include/iresearch/index/index_features.hpp
+++ b/libs/iresearch/include/iresearch/index/index_features.hpp
@@ -22,13 +22,11 @@
 
 #pragma once
 
-#include <functional>
 #include <map>
 #include <set>
 #include <span>
 
 #include "basics/bit_utils.hpp"
-#include "iresearch/index/column_info.hpp"
 #include "iresearch/store/data_output.hpp"
 #include "iresearch/utils/type_info.hpp"
 
@@ -87,8 +85,5 @@ struct FeatureWriter : memory::Managed {
 
 using FeatureWriterFactory =
   FeatureWriter::ptr (*)(std::span<const bytes_view>);
-
-using FeatureInfoProvider =
-  std::function<std::pair<ColumnInfo, FeatureWriterFactory>(IndexFeatures)>;
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/index/index_writer.cpp
+++ b/libs/iresearch/include/iresearch/index/index_writer.cpp
@@ -64,12 +64,6 @@ const ColumnInfoProvider kDefaultColumnInfo = [](std::string_view) {
   return ColumnInfo{irs::Type<compression::None>::get(), {}, false};
 };
 
-const FeatureInfoProvider kDefaultFeatureInfo = [](irs::IndexFeatures) {
-  // no compression, no encryption
-  return std::pair{ColumnInfo{irs::Type<compression::None>::get(), {}, false},
-                   FeatureWriterFactory{}};
-};
-
 struct FlushedSegmentContext {
   FlushedSegmentContext(std::shared_ptr<const SegmentReaderImpl>&& reader,
                         IndexWriter::SegmentContext& segment,
@@ -1101,11 +1095,9 @@ IndexWriter::IndexWriter(
   Directory& dir, Format::ptr codec, size_t segment_pool_size,
   const SegmentOptions& segment_limits, const Comparer* comparator,
   const ColumnInfoProvider& column_info,
-  const FeatureInfoProvider& feature_info,
   const PayloadProvider& meta_payload_provider,
   std::shared_ptr<const DirectoryReaderImpl>&& committed_reader)
-  : _feature_info{feature_info},
-    _column_info{column_info},
+  : _column_info{column_info},
     _meta_payload_provider{meta_payload_provider},
     _comparator{comparator},
     _codec{std::move(codec)},
@@ -1118,8 +1110,7 @@ IndexWriter::IndexWriter(
     _writer{_codec->get_index_meta_writer()},
     _write_lock{std::move(lock)},
     _write_lock_file_ref{std::move(lock_file_ref)} {
-  SDB_ASSERT(column_info);   // ensured by 'make'
-  SDB_ASSERT(feature_info);  // ensured by 'make'
+  SDB_ASSERT(column_info);  // ensured by 'make'
   SDB_ASSERT(_codec);
 
   _wand_scorer = _committed_reader->Options().scorer;
@@ -1249,7 +1240,6 @@ IndexWriter::ptr IndexWriter::Make(Directory& dir, Format::ptr codec,
     std::move(codec), options.segment_pool_size, SegmentOptions{options},
     options.comparator,
     options.column_info ? options.column_info : kDefaultColumnInfo,
-    options.features ? options.features : kDefaultFeatureInfo,
     options.meta_payload_provider, std::move(reader));
   // Remove non-index files from directory
   directory_utils::RemoveAllUnreferenced(dir);
@@ -1672,7 +1662,6 @@ SegmentWriterOptions IndexWriter::GetSegmentWriterOptions(
   bool consolidation) const noexcept {
   return {
     .column_info = _column_info,
-    .feature_info = _feature_info,
     .scorers_features = _wand_features,
     .scorer = _wand_scorer,
     .comparator = _comparator,

--- a/libs/iresearch/include/iresearch/index/index_writer.hpp
+++ b/libs/iresearch/include/iresearch/index/index_writer.hpp
@@ -143,10 +143,6 @@ struct IndexWriterOptions : public SegmentOptions {
   // Options for snapshot management
   IndexReaderOptions reader_options;
 
-  // Returns column info for a feature the writer should use for
-  // columnstore
-  FeatureInfoProvider features;
-
   // Returns column info the writer should use for columnstore
   ColumnInfoProvider column_info;
 
@@ -599,11 +595,6 @@ class IndexWriter : private util::Noncopyable {
     return modified;
   }
 
-  // Returns field features.
-  const FeatureInfoProvider& FeatureInfo() const noexcept {
-    return _feature_info;
-  }
-
   bool FlushRequired(const SegmentWriter& writer) const noexcept;
 
   // public because we want to use std::make_shared
@@ -612,7 +603,6 @@ class IndexWriter : private util::Noncopyable {
               Format::ptr codec, size_t segment_pool_size,
               const SegmentOptions& segment_limits, const Comparer* comparator,
               const ColumnInfoProvider& column_info,
-              const FeatureInfoProvider& feature_info,
               const PayloadProvider& meta_payload_provider,
               std::shared_ptr<const DirectoryReaderImpl>&& committed_reader);
 
@@ -960,7 +950,6 @@ class IndexWriter : private util::Noncopyable {
 
   IndexFeatures _wand_features{};  // Set of features required for wand
   ScorerPtr _wand_scorer;
-  FeatureInfoProvider _feature_info;
   ColumnInfoProvider _column_info;
   PayloadProvider _meta_payload_provider;  // provides payload for new segments
   const Comparer* _comparator;

--- a/libs/iresearch/include/iresearch/index/merge_writer.cpp
+++ b/libs/iresearch/include/iresearch/index/merge_writer.cpp
@@ -44,6 +44,7 @@
 #include "iresearch/index/index_meta.hpp"
 #include "iresearch/index/norm.hpp"
 #include "iresearch/utils/bytes_output.hpp"
+#include "iresearch/utils/compression.hpp"
 #include "iresearch/utils/directory_utils.hpp"
 #include "iresearch/utils/string.hpp"
 #include "iresearch/utils/type_limits.hpp"
@@ -1275,7 +1276,6 @@ bool WriteColumns(Columnstore& cs, Iterator& columns,
 template<typename Iterator>
 bool WriteFields(Columnstore& cs, Iterator& feature_itr,
                  const irs::FlushState& flush_state, const SegmentMeta& meta,
-                 const FeatureInfoProvider& column_info,
                  CompoundFieldIterator& field_itr,
                  IndexFeatures scorers_features,
                  const MergeWriter::FlushProgress& progress,
@@ -1340,11 +1340,9 @@ bool WriteFields(Columnstore& cs, Iterator& feature_itr,
       return false;
     }
 
-    const auto [info, factory] = column_info(kFeature);
-
-    std::optional<field_id> res;
-    auto feature_writer =
-      factory ? (*factory)({hdrs.data(), hdrs.size()}) : FeatureWriter::ptr{};
+    // no compression, no encryption
+    const ColumnInfo info{Type<compression::None>::get(), {}, false};
+    auto feature_writer = Norm::MakeWriter({hdrs.data(), hdrs.size()});
 
     auto* buffered_column = IsSubsetOf(kFeature, scorers_features)
                               ? &buffered_columns.PushColumn()
@@ -1357,8 +1355,9 @@ bool WriteFields(Columnstore& cs, Iterator& feature_itr,
       buffered_column->Reserve(count, kValueSize);
     }
 
+    std::optional<field_id> res;
     if (feature_writer) {
-      auto write_values = [&, &info = info]<typename T>(T&& value_writer) {
+      auto write_values = [&]<typename T>(T&& value_writer) {
         return cs.insert(feature_itr, info,
                          ColumnFinalizer{
                            [feature_writer = std::move(feature_writer)](
@@ -1379,24 +1378,6 @@ bool WriteFields(Columnstore& cs, Iterator& feature_itr,
             writer->write(out, payload);
           });
       }
-
-    } else if (!factory) {
-      // Factory has failed to instantiate a writer
-      res = cs.insert(
-        feature_itr, info,
-        ColumnFinalizer{
-          [](DataOutput&) {},
-          [] { return std::string_view{}; },
-        },
-        [buffered_column](ColumnOutput& out, doc_id_t doc, bytes_view payload) {
-          out.Prepare(doc);
-          if (!payload.empty()) {
-            out.WriteBytes(payload.data(), payload.size());
-            if (buffered_column) {
-              buffered_column->PushBack(doc, payload);
-            }
-          }
-        });
     }
 
     if (!res.has_value()) {
@@ -1501,7 +1482,6 @@ bool MergeWriter::FlushUnsorted(TrackingDirectory& dir, SegmentMeta& segment,
   SDB_ASSERT(progress);
   SDB_ASSERT(!_comparator);
   SDB_ASSERT(_column_info && *_column_info);
-  SDB_ASSERT(_feature_info && *_feature_info);
 
   const size_t size = _readers.size();
 
@@ -1590,8 +1570,8 @@ bool MergeWriter::FlushUnsorted(TrackingDirectory& dir, SegmentMeta& segment,
     return false;  // progress callback requested termination
   }
   // Write field meta and field term data
-  if (!WriteFields(cs, remapping_itrs, state, segment, *_feature_info,
-                   fields_itr, _scorers_features, progress,
+  if (!WriteFields(cs, remapping_itrs, state, segment, fields_itr,
+                   _scorers_features, progress,
                    _readers.get_allocator().Manager())) {
     return false;  // Flush failure
   }
@@ -1610,7 +1590,6 @@ bool MergeWriter::FlushSorted(TrackingDirectory& dir, SegmentMeta& segment,
   SDB_ASSERT(progress);
   SDB_ASSERT(_comparator);
   SDB_ASSERT(_column_info && *_column_info);
-  SDB_ASSERT(_feature_info && *_feature_info);
 
   const size_t size = _readers.size();
 
@@ -1823,8 +1802,8 @@ bool MergeWriter::FlushSorted(TrackingDirectory& dir, SegmentMeta& segment,
   }
 
   // Write field meta and field term data
-  if (!WriteFields(cs, sorting_doc_it, state, segment, *_feature_info,
-                   fields_itr, _scorers_features, progress,
+  if (!WriteFields(cs, sorting_doc_it, state, segment, fields_itr,
+                   _scorers_features, progress,
                    _readers.get_allocator().Manager())) {
     return false;  // flush failure
   }

--- a/libs/iresearch/include/iresearch/index/merge_writer.cpp
+++ b/libs/iresearch/include/iresearch/index/merge_writer.cpp
@@ -44,7 +44,6 @@
 #include "iresearch/index/index_meta.hpp"
 #include "iresearch/index/norm.hpp"
 #include "iresearch/utils/bytes_output.hpp"
-#include "iresearch/utils/compression.hpp"
 #include "iresearch/utils/directory_utils.hpp"
 #include "iresearch/utils/string.hpp"
 #include "iresearch/utils/type_limits.hpp"
@@ -1356,31 +1355,29 @@ bool WriteFields(Columnstore& cs, Iterator& feature_itr,
     }
 
     std::optional<field_id> res;
-    if (feature_writer) {
-      auto write_values = [&]<typename T>(T&& value_writer) {
-        return cs.insert(feature_itr, info,
-                         ColumnFinalizer{
-                           [feature_writer = std::move(feature_writer)](
-                             DataOutput& out) { feature_writer->finish(out); },
-                           [] { return std::string_view{}; },
-                         },
-                         std::forward<T>(value_writer));
-      };
+    auto write_values = [&]<typename T>(T&& value_writer) {
+      return cs.insert(feature_itr, info,
+                       ColumnFinalizer{
+                         [feature_writer = std::move(feature_writer)](
+                           DataOutput& out) { feature_writer->finish(out); },
+                         [] { return std::string_view{}; },
+                       },
+                       std::forward<T>(value_writer));
+    };
 
-      if (buffered_column) {
-        buffered_column->SetFeatureWriter(*feature_writer);
-        res = write_values(*buffered_column);
-      } else {
-        res =
-          write_values([writer = feature_writer.get()](
-                         ColumnOutput& out, doc_id_t doc, bytes_view payload) {
-            out.Prepare(doc);
-            writer->write(out, payload);
-          });
-      }
+    if (buffered_column) {
+      buffered_column->SetFeatureWriter(*feature_writer);
+      res = write_values(*buffered_column);
+    } else {
+      res =
+        write_values([writer = feature_writer.get()](
+                       ColumnOutput& out, doc_id_t doc, bytes_view payload) {
+          out.Prepare(doc);
+          writer->write(out, payload);
+        });
     }
 
-    if (!res.has_value()) {
+    if (!res) {
       return false;  // Failed to insert all values
     }
 

--- a/libs/iresearch/include/iresearch/index/merge_writer.hpp
+++ b/libs/iresearch/include/iresearch/index/merge_writer.hpp
@@ -58,7 +58,6 @@ class MergeWriter : public util::Noncopyable {
     : _dir{dir},
       _readers{{options.resource_manager}},
       _column_info{&options.column_info},
-      _feature_info{&options.feature_info},
       _scorer{options.scorer},
       _comparator{options.comparator},
       _scorers_features{options.scorers_features} {
@@ -98,7 +97,6 @@ class MergeWriter : public util::Noncopyable {
   Directory& _dir;
   ManagedVector<ReaderCtx> _readers;
   const ColumnInfoProvider* _column_info{};
-  const FeatureInfoProvider* _feature_info{};
   ScorerPtr _scorer;
   const Comparer* const _comparator{};
   IndexFeatures _scorers_features{};

--- a/libs/iresearch/include/iresearch/index/segment_writer.cpp
+++ b/libs/iresearch/include/iresearch/index/segment_writer.cpp
@@ -147,8 +147,7 @@ SegmentWriter::SegmentWriter(ConstructToken, Directory& dir,
     _cached_columns{{options.resource_manager}},
     _sort{options.column_info, {}, options.resource_manager},
     _docs_context{{options.resource_manager}},
-    _fields{options.feature_info, _cached_columns, options.scorers_features,
-            options.comparator},
+    _fields{_cached_columns, options.scorers_features, options.comparator},
     _columns{{options.resource_manager}},
     _column_info{&options.column_info} {
   _docs_mask.set = decltype(_docs_mask.set){{options.resource_manager}};

--- a/server/search/inverted_index_shard.cpp
+++ b/server/search/inverted_index_shard.cpp
@@ -184,14 +184,6 @@ InvertedIndexShard::InvertedIndexShard(ObjectId id,
   irs::IndexWriterOptions writer_options;
   writer_options.segment_memory_max = 256 * (size_t{1} << 20);  // 256MB
   writer_options.lock_repository = false;  // RocksDB has its own lock
-  writer_options.features = [](irs::IndexFeatures feature) {
-    irs::ColumnInfo info{irs::Type<irs::compression::None>::get(), {}, false};
-    irs::FeatureWriterFactory factory = nullptr;
-    if (feature == irs::IndexFeatures::Norm) {
-      factory = &irs::Norm::MakeWriter;
-    }
-    return std::make_pair(info, factory);
-  };
 
   writer_options.meta_payload_provider = [this](uint64_t tick,
                                                 irs::bstring& out) {

--- a/tests/bench/search-benchmark-game/index_builder.cpp
+++ b/tests/bench/search-benchmark-game/index_builder.cpp
@@ -32,14 +32,6 @@ static irs::IndexWriterOptions MakeWriterOptions(irs::ScorerPtr scorer_ptr,
   writer_opts.reader_options.scorer = scorer_ptr;
   writer_opts.segment_pool_size = segment_pool_size;
   writer_opts.segment_memory_max = segment_mem_max;
-  writer_opts.features = [](irs::IndexFeatures id) {
-    const irs::ColumnInfo info{
-      irs::Type<irs::compression::None>::get(), {}, false};
-    if (irs::IndexFeatures::Norm == id) {
-      return std::make_pair(info, &irs::Norm::MakeWriter);
-    }
-    return std::make_pair(info, irs::FeatureWriterFactory{});
-  };
   return writer_opts;
 }
 

--- a/tests/libs/iresearch/index/assert_format.cpp
+++ b/tests/libs/iresearch/index/assert_format.cpp
@@ -36,6 +36,7 @@
 #include "iresearch/index/directory_reader_impl.hpp"
 #include "iresearch/index/field_meta.hpp"
 #include "iresearch/index/index_features.hpp"
+#include "iresearch/index/norm.hpp"
 #include "iresearch/search/boolean_filter.hpp"
 #include "iresearch/search/cost.hpp"
 #include "iresearch/search/term_filter.hpp"
@@ -299,29 +300,20 @@ void IndexSegment::insert_indexed(const Ifield& f) {
     auto& new_field = res.first->second;
     _id_to_field.emplace_back(&new_field);
 
-    auto write_feature = [&](irs::IndexFeatures feature) -> irs::field_id {
-      if (feature != irs::IndexFeatures::None) {
-        auto handler = _field_features(feature);
+    if (irs::IsSubsetOf(irs::IndexFeatures::Norm, requested_features)) {
+      auto feature_writer = irs::Norm::MakeWriter({});
+      if (feature_writer) {
+        const size_t id = _columns.size();
+        EXPECT_LE(id, std::numeric_limits<irs::field_id>::max());
+        _columns.emplace_back(id, &irs::Norm::MakeWriter, feature_writer.get());
 
-        auto feature_writer = handler.second ? (*handler.second)({}) : nullptr;
+        new_field.feature_infos.emplace_back(
+          Field::FeatureInfo{irs::field_id{id}, &irs::Norm::MakeWriter,
+                             std::move(feature_writer)});
 
-        if (feature_writer) {
-          const size_t id = _columns.size();
-          EXPECT_LE(id, std::numeric_limits<irs::field_id>::max());
-          _columns.emplace_back(id, handler.second, feature_writer.get());
-
-          new_field.feature_infos.emplace_back(Field::FeatureInfo{
-            irs::field_id{id}, handler.second, std::move(feature_writer)});
-
-          return irs::field_id{id};
-        }
+        new_field.norm = irs::field_id{id};
       }
-
-      return irs::field_limits::invalid();
-    };
-
-    new_field.norm =
-      write_feature(requested_features & irs::IndexFeatures::Norm);
+    }
     const_cast<std::string_view&>(res.first->first) = field.name;
   }
 

--- a/tests/libs/iresearch/index/assert_format.hpp
+++ b/tests/libs/iresearch/index/assert_format.hpp
@@ -157,8 +157,7 @@ class IndexSegment : irs::util::Noncopyable {
   using columns_t = std::deque<ColumnValues>;  // pointers remain valid
   using named_columns_t = std::map<std::string, ColumnValues*>;
 
-  explicit IndexSegment(const irs::FeatureInfoProvider& features)
-    : _field_features{features} {}
+  IndexSegment() = default;
   IndexSegment(IndexSegment&& rhs) = default;
   IndexSegment& operator=(IndexSegment&& rhs) = default;
 
@@ -203,7 +202,6 @@ class IndexSegment : irs::util::Noncopyable {
   void insert_sorted(const Ifield* field);
   void compute_features();
 
-  irs::FeatureInfoProvider _field_features;
   named_columns_t _named_columns;
   std::vector<std::tuple<irs::bstring, irs::doc_id_t, irs::doc_id_t>> _sort;
   std::vector<const Field*> _id_to_field;

--- a/tests/libs/iresearch/index/index_death_tests.cpp
+++ b/tests/libs/iresearch/index/index_death_tests.cpp
@@ -242,17 +242,6 @@ class FailingDirectory : public tests::DirectoryMock {
   mutable std::set<FailT, FailLess> _failures;
 };
 
-irs::FeatureInfoProvider DefaultFeatureInfo() {
-  return [](irs::IndexFeatures) {
-    return std::make_pair(
-      irs::ColumnInfo{.compression = irs::Type<irs::compression::None>::get(),
-                      .options = {},
-                      .encryption = true,
-                      .track_prev_doc = false},
-      irs::FeatureWriterFactory{});
-  };
-}
-
 void OpenReader(std::string_view format,
                 std::function<void(FailingDirectory& dir)> failure_registerer) {
   constexpr irs::IndexFeatures kAllFeatures = irs::IndexFeatures::Freq |
@@ -305,7 +294,7 @@ void OpenReader(std::string_view format,
 
   // validate index
   tests::index_t expected_index;
-  expected_index.emplace_back(::DefaultFeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(*doc1);
   expected_index.back().insert(*doc2);
   tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
@@ -434,7 +423,7 @@ TEST(index_death_test_formats_15, index_meta_write_fail_1st_phase) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -576,7 +565,7 @@ TEST(index_death_test_formats_15, index_commit_fail_sync_1st_phase) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -689,7 +678,7 @@ TEST(index_death_test_formats_15, index_meta_write_failure_2nd_phase) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -792,7 +781,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -857,7 +846,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -928,9 +917,9 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -1099,7 +1088,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -1250,7 +1239,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
 
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
@@ -1377,7 +1366,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -1477,9 +1466,9 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -1620,13 +1609,13 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc3);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc4);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -1806,11 +1795,11 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc3);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -1950,11 +1939,11 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc3);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -2097,9 +2086,9 @@ TEST(index_death_test_formats_15, segment_components_write_fail_consolidation) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -2219,9 +2208,9 @@ TEST(index_death_test_formats_15, segment_components_sync_fail_consolidation) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc2);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -2409,7 +2398,7 @@ TEST(index_death_test_formats_15, segment_components_fail_import) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -2541,7 +2530,7 @@ TEST(index_death_test_formats_15, segment_components_fail_import) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -2716,7 +2705,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc3);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -2822,7 +2811,7 @@ TEST(index_death_test_formats_15,
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
 
@@ -3047,7 +3036,7 @@ TEST(index_death_test_formats_15, fails_in_consolidate_with_removals) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     expected_index.back().insert(*doc2);
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
@@ -3154,7 +3143,7 @@ TEST(index_death_test_formats_15, fails_in_exists) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     expected_index.back().insert(*doc2);
     expected_index.back().insert(*doc3);
@@ -3346,7 +3335,7 @@ TEST(index_death_test_formats_15, fails_in_length) {
 
     // validate index
     tests::index_t expected_index;
-    expected_index.emplace_back(writer->FeatureInfo());
+    expected_index.emplace_back();
     expected_index.back().insert(*doc1);
     expected_index.back().insert(*doc2);
     expected_index.back().insert(*doc3);
@@ -3468,7 +3457,7 @@ TEST(index_death_test_formats_15, columnstore_reopen_fail) {
 
   // validate index
   tests::index_t expected_index;
-  expected_index.emplace_back(::DefaultFeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(*doc1);
   expected_index.back().insert(*doc2);
   tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
@@ -3574,7 +3563,7 @@ TEST(index_death_test_formats_15, fails_in_dup) {
 
   // validate index
   tests::index_t expected_index;
-  expected_index.emplace_back(::DefaultFeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(*doc1);
   expected_index.back().insert(*doc2);
   expected_index.back().insert(*doc3);
@@ -3683,7 +3672,7 @@ TEST(index_death_test_formats_15, postings_reopen_fail) {
 
   // validate index
   tests::index_t expected_index;
-  expected_index.emplace_back(::DefaultFeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(*doc1);
   expected_index.back().insert(*doc2);
   tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);

--- a/tests/libs/iresearch/index/index_tests.cpp
+++ b/tests/libs/iresearch/index/index_tests.cpp
@@ -258,7 +258,7 @@ void IndexTestBase::write_segment_batched(irs::IndexWriter& writer,
 
 void IndexTestBase::add_segment(irs::IndexWriter& writer,
                                 tests::DocGeneratorBase& gen) {
-  _index.emplace_back(writer.FeatureInfo());
+  _index.emplace_back();
   write_segment(writer, _index.back(), gen);
   writer.Commit();
 }
@@ -266,7 +266,7 @@ void IndexTestBase::add_segment(irs::IndexWriter& writer,
 void IndexTestBase::add_segments(irs::IndexWriter& writer,
                                  std::vector<DocGeneratorBase::ptr>& gens) {
   for (auto& gen : gens) {
-    _index.emplace_back(writer.FeatureInfo());
+    _index.emplace_back();
     write_segment(writer, _index.back(), *gen);
   }
   writer.Commit();
@@ -284,7 +284,7 @@ void IndexTestBase::add_segment_batched(
   irs::OpenMode mode /*= irs::kOmCreate*/,
   const irs::IndexWriterOptions& opts /*= {}*/) {
   auto writer = open_writer(mode, opts);
-  _index.emplace_back(writer->FeatureInfo());
+  _index.emplace_back();
   write_segment_batched(*writer, _index.back(), gen, batch_size);
   writer->Commit();
 }
@@ -293,21 +293,6 @@ void IndexTestBase::add_segment_batched(
 
 class IndexTestCase : public tests::IndexTestBase {
  public:
-  static irs::FeatureInfoProvider FeaturesWithNorms() {
-    return [](irs::IndexFeatures id) {
-      const irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(),
-                                 {},
-
-                                 false};
-
-      if (irs::IndexFeatures::Norm == id) {
-        return std::make_pair(info, &irs::Norm::MakeWriter);
-      }
-
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
-  }
-
   void assert_index(size_t skip = 0,
                     irs::automaton_table_matcher* matcher = nullptr) const {
     // index_test_base::assert_index(irs::IndexFeatures::None, skip, matcher);
@@ -2398,7 +2383,7 @@ TEST_P(IndexTestCase, s2sequence) {
     tests::Document doc;
     doc.indexed.push_back(field);
 
-    auto& expected_segment = this->index().emplace_back(writer->FeatureInfo());
+    auto& expected_segment = this->index().emplace_back();
     while (std::getline(stream, str)) {
       if (str.starts_with("#")) {
         break;
@@ -7005,7 +6990,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
   // populate initial 2 very small segments
   {
     auto& index_ref = const_cast<tests::index_t&>(index());
-    index_ref.emplace_back(writer->FeatureInfo());
+    index_ref.emplace_back();
     gen0.reset();
     write_segment(*writer, index_ref.back(), gen0);
     writer->Commit();
@@ -7014,7 +6999,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
 
   {
     auto& index_ref = const_cast<tests::index_t&>(index());
-    index_ref.emplace_back(writer->FeatureInfo());
+    index_ref.emplace_back();
     gen1.reset();
     write_segment(*writer, index_ref.back(), gen1);
     writer->Commit();
@@ -7024,7 +7009,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
   // populate initial small segment
   {
     auto& index_ref = const_cast<tests::index_t&>(index());
-    index_ref.emplace_back(writer->FeatureInfo());
+    index_ref.emplace_back();
     gen0.reset();
     write_segment(*writer, index_ref.back(), gen0);
     gen1.reset();
@@ -7036,7 +7021,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
   // populate initial large segment
   {
     auto& index_ref = const_cast<tests::index_t&>(index());
-    index_ref.emplace_back(writer->FeatureInfo());
+    index_ref.emplace_back();
 
     for (size_t i = 100; i > 0; --i) {
       gen0.reset();
@@ -7054,7 +7039,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
   // index_wirter::flush_context_pool_.size() == 2
   for (size_t i = 10; i > 0; --i) {
     auto& index_ref = const_cast<tests::index_t&>(index());
-    index_ref.emplace_back(writer->FeatureInfo());
+    index_ref.emplace_back();
 
     // add varying sized segments
     for (size_t j = 0; j < i; ++j) {
@@ -7114,7 +7099,6 @@ TEST_P(IndexTestCase, segment_column_user_system) {
   const tests::Document* doc2 = gen.next();
 
   irs::IndexWriterOptions opts;
-  opts.features = FeaturesWithNorms();
 
   auto writer = open_writer(irs::kOmCreate, opts);
 
@@ -7897,7 +7881,7 @@ TEST_P(IndexTestCase, consolidate_single_segment) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     tests::AssertIndex(this->dir(), codec(), expected, kAllFeatures);
 
@@ -8067,11 +8051,11 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc4);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     tests::AssertIndex(this->dir(), codec(), expected, kAllFeatures);
@@ -8243,11 +8227,11 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc4);
     tests::AssertIndex(this->dir(), codec(), expected, kAllFeatures);
 
@@ -8412,7 +8396,7 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // validate structure (does not take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -8576,7 +8560,7 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // validate structure (does not take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -8912,7 +8896,7 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -9003,10 +8987,10 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     expected.back().insert(*doc4);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -9130,10 +9114,10 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     expected.back().insert(*doc4);
     expected.back().insert(*doc5);
@@ -9286,7 +9270,7 @@ TEST_P(IndexTestCase, consolidate_check_consolidating_segments) {
   gen.reset();
   tests::index_t expected;
   for (size_t i = 0; i < segments_count / 2; ++i) {
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     const auto* doc = gen.next();
     expected.back().insert(*doc);
     doc = gen.next();
@@ -9451,7 +9435,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -9565,10 +9549,10 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     expected.back().insert(*doc4);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -9720,13 +9704,13 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     expected.back().insert(*doc4);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc5);
     expected.back().insert(*doc6);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -9900,7 +9884,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -10050,7 +10034,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -10200,7 +10184,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -10532,7 +10516,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_NE(0, irs::DirectoryCleaner::clean(dir()));
 
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -10624,12 +10608,12 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
     expected.back().insert(*doc4);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc5);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
 
@@ -10813,9 +10797,9 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc5);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
     expected.back().insert(*doc3);
@@ -11022,10 +11006,10 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc1);
     expected.back().insert(*doc2);
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc5);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
 
@@ -11333,7 +11317,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
 
@@ -11381,7 +11365,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
 
@@ -11431,7 +11415,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
 
@@ -11481,7 +11465,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc3);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
 
@@ -11605,7 +11589,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     expected.back().insert(*doc4);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -11660,7 +11644,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     expected.back().insert(*doc4);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -11717,7 +11701,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     expected.back().insert(*doc4);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -11774,7 +11758,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     expected.back().insert(*doc4);
     tests::AssertIndex(dir(), codec(), expected, kAllFeatures);
@@ -11838,7 +11822,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     expected.back().insert(*doc4);
     expected.back().insert(*doc6);
@@ -11907,7 +11891,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     // validate structure
     tests::index_t expected;
-    expected.emplace_back(writer->FeatureInfo());
+    expected.emplace_back();
     expected.back().insert(*doc2);
     expected.back().insert(*doc4);
     expected.back().insert(*doc6);
@@ -13373,7 +13357,6 @@ TEST_P(IndexTestCase, ensure_no_empty_norms_written) {
 
   {
     irs::IndexWriterOptions opts;
-    opts.features = FeaturesWithNorms();
 
     auto writer = open_writer(irs::kOmCreate, opts);
 
@@ -13554,17 +13537,6 @@ TEST_P(IndexTestCase14, write_field_with_multiple_stored_features) {
 
   {
     irs::IndexWriterOptions opts;
-    opts.features = [](irs::IndexFeatures id) {
-      irs::FeatureWriterFactory handler{};
-
-      return std::make_pair(
-        irs::ColumnInfo{irs::Type<irs::compression::None>::get(),
-                        {},
-
-                        false},
-        std::move(handler));
-    };
-
     auto writer = open_writer(irs::kOmCreate, opts);
 
     // doc1
@@ -13627,17 +13599,6 @@ TEST_P(IndexTestCase14, consolidate_multiple_stored_features) {
   TestField field;
 
   irs::IndexWriterOptions opts;
-  opts.features = [](irs::IndexFeatures id) {
-    irs::FeatureWriterFactory handler{};
-
-    return std::make_pair(
-      irs::ColumnInfo{irs::Type<irs::compression::None>::get(),
-                      {},
-
-                      false},
-      std::move(handler));
-  };
-
   auto writer = open_writer(irs::kOmCreate, opts);
 
   // doc1

--- a/tests/libs/iresearch/index/merge_writer_tests.cpp
+++ b/tests/libs/iresearch/index/merge_writer_tests.cpp
@@ -187,16 +187,6 @@ struct MergeWriterTestCase : public tests::DirectoryTestCaseBase<std::string> {
     };
   }
 
-  static irs::FeatureInfoProvider DefaultFeatureInfo() {
-    return [](irs::IndexFeatures) {
-      return std::make_pair(
-        irs::ColumnInfo{.compression = irs::Type<irs::compression::Lz4>::get(),
-                        .options = {},
-                        .encryption = true},
-        irs::FeatureWriterFactory{});
-    };
-  }
-
   void EnsureDocBlocksNotMixed(bool primary_sort);
 };
 
@@ -382,12 +372,9 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns_remove) {
 
   const auto column_info = DefaultColumnInfo();
   ASSERT_TRUE(column_info);
-  const auto feature_info = DefaultFeatureInfo();
-  ASSERT_TRUE(feature_info);
 
   auto reader = irs::DirectoryReader(dir, codec_ptr);
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
   irs::MergeWriter writer(dir, options);
 
@@ -797,12 +784,9 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns) {
 
   const auto column_info = DefaultColumnInfo();
   ASSERT_TRUE(column_info);
-  const auto feature_info = DefaultFeatureInfo();
-  ASSERT_TRUE(feature_info);
 
   auto reader = irs::DirectoryReader(dir, codec_ptr);
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
   irs::MergeWriter writer(dir, options);
 
@@ -1136,13 +1120,10 @@ TEST_P(MergeWriterTestCase, test_merge_writer_add_segments) {
   {
     const auto column_info = DefaultColumnInfo();
     ASSERT_TRUE(column_info);
-    const auto feature_info = DefaultFeatureInfo();
-    ASSERT_TRUE(feature_info);
 
     irs::MemoryDirectory dir;
     irs::SegmentMeta index_segment;
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
     writer.Reset(reader.begin(), reader.end());
@@ -1192,8 +1173,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_flush_progress) {
 
   const auto column_info = DefaultColumnInfo();
   ASSERT_TRUE(column_info);
-  const auto feature_info = DefaultFeatureInfo();
-  ASSERT_TRUE(feature_info);
 
   // test default progress (false)
   {
@@ -1201,7 +1180,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_flush_progress) {
     irs::SegmentMeta index_segment;
     irs::MergeWriter::FlushProgress progress;
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
 
@@ -1226,7 +1204,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_flush_progress) {
     irs::SegmentMeta index_segment;
     irs::MergeWriter::FlushProgress progress = []() -> bool { return false; };
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
 
@@ -1258,7 +1235,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_flush_progress) {
       return true;
     };
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
 
@@ -1290,7 +1266,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_flush_progress) {
       return --call_count;
     };
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
 
@@ -1356,8 +1331,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_field_features) {
 
   const auto column_info = DefaultColumnInfo();
   ASSERT_TRUE(column_info);
-  const auto feature_info = DefaultFeatureInfo();
-  ASSERT_TRUE(feature_info);
 
   // test merge existing with feature subset (success)
   {
@@ -1367,7 +1340,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_field_features) {
     };
 
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
     writer.Reset(segments.begin(), segments.end());
@@ -1385,7 +1357,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer_field_features) {
     };
 
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MergeWriter writer(dir, options);
     writer.Reset(segments.begin(), segments.end());
@@ -1479,11 +1450,8 @@ TEST_P(MergeWriterTestCase, test_merge_writer_sorted) {
 
   const auto column_info = DefaultColumnInfo();
   ASSERT_TRUE(column_info);
-  const auto feature_info = DefaultFeatureInfo();
-  ASSERT_TRUE(feature_info);
 
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {},
                                           .comparator = &test_comparer};
   irs::MergeWriter writer(dir, options);
@@ -1714,19 +1682,6 @@ TEST_P(MergeWriterTestCase, test_merge_writer) {
     "doc_text", text3, true));
 
   irs::IndexWriterOptions opts;
-  opts.features = [](irs::IndexFeatures type) {
-    irs::FeatureWriterFactory handler{};
-    if (type == irs::IndexFeatures::Norm) {
-      handler =
-        [](std::span<const irs::bytes_view>) -> irs::FeatureWriter::ptr {
-        return irs::memory::make_managed<TestFeatureWriter>(0U);
-      };
-    }
-
-    return std::make_pair(
-      irs::ColumnInfo{irs::Type<irs::compression::Lz4>::get(), {}, false},
-      std::move(handler));
-  };
 
   // populate directory
   {
@@ -2493,11 +2448,8 @@ TEST_P(MergeWriterTestCase, test_merge_writer) {
 
   const auto column_info = DefaultColumnInfo();
   ASSERT_TRUE(column_info);
-  const auto feature_info = DefaultFeatureInfo();
-  ASSERT_TRUE(feature_info);
 
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
   irs::MergeWriter writer(dir, options);
   writer.Reset(reader.begin(), reader.end());

--- a/tests/libs/iresearch/index/norm_test.cpp
+++ b/tests/libs/iresearch/index/norm_test.cpp
@@ -297,20 +297,6 @@ TEST(NormHeaderTest, ResetByPayload) {
 
 class NormTestCase : public tests::IndexTestBase {
  protected:
-  irs::FeatureInfoProvider Features() {
-    return [](irs::IndexFeatures id) {
-      if (id == irs::IndexFeatures::Norm) {
-        return std::make_pair(
-          irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-          &irs::Norm::MakeWriter);
-      }
-
-      return std::make_pair(
-        irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-        irs::FeatureWriterFactory{});
-    };
-  }
-
   void AssertIndex() {
     IndexTestBase::assert_index(irs::IndexFeatures::None);
     IndexTestBase::assert_index(irs::IndexFeatures::Freq);
@@ -411,7 +397,6 @@ TEST_P(NormTestCase, CheckNorms) {
   auto* doc3 = gen.next();  // name == 'D'
 
   irs::IndexWriterOptions opts;
-  opts.features = Features();
 
   // Create actual index
   auto writer = open_writer(irs::kOmCreate, opts);
@@ -429,7 +414,7 @@ TEST_P(NormTestCase, CheckNorms) {
 
   // Create expected index
   auto& expected_index = index();
-  expected_index.emplace_back(writer->FeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
                                doc0->stored.begin(), doc0->stored.end());
   expected_index.back().insert(doc1->indexed.begin(), doc1->indexed.end(),
@@ -527,7 +512,6 @@ TEST_P(NormTestCase, CheckNormsBatched) {
   auto* doc3 = docs[3];
 
   irs::IndexWriterOptions opts;
-  opts.features = Features();
 
   // Create actual index
   auto writer = open_writer(irs::kOmCreate, opts);
@@ -539,7 +523,7 @@ TEST_P(NormTestCase, CheckNormsBatched) {
 
   // Create expected index
   auto& expected_index = index();
-  expected_index.emplace_back(writer->FeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
                                doc0->stored.begin(), doc0->stored.end());
   expected_index.back().insert(doc1->indexed.begin(), doc1->indexed.end(),
@@ -634,7 +618,6 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
   auto* doc6 = gen.next();  // name == 'G'
 
   irs::IndexWriterOptions opts;
-  opts.features = Features();
 
   // Create actual index
   auto writer = open_writer(irs::kOmCreate, opts);
@@ -660,7 +643,7 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
 
   // Create expected index
   auto& expected_index = index();
-  expected_index.emplace_back(writer->FeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
                                doc0->stored.begin(), doc0->stored.end());
   expected_index.back().insert(doc1->indexed.begin(), doc1->indexed.end(),
@@ -669,7 +652,7 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
                                doc2->stored.begin(), doc2->stored.end());
   expected_index.back().insert(doc3->indexed.begin(), doc3->indexed.end(),
                                doc3->stored.begin(), doc3->stored.end());
-  expected_index.emplace_back(writer->FeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(doc4->indexed.begin(), doc4->indexed.end(),
                                doc4->stored.begin(), doc4->stored.end());
   expected_index.back().insert(doc5->indexed.begin(), doc5->indexed.end(),
@@ -776,7 +759,7 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
 
     // Simulate consolidation
     index().clear();
-    index().emplace_back(writer->FeatureInfo());
+    index().emplace_back();
     auto& segment = index().back();
     expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
                                  doc0->stored.begin(), doc0->stored.end());
@@ -897,7 +880,6 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
   auto* doc6 = gen.next();  // name == 'G'
 
   irs::IndexWriterOptions opts;
-  opts.features = Features();
 
   // Create actual index
   auto writer = open_writer(irs::kOmCreate, opts);
@@ -923,7 +905,7 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
 
   // Create expected index
   auto& expected_index = index();
-  expected_index.emplace_back(writer->FeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
                                doc0->stored.begin(), doc0->stored.end());
   expected_index.back().insert(doc1->indexed.begin(), doc1->indexed.end(),
@@ -932,7 +914,7 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
                                doc2->stored.begin(), doc2->stored.end());
   expected_index.back().insert(doc3->indexed.begin(), doc3->indexed.end(),
                                doc3->stored.begin(), doc3->stored.end());
-  expected_index.emplace_back(writer->FeatureInfo());
+  expected_index.emplace_back();
   expected_index.back().insert(doc4->indexed.begin(), doc4->indexed.end(),
                                doc4->stored.begin(), doc4->stored.end());
   expected_index.back().insert(doc5->indexed.begin(), doc5->indexed.end(),
@@ -1047,7 +1029,7 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
 
     // Simulate consolidation
     index().clear();
-    index().emplace_back(writer->FeatureInfo());
+    index().emplace_back();
     auto& segment = index().back();
     expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
                                  doc0->stored.begin(), doc0->stored.end());

--- a/tests/libs/iresearch/index/segment_writer_tests.cpp
+++ b/tests/libs/iresearch/index/segment_writer_tests.cpp
@@ -48,17 +48,6 @@ class SegmentWriterTests : public TestBase {
     };
   }
 
-  static irs::FeatureInfoProvider DefaultFeatureInfo() {
-    return [](irs::IndexFeatures) {
-      return std::make_pair(
-        irs::ColumnInfo{.compression = irs::Type<irs::compression::Lz4>::get(),
-                        .options = {},
-                        .encryption = true,
-                        .track_prev_doc = false},
-        irs::FeatureWriterFactory{});
-    };
-  }
-
   static auto DefaultCodec() { return irs::formats::Get("1_5simd"); }
 };
 
@@ -96,20 +85,15 @@ TEST_F(SegmentWriterTests, memory_sorted_vs_unsorted) {
   Comparator compare;
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
   irs::MemoryDirectory dir;
 
   const irs::SegmentWriterOptions options_with_comparer{
-    .column_info = column_info,
-    .feature_info = feature_info,
-    .scorers_features = {},
-    .comparator = &compare};
+    .column_info = column_info, .scorers_features = {}, .comparator = &compare};
   auto writer_sorted = irs::SegmentWriter::make(dir, options_with_comparer);
   ASSERT_EQ(0, writer_sorted->memory_active());
 
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
   auto writer_unsorted = irs::SegmentWriter::make(dir, options);
   ASSERT_EQ(0, writer_unsorted->memory_active());
@@ -165,9 +149,7 @@ TEST_F(SegmentWriterTests, insert_sorted_without_comparator) {
       irs::Type<irs::compression::Lz4>::get(),
       irs::compression::Options(irs::compression::Options::Hint::Speed), true};
   };
-  auto feature_info = DefaultFeatureInfo();
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
 
   irs::MemoryDirectory dir;
@@ -210,12 +192,9 @@ TEST_F(SegmentWriterTests, memory_store_sorted_field) {
   Comparator compare;
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
-  const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
-                                          .scorers_features = {},
-                                          .comparator = &compare};
+  const irs::SegmentWriterOptions options{
+    .column_info = column_info, .scorers_features = {}, .comparator = &compare};
   {
     irs::MemoryDirectory dir;
     auto writer = irs::SegmentWriter::make(dir, options);
@@ -296,12 +275,9 @@ TEST_F(SegmentWriterTests, memory_index_store_sorted_field) {
   Comparator compare;
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
-  const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
-                                          .scorers_features = {},
-                                          .comparator = &compare};
+  const irs::SegmentWriterOptions options{
+    .column_info = column_info, .scorers_features = {}, .comparator = &compare};
   {
     TokenizerMock stream;
     FieldT field(stream);
@@ -391,12 +367,9 @@ TEST_F(SegmentWriterTests, memory_store_field_sorted) {
   Comparator compare;
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
-  const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
-                                          .scorers_features = {},
-                                          .comparator = &compare};
+  const irs::SegmentWriterOptions options{
+    .column_info = column_info, .scorers_features = {}, .comparator = &compare};
   {
     irs::MemoryDirectory dir;
     auto writer = irs::SegmentWriter::make(dir, options);
@@ -466,10 +439,8 @@ TEST_F(SegmentWriterTests, memory_store_field_unsorted) {
   } field;
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
   {
     irs::MemoryDirectory dir;
@@ -548,10 +519,8 @@ TEST_F(SegmentWriterTests, memory_index_store_field_unsorted) {
   };
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
   {
     TokenizerMock stream;
@@ -643,9 +612,7 @@ TEST_F(SegmentWriterTests, memory_index_field) {
   FieldT field(stream);
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
   const irs::SegmentWriterOptions options{.column_info = column_info,
-                                          .feature_info = feature_info,
                                           .scorers_features = {}};
 
   {
@@ -718,7 +685,6 @@ TEST_F(SegmentWriterTests, index_field) {
   };
 
   auto column_info = DefaultColumnInfo();
-  auto feature_info = DefaultFeatureInfo();
 
   // test missing token_stream attributes (increment)
   {
@@ -728,7 +694,6 @@ TEST_F(SegmentWriterTests, index_field) {
     ASSERT_NE(nullptr, segment.codec);
 
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MemoryDirectory dir;
     auto writer = irs::SegmentWriter::make(dir, options);
@@ -757,7 +722,6 @@ TEST_F(SegmentWriterTests, index_field) {
     ASSERT_NE(nullptr, segment.codec);
 
     const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
                                             .scorers_features = {}};
     irs::MemoryDirectory dir;
     auto writer = irs::SegmentWriter::make(dir, options);
@@ -850,13 +814,10 @@ TEST_F(SegmentWriterTests, reorder) {
     Reorder(docs, ctxs, order);
 
     auto column_info = DefaultColumnInfo();
-    auto feature_info = DefaultFeatureInfo();
     StringComparer less;
 
-    const irs::SegmentWriterOptions options{.column_info = column_info,
-                                            .feature_info = feature_info,
-                                            .scorers_features = {},
-                                            .comparator = &less};
+    const irs::SegmentWriterOptions options{
+      .column_info = column_info, .scorers_features = {}, .comparator = &less};
     irs::MemoryDirectory dir;
     auto writer = irs::SegmentWriter::make(dir, options);
     ASSERT_EQ(0, writer->memory_active());

--- a/tests/libs/iresearch/index/sorted_index_tests.cpp
+++ b/tests/libs/iresearch/index/sorted_index_tests.cpp
@@ -218,23 +218,6 @@ class SortedIndexTestCase : public tests::IndexTestBase {
  protected:
   bool SupportsPluggableFeatures() const noexcept { return true; }
 
-  irs::FeatureInfoProvider Features() {
-    return [this](irs::IndexFeatures id) {
-      if (SupportsPluggableFeatures()) {
-        if (irs::IndexFeatures::Norm == id) {
-          return std::make_pair(
-            irs::ColumnInfo{
-              irs::Type<irs::compression::None>::get(), {}, false},
-            &irs::Norm::MakeWriter);
-        }
-      }
-
-      return std::make_pair(
-        irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-        irs::FeatureWriterFactory{});
-    };
-  }
-
   irs::IndexFeatures FieldFeatures() {
     return SupportsPluggableFeatures() ? irs::IndexFeatures::Norm
                                        : irs::IndexFeatures::None;
@@ -321,7 +304,6 @@ TEST_P(SortedIndexTestCase, simple_sequential) {
 
   irs::IndexWriterOptions opts;
   opts.comparator = &compare;
-  opts.features = Features();
 
   add_segment(gen, irs::kOmCreate, opts);  // add segment
 
@@ -570,7 +552,6 @@ TEST_P(SortedIndexTestCase, simple_sequential_consolidate) {
 
   irs::IndexWriterOptions opts;
   opts.comparator = &compare;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -750,7 +731,7 @@ TEST_P(SortedIndexTestCase, simple_sequential_consolidate) {
 
     // simulate consolidation
     index().clear();
-    index().emplace_back(writer->FeatureInfo());
+    index().emplace_back();
     auto& segment = index().back();
 
     gen.reset();
@@ -933,7 +914,6 @@ TEST_P(SortedIndexTestCase, simple_sequential_already_sorted) {
   LongComparer comparer;
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   add_segment(gen, irs::kOmCreate, opts);  // add segment
 
@@ -1080,7 +1060,6 @@ TEST_P(SortedIndexTestCase, europarl) {
 
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   add_segment(gen, irs::kOmCreate, opts);
 
@@ -1095,7 +1074,6 @@ TEST_P(SortedIndexTestCase, europarl_docs_batched) {
 
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   add_segment_batched(gen, 123, irs::kOmCreate, opts);
 
@@ -1126,7 +1104,6 @@ TEST_P(SortedIndexTestCase, multi_valued_sorting_field) {
   } comparer;
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -1247,7 +1224,6 @@ TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_dense) {
   // open writer
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -1405,7 +1381,7 @@ TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_dense) {
 
   // Create expected index
   auto& expected_index = index();
-  auto& segment = expected_index.emplace_back(writer->FeatureInfo());
+  auto& segment = expected_index.emplace_back();
   segment.insert(doc0->indexed.begin(), doc0->indexed.end(),
                  doc0->stored.begin(), doc0->stored.end(), doc0->sorted.get());
   segment.insert(doc2->indexed.begin(), doc2->indexed.end(),
@@ -1453,7 +1429,6 @@ TEST_P(SortedIndexTestCase,
   // open writer
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
   ASSERT_EQ(&comparer, writer->Comparator());
@@ -1692,7 +1667,7 @@ TEST_P(SortedIndexTestCase,
 
   // Create expected index
   auto& expected_index = index();
-  auto& segment = expected_index.emplace_back(writer->FeatureInfo());
+  auto& segment = expected_index.emplace_back();
   segment.insert(doc0->indexed.begin(), doc0->indexed.end(),
                  doc0->stored.begin(), doc0->stored.end(), doc0->sorted.get());
   segment.insert(doc1->indexed.begin(), doc1->indexed.end(),
@@ -1731,7 +1706,6 @@ TEST_P(SortedIndexTestCase, doc_removal_same_key_within_trx) {
     // open writer
     irs::IndexWriterOptions opts;
     opts.comparator = &comparer;
-    opts.features = Features();
     auto writer = open_writer(irs::kOmCreate, opts);
     ASSERT_NE(nullptr, writer);
     ASSERT_EQ(&comparer, writer->Comparator());
@@ -1814,7 +1788,6 @@ TEST_P(SortedIndexTestCase, doc_removal_same_key_within_trx_flush) {
     // open writer
     irs::IndexWriterOptions opts;
     opts.comparator = &comparer;
-    opts.features = Features();
     auto writer = open_writer(irs::kOmCreate, opts);
     ASSERT_NE(nullptr, writer);
     ASSERT_EQ(&comparer, writer->Comparator());
@@ -1898,7 +1871,6 @@ TEST_P(SortedIndexTestCase,
   StringComparer comparer;
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -2056,7 +2028,7 @@ TEST_P(SortedIndexTestCase,
 
   // Create expected index
   auto& expected_index = index();
-  auto& segment = expected_index.emplace_back(writer->FeatureInfo());
+  auto& segment = expected_index.emplace_back();
   segment.insert(doc2->indexed.begin(), doc2->indexed.end(),
                  doc2->stored.begin(), doc2->stored.end(), &kEmpty);
   segment.insert(doc0->indexed.begin(), doc0->indexed.end(),
@@ -2100,7 +2072,6 @@ TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_sparse) {
   StringComparer comparer;
   irs::IndexWriterOptions opts;
   opts.comparator = &comparer;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -2286,7 +2257,7 @@ TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_sparse) {
 
   // Create expected index
   auto& expected_index = index();
-  auto& segment = expected_index.emplace_back(writer->FeatureInfo());
+  auto& segment = expected_index.emplace_back();
   segment.insert(doc2->indexed.begin(), doc2->indexed.end(),
                  doc2->stored.begin(), doc2->stored.end(), &kEmpty);
   segment.insert(doc0->indexed.begin(), doc0->indexed.end(),
@@ -2337,7 +2308,6 @@ TEST_P(SortedIndexTestCase,
   StringComparer compare;
   irs::IndexWriterOptions opts;
   opts.comparator = &compare;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -2525,7 +2495,7 @@ TEST_P(SortedIndexTestCase,
 
   // Create expected index
   auto& expected_index = index();
-  auto& segment = expected_index.emplace_back(writer->FeatureInfo());
+  auto& segment = expected_index.emplace_back();
   segment.insert(doc2->indexed.begin(), doc2->indexed.end(),
                  doc2->stored.begin(), doc2->stored.end(), &kEmpty);
   segment.insert(doc0->indexed.begin(), doc0->indexed.end(),
@@ -2576,7 +2546,6 @@ TEST_P(SortedIndexTestCase,
   StringComparer compare;
   irs::IndexWriterOptions opts;
   opts.comparator = &compare;
-  opts.features = Features();
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);
@@ -2767,7 +2736,7 @@ TEST_P(SortedIndexTestCase,
 
   // Create expected index
   auto& expected_index = index();
-  auto& segment = expected_index.emplace_back(writer->FeatureInfo());
+  auto& segment = expected_index.emplace_back();
   segment.insert(*docs[0].first, 5, false);
   segment.insert(*docs[1].first, 1, true);
   segment.insert(*docs[12].first, 2, false);
@@ -2835,7 +2804,6 @@ TEST_P(SortedIndexStressTestCase, doc_removal_same_key_within_trx) {
         StringComparer compare;
         irs::IndexWriterOptions opts;
         opts.comparator = &compare;
-        opts.features = Features();
         auto writer = open_writer(irs::kOmCreate, opts);
         ASSERT_NE(nullptr, writer);
         ASSERT_EQ(&compare, writer->Comparator());
@@ -2936,7 +2904,6 @@ TEST_P(SortedIndexStressTestCase, commit_on_tick) {
       irs::IndexWriterOptions opts;
       opts.segment_docs_max = 2;
       opts.comparator = &compare;
-      opts.features = Features();
       auto writer = open_writer(irs::kOmCreate, opts);
       ASSERT_NE(nullptr, writer);
       ASSERT_EQ(&compare, writer->Comparator());
@@ -3050,7 +3017,6 @@ TEST_P(SortedIndexStressTestCase, split_empty_commit) {
   StringComparer compare;
   irs::IndexWriterOptions opts;
   opts.comparator = &compare;
-  opts.features = Features();
   auto writer = open_writer(irs::kOmCreate, opts);
   auto segment1 = writer->GetBatch();
   auto insert_doc = [&](size_t i) {
@@ -3113,7 +3079,6 @@ TEST_P(SortedIndexStressTestCase, remove_tick) {
   StringComparer compare;
   irs::IndexWriterOptions opts;
   opts.comparator = &compare;
-  opts.features = Features();
   auto writer = open_writer(irs::kOmCreate, opts);
   auto segment1 = writer->GetBatch();
   auto insert_doc = [&](size_t i) {

--- a/tests/libs/iresearch/search/block_scoring_test.cpp
+++ b/tests/libs/iresearch/search/block_scoring_test.cpp
@@ -241,7 +241,7 @@ class BlockScoringTestCase : public IndexTestBase {
   void WriteSegment(irs::IndexWriter& writer, auto& gens) {
     auto& index = const_cast<tests::index_t&>(this->index());
     for (auto& gen : gens) {
-      index.emplace_back(writer.FeatureInfo());
+      index.emplace_back();
       write_segment(writer, index.back(), gen);
     }
     writer.Commit();
@@ -274,7 +274,7 @@ class BlockScoringTestCase : public IndexTestBase {
     {
       tests::JsonDocGenerator gen(resource("block_scoring_segment1.json"),
                                   &BlockScoringFieldFactory);
-      index_ref.emplace_back(writer->FeatureInfo());
+      index_ref.emplace_back();
       write_segment(*writer, index_ref.back(), gen);
       writer->Commit();
     }
@@ -283,7 +283,7 @@ class BlockScoringTestCase : public IndexTestBase {
     {
       tests::JsonDocGenerator gen(resource("block_scoring_segment2.json"),
                                   &BlockScoringFieldFactory);
-      index_ref.emplace_back(writer->FeatureInfo());
+      index_ref.emplace_back();
       write_segment(*writer, index_ref.back(), gen);
       writer->Commit();
     }
@@ -292,7 +292,7 @@ class BlockScoringTestCase : public IndexTestBase {
     {
       tests::JsonDocGenerator gen(resource("block_scoring_segment3.json"),
                                   &BlockScoringFieldFactory);
-      index_ref.emplace_back(writer->FeatureInfo());
+      index_ref.emplace_back();
       write_segment(*writer, index_ref.back(), gen);
       writer->Commit();
     }

--- a/tests/libs/iresearch/search/bm25_test.cpp
+++ b/tests/libs/iresearch/search/bm25_test.cpp
@@ -90,15 +90,6 @@ void Bm25TestCase::TestQueryNorms(irs::FeatureWriterFactory handler) {
       });
 
     irs::IndexWriterOptions opts;
-    opts.features = [&](irs::IndexFeatures id) {
-      irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
-
-      if (id == irs::IndexFeatures::Norm) {
-        return std::make_pair(info, handler);
-      }
-
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
 
     add_segment(gen, irs::kOmCreate, opts);
   }

--- a/tests/libs/iresearch/search/dfi_test.cpp
+++ b/tests/libs/iresearch/search/dfi_test.cpp
@@ -110,14 +110,6 @@ void DFIIndexTest::BuildFixture() {
               true, false);
 
   irs::IndexWriterOptions opts;
-  opts.features = [&](irs::IndexFeatures id) {
-    irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
-    if (id == irs::IndexFeatures::Norm) {
-      return std::make_pair(info,
-                            irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
-    }
-    return std::make_pair(info, irs::FeatureWriterFactory{});
-  };
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);

--- a/tests/libs/iresearch/search/granular_range_filter_tests.cpp
+++ b/tests/libs/iresearch/search/granular_range_filter_tests.cpp
@@ -1908,7 +1908,7 @@ TEST_P(GranularRangeFilterTestCase, by_range_order_multiple_sorts) {
     ASSERT_NE(nullptr, writer);
 
     // add segment
-    index().emplace_back(writer->FeatureInfo());
+    index().emplace_back();
     auto& segment = index().back();
 
     {

--- a/tests/libs/iresearch/search/indri_dirichlet_test.cpp
+++ b/tests/libs/iresearch/search/indri_dirichlet_test.cpp
@@ -97,14 +97,6 @@ void IndriDirichletIndexTest::BuildFixture() {
               true, false);
 
   irs::IndexWriterOptions opts;
-  opts.features = [&](irs::IndexFeatures id) {
-    irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
-    if (id == irs::IndexFeatures::Norm) {
-      return std::make_pair(info,
-                            irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
-    }
-    return std::make_pair(info, irs::FeatureWriterFactory{});
-  };
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);

--- a/tests/libs/iresearch/search/levenshtein_filter_test.cpp
+++ b/tests/libs/iresearch/search/levenshtein_filter_test.cpp
@@ -550,16 +550,6 @@ TEST_P(ByEditDistanceTestCase, bm25) {
       });
 
     irs::IndexWriterOptions opts;
-    opts.features = [](irs::IndexFeatures id) {
-      const irs::ColumnInfo info{
-        irs::Type<irs::compression::Lz4>::get(), {}, false};
-
-      if (irs::IndexFeatures::Norm == id) {
-        return std::make_pair(info, &irs::Norm::MakeWriter);
-      }
-
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
 
     add_segment(gen, irs::kOmCreate, opts);
   }

--- a/tests/libs/iresearch/search/lm_test.cpp
+++ b/tests/libs/iresearch/search/lm_test.cpp
@@ -185,14 +185,6 @@ void LMIndexTest::BuildFixture() {
               true, false);
 
   irs::IndexWriterOptions opts;
-  opts.features = [&](irs::IndexFeatures id) {
-    irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
-    if (id == irs::IndexFeatures::Norm) {
-      return std::make_pair(info,
-                            irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
-    }
-    return std::make_pair(info, irs::FeatureWriterFactory{});
-  };
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);

--- a/tests/libs/iresearch/search/ngram_similarity_filter_tests.cpp
+++ b/tests/libs/iresearch/search/ngram_similarity_filter_tests.cpp
@@ -121,21 +121,7 @@ TEST(ngram_similarity_base_test, equal) {
   }
 }
 
-class NGramSimilarityFilterTestCase : public tests::FilterTestCaseBase {
- protected:
-  static irs::FeatureInfoProvider FeaturesWithNorms() {
-    return [](irs::IndexFeatures id) {
-      const irs::ColumnInfo info{
-        irs::Type<irs::compression::Lz4>::get(), {}, false};
-
-      if (irs::IndexFeatures::Norm == id) {
-        return std::make_pair(info, &irs::Norm::MakeWriter);
-      }
-
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
-  }
-};
+class NGramSimilarityFilterTestCase : public tests::FilterTestCaseBase {};
 
 TEST_P(NGramSimilarityFilterTestCase, boost) {
   // no boost
@@ -1278,7 +1264,6 @@ TEST_P(NGramSimilarityFilterTestCase, missed_frequency_test) {
 TEST_P(NGramSimilarityFilterTestCase, missed_first_tfidf_norm_test) {
   {
     irs::IndexWriterOptions opts;
-    opts.features = FeaturesWithNorms();
 
     tests::JsonDocGenerator gen(resource("ngram_similarity.json"),
                                 &tests::NormalizedStringJsonFieldFactory);
@@ -1301,7 +1286,6 @@ TEST_P(NGramSimilarityFilterTestCase, missed_first_tfidf_norm_test) {
 TEST_P(NGramSimilarityFilterTestCase, all_match_ngram_score_test) {
   {
     irs::IndexWriterOptions opts;
-    opts.features = FeaturesWithNorms();
 
     tests::JsonDocGenerator gen(resource("ngram_similarity.json"),
                                 &tests::NormalizedStringJsonFieldFactory);
@@ -1337,7 +1321,6 @@ TEST_P(NGramSimilarityFilterTestCase, all_match_ngram_score_test) {
 TEST_P(NGramSimilarityFilterTestCase, missed_first_tfidf_test) {
   {
     irs::IndexWriterOptions opts;
-    opts.features = FeaturesWithNorms();
 
     tests::JsonDocGenerator gen(resource("ngram_similarity.json"),
                                 &tests::NormalizedStringJsonFieldFactory);
@@ -1360,7 +1343,6 @@ TEST_P(NGramSimilarityFilterTestCase, missed_first_tfidf_test) {
 TEST_P(NGramSimilarityFilterTestCase, missed_first_bm25_test) {
   {
     irs::IndexWriterOptions opts;
-    opts.features = FeaturesWithNorms();
 
     tests::JsonDocGenerator gen(resource("ngram_similarity.json"),
                                 &tests::NormalizedStringJsonFieldFactory);
@@ -1383,7 +1365,6 @@ TEST_P(NGramSimilarityFilterTestCase, missed_first_bm25_test) {
 TEST_P(NGramSimilarityFilterTestCase, missed_first_bm15_test) {
   {
     irs::IndexWriterOptions opts;
-    opts.features = FeaturesWithNorms();
 
     tests::JsonDocGenerator gen(resource("ngram_similarity.json"),
                                 &tests::NormalizedStringJsonFieldFactory);

--- a/tests/libs/iresearch/search/prefix_filter_test.cpp
+++ b/tests/libs/iresearch/search/prefix_filter_test.cpp
@@ -146,16 +146,6 @@ class PrefixFilterTestCase : public tests::FilterTestCaseBase {
     irs::BM25 bm25;
     irs::Scorer* score = &bm25;
     irs::IndexWriterOptions opts;
-    opts.features = [](irs::IndexFeatures id) {
-      if (irs::IndexFeatures::Norm == id) {
-        return std::pair{
-          irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-          &irs::Norm::MakeWriter};
-      }
-      return std::pair{
-        irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-        irs::FeatureWriterFactory{}};
-    };
     if (codec()->type()().name().starts_with("1_5simd") && wand) {
       opts.reader_options.scorer = score;
     }

--- a/tests/libs/iresearch/search/raw_tf_test.cpp
+++ b/tests/libs/iresearch/search/raw_tf_test.cpp
@@ -86,14 +86,6 @@ void RawTfIndexTest::BuildFixture() {
               true, false);
 
   irs::IndexWriterOptions opts;
-  opts.features = [&](irs::IndexFeatures id) {
-    irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
-    if (id == irs::IndexFeatures::Norm) {
-      return std::make_pair(info,
-                            irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
-    }
-    return std::make_pair(info, irs::FeatureWriterFactory{});
-  };
 
   auto writer = open_writer(irs::kOmCreate, opts);
   ASSERT_NE(nullptr, writer);

--- a/tests/libs/iresearch/search/tfidf_test.cpp
+++ b/tests/libs/iresearch/search/tfidf_test.cpp
@@ -87,15 +87,6 @@ void TfidfTestCase::TestQueryNorms(irs::FeatureWriterFactory handler) {
       });
 
     irs::IndexWriterOptions opts;
-    opts.features = [&](irs::IndexFeatures id) {
-      irs::ColumnInfo info{irs::Type<irs::compression::Lz4>::get(), {}, false};
-
-      if (id == irs::IndexFeatures::Norm) {
-        return std::make_pair(info, handler);
-      }
-
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
 
     add_segment(gen, irs::kOmCreate, opts);
   }

--- a/tests/libs/iresearch/search/wand_scoring_test.cpp
+++ b/tests/libs/iresearch/search/wand_scoring_test.cpp
@@ -84,7 +84,7 @@ class WandScoringTestCase : public IndexTestBase {
   void WriteSegment(irs::IndexWriter& writer, auto& gens) {
     auto& index = const_cast<tests::index_t&>(this->index());
     for (auto& gen : gens) {
-      index.emplace_back(writer.FeatureInfo());
+      index.emplace_back();
       write_segment(writer, index.back(), gen);
     }
     writer.Commit();
@@ -95,14 +95,6 @@ class WandScoringTestCase : public IndexTestBase {
                                         size_t multiplier = 1) {
     irs::IndexWriterOptions opts;
     opts.reader_options.scorer = &scorer;
-    opts.features = [](irs::IndexFeatures id) {
-      irs::ColumnInfo info{irs::Type<irs::compression::None>::get(), {}, false};
-      if (id == irs::IndexFeatures::Norm) {
-        return std::make_pair(
-          info, irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
-      }
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
     auto writer = open_writer(irs::kOmCreate, opts);
 
     std::vector<tests::JsonDocGenerator> gens;
@@ -125,14 +117,6 @@ class WandScoringTestCase : public IndexTestBase {
                                                size_t multiplier = 1) {
     irs::IndexWriterOptions opts;
     opts.reader_options.scorer = &scorer;
-    opts.features = [](irs::IndexFeatures id) {
-      irs::ColumnInfo info{irs::Type<irs::compression::None>::get(), {}, false};
-      if (id == irs::IndexFeatures::Norm) {
-        return std::make_pair(
-          info, irs::FeatureWriterFactory{&irs::Norm::MakeWriter});
-      }
-      return std::make_pair(info, irs::FeatureWriterFactory{});
-    };
     auto writer = open_writer(irs::kOmCreate, opts);
     auto& index_ref = const_cast<tests::index_t&>(index());
 
@@ -145,7 +129,7 @@ class WandScoringTestCase : public IndexTestBase {
     for (const auto& file : files) {
       for (size_t i = 0; i < multiplier; ++i) {
         tests::JsonDocGenerator gen(resource(file), &WandScoringFieldFactory);
-        index_ref.emplace_back(writer->FeatureInfo());
+        index_ref.emplace_back();
         write_segment(*writer, index_ref.back(), gen);
       }
       writer->Commit();

--- a/tests/libs/iresearch/search/wand_test.cpp
+++ b/tests/libs/iresearch/search/wand_test.cpp
@@ -225,17 +225,7 @@ irs::IndexWriterOptions WandTestCase::GetWriterOptions(irs::ScorerPtr scorer,
                                                        bool write_norms) {
   irs::IndexWriterOptions writer_options;
   writer_options.reader_options.scorer = scorer;
-  writer_options.features = [write_norms](irs::IndexFeatures id) {
-    if (write_norms && irs::IndexFeatures::Norm == id) {
-      return std::make_pair(
-        irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-        &irs::Norm::MakeWriter);
-    }
-
-    return std::make_pair(
-      irs::ColumnInfo{irs::Type<irs::compression::None>::get(), {}, false},
-      irs::FeatureWriterFactory{});
-  };
+  (void)write_norms;
 
   return writer_options;
 }

--- a/tests/server/connector/duckdb_search_sink_writer_test.cpp
+++ b/tests/server/connector/duckdb_search_sink_writer_test.cpp
@@ -71,17 +71,8 @@ class DuckDBSearchSinkWriterTest : public ::testing::Test {
         .track_prev_doc = false};
     };
 
-    auto feature_provider = [](irs::IndexFeatures) {
-      return std::make_pair(
-        irs::ColumnInfo{.compression = irs::Type<irs::compression::None>::get(),
-                        .options = {},
-                        .encryption = false,
-                        .track_prev_doc = false},
-        irs::FeatureWriterFactory{});
-    };
     irs::IndexWriterOptions options;
     options.column_info = column_info_provider;
-    options.features = feature_provider;
     _codec = irs::formats::Get("1_5simd");
     _data_writer =
       irs::IndexWriter::Make(_dir, _codec, irs::kOmCreate, options);
@@ -729,17 +720,8 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteInsertOnePendingWithFlush) {
       .track_prev_doc = false};
   };
 
-  auto feature_provider = [](irs::IndexFeatures) {
-    return std::make_pair(
-      irs::ColumnInfo{.compression = irs::Type<irs::compression::None>::get(),
-                      .options = {},
-                      .encryption = false,
-                      .track_prev_doc = false},
-      irs::FeatureWriterFactory{});
-  };
   irs::IndexWriterOptions options;
   options.column_info = column_info_provider;
-  options.features = feature_provider;
   // force writer to make flushes every 2 documents
   options.segment_docs_max = 2;
   // local block is needed as reader/writer should not outlive directory


### PR DESCRIPTION
`FeatureInfoProvider` was a runtime callback `(IndexFeatures) -> (ColumnInfo, FeatureWriterFactory)` that mapped each index feature to its column config and writer factory. It dates back to when iresearch had a pluggable index-feature concept, but `Norm` is the only feature that ever used a writer, and every caller passed the same lambda — a static dispatch dressed up as runtime polymorphism.

This change removes the abstraction and bakes norm handling directly into iresearch.
