### PR TITLE
fix(ci): publish correct multi-arch manifest for build-image latest tag

### DIFF
--- a/scripts/ci/build_images.sh
+++ b/scripts/ci/build_images.sh
@@ -66,7 +66,6 @@ for os in ubuntu; do
 
 	# 3. Multi-Arch Build & Push
 	if [ "$PUSH_ENABLED" = "true" ]; then
-		# Build each arch separately and export (anonymous pulls, no login needed)
 		for arch in amd64 arm64; do
 			echo "    > Building linux/${arch}..."
 			docker buildx build \
@@ -76,14 +75,12 @@ for os in ubuntu; do
 				--file "${DOCKERFILE}" .
 		done
 
-		# Load into docker daemon
 		echo "    > Loading images..."
 		for arch in amd64 arm64; do
 			docker load </tmp/${os}-${arch}.tar
 			rm -f "/tmp/${os}-${arch}.tar"
 		done
 
-		# Login and push (same pattern as serenedb/sereneui)
 		echo "[*] Logging in to Docker Hub as $DOCKER_USERNAME..."
 		echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 		trap 'docker logout' EXIT INT TERM
@@ -93,23 +90,20 @@ for os in ubuntu; do
 			docker push "${REPO}:${IMAGE_TAG}-${arch}"
 		done
 
-		# Create and push multi-arch manifests
-		echo "    > Creating multi-arch manifests..."
-		for tag in "${IMAGE_TAG}" "latest"; do
-			docker manifest create --amend "${REPO}:${tag}" \
-				"${REPO}:${IMAGE_TAG}-amd64" \
-				"${REPO}:${IMAGE_TAG}-arm64"
-			docker manifest push "${REPO}:${tag}"
-		done
+		echo "    > Creating manifests ${REPO}:{${IMAGE_TAG},latest}..."
+		docker buildx imagetools create \
+			--tag "${REPO}:${IMAGE_TAG}" \
+			--tag "${REPO}:latest" \
+			"${REPO}:${IMAGE_TAG}-amd64" \
+			"${REPO}:${IMAGE_TAG}-arm64"
 
 		echo "[+] SUCCESS: Pushed ${REPO}:${IMAGE_TAG}"
 
-		# Cleanup arch-specific images
 		for arch in amd64 arm64; do
 			docker rmi "${REPO}:${IMAGE_TAG}-${arch}" >/dev/null 2>&1 || true
 		done
 	else
-		echo "[!] SKIP: Pushing disabled. Image will be removed locally."
+		echo "[!] SKIP: Pushing disabled."
 	fi
 
 	# Cleanup local probe tag


### PR DESCRIPTION
## Summary

The `latest` tag of `serenedb/serenedb-build-ubuntu` on Docker Hub
points at stale per-arch layers (~0.5 GB) instead of the freshly built
image (~1.1 GB). New CI builds resolve `BUILD_IMAGE=latest` and pull the
old layers, so anything that depends on packages added since the last
`latest` push (R, Ruby, .NET, Java, Node, PHP, etc.) breaks.

## Root cause

`scripts/ci/build_images.sh` used `docker manifest create --amend
<tag>` to assemble the multi-arch manifest list. `--amend` modifies the
existing **local** manifest store rather than replacing it. The build
job runs on a self-hosted runner whose Docker state persists across
runs, so each invocation appended a new pair of per-arch entries to
`latest` without removing the previous pair. The pushed list ended up
with multiple entries per architecture; Docker Hub picked the first
match, which was the oldest amd64/arm64 reference.

Evidence from run 25454329858: the freshly created versioned tag and
the `latest` tag pushed in the same run produced different manifest
digests — they should be identical if both lists held the same two
entries.

## Fix

Replace `docker manifest create --amend` with `docker buildx imagetools
create`, which builds the manifest list directly from registry
references and has no local state to leak between runs. Also collapse
the two-iteration manifest loop into one `imagetools create` call with
two `--tag` flags.

The build / load / push split is preserved on purpose: the Docker Hub
push token only has scope for the destination repo, so logging in
before the build breaks anonymous pulls of `rust:latest`,
`ubuntu:24.04`, `docker:latest` with `401 Unauthorized: access token
has insufficient scopes`. The constraint is now spelled out in a
comment instead of "anonymous pulls, no login needed".

## Recovery

The next workflow run with `PUSH_IMAGES_2_REGISTRY=true` will publish
a clean two-entry manifest list for `latest`, replacing the
accumulated stale list currently on Docker Hub.

## Test plan

- [ ] Trigger `serenedb | create infra` with
  `PUSH_IMAGES_2_REGISTRY=true`.
- [ ] Verify `docker buildx imagetools inspect serenedb/serenedb-build-ubuntu:latest`
  reports exactly two manifests (linux/amd64, linux/arm64) whose
  digests match `serenedb/serenedb-build-ubuntu:<IMAGE_TAG>-amd64` and
  `…-arm64`.
- [ ] Re-run a CI job that resolves `BUILD_IMAGE=latest` and confirm
  it pulls the ~1.1 GB image, not the stale 0.5 GB one.
