### PR TITLE
Support text search inside ann query

### DIFF
--- a/server/connector/duckdb_ann_filter.cpp
+++ b/server/connector/duckdb_ann_filter.cpp
@@ -20,9 +20,6 @@
 
 #include "connector/duckdb_ann_filter.h"
 
-#include <algorithm>
-#include <array>
-
 #include "basics/assert.h"
 #include "connector/duckdb_client_state.h"
 #include "connector/duckdb_table_function.h"
@@ -170,24 +167,21 @@ bool TextScanFilter::Accept(faiss::idx_t id) const {
   return _it->seek(doc_id) == doc_id;
 }
 
-CompositeScanFilter::CompositeScanFilter(
-  std::vector<std::unique_ptr<ScanFilter>> fs)
-  : _filters{std::move(fs)} {
-  std::sort(_filters.begin(), _filters.end(),
-            [](const auto& a, const auto& b) { return a->Cost() < b->Cost(); });
-}
-
 void CompositeScanFilter::Reset(const irs::SubReader& segment) {
-  for (auto& f : _filters) {
-    f->Reset(segment);
+  if (_text) {
+    _text->Reset(segment);
+  }
+  if (_ann) {
+    _ann->Reset(segment);
   }
 }
 
 bool CompositeScanFilter::is_member(faiss::idx_t id) const {
-  for (const auto& f : _filters) {
-    if (!f->Accept(id)) {
-      return false;
-    }
+  if (_text && !_text->Accept(id)) {
+    return false;
+  }
+  if (_ann && !_ann->Accept(id)) {
+    return false;
   }
   return true;
 }

--- a/server/connector/duckdb_ann_filter.cpp
+++ b/server/connector/duckdb_ann_filter.cpp
@@ -20,6 +20,7 @@
 
 #include "connector/duckdb_ann_filter.h"
 
+#include <algorithm>
 #include <array>
 
 #include "basics/assert.h"
@@ -79,8 +80,8 @@ void InitAnnFilterContext(
   });
 }
 
