### PR TITLE
fix: Fix SendAsync Close to use asio_ns::dispatch

### DIFF
--- a/server/pg/pg_comm_task.cpp
+++ b/server/pg/pg_comm_task.cpp
@@ -1800,7 +1800,11 @@ void PgSQLCommTask<T>::Start() {
 template<rest::SocketType T>
 void PgSQLCommTask<T>::SendAsync(message::SequenceView data) noexcept {
   if (_send_should_close.load(std::memory_order_acquire)) {
-    Base::Close(this->_close_error);
+    asio_ns::dispatch(
+      this->_protocol->context.io_context,
+      [self = this->shared_from_this(), ec = this->_close_error] {
+        basics::downCast<PgSQLCommTask<T>>(*self).Base::Close(ec);
+      });
     return;
   }
   if (data.Empty()) {


### PR DESCRIPTION
Otherwise segfault is possible, because close should be called in asio io thread.

Actually currently close looks like this io_context recv close => make singal for send + cause send => send dispatch to io_context again.

Old issue with send async called after close still fixed, but now close also always correct 
