### PR TITLE
Update README to include video link instead of image

### DIFF
--- a/serene-ui/README.md
+++ b/serene-ui/README.md
@@ -10,9 +10,7 @@
 
 </div>
 
-<img width="1482" height="919" alt="overview" src="https://github.com/user-attachments/assets/3ca72fd5-09e5-4ece-a3e2-bd2b25c15bc9" />
-
-<br/>
+[![Watch the video](https://github.com/user-attachments/assets/7f89b1f9-b723-4df8-8cb0-5b4b2cbc7873)](https://youtu.be/mVaudH7w8yw)
 
 SereneUI is an open-source database client built for [SereneDB](https://github.com/serenedb/serenedb) and compatible with PostgreSQL. It gives transactional and analytical workflows a single workspace: connect to Postgres and SereneDB, write queries, inspect results, manage saved work, build dashboards and move between environments without switching tools.
 


### PR DESCRIPTION
Now, when the user clicks on the image, they are redirected to the video.