### PR TITLE
Fix iceberg multi-threaded execution

### DIFF
--- a/server/connector/duckdb_catalog.cpp
+++ b/server/connector/duckdb_catalog.cpp
@@ -955,6 +955,7 @@ duckdb::unique_ptr<duckdb::LogicalOperator> SereneDBCatalog::BindCreateIndex(
       if (leaf_get->bind_data) {
         pinned_iceberg_snapshot_id =
           ExtractIcebergSnapshotId(*leaf_get->bind_data);
+        EnableIcebergSort(leaf_get->bind_data.get());
       }
     }
   } else {

--- a/server/connector/view_fast_path.cpp
+++ b/server/connector/view_fast_path.cpp
@@ -437,6 +437,20 @@ duckdb::TableFunction MakeFastPathLookupFunction(const ViewFastPath& fp) {
   return entry->make_lookup();
 }
 
+void EnableIcebergSort(duckdb::FunctionData* bind_data) noexcept {
+  if (!bind_data) {
+    return;
+  }
+  auto* multi_bd = dynamic_cast<duckdb::MultiFileBindData*>(bind_data);
+  if (!multi_bd || !multi_bd->file_list) {
+    return;
+  }
+  if (auto* iceberg_list = dynamic_cast<duckdb::IcebergMultiFileList*>(
+        multi_bd->file_list.get())) {
+    iceberg_list->need_sort = true;
+  }
+}
+
 duckdb::unique_ptr<duckdb::FunctionData> BindFastPathSource(
   duckdb::ClientContext& context, const ViewFastPath& fp) {
   SDB_ASSERT(!catalog::IsRocksPK(fp.pk_spec));
@@ -460,6 +474,9 @@ duckdb::unique_ptr<duckdb::FunctionData> BindFastPathSource(
     auto fn = entry.GetScanFunction(context, bind_data, lookup);
     if (fn.get_virtual_columns && bind_data) {
       fn.get_virtual_columns(context, bind_data.get());
+    }
+    if (fp.function_name == "iceberg_scan" && bind_data) {
+      EnableIcebergSort(bind_data.get());
     }
     return bind_data;
   }
@@ -502,6 +519,10 @@ duckdb::unique_ptr<duckdb::FunctionData> BindFastPathSource(
   if (reader.get_virtual_columns && bind_data) {
     reader.get_virtual_columns(context, bind_data.get());
   }
+  if (fp.function_name == "iceberg_scan" && bind_data) {
+    EnableIcebergSort(bind_data.get());
+  }
+
   return bind_data;
 }
 

--- a/server/connector/view_fast_path.h
+++ b/server/connector/view_fast_path.h
@@ -77,6 +77,8 @@ duckdb::unique_ptr<duckdb::FunctionData> BindFastPathSource(
 // 0 for non-iceberg.
 int64_t ExtractIcebergSnapshotId(duckdb::FunctionData& bind_data) noexcept;
 
+void EnableIcebergSort(duckdb::FunctionData* bind_data) noexcept;
+
 std::string FormatLookupLabel(const ViewFastPath& fp);
 
 }  // namespace sdb::connector

--- a/tests/sqllogic/sdb/pg/simple/iceberg_scan.test_slow
+++ b/tests/sqllogic/sdb/pg/simple/iceberg_scan.test_slow
@@ -1,0 +1,165 @@
+control substitution on
+
+statement ok
+CREATE OR REPLACE SECRET iceberg_${__DATABASE__} (
+  TYPE S3,
+  KEY_ID '${MINIO_ACCESS_KEY}',
+  SECRET '${MINIO_SECRET_KEY}',
+  ENDPOINT '${MINIO_HOST}:${MINIO_PORT}',
+  URL_STYLE 'path',
+  USE_SSL false,
+  SCOPE 's3://${MINIO_BUCKET}/warehouse/${__DATABASE__}/'
+);
+
+
+statement ok
+SET s3_use_ssl=false;
+
+
+statement ok
+SET unsafe_enable_version_guessing=true;
+
+
+statement ok
+DETACH DATABASE IF EXISTS iceberg_${__DATABASE__};
+
+statement ok
+ATTACH '${ICEBERG_WAREHOUSE}' AS iceberg_${__DATABASE__} (
+  TYPE ICEBERG,
+  ENDPOINT '${ICEBERG_REST_URL}',
+  AUTHORIZATION_TYPE 'none'
+);
+
+
+statement ok
+CREATE SCHEMA iceberg_${__DATABASE__}.${__DATABASE__};
+
+
+statement ok
+CREATE TABLE iceberg_${__DATABASE__}.${__DATABASE__}.scan_t (id INTEGER, val BIGINT);
+
+
+statement count 3
+INSERT INTO iceberg_${__DATABASE__}.${__DATABASE__}.scan_t VALUES (1, 10), (2, 20), (3, 30);
+
+statement count 3
+INSERT INTO iceberg_${__DATABASE__}.${__DATABASE__}.scan_t VALUES (4, 40), (5, 50), (6, 60);
+
+statement count 3
+INSERT INTO iceberg_${__DATABASE__}.${__DATABASE__}.scan_t VALUES (7, 70), (8, 80), (9, 90);
+
+statement count 1
+INSERT INTO iceberg_${__DATABASE__}.${__DATABASE__}.scan_t VALUES (10, 100);
+
+
+query
+SELECT count(*) FROM iceberg_scan(
+  's3://${MINIO_BUCKET}/warehouse/${__DATABASE__}/scan_t',
+  allow_moved_paths=true);
+----
+count
+10
+
+
+query
+SELECT sum(val) FROM iceberg_scan(
+  's3://${MINIO_BUCKET}/warehouse/${__DATABASE__}/scan_t',
+  allow_moved_paths=true);
+----
+sum
+550
+
+
+query
+SELECT id, val FROM iceberg_scan(
+  's3://${MINIO_BUCKET}/warehouse/${__DATABASE__}/scan_t',
+  allow_moved_paths=true)
+ORDER BY id;
+----
+id	val
+1	10
+2	20
+3	30
+4	40
+5	50
+6	60
+7	70
+8	80
+9	90
+10	100
+
+
+# Filter pushdown: planner pushes id <= 3 through ComplexFilterPushdown,
+# which builds a child IcebergMultiFileList. Verify only the matching rows
+# come back regardless of which manifest holds them.
+query
+SELECT id, val FROM iceberg_scan(
+  's3://${MINIO_BUCKET}/warehouse/${__DATABASE__}/scan_t',
+  allow_moved_paths=true)
+WHERE id <= 3
+ORDER BY id;
+----
+id	val
+1	10
+2	20
+3	30
+
+
+query
+SELECT id, val FROM iceberg_scan(
+  's3://${MINIO_BUCKET}/warehouse/${__DATABASE__}/scan_t',
+  allow_moved_paths=true)
+WHERE id BETWEEN 5 AND 8
+ORDER BY id;
+----
+id	val
+5	50
+6	60
+7	70
+8	80
+
+
+query
+SELECT count(*) FROM iceberg_scan(
+  '${ICEBERG_FIXTURES}/equality_deletes/warehouse/mydb/mytable',
+  allow_moved_paths=true);
+----
+count
+2
+
+
+query
+SELECT id, name FROM iceberg_scan(
+  '${ICEBERG_FIXTURES}/equality_deletes/warehouse/mydb/mytable',
+  allow_moved_paths=true)
+ORDER BY id;
+----
+id	name
+4	d
+5	e
+
+
+query
+SELECT count(*) FROM iceberg_scan(
+  '${ICEBERG_FIXTURES}/equality_deletes/warehouse/mydb/mytable',
+  allow_moved_paths=true)
+WHERE id IN (1, 2, 3, 6);
+----
+count
+0
+
+
+statement ok
+DROP TABLE iceberg_${__DATABASE__}.${__DATABASE__}.scan_t;
+
+
+statement ok
+DROP SCHEMA iceberg_${__DATABASE__}.${__DATABASE__};
+
+
+statement ok
+DETACH DATABASE iceberg_${__DATABASE__};
+
+
+statement ok
+DROP SECRET iceberg_${__DATABASE__};


### PR DESCRIPTION
Iceberg scans use a `MultiFileList` whose file iteration order is not stable across threads, so multi-threaded plans (and filter-pushdown children built via `ComplexFilterPushdown`) could produce inconsistent results. We enable sorting on `IcebergMultiFileList` (`need_sort = true`) whenever we bind an `iceberg_scan` (fast-path source bind and `BindCreateIndex`) to get a stable file order and consistent results across threads.

- `EnableIcebergSort` helper in `view_fast_path.cpp`
- Bumps `duckdb_iceberg` submodule to pick up the `need_sort` field
- Adds `iceberg_scan.test_slow` covering count/sum/order-by, filter pushdown, and equality deletes

iceberg PR: https://github.com/serenedb/duckdb-iceberg/pull/3