-ANNFilter::ANNFilter(const ANNFilterContext& ctx, const irs::SubReader& segment)
-  : _ctx{ctx}, _segment{segment}, _executor{ctx.context} {
+ANNFilter::ANNFilter(const ANNFilterContext& ctx)
+  : _ctx{ctx}, _executor{ctx.context} {
   _executor.AddExpression(*ctx.filter_expr);
   duckdb::vector<duckdb::LogicalType> scratch_types{ctx.filter_types.begin(),
                                                     ctx.filter_types.end()};
@@ -89,12 +90,14 @@ ANNFilter::ANNFilter(const ANNFilterContext& ctx, const irs::SubReader& segment)
   duckdb::vector<duckdb::LogicalType> bool_types{1,
                                                  duckdb::LogicalType::BOOLEAN};
   _bool_out.Initialize(duckdb::Allocator::Get(ctx.context), bool_types);
+}
 
-  auto opened = OpenSegmentPkIterator(_segment, _it);
+void ANNFilter::Reset(const irs::SubReader& segment) {
+  auto opened = OpenSegmentPkIterator(segment, _it);
   SDB_ASSERT(opened);
 }
 
-bool ANNFilter::is_member(faiss::idx_t id) const {
+bool ANNFilter::Accept(faiss::idx_t id) const {
   SDB_ASSERT(_it);
   auto [_, doc_id] = irs::UnpackSegmentWithDoc(id);
   if (_it.iter->value() > doc_id) {
@@ -148,6 +151,41 @@ bool ANNFilter::is_member(faiss::idx_t id) const {
       return false;
     }
     if (!duckdb::UnifiedVectorFormat::GetData<bool>(fmt)[idx]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TextScanFilter::TextScanFilter(const irs::Filter::Query& query)
+  : _query{query} {}
+
+void TextScanFilter::Reset(const irs::SubReader& segment) {
+  _it = _query.execute({.segment = segment});
+  SDB_ASSERT(_it);
+}
+
+bool TextScanFilter::Accept(faiss::idx_t id) const {
+  auto [_, doc_id] = irs::UnpackSegmentWithDoc(id);
+  return _it->seek(doc_id) == doc_id;
+}
+
+CompositeScanFilter::CompositeScanFilter(
+  std::vector<std::unique_ptr<ScanFilter>> fs)
+  : _filters{std::move(fs)} {
+  std::sort(_filters.begin(), _filters.end(),
+            [](const auto& a, const auto& b) { return a->Cost() < b->Cost(); });
+}
+
+void CompositeScanFilter::Reset(const irs::SubReader& segment) {
+  for (auto& f : _filters) {
+    f->Reset(segment);
+  }
+}
+
+bool CompositeScanFilter::is_member(faiss::idx_t id) const {
+  for (const auto& f : _filters) {
+    if (!f->Accept(id)) {
       return false;
     }
   }

--- a/server/connector/duckdb_ann_filter.h
+++ b/server/connector/duckdb_ann_filter.h
@@ -24,8 +24,10 @@
 
 #include <duckdb.hpp>
 #include <duckdb/execution/expression_executor.hpp>
+#include <iresearch/search/filter.hpp>
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include "connector/index_source.h"
 #include "connector/search_pk_lookup.h"
@@ -40,6 +42,17 @@ namespace sdb::connector {
 
 struct SereneDBScanBindData;
 
+class ScanFilter {
+ public:
+  virtual ~ScanFilter() = default;
+
+  virtual bool Accept(faiss::idx_t id) const = 0;
+
+  virtual int Cost() const = 0;
+
+  virtual void Reset(const irs::SubReader& segment) = 0;
+};
+
 struct ANNFilterContext {
   duckdb::ClientContext& context;
   duckdb::unique_ptr<duckdb::Expression> filter_expr;
@@ -52,26 +65,25 @@ struct ANNFilterContext {
   std::vector<catalog::Column::Id> filter_column_ids;
 };
 
-// faiss IDSelector: per HNSW candidate, materializes the row's filter
-// columns and evaluates the filter expressions to gate inclusion.
-class ANNFilter final : public faiss::IDSelector {
+// Row-by-row filter: per HNSW candidate, materializes the row's filter
+// columns and evaluates the filter expression. Expensive (RocksDB lookup
+// per candidate).
+class ANNFilter final : public ScanFilter {
  public:
-  ANNFilter(const ANNFilterContext& ctx, const irs::SubReader& segment);
+  ANNFilter(const ANNFilterContext& ctx);
 
-  bool is_member(faiss::idx_t id) const final;
+  void Reset(const irs::SubReader& segment);
+  bool Accept(faiss::idx_t id) const final;
+  int Cost() const final { return 100; }
 
  private:
   const ANNFilterContext& _ctx;
-  const irs::SubReader& _segment;
   mutable duckdb::ExpressionExecutor _executor;
   mutable duckdb::DataChunk _scratch;
   mutable duckdb::DataChunk _bool_out;
 
-  // Default-constructed to std::monostate; switched on first is_member call.
   mutable PrimaryKeyBatch _pk_batch;
-
   mutable std::shared_ptr<IndexSource> _index_source;
-
   mutable SegmentPkIterator _it;
 };
 
@@ -81,5 +93,33 @@ void InitAnnFilterContext(
   const std::vector<catalog::Column::Id>& filter_column_ids, ObjectId index_id,
   const rocksdb::Snapshot* rocks_snapshot,
   const SereneDBScanBindData& bind_data);
+
+class TextScanFilter final : public ScanFilter {
+ public:
+  TextScanFilter(const irs::Filter::Query& query);
+
+  bool Accept(faiss::idx_t id) const final;
+  int Cost() const final { return 1; }
+  void Reset(const irs::SubReader& segment);
+
+ private:
+  const irs::Filter::Query& _query;
+  mutable irs::DocIterator::ptr _it;
+};
+
+class CompositeScanFilter final : public faiss::IDSelector {
+ public:
+  CompositeScanFilter() = default;
+  explicit CompositeScanFilter(std::vector<std::unique_ptr<ScanFilter>> fs);
+
+  bool Empty() const { return _filters.empty(); }
+
+  bool is_member(faiss::idx_t id) const final;
+
+  void Reset(const irs::SubReader& reader);
+
+ private:
+  std::vector<std::unique_ptr<ScanFilter>> _filters;
+};
 
 }  // namespace sdb::connector

--- a/server/connector/duckdb_ann_filter.h
+++ b/server/connector/duckdb_ann_filter.h
@@ -27,7 +27,7 @@
 #include <iresearch/search/filter.hpp>
 #include <limits>
 #include <memory>
-#include <vector>
+#include <optional>
 
 #include "connector/index_source.h"
 #include "connector/search_pk_lookup.h"
@@ -41,17 +41,6 @@ class Transaction;
 namespace sdb::connector {
 
 struct SereneDBScanBindData;
-
-class ScanFilter {
- public:
-  virtual ~ScanFilter() = default;
-
-  virtual bool Accept(faiss::idx_t id) const = 0;
-
-  virtual int Cost() const = 0;
-
-  virtual void Reset(const irs::SubReader& segment) = 0;
-};
 
 struct ANNFilterContext {
   duckdb::ClientContext& context;
@@ -68,13 +57,12 @@ struct ANNFilterContext {
 // Row-by-row filter: per HNSW candidate, materializes the row's filter
 // columns and evaluates the filter expression. Expensive (RocksDB lookup
 // per candidate).
-class ANNFilter final : public ScanFilter {
+class ANNFilter {
  public:
   ANNFilter(const ANNFilterContext& ctx);
 
   void Reset(const irs::SubReader& segment);
-  bool Accept(faiss::idx_t id) const final;
-  int Cost() const final { return 100; }
+  bool Accept(faiss::idx_t id) const;
 
  private:
   const ANNFilterContext& _ctx;
@@ -94,12 +82,11 @@ void InitAnnFilterContext(
   const rocksdb::Snapshot* rocks_snapshot,
   const SereneDBScanBindData& bind_data);
 
-class TextScanFilter final : public ScanFilter {
+class TextScanFilter {
  public:
   TextScanFilter(const irs::Filter::Query& query);
 
-  bool Accept(faiss::idx_t id) const final;
-  int Cost() const final { return 1; }
+  bool Accept(faiss::idx_t id) const;
   void Reset(const irs::SubReader& segment);
 
  private:
@@ -110,16 +97,19 @@ class TextScanFilter final : public ScanFilter {
 class CompositeScanFilter final : public faiss::IDSelector {
  public:
   CompositeScanFilter() = default;
-  explicit CompositeScanFilter(std::vector<std::unique_ptr<ScanFilter>> fs);
 
-  bool Empty() const { return _filters.empty(); }
+  void EnableText(const irs::Filter::Query& query) { _text.emplace(query); }
+  void EnableAnn(const ANNFilterContext& ctx) { _ann.emplace(ctx); }
+
+  bool Empty() const { return !_text && !_ann; }
 
   bool is_member(faiss::idx_t id) const final;
 
   void Reset(const irs::SubReader& reader);
 
  private:
-  std::vector<std::unique_ptr<ScanFilter>> _filters;
+  std::optional<TextScanFilter> _text;
+  std::optional<ANNFilter> _ann;
 };
 
 }  // namespace sdb::connector

--- a/server/connector/duckdb_search_ann_scan.cpp
+++ b/server/connector/duckdb_search_ann_scan.cpp
@@ -25,6 +25,7 @@
 #include <iresearch/analysis/token_attributes.hpp>
 #include <iresearch/formats/column/hnsw_index.hpp>
 #include <iresearch/index/index_reader.hpp>
+#include <iresearch/search/proxy_filter.hpp>
 #include <limits>
 #include <numeric>
 #include <span>
@@ -75,7 +76,7 @@ bool ClaimNextLiveSegment(std::atomic_uint32_t& next_segment,
 }
 
 void ANNSearchSegment(const irs::SubReader& segment_reader, uint32_t segment_id,
-                      std::optional<ANNFilter>& filter,
+                      CompositeScanFilter& composite,
                       SearchAnnScanGlobalState& gstate,
                       SearchAnnScanLocalState& lstate) {
   SDB_ASSERT(gstate.scan->top_k > 0);
@@ -90,7 +91,7 @@ void ANNSearchSegment(const irs::SubReader& segment_reader, uint32_t segment_id,
   const int requested_ef =
     gstate.ef_search > 0 ? gstate.ef_search : info.params.efSearch;
   info.params.efSearch = std::max(requested_ef, static_cast<int>(top_k));
-  info.params.sel = filter.has_value() ? &*filter : nullptr;
+  info.params.sel = composite.Empty() ? nullptr : &composite;
 
   SDB_ASSERT(gstate.reader);
 
@@ -226,7 +227,7 @@ void EmitResult(duckdb::ClientContext& context,
 void RangeSearchSegment(duckdb::ClientContext& context,
                         const SereneDBScanBindData& bind_data,
                         const irs::SubReader& sub, uint32_t segment_id,
-                        std::optional<ANNFilter>& filter,
+                        CompositeScanFilter& composite,
                         SearchRangeScanGlobalState& g,
                         SearchRangeScanLocalState& l) {
   l.range_buffer.dis.clear();
@@ -240,7 +241,7 @@ void RangeSearchSegment(duckdb::ClientContext& context,
   if (g.ef_search > 0) {
     info.params.efSearch = static_cast<size_t>(g.ef_search);
   }
-  info.params.sel = filter.has_value() ? &*filter : nullptr;
+  info.params.sel = composite.Empty() ? nullptr : &composite;
   sub.RangeSearch(g.scan->field_name, info, l.range_buffer, segment_id);
 
   auto& ids = l.range_buffer.ids;
@@ -342,8 +343,15 @@ duckdb::unique_ptr<duckdb::LocalTableFunctionState> SearchAnnScanInitLocal(
   dis.resize(dis.size() + gstate.scan->top_k);
   SDB_ASSERT(ids.capacity() == gstate.MaxThreads() * gstate.scan->top_k);
   SDB_ASSERT(dis.capacity() == gstate.MaxThreads() * gstate.scan->top_k);
-  return duckdb::make_uniq<SearchAnnScanLocalState>(
+  auto lstate = duckdb::make_uniq<SearchAnnScanLocalState>(
     dis.data() + dis_begin, ids.data() + ids_begin, gstate.scan->top_k);
+  if (gstate.scan->stored_text_filter) {
+    auto& pf =
+      basics::downCast<irs::ProxyFilter>(*gstate.scan->stored_text_filter);
+    lstate->text_filter_query =
+      pf.prepare({.index = *gstate.reader, .scorer = nullptr});
+  }
+  return lstate;
 }
 
 void SearchAnnScanFunction(duckdb::ClientContext& context,
@@ -355,17 +363,21 @@ void SearchAnnScanFunction(duckdb::ClientContext& context,
   size_t processed = 0;
   uint32_t segment;
   SDB_ASSERT(g.reader);
-  std::optional<ANNFilter> filter;
+  std::vector<std::unique_ptr<ScanFilter>> filters;
+  if (l.text_filter_query) {
+    filters.emplace_back(
+      std::make_unique<TextScanFilter>(*l.text_filter_query));
+  }
+  if (g.filter_ctx) {
+    filters.emplace_back(std::make_unique<ANNFilter>(*g.filter_ctx));
+  }
+  CompositeScanFilter composite{std::move(filters)};
   while (ClaimNextLiveSegment(g.next_segment, g.total_segments, *g.reader,
                               segment)) {
     const auto& reader = (*g.reader)[segment];
-
-    if (g.filter_ctx) {
-      filter.emplace(*g.filter_ctx, reader);
-    }
-    ANNSearchSegment(reader, segment, filter, g, l);
+    composite.Reset(reader);
+    ANNSearchSegment(reader, segment, composite, g, l);
     processed++;
-    filter.reset();
   }
   auto remained =
     g.remained_segments.fetch_sub(processed, std::memory_order_acq_rel);
@@ -402,8 +414,16 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> SearchRangeScanInitGlobal(
 duckdb::unique_ptr<duckdb::LocalTableFunctionState> SearchRangeScanInitLocal(
   duckdb::ExecutionContext& /*context*/,
   duckdb::TableFunctionInitInput& /*input*/,
-  duckdb::GlobalTableFunctionState* /*global_state*/) {
-  return duckdb::make_uniq<SearchRangeScanLocalState>();
+  duckdb::GlobalTableFunctionState* state) {
+  auto& gstate = state->Cast<SearchRangeScanGlobalState>();
+  auto lstate = duckdb::make_uniq<SearchRangeScanLocalState>();
+  if (gstate.scan->stored_text_filter) {
+    auto& pf =
+      basics::downCast<irs::ProxyFilter>(*gstate.scan->stored_text_filter);
+    lstate->text_filter_query =
+      pf.prepare({.index = *gstate.reader, .scorer = nullptr});
+  }
+  return lstate;
 }
 
 void SearchRangeScanFunction(duckdb::ClientContext& context,
@@ -413,17 +433,22 @@ void SearchRangeScanFunction(duckdb::ClientContext& context,
   auto& l = data.local_state->Cast<SearchRangeScanLocalState>();
   auto& bind_data = data.bind_data->Cast<SereneDBScanBindData>();
 
-  std::optional<ANNFilter> filter;
   uint32_t segment;
+  std::vector<std::unique_ptr<ScanFilter>> filters;
+  if (l.text_filter_query) {
+    filters.emplace_back(
+      std::make_unique<TextScanFilter>(*l.text_filter_query));
+  }
+  if (g.filter_ctx) {
+    filters.emplace_back(std::make_unique<ANNFilter>(*g.filter_ctx));
+  }
+  CompositeScanFilter composite{std::move(filters)};
   while (LocalPkSize(l.pk_batch) - l.current_idx < STANDARD_VECTOR_SIZE &&
          ClaimNextLiveSegment(g.next_segment, g.total_segments, *g.reader,
                               segment)) {
     const auto& sub = (*g.reader)[segment];
-    if (g.filter_ctx) {
-      filter.emplace(*g.filter_ctx, sub);
-    }
-    RangeSearchSegment(context, bind_data, sub, segment, filter, g, l);
-    filter.reset();
+    composite.Reset(sub);
+    RangeSearchSegment(context, bind_data, sub, segment, composite, g, l);
   }
 
   const size_t total = LocalPkSize(l.pk_batch);

--- a/server/connector/duckdb_search_ann_scan.cpp
+++ b/server/connector/duckdb_search_ann_scan.cpp
@@ -363,15 +363,13 @@ void SearchAnnScanFunction(duckdb::ClientContext& context,
   size_t processed = 0;
   uint32_t segment;
   SDB_ASSERT(g.reader);
-  std::vector<std::unique_ptr<ScanFilter>> filters;
+  CompositeScanFilter composite;
   if (l.text_filter_query) {
-    filters.emplace_back(
-      std::make_unique<TextScanFilter>(*l.text_filter_query));
+    composite.EnableText(*l.text_filter_query);
   }
   if (g.filter_ctx) {
-    filters.emplace_back(std::make_unique<ANNFilter>(*g.filter_ctx));
+    composite.EnableAnn(*g.filter_ctx);
   }
-  CompositeScanFilter composite{std::move(filters)};
   while (ClaimNextLiveSegment(g.next_segment, g.total_segments, *g.reader,
                               segment)) {
     const auto& reader = (*g.reader)[segment];
@@ -434,15 +432,13 @@ void SearchRangeScanFunction(duckdb::ClientContext& context,
   auto& bind_data = data.bind_data->Cast<SereneDBScanBindData>();
 
   uint32_t segment;
-  std::vector<std::unique_ptr<ScanFilter>> filters;
+  CompositeScanFilter composite;
   if (l.text_filter_query) {
-    filters.emplace_back(
-      std::make_unique<TextScanFilter>(*l.text_filter_query));
+    composite.EnableText(*l.text_filter_query);
   }
   if (g.filter_ctx) {
-    filters.emplace_back(std::make_unique<ANNFilter>(*g.filter_ctx));
+    composite.EnableAnn(*g.filter_ctx);
   }
-  CompositeScanFilter composite{std::move(filters)};
   while (LocalPkSize(l.pk_batch) - l.current_idx < STANDARD_VECTOR_SIZE &&
          ClaimNextLiveSegment(g.next_segment, g.total_segments, *g.reader,
                               segment)) {

--- a/server/connector/duckdb_search_ann_scan.h
+++ b/server/connector/duckdb_search_ann_scan.h
@@ -25,6 +25,8 @@
 #include <duckdb.hpp>
 #include <duckdb/execution/expression_executor.hpp>
 #include <iresearch/formats/column/hnsw_index.hpp>
+#include <iresearch/search/filter.hpp>
+#include <iresearch/search/proxy_filter.hpp>
 #include <memory>
 #include <string>
 #include <vector>
@@ -72,6 +74,7 @@ struct SearchAnnScanLocalState : public CommonScanLocalState {
   SearchAnnScanLocalState(float* dis_data, int64_t* ids_data, size_t size)
     : buffer{dis_data, ids_data, size} {}
   irs::HNSWSearchBuffer buffer;
+  irs::Filter::Query::ptr text_filter_query;
 };
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> SearchAnnScanInitGlobal(
@@ -107,6 +110,7 @@ struct SearchRangeScanLocalState : public CommonScanLocalState {
   size_t current_idx = 0;
   irs::HNSWRangeSearchBuffer range_buffer;
   std::vector<uint32_t> lookup_scratch;
+  irs::Filter::Query::ptr text_filter_query;
 };
 
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> SearchRangeScanInitGlobal(

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -46,6 +46,7 @@
 #include "connector/duckdb_sk_point_lookup.hpp"
 #include "connector/duckdb_sk_range_scan.hpp"
 #include "connector/rocksdb_filter.hpp"
+#include "connector/search_filter_printer.hpp"
 #include "functions/search.h"
 #include "pg/connection_context.h"
 #include "search/inverted_index_shard.h"
@@ -430,11 +431,22 @@ void SkRangeScan::AppendSummary(
 namespace {
 
 void AppendVectorSearchSummary(
-  const VectorSearchScan& scan,
+  const SereneDBScanBindData& bind, const VectorSearchScan& scan,
   duckdb::InsertionOrderPreservingMap<std::string>& out) {
   out.insert("Dims", std::to_string(scan.query_vector.size()));
-  if (!scan.text_filter_summary.empty()) {
-    out.insert("TextFilter", scan.text_filter_summary);
+  if (scan.text_filter_root) {
+    auto col_name = [&bind](catalog::Column::Id col_id) -> std::string_view {
+      static thread_local std::string fallback;
+      auto name = bind.ColumnNameById(col_id);
+      if (!name.empty()) {
+        return name;
+      }
+      fallback = absl::StrCat("col", col_id);
+      return fallback;
+    };
+    SDB_ASSERT(scan.text_filter_root);
+    out.insert("TextFilter",
+               irs::ToStringDemangled(*scan.text_filter_root, col_name));
   }
   if (!scan.filter_expression) {
     return;
@@ -449,17 +461,17 @@ void AppendVectorSearchSummary(
 }  // namespace
 
 void ANNScan::AppendSummary(
-  const SereneDBScanBindData& /*bind*/,
+  const SereneDBScanBindData& bind,
   duckdb::InsertionOrderPreservingMap<std::string>& out) const {
   out.insert("TopK", std::to_string(top_k));
-  AppendVectorSearchSummary(*this, out);
+  AppendVectorSearchSummary(bind, *this, out);
 }
 
 void RangeSearchScan::AppendSummary(
-  const SereneDBScanBindData& /*bind*/,
+  const SereneDBScanBindData& bind,
   duckdb::InsertionOrderPreservingMap<std::string>& out) const {
   out.insert("Radius", std::to_string(radius));
-  AppendVectorSearchSummary(*this, out);
+  AppendVectorSearchSummary(bind, *this, out);
 }
 
 void CountScan::AppendSummary(

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -433,6 +433,9 @@ void AppendVectorSearchSummary(
   const VectorSearchScan& scan,
   duckdb::InsertionOrderPreservingMap<std::string>& out) {
   out.insert("Dims", std::to_string(scan.query_vector.size()));
+  if (!scan.text_filter_summary.empty()) {
+    out.insert("TextFilter", scan.text_filter_summary);
+  }
   if (!scan.filter_expression) {
     return;
   }

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -229,6 +229,9 @@ struct VectorSearchScan : ScanSource {
   std::vector<float> query_vector;
   duckdb::unique_ptr<duckdb::Expression> filter_expression;
   std::vector<catalog::Column::Id> filter_column_ids;
+
+  std::unique_ptr<irs::Filter> stored_text_filter;
+  std::string text_filter_summary;
 };
 
 struct ANNScan : VectorSearchScan {

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -231,7 +231,7 @@ struct VectorSearchScan : ScanSource {
   std::vector<catalog::Column::Id> filter_column_ids;
 
   std::unique_ptr<irs::Filter> stored_text_filter;
-  std::string text_filter_summary;
+  irs::Filter* text_filter_root = nullptr;
 };
 
 struct ANNScan : VectorSearchScan {

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -45,8 +45,11 @@
 #include <duckdb/planner/operator/logical_order.hpp>
 #include <duckdb/planner/operator/logical_projection.hpp>
 #include <duckdb/planner/operator/logical_top_n.hpp>
+#include <iresearch/search/boolean_filter.hpp>
+#include <iresearch/search/proxy_filter.hpp>
 
 #include "basics/down_cast.h"
+#include "basics/resource_manager.hpp"
 #include "catalog/catalog.h"
 #include "catalog/inverted_index.h"
 #include "connector/duckdb_index_scan_entry.h"
@@ -308,7 +311,165 @@ bool RewriteFilterColumnRefs(
   return ok;
 }
 
-bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
+struct SearchColumnContext {
+  duckdb::TableIndex table_index;
+  std::span<const catalog::Column::Id> projected_column_ids;
+  containers::FlatHashMap<catalog::Column::Id, duckdb::LogicalType>
+    column_type_by_id;
+  containers::FlatHashSet<catalog::Column::Id> indexed_column_ids;
+  std::function<catalog::ColumnTokenizer(catalog::Column::Id)>
+    tokenizer_provider;
+  // Optional JSON-path tokenizer lookup: returns the per-path tokenizer
+  // resolved against the catalog, or nullopt if the column is not
+  // indexed at `path`.
+  std::function<std::optional<catalog::ColumnTokenizer>(
+    catalog::Column::Id, std::span<const std::string>)>
+    json_path_tokenizer_provider;
+};
+
+connector::ColumnGetter MakeColumnGetter(SearchColumnContext& ctx) {
+  return [&ctx](const duckdb::BoundColumnRefExpression& ref)
+           -> std::optional<connector::SearchColumnInfo> {
+    if (ref.binding.table_index != ctx.table_index) {
+      return std::nullopt;
+    }
+    if (ref.binding.column_index >= ctx.projected_column_ids.size()) {
+      return std::nullopt;
+    }
+    const auto col_id = ctx.projected_column_ids[ref.binding.column_index];
+    if (col_id == std::numeric_limits<catalog::Column::Id>::max()) {
+      return std::nullopt;
+    }
+    if (!ctx.indexed_column_ids.contains(col_id)) {
+      return std::nullopt;
+    }
+    auto type_it = ctx.column_type_by_id.find(col_id);
+    if (type_it == ctx.column_type_by_id.end()) {
+      return std::nullopt;
+    }
+    connector::SearchColumnInfo info;
+    info.column_id = col_id;
+    info.logical_type = type_it->second;
+    info.tokenizer = ctx.tokenizer_provider(col_id);
+    return info;
+  };
+}
+
+connector::JsonPathGetter MakeJsonPathGetter(SearchColumnContext& ctx) {
+  return [&ctx](const duckdb::BoundColumnRefExpression& ref,
+                std::span<const std::string> path)
+           -> std::optional<connector::SearchColumnInfo> {
+    if (ref.binding.table_index != ctx.table_index) {
+      return std::nullopt;
+    }
+    if (ref.binding.column_index >= ctx.projected_column_ids.size()) {
+      return std::nullopt;
+    }
+    const auto col_id = ctx.projected_column_ids[ref.binding.column_index];
+    if (col_id == std::numeric_limits<catalog::Column::Id>::max()) {
+      return std::nullopt;
+    }
+    if (!ctx.json_path_tokenizer_provider) {
+      return std::nullopt;
+    }
+    auto tokenizer = ctx.json_path_tokenizer_provider(col_id, path);
+    if (!tokenizer) {
+      return std::nullopt;
+    }
+    connector::SearchColumnInfo info;
+    info.column_id = col_id;
+    // The default leaf type is VARCHAR (the string-leaf path); the filter
+    // builder may override this when the user wraps the path in an
+    // explicit cast like `(content->>'val')::int`, so numeric/bool/null
+    // queries hit the right pre-emitted per-type field.
+    info.logical_type = duckdb::LogicalType::VARCHAR;
+    info.tokenizer = *std::move(tokenizer);
+    info.json_path.assign(path.begin(), path.end());
+    return info;
+  };
+}
+
+// Builds a SearchColumnContext for a LogicalGet that produces the same
+// column-id space as the bind data; reused by TryAnnTopk / TryAnnRange to
+// drive iresearch text-filter pushdown.
+void InitSearchColumnContextForGet(
+  SearchColumnContext& ctx,
+  std::vector<catalog::Column::Id>& projected_ids_storage,
+  const duckdb::LogicalGet& get,
+  const connector::SereneDBScanBindData& bind_data,
+  const ResolvedIresearch& resolved,
+  std::shared_ptr<const catalog::Snapshot> snapshot) {
+  constexpr auto kInvalidId = std::numeric_limits<catalog::Column::Id>::max();
+  projected_ids_storage.clear();
+  projected_ids_storage.reserve(get.GetColumnIds().size());
+  for (const auto& ci : get.GetColumnIds()) {
+    if (!ci.HasPrimaryIndex()) {
+      projected_ids_storage.push_back(kInvalidId);
+      continue;
+    }
+    const auto phys = ci.GetPrimaryIndex();
+    projected_ids_storage.push_back(phys < bind_data.column_ids.size()
+                                      ? bind_data.column_ids[phys]
+                                      : kInvalidId);
+  }
+  ctx.table_index = get.table_index;
+  ctx.projected_column_ids = projected_ids_storage;
+  bind_data.IterateColumns(
+    [&](catalog::Column::Id id, const duckdb::LogicalType& type) {
+      ctx.column_type_by_id.emplace(id, type);
+    });
+  for (auto col_id : resolved.index->GetColumnIds()) {
+    ctx.indexed_column_ids.insert(col_id);
+  }
+  auto index_ptr = resolved.index;
+  ctx.tokenizer_provider = [index_ptr, snapshot](catalog::Column::Id col_id) {
+    return index_ptr->GetColumnTokenizer(snapshot, col_id);
+  };
+  ctx.json_path_tokenizer_provider = [index_ptr, snapshot](
+                                       catalog::Column::Id col_id,
+                                       std::span<const std::string> path) {
+    return index_ptr->GetJsonPathTokenizer(snapshot, col_id, path);
+  };
+}
+
+// Returns a column-name lookup suitable for `irs::ToStringDemangled`.
+// Falls back to "col<id>" for ids not known to the bind data; the
+// fallback string lives in a thread-local so the returned string_view
+// stays valid for the duration of one printer invocation.
+auto MakeColumnNameLookup(const connector::SereneDBScanBindData& bind_data) {
+  return [&bind_data](catalog::Column::Id col_id) -> std::string_view {
+    static thread_local std::string fallback;
+    auto name = bind_data.ColumnNameById(col_id);
+    if (!name.empty()) {
+      return name;
+    }
+    fallback = absl::StrCat("col", col_id);
+    return fallback;
+  };
+}
+
+// Try to push a single residual conjunct into `and_root` as an iresearch
+// filter. Snapshots `and_root.size()` so we can roll back on failure.
+bool TryClaimIresearchConjunct(
+  irs::And& and_root, const duckdb::unique_ptr<duckdb::Expression>& conjunct,
+  const connector::ColumnGetter& getter,
+  const connector::JsonPathGetter& json_getter,
+  const connector::SearchFilterOptions& options) {
+  const auto before = and_root.size();
+  std::span<const duckdb::unique_ptr<duckdb::Expression>> single{&conjunct, 1};
+  auto r =
+    connector::MakeSearchFilter(and_root, single, getter, options, json_getter);
+  if (r.ok() && and_root.size() > before) {
+    return true;
+  }
+  while (and_root.size() > before) {
+    and_root.PopBack();
+  }
+  return false;
+}
+
+bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
+                const connector::SearchFilterOptions& options) {
   if (plan->type != duckdb::LogicalOperatorType::LOGICAL_TOP_N) {
     return false;
   }
@@ -427,12 +588,44 @@ bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
   ann->query_vector = std::move(query_vector);
   ann->top_k = static_cast<size_t>(top_n.limit);
 
+  // Claim iresearch-indexable conjuncts as a cheap text filter; the rest
+  // fall through to the existing row-by-row ANNFilter.
+  SearchColumnContext sctx;
+  std::vector<catalog::Column::Id> proj_ids_storage;
+  InitSearchColumnContextForGet(sctx, proj_ids_storage, get, bind_data,
+                                *resolved, snapshot);
+  auto getter = MakeColumnGetter(sctx);
+  auto json_getter = MakeJsonPathGetter(sctx);
+
+  auto proxy = std::make_unique<irs::ProxyFilter>();
+  auto [and_root, cache] =
+    proxy->set_filter<irs::And>(irs::IResourceManager::gNoop);
+
+  std::vector<std::vector<bool>> claimed_per_filter;
+  bool any_claimed = false;
+  claimed_per_filter.reserve(residual_filters.size());
+  for (auto* f : residual_filters) {
+    std::vector<bool> claimed(f->expressions.size(), false);
+    for (size_t i = 0; i < f->expressions.size(); ++i) {
+      if (TryClaimIresearchConjunct(and_root, f->expressions[i], getter,
+                                    json_getter, options)) {
+        claimed[i] = true;
+        any_claimed = true;
+      }
+    }
+    claimed_per_filter.push_back(std::move(claimed));
+  }
+
   bool pushdown_filter = true;
   std::vector<duckdb::unique_ptr<duckdb::Expression>> rewritten_exprs;
   std::vector<catalog::Column::Id> filter_col_ids;
-  for (auto* f : residual_filters) {
-    for (auto& e : f->expressions) {
-      auto copy = e->Copy();
+  for (size_t fi = 0; fi < residual_filters.size(); ++fi) {
+    auto* f = residual_filters[fi];
+    for (size_t i = 0; i < f->expressions.size(); ++i) {
+      if (claimed_per_filter[fi][i]) {
+        continue;
+      }
+      auto copy = f->expressions[i]->Copy();
       if (!RewriteFilterColumnRefs(*copy, get, bind_data, filter_col_ids)) {
         pushdown_filter = false;
         break;
@@ -447,6 +640,11 @@ bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
     ann->filter_expression =
       CombineFilterExpressions(std::move(rewritten_exprs));
     ann->filter_column_ids = std::move(filter_col_ids);
+    if (any_claimed) {
+      ann->text_filter_summary =
+        irs::ToStringDemangled(and_root, MakeColumnNameLookup(bind_data));
+      ann->stored_text_filter = std::move(proxy);
+    }
   }
 
   bind_data.scan_source = std::move(ann);
@@ -461,7 +659,8 @@ bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
   return true;
 }
 
-bool TryAnnRange(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
+bool TryAnnRange(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
+                 const connector::SearchFilterOptions& options) {
   if (plan->type != duckdb::LogicalOperatorType::LOGICAL_FILTER) {
     return false;
   }
@@ -617,11 +816,37 @@ bool TryAnnRange(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
 
   filter.expressions.erase(filter.expressions.begin() + match_idx);
 
+  // Claim iresearch-indexable conjuncts as a cheap text filter; the rest
+  // fall through to the existing row-by-row ANNFilter.
+  SearchColumnContext sctx;
+  std::vector<catalog::Column::Id> proj_ids_storage;
+  InitSearchColumnContextForGet(sctx, proj_ids_storage, get, bind_data,
+                                *resolved, snapshot);
+  auto getter = MakeColumnGetter(sctx);
+  auto json_getter = MakeJsonPathGetter(sctx);
+
+  auto proxy = std::make_unique<irs::ProxyFilter>();
+  auto [and_root, cache] =
+    proxy->set_filter<irs::And>(irs::IResourceManager::gNoop);
+
+  std::vector<bool> claimed(filter.expressions.size(), false);
+  bool any_claimed = false;
+  for (size_t i = 0; i < filter.expressions.size(); ++i) {
+    if (TryClaimIresearchConjunct(and_root, filter.expressions[i], getter,
+                                  json_getter, options)) {
+      claimed[i] = true;
+      any_claimed = true;
+    }
+  }
+
   bool pushdown_filter = true;
   std::vector<duckdb::unique_ptr<duckdb::Expression>> rewritten_exprs;
   std::vector<catalog::Column::Id> filter_col_ids;
-  for (auto& e : filter.expressions) {
-    auto copy = e->Copy();
+  for (size_t i = 0; i < filter.expressions.size(); ++i) {
+    if (claimed[i]) {
+      continue;
+    }
+    auto copy = filter.expressions[i]->Copy();
     if (!RewriteFilterColumnRefs(*copy, get, bind_data, filter_col_ids)) {
       pushdown_filter = false;
       break;
@@ -632,6 +857,11 @@ bool TryAnnRange(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
     rss->filter_expression =
       CombineFilterExpressions(std::move(rewritten_exprs));
     rss->filter_column_ids = std::move(filter_col_ids);
+    if (any_claimed) {
+      rss->text_filter_summary =
+        irs::ToStringDemangled(and_root, MakeColumnNameLookup(bind_data));
+      rss->stored_text_filter = std::move(proxy);
+    }
     filter.expressions.clear();
   }
 
@@ -642,84 +872,6 @@ bool TryAnnRange(duckdb::unique_ptr<duckdb::LogicalOperator>& plan) {
     plan = std::move(filter.children[0]);
   }
   return true;
-}
-
-struct SearchColumnContext {
-  duckdb::TableIndex table_index;
-  std::span<const catalog::Column::Id> projected_column_ids;
-  containers::FlatHashMap<catalog::Column::Id, duckdb::LogicalType>
-    column_type_by_id;
-  containers::FlatHashSet<catalog::Column::Id> indexed_column_ids;
-  std::function<catalog::ColumnTokenizer(catalog::Column::Id)>
-    tokenizer_provider;
-  // Optional JSON-path tokenizer lookup: returns the per-path tokenizer
-  // resolved against the catalog, or nullopt if the column is not
-  // indexed at `path`.
-  std::function<std::optional<catalog::ColumnTokenizer>(
-    catalog::Column::Id, std::span<const std::string>)>
-    json_path_tokenizer_provider;
-};
-
-connector::ColumnGetter MakeColumnGetter(SearchColumnContext& ctx) {
-  return [&ctx](const duckdb::BoundColumnRefExpression& ref)
-           -> std::optional<connector::SearchColumnInfo> {
-    if (ref.binding.table_index != ctx.table_index) {
-      return std::nullopt;
-    }
-    if (ref.binding.column_index >= ctx.projected_column_ids.size()) {
-      return std::nullopt;
-    }
-    const auto col_id = ctx.projected_column_ids[ref.binding.column_index];
-    if (col_id == std::numeric_limits<catalog::Column::Id>::max()) {
-      return std::nullopt;
-    }
-    if (!ctx.indexed_column_ids.contains(col_id)) {
-      return std::nullopt;
-    }
-    auto type_it = ctx.column_type_by_id.find(col_id);
-    if (type_it == ctx.column_type_by_id.end()) {
-      return std::nullopt;
-    }
-    connector::SearchColumnInfo info;
-    info.column_id = col_id;
-    info.logical_type = type_it->second;
-    info.tokenizer = ctx.tokenizer_provider(col_id);
-    return info;
-  };
-}
-
-connector::JsonPathGetter MakeJsonPathGetter(SearchColumnContext& ctx) {
-  return [&ctx](const duckdb::BoundColumnRefExpression& ref,
-                std::span<const std::string> path)
-           -> std::optional<connector::SearchColumnInfo> {
-    if (ref.binding.table_index != ctx.table_index) {
-      return std::nullopt;
-    }
-    if (ref.binding.column_index >= ctx.projected_column_ids.size()) {
-      return std::nullopt;
-    }
-    const auto col_id = ctx.projected_column_ids[ref.binding.column_index];
-    if (col_id == std::numeric_limits<catalog::Column::Id>::max()) {
-      return std::nullopt;
-    }
-    if (!ctx.json_path_tokenizer_provider) {
-      return std::nullopt;
-    }
-    auto tokenizer = ctx.json_path_tokenizer_provider(col_id, path);
-    if (!tokenizer) {
-      return std::nullopt;
-    }
-    connector::SearchColumnInfo info;
-    info.column_id = col_id;
-    // The default leaf type is VARCHAR (the string-leaf path); the filter
-    // builder may override this when the user wraps the path in an
-    // explicit cast like `(content->>'val')::int`, so numeric/bool/null
-    // queries hit the right pre-emitted per-type field.
-    info.logical_type = duckdb::LogicalType::VARCHAR;
-    info.tokenizer = *std::move(tokenizer);
-    info.json_path.assign(path.begin(), path.end());
-    return info;
-  };
 }
 
 bool TrySearchFilter(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
@@ -762,42 +914,10 @@ bool TrySearchFilter(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
     return false;
   }
 
-  // ctx.projected_column_ids spans projected_ids -- it must outlive ctx.
-  constexpr auto kInvalidId = std::numeric_limits<catalog::Column::Id>::max();
-  std::vector<catalog::Column::Id> projected_ids;
-  projected_ids.reserve(get.GetColumnIds().size());
-  for (const auto& ci : get.GetColumnIds()) {
-    if (!ci.HasPrimaryIndex()) {
-      projected_ids.push_back(kInvalidId);
-      continue;
-    }
-    const auto phys = ci.GetPrimaryIndex();
-    projected_ids.push_back(phys < bind_data.column_ids.size()
-                              ? bind_data.column_ids[phys]
-                              : kInvalidId);
-  }
   SearchColumnContext ctx;
-  ctx.table_index = get.table_index;
-  ctx.projected_column_ids = projected_ids;
-
-  bind_data.IterateColumns(
-    [&](catalog::Column::Id id, const duckdb::LogicalType& type) {
-      ctx.column_type_by_id.emplace(id, type);
-    });
-  for (auto col_id : resolved->index->GetColumnIds()) {
-    ctx.indexed_column_ids.insert(col_id);
-  }
-  auto index_ptr = resolved->index;
-  auto snapshot_for_analyzer = snapshot;
-  ctx.tokenizer_provider = [index_ptr,
-                            snapshot_for_analyzer](catalog::Column::Id col_id) {
-    return index_ptr->GetColumnTokenizer(snapshot_for_analyzer, col_id);
-  };
-  ctx.json_path_tokenizer_provider = [index_ptr, snapshot_for_analyzer](
-                                       catalog::Column::Id col_id,
-                                       std::span<const std::string> path) {
-    return index_ptr->GetJsonPathTokenizer(snapshot_for_analyzer, col_id, path);
-  };
+  std::vector<catalog::Column::Id> projected_ids;
+  InitSearchColumnContextForGet(ctx, projected_ids, get, bind_data, *resolved,
+                                snapshot);
   auto getter = MakeColumnGetter(ctx);
   auto json_getter = MakeJsonPathGetter(ctx);
 
@@ -867,17 +987,8 @@ bool TrySearchFilter(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
 
   // Capture the demangled filter summary BEFORE preparing (prepare
   // consumes the tree into an opaque Query).
-  auto col_name_lookup =
-    [&bind_data](catalog::Column::Id col_id) -> std::string_view {
-    static thread_local std::string fallback;
-    auto name = bind_data.ColumnNameById(col_id);
-    if (!name.empty()) {
-      return name;
-    }
-    fallback = absl::StrCat("col", col_id);
-    return fallback;
-  };
-  std::string filter_summary = irs::ToStringDemangled(*root, col_name_lookup);
+  std::string filter_summary =
+    irs::ToStringDemangled(*root, MakeColumnNameLookup(bind_data));
 
   auto search = std::make_unique<connector::SearchScan>();
   search->snapshot = resolved->shard->GetInvertedIndexSnapshot();
@@ -2034,7 +2145,7 @@ class IresearchPlanOptimizer : public duckdb::OptimizerExtension {
     duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
     const connector::SearchFilterOptions& options) {
     if (plan->type == duckdb::LogicalOperatorType::LOGICAL_TOP_N) {
-      if (TryAnnTopk(plan)) {
+      if (TryAnnTopk(plan, options)) {
         return true;
       }
       bool changed = TryAttachScoreTopK(plan);
@@ -2068,7 +2179,7 @@ class IresearchPlanOptimizer : public duckdb::OptimizerExtension {
       return changed;
     }
     if (plan->type == duckdb::LogicalOperatorType::LOGICAL_FILTER) {
-      if (TryAnnRange(plan)) {
+      if (TryAnnRange(plan, options)) {
         return true;
       }
       bool changed = TrySearchFilter(plan, options);
@@ -2132,22 +2243,23 @@ class IresearchPlanOptimizer : public duckdb::OptimizerExtension {
   }
 
   static bool TopDownAnnPass(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
-                             bool in_mutation) {
+                             bool in_mutation,
+                             const connector::SearchFilterOptions& options) {
     const bool subtree_in_mutation = in_mutation || IsMutationOp(plan->type);
     bool changed = false;
     if (!subtree_in_mutation) {
       if (plan->type == duckdb::LogicalOperatorType::LOGICAL_TOP_N) {
-        if (TryAnnTopk(plan)) {
+        if (TryAnnTopk(plan, options)) {
           changed = true;
         }
       } else if (plan->type == duckdb::LogicalOperatorType::LOGICAL_FILTER) {
-        if (TryAnnRange(plan)) {
+        if (TryAnnRange(plan, options)) {
           changed = true;
         }
       }
     }
     for (auto& child : plan->children) {
-      changed |= TopDownAnnPass(child, subtree_in_mutation);
+      changed |= TopDownAnnPass(child, subtree_in_mutation, options);
     }
     return changed;
   }
@@ -2209,7 +2321,7 @@ class IresearchPlanOptimizer : public duckdb::OptimizerExtension {
         options.scored_terms_limit = static_cast<size_t>(v.GetValue<int32_t>());
       }
     }
-    bool changed = TopDownAnnPass(plan, /*in_mutation=*/false);
+    bool changed = TopDownAnnPass(plan, /*in_mutation=*/false, options);
     changed |= Walk(plan, plan, /*in_mutation=*/false, /*pass=*/1, options);
     changed |= Walk(plan, plan, /*in_mutation=*/false, /*pass=*/2, options);
 

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -420,9 +420,6 @@ void InitSearchColumnContextForGet(
     });
   auto columns = resolved.index->GetColumnIds();
   ctx.indexed_column_ids.insert(columns.begin(), columns.end());
-  for (auto col_id : resolved.index->GetColumnIds()) {
-    ctx.indexed_column_ids.insert(col_id);
-  }
   auto index_ptr = resolved.index;
   ctx.tokenizer_provider = [index_ptr, snapshot](catalog::Column::Id col_id) {
     return index_ptr->GetColumnTokenizer(snapshot, col_id);

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -418,6 +418,8 @@ void InitSearchColumnContextForGet(
     [&](catalog::Column::Id id, const duckdb::LogicalType& type) {
       ctx.column_type_by_id.emplace(id, type);
     });
+  auto columns = resolved.index->GetColumnIds();
+  ctx.indexed_column_ids.insert(columns.begin(), columns.end());
   for (auto col_id : resolved.index->GetColumnIds()) {
     ctx.indexed_column_ids.insert(col_id);
   }
@@ -613,7 +615,7 @@ bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
         any_claimed = true;
       }
     }
-    claimed_per_filter.push_back(std::move(claimed));
+    claimed_per_filter.emplace_back(std::move(claimed));
   }
 
   bool pushdown_filter = true;
@@ -641,8 +643,7 @@ bool TryAnnTopk(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
       CombineFilterExpressions(std::move(rewritten_exprs));
     ann->filter_column_ids = std::move(filter_col_ids);
     if (any_claimed) {
-      ann->text_filter_summary =
-        irs::ToStringDemangled(and_root, MakeColumnNameLookup(bind_data));
+      ann->text_filter_root = &and_root;
       ann->stored_text_filter = std::move(proxy);
     }
   }
@@ -858,8 +859,7 @@ bool TryAnnRange(duckdb::unique_ptr<duckdb::LogicalOperator>& plan,
       CombineFilterExpressions(std::move(rewritten_exprs));
     rss->filter_column_ids = std::move(filter_col_ids);
     if (any_claimed) {
-      rss->text_filter_summary =
-        irs::ToStringDemangled(and_root, MakeColumnNameLookup(bind_data));
+      rss->text_filter_root = &and_root;
       rss->stored_text_filter = std::move(proxy);
     }
     filter.expressions.clear();

--- a/tests/sqllogic/sdb/pg/index/vector_search.test
+++ b/tests/sqllogic/sdb/pg/index/vector_search.test
@@ -771,7 +771,7 @@ CREATE TABLE t_proj (id INT, category INT, payload VARCHAR, emb FLOAT[3]);
 
 
 statement ok
-CREATE INDEX proj_idx ON t_proj USING inverted(id, category, emb hnsw (metric = 'l2'));
+CREATE INDEX proj_idx ON t_proj USING inverted(emb hnsw (metric = 'l2'));
 
 
 statement count 4
@@ -886,7 +886,7 @@ QUERY PLAN
 
 
 statement ok
-CREATE TEXT SEARCH DICTIONARY en(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false);
+CREATE TEXT SEARCH DICTIONARY en(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true);
 
 
 statement ok
@@ -894,7 +894,7 @@ CREATE TABLE t_mixed (id INT, body VARCHAR, emb FLOAT[3]);
 
 
 statement ok
-CREATE INDEX mixed_idx ON t_mixed USING inverted(id, body en, emb hnsw (metric = 'l2'));
+CREATE INDEX mixed_idx ON t_mixed USING inverted(body en, emb hnsw (metric = 'l2'));
 
 
 statement count 4
@@ -926,6 +926,208 @@ SELECT id FROM mixed_idx WHERE id % 2 = 1 ORDER BY emb <-> [0, 0, 0]::FLOAT[3] L
 id
 3
 1
+
+
+query
+EXPLAIN SELECT id FROM mixed_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+QUERY PLAN
+┌───────────────────────────┐
+│     IRESEARCH_ANN_SCAN    │
+│    ────────────────────   │
+│      Index: mixed_idx     │
+│      Lookup: rocksdb      │
+│          TopK: 2          │
+│          Dims: 3          │
+│                           │
+│        TextFilter:        │
+│ AND[PHRASE[body(string) = │
+│    <Term:red(0, 0); >]]   │
+│                           │
+│      Projections: id      │
+│                           │
+│          ~4 rows          │
+└───────────────────────────┘
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+3
+
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 1;
+----
+id
+1
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_phrase('blue cat') ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+2
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_any(['fox', 'bird']) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+3
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_any(['red', 'blue']) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 4;
+----
+id
+1
+3
+2
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_all(['red', 'fox']) ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_all(['blue', 'dog']) ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_starts_with('re') ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+3
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_starts_with('bl') ORDER BY emb <-> [50, 50, 50]::FLOAT[3] LIMIT 2;
+----
+id
+2
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_like('re_') ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+3
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_like('b%') ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 4;
+----
+id
+3
+2
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_regexp('bl.*') ORDER BY emb <-> [50, 50, 50]::FLOAT[3] LIMIT 2;
+----
+id
+2
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_ngram('blue') ORDER BY emb <-> [50, 50, 50]::FLOAT[3] LIMIT 2;
+----
+id
+2
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE body @@ ts_levenshtein('rid', 1) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+3
+
+
+# Hybrid: rocksdb id filter + text index filter
+query
+EXPLAIN SELECT id FROM mixed_idx WHERE id > 2 AND body @@ ts_any(['red', 'blue']) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+QUERY PLAN
+┌───────────────────────────┐
+│     IRESEARCH_ANN_SCAN    │
+│    ────────────────────   │
+│      Index: mixed_idx     │
+│      Lookup: rocksdb      │
+│          TopK: 2          │
+│          Dims: 3          │
+│                           │
+│        TextFilter:        │
+│  AND[OR[Term(body(string) │
+│ =red) || Term(body(string)│
+│          =blue)]]         │
+│                           │
+│      Filter: (#0 > 2)     │
+│      Projections: id      │
+│                           │
+│          ~4 rows          │
+└───────────────────────────┘
+
+
+query
+SELECT id FROM mixed_idx WHERE id > 2 AND body @@ ts_any(['red', 'blue']) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+3
+4
+
+
+query
+SELECT id FROM mixed_idx WHERE id IN (2, 3) AND body @@ ts_starts_with('re') ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+3
+
+
+query
+SELECT id FROM mixed_idx WHERE id % 2 = 1 AND body @@ ts_starts_with('bl') ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+
+
+query
+SELECT id FROM mixed_idx WHERE id < 4 AND body @@ ts_phrase('blue cat') ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+2
+
+
+query
+SELECT id FROM mixed_idx WHERE id >= 1 AND body @@ ts_all(['red', 'fox']) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+
+
+query
+SELECT id FROM mixed_idx WHERE (id = 1 OR id = 4) AND body @@ ts_any(['fox', 'dog']) ORDER BY emb <-> [50, 0, 0]::FLOAT[3] LIMIT 2;
+----
+id
+1
+4
 
 
 statement ok

--- a/tests/sqllogic/sdb/pg/index/vector_search.test_slow
+++ b/tests/sqllogic/sdb/pg/index/vector_search.test_slow
@@ -359,7 +359,3 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_hybrid2 WHERE id IN (SELECT
 ----
 ?column?
 t
-
-
-statement ok
-SET sdb_ef_search TO 512;

--- a/tests/sqllogic/sdb/pg/index/vector_search.test_slow
+++ b/tests/sqllogic/sdb/pg/index/vector_search.test_slow
@@ -37,7 +37,7 @@ INSERT INTO correct_filtered SELECT id FROM vecs WHERE id > 25000 ORDER BY emb <
 
 
 statement ok
-CREATE INDEX vecs_hnsw ON vecs USING inverted(id, emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
+CREATE INDEX vecs_hnsw ON vecs USING inverted(emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
 
 
 statement ok
@@ -204,3 +204,162 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_ip WHERE id IN (SELECT id FROM r
 ----
 ?column?
 t
+
+
+# Hybrid recall: text-index filter + ANN, and text + rocksdb + ANN
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY en(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true);
+
+
+statement ok
+CREATE TABLE vecs_text (id INT, body VARCHAR, emb FLOAT[8]);
+
+
+statement ok
+INSERT INTO vecs_text
+SELECT
+  s AS id,
+  CASE s % 4
+    WHEN 0 THEN 'red fox'
+    WHEN 1 THEN 'blue cat'
+    WHEN 2 THEN 'green bird'
+    ELSE 'yellow dog'
+  END AS body,
+  [
+    sin(s * 0.001)::FLOAT,
+    cos(s * 0.001)::FLOAT,
+    sin(s * 0.003)::FLOAT,
+    cos(s * 0.003)::FLOAT,
+    sin(s * 0.007)::FLOAT,
+    cos(s * 0.007)::FLOAT,
+    sin(s * 0.013)::FLOAT,
+    cos(s * 0.013)::FLOAT
+  ]::FLOAT[8] AS emb
+FROM generate_series(1, 50000) AS s;
+
+
+# Brute-force ground truth for hybrid queries (computed via base table, no ANN index yet)
+
+statement ok
+CREATE TABLE correct_text_phrase(id INT);
+
+
+statement ok
+INSERT INTO correct_text_phrase SELECT id FROM vecs_text WHERE body = 'red fox' ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_any(id INT);
+
+
+statement ok
+INSERT INTO correct_text_any SELECT id FROM vecs_text WHERE body IN ('red fox', 'blue cat') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_starts(id INT);
+
+
+statement ok
+INSERT INTO correct_text_starts SELECT id FROM vecs_text WHERE body = 'green bird' ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_all(id INT);
+
+
+statement ok
+INSERT INTO correct_text_all SELECT id FROM vecs_text WHERE body = 'blue cat' ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_hybrid(id INT);
+
+
+statement ok
+INSERT INTO correct_text_hybrid SELECT id FROM vecs_text WHERE body IN ('red fox', 'blue cat') AND id > 10000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_hybrid2(id INT);
+
+
+statement ok
+INSERT INTO correct_text_hybrid2 SELECT id FROM vecs_text WHERE body = 'red fox' AND id % 2 = 0 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE INDEX vecs_text_idx ON vecs_text USING inverted(id, body en, emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
+
+
+statement ok
+VACUUM (UPDATE_INDEXES) vecs_text;
+
+
+# Filtered ANN needs higher efSearch to maintain recall
+statement ok
+SET sdb_ef_search TO 4096;
+
+
+# Text filter (ts_phrase) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_phrase WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Text filter (ts_any) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_idx WHERE body @@ ts_any(['red', 'blue']) ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_any WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Text filter (ts_starts_with) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_idx WHERE body @@ ts_starts_with('gr') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_starts WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Text filter (ts_all) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_idx WHERE body @@ ts_all(['blue', 'cat']) ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_all WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Hybrid: text filter + rocksdb (id) filter + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_idx WHERE body @@ ts_any(['red', 'blue']) AND id > 10000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_hybrid WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+query
+WITH
+  result AS (SELECT id FROM vecs_text_idx WHERE body @@ ts_starts_with('re') AND id % 2 = 0 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_hybrid2 WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+statement ok
+SET sdb_ef_search TO 512;

--- a/tests/sqllogic/sdb/pg/index/vector_search_view.test_slow
+++ b/tests/sqllogic/sdb/pg/index/vector_search_view.test_slow
@@ -35,8 +35,6 @@ statement ok
 INSERT INTO correct_filtered SELECT id FROM vecs WHERE id > 25000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
 
 
-# Text-side ground truths
-
 statement ok
 CREATE TEXT SEARCH DICTIONARY en(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true);
 
@@ -120,17 +118,6 @@ statement ok
 SET sdb_ef_search TO 512;
 
 
-# =============================================================================
-# ANN over a parquet-backed view inverted index.
-#
-# Mirrors the recall tests above (same data, same query vector, same ground
-# truths in `correct`, `correct_filtered`, `correct_text_*`), but the source
-# is a single-file parquet read through a view instead of the base table.
-# Exercises the optimizer + IRESEARCH_ANN_SCAN path against
-# ViewFileSingleFileIndexSource for row materialisation.
-# =============================================================================
-
-# --- plain ANN top-k over a parquet view -------------------------------------
 
 statement ok
 COPY (SELECT id, emb FROM vecs)
@@ -147,7 +134,6 @@ CREATE INDEX vecs_pq_hnsw ON vecs_pq
 USING inverted(emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
 
 
-# Confirm the planner picks IRESEARCH_ANN_SCAN over the view-backed index.
 query
 EXPLAIN SELECT id FROM vecs_pq_hnsw ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 10;
 ----
@@ -174,8 +160,6 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct WHERE id IN (SELECT id FROM resu
 t
 
 
-# Filtered ANN over the view: residual scalar filter must materialise rows
-# from parquet via ViewFileSingleFileIndexSource.
 statement ok
 SET sdb_ef_search TO 2048;
 
@@ -211,8 +195,6 @@ statement ok
 SET sdb_ef_search TO 512;
 
 
-# --- hybrid: text filter + ANN over a parquet view --------------------------
-
 statement ok
 COPY (SELECT id, body, emb FROM vecs_text)
 TO '/tmp/${__DATABASE__}_vecs_text.parquet' (FORMAT PARQUET);
@@ -232,7 +214,6 @@ statement ok
 SET sdb_ef_search TO 4096;
 
 
-# Text filter (ts_phrase) + ANN
 query
 WITH
   result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
@@ -242,7 +223,6 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_phrase WHERE id IN (SELECT 
 t
 
 
-# Text filter (ts_any) + ANN
 query
 WITH
   result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_any(['red', 'blue']) ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
@@ -252,7 +232,6 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_any WHERE id IN (SELECT id 
 t
 
 
-# Text filter (ts_starts_with) + ANN
 query
 WITH
   result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_starts_with('gr') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
@@ -262,7 +241,6 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_starts WHERE id IN (SELECT 
 t
 
 
-# Text filter (ts_all) + ANN
 query
 WITH
   result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_all(['blue', 'cat']) ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
@@ -272,7 +250,6 @@ SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_all WHERE id IN (SELECT id 
 t
 
 
-# Hybrid: text filter + scalar (id) filter materialised from parquet + ANN
 query
 WITH
   result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_any(['red', 'blue']) AND id > 10000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)

--- a/tests/sqllogic/sdb/pg/index/vector_search_view.test_slow
+++ b/tests/sqllogic/sdb/pg/index/vector_search_view.test_slow
@@ -1,0 +1,295 @@
+statement ok
+CREATE TABLE vecs (id INT, emb FLOAT[8]);
+
+
+statement ok
+INSERT INTO vecs
+SELECT
+  s AS id,
+  [
+    sin(s * 0.001)::FLOAT,
+    cos(s * 0.001)::FLOAT,
+    sin(s * 0.003)::FLOAT,
+    cos(s * 0.003)::FLOAT,
+    sin(s * 0.007)::FLOAT,
+    cos(s * 0.007)::FLOAT,
+    sin(s * 0.013)::FLOAT,
+    cos(s * 0.013)::FLOAT
+  ]::FLOAT[8] AS emb
+FROM generate_series(1, 50000) AS s;
+
+
+statement ok
+CREATE TABLE correct(id INT);
+
+
+statement ok
+INSERT INTO correct SELECT id FROM vecs ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_filtered(id INT);
+
+
+statement ok
+INSERT INTO correct_filtered SELECT id FROM vecs WHERE id > 25000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+# Text-side ground truths
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY en(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true);
+
+
+statement ok
+CREATE TABLE vecs_text (id INT, body VARCHAR, emb FLOAT[8]);
+
+
+statement ok
+INSERT INTO vecs_text
+SELECT
+  s AS id,
+  CASE s % 4
+    WHEN 0 THEN 'red fox'
+    WHEN 1 THEN 'blue cat'
+    WHEN 2 THEN 'green bird'
+    ELSE 'yellow dog'
+  END AS body,
+  [
+    sin(s * 0.001)::FLOAT,
+    cos(s * 0.001)::FLOAT,
+    sin(s * 0.003)::FLOAT,
+    cos(s * 0.003)::FLOAT,
+    sin(s * 0.007)::FLOAT,
+    cos(s * 0.007)::FLOAT,
+    sin(s * 0.013)::FLOAT,
+    cos(s * 0.013)::FLOAT
+  ]::FLOAT[8] AS emb
+FROM generate_series(1, 50000) AS s;
+
+
+statement ok
+CREATE TABLE correct_text_phrase(id INT);
+
+
+statement ok
+INSERT INTO correct_text_phrase SELECT id FROM vecs_text WHERE body = 'red fox' ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_any(id INT);
+
+
+statement ok
+INSERT INTO correct_text_any SELECT id FROM vecs_text WHERE body IN ('red fox', 'blue cat') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_starts(id INT);
+
+
+statement ok
+INSERT INTO correct_text_starts SELECT id FROM vecs_text WHERE body = 'green bird' ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_all(id INT);
+
+
+statement ok
+INSERT INTO correct_text_all SELECT id FROM vecs_text WHERE body = 'blue cat' ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_hybrid(id INT);
+
+
+statement ok
+INSERT INTO correct_text_hybrid SELECT id FROM vecs_text WHERE body IN ('red fox', 'blue cat') AND id > 10000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+CREATE TABLE correct_text_hybrid2(id INT);
+
+
+statement ok
+INSERT INTO correct_text_hybrid2 SELECT id FROM vecs_text WHERE body = 'red fox' AND id % 2 = 0 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512;
+
+
+statement ok
+SET sdb_ef_search TO 512;
+
+
+# =============================================================================
+# ANN over a parquet-backed view inverted index.
+#
+# Mirrors the recall tests above (same data, same query vector, same ground
+# truths in `correct`, `correct_filtered`, `correct_text_*`), but the source
+# is a single-file parquet read through a view instead of the base table.
+# Exercises the optimizer + IRESEARCH_ANN_SCAN path against
+# ViewFileSingleFileIndexSource for row materialisation.
+# =============================================================================
+
+# --- plain ANN top-k over a parquet view -------------------------------------
+
+statement ok
+COPY (SELECT id, emb FROM vecs)
+TO '/tmp/${__DATABASE__}_vecs.parquet' (FORMAT PARQUET);
+
+
+statement ok
+CREATE VIEW vecs_pq AS
+SELECT id, emb::FLOAT[8] as emb FROM read_parquet('/tmp/${__DATABASE__}_vecs.parquet');
+
+
+statement ok
+CREATE INDEX vecs_pq_hnsw ON vecs_pq
+USING inverted(emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
+
+
+# Confirm the planner picks IRESEARCH_ANN_SCAN over the view-backed index.
+query
+EXPLAIN SELECT id FROM vecs_pq_hnsw ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 10;
+----
+QUERY PLAN
+┌───────────────────────────┐
+│     IRESEARCH_ANN_SCAN    │
+│    ────────────────────   │
+│    Index: vecs_pq_hnsw    │
+│      Lookup: parquet      │
+│          TopK: 10         │
+│          Dims: 8          │
+│      Projections: id      │
+│                           │
+│        ~50,000 rows       │
+└───────────────────────────┘
+
+
+query
+WITH
+  result AS (SELECT id FROM vecs_pq_hnsw ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Filtered ANN over the view: residual scalar filter must materialise rows
+# from parquet via ViewFileSingleFileIndexSource.
+statement ok
+SET sdb_ef_search TO 2048;
+
+
+query
+EXPLAIN SELECT id FROM vecs_pq_hnsw WHERE id > 25000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 10;
+----
+QUERY PLAN
+┌───────────────────────────┐
+│     IRESEARCH_ANN_SCAN    │
+│    ────────────────────   │
+│    Index: vecs_pq_hnsw    │
+│      Lookup: parquet      │
+│          TopK: 10         │
+│          Dims: 8          │
+│    Filter: (#0 > 25000)   │
+│      Projections: id      │
+│                           │
+│        ~50,000 rows       │
+└───────────────────────────┘
+
+
+query
+WITH
+  result AS (SELECT id FROM vecs_pq_hnsw WHERE id > 25000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_filtered WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+statement ok
+SET sdb_ef_search TO 512;
+
+
+# --- hybrid: text filter + ANN over a parquet view --------------------------
+
+statement ok
+COPY (SELECT id, body, emb FROM vecs_text)
+TO '/tmp/${__DATABASE__}_vecs_text.parquet' (FORMAT PARQUET);
+
+
+statement ok
+CREATE VIEW vecs_text_pq AS
+SELECT id, body, emb::FLOAT[8] as emb FROM read_parquet('/tmp/${__DATABASE__}_vecs_text.parquet');
+
+
+statement ok
+CREATE INDEX vecs_text_pq_idx ON vecs_text_pq
+USING inverted(id, body en, emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
+
+
+statement ok
+SET sdb_ef_search TO 4096;
+
+
+# Text filter (ts_phrase) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_phrase WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Text filter (ts_any) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_any(['red', 'blue']) ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_any WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Text filter (ts_starts_with) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_starts_with('gr') ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_starts WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Text filter (ts_all) + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_all(['blue', 'cat']) ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_all WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+# Hybrid: text filter + scalar (id) filter materialised from parquet + ANN
+query
+WITH
+  result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_any(['red', 'blue']) AND id > 10000 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_hybrid WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+query
+WITH
+  result AS (SELECT id FROM vecs_text_pq_idx WHERE body @@ ts_starts_with('re') AND id % 2 = 0 ORDER BY emb <-> [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]::FLOAT[8] LIMIT 512)
+SELECT COUNT(*)::FLOAT / 512 > 0.9 FROM correct_text_hybrid2 WHERE id IN (SELECT id FROM result);
+----
+?column?
+t
+
+
+statement ok
+SET sdb_ef_search TO 512;


### PR DESCRIPTION
 Pushes iresearch-indexable predicates out of the row-by-row ANNFilter and into a cheap TextScanFilter evaluated against the inverted index, so HNSW candidates get rejected before any RocksDB lookup.
Example:
```sql
SELECT id FROM mixed_idx WHERE body @@ ts_phrase('red') ORDER BY emb <-> :query LIMIT :k;
```