### PR TITLE
fix: data race in transaction Ensure/Add/Get

### DIFF
--- a/server/connector/duckdb_client_state.cpp
+++ b/server/connector/duckdb_client_state.cpp
@@ -108,8 +108,7 @@ void SereneDBClientState::Register(
           ERR_HINT("Available values: repeatable read, read committed."));
       }
       auto& conn_ctx = GetSereneDBContext(ctx);
-      if (conn_ctx.IsExplicitTransaction() &&
-          (conn_ctx.HasRocksDBRead() || conn_ctx.HasRocksDBWrite()) &&
+      if (conn_ctx.IsExplicitTransaction() && conn_ctx.HasRocksDBSnapshot() &&
           level != conn_ctx.GetIsolationLevel()) {
         throw duckdb::InvalidInputException(
           "SET TRANSACTION ISOLATION LEVEL must be called before any query");

--- a/server/connector/duckdb_physical_create_index.cpp
+++ b/server/connector/duckdb_physical_create_index.cpp
@@ -460,14 +460,13 @@ SereneDBPhysicalCreateIndex::GetGlobalSinkState(
   }
 
   auto& conn_ctx = GetSereneDBContext(context);
-  conn_ctx.AddRocksDBWrite();
   auto index = snapshot->GetObject<catalog::Index>(catalog_index->GetId());
   SDB_ASSERT(index);
 
   if (state->index_type == catalog::ObjectType::SecondaryIndex) {
     auto& sec_index = basics::downCast<const catalog::SecondaryIndex>(*index);
     auto sk_columns = BuildSKColumnsForBackfill(*index, columns);
-    auto& trx = conn_ctx.EnsureRocksDBTransaction();
+    auto& trx = conn_ctx.GetRocksDBTransaction();
 
     if (sec_index.IsUnique()) {
       state->writer = std::make_unique<DuckDBSecondarySinkInsertWriter<true>>(

--- a/server/connector/duckdb_physical_ctas.cpp
+++ b/server/connector/duckdb_physical_ctas.cpp
@@ -146,7 +146,6 @@ SereneDBPhysicalCTAS::GetGlobalSinkState(duckdb::ClientContext& context) const {
 
   auto& conn_ctx = GetSereneDBContext(context);
   conn_ctx.DropCatalogSnapshot();
-  conn_ctx.AddRocksDBWrite();
 
   return state;
 }

--- a/server/connector/duckdb_physical_delete.cpp
+++ b/server/connector/duckdb_physical_delete.cpp
@@ -133,8 +133,7 @@ SereneDBPhysicalDelete::GetGlobalSinkState(
     });
   }
 
-  conn_ctx.AddRocksDBWrite();
-  state->txn = &conn_ctx.EnsureRocksDBTransaction();
+  state->txn = &conn_ctx.GetRocksDBTransaction();
 
   // Build column-ID-to-chunk-position mapping for index writers.
   // The scan output has: [..., pk_cols, indexed_cols, rowid].

--- a/server/connector/duckdb_physical_insert.cpp
+++ b/server/connector/duckdb_physical_insert.cpp
@@ -149,9 +149,7 @@ SereneDBPhysicalInsert::GetGlobalSinkState(
     }
   }
 
-  // Set up transaction and index writers once
-  conn_ctx.AddRocksDBWrite();
-  state->txn = &conn_ctx.EnsureRocksDBTransaction();
+  state->txn = &conn_ctx.GetRocksDBTransaction();
   state->conflict_resolver.Init(*state->txn, *state->cf, _on_conflict,
                                 state->table_name);
   state->index_writers = CreateDuckDBIndexWriters<DuckDBWriteKind::Insert>(

--- a/server/connector/duckdb_physical_sst_insert.cpp
+++ b/server/connector/duckdb_physical_sst_insert.cpp
@@ -140,7 +140,6 @@ SereneDBPhysicalSSTInsert::GetGlobalSinkState(
 
   // Create index writers
   auto& conn_ctx = GetSereneDBContext(context);
-  conn_ctx.AddRocksDBWrite();
   state->table_shard =
     conn_ctx.EnsureCatalogSnapshot()->GetTableShard(state->table_id);
   SDB_ASSERT(state->table_shard);

--- a/server/connector/duckdb_physical_update.cpp
+++ b/server/connector/duckdb_physical_update.cpp
@@ -272,8 +272,7 @@ SereneDBPhysicalUpdate::GetGlobalSinkState(
     }
   }
 
-  conn_ctx.AddRocksDBWrite();
-  state->txn = &conn_ctx.EnsureRocksDBTransaction();
+  state->txn = &conn_ctx.GetRocksDBTransaction();
   state->conflict_resolver.Init(*state->txn, *state->cf,
                                 duckdb::OnConflictAction::THROW,
                                 state->table_name);

--- a/server/connector/duckdb_scan_base.cpp
+++ b/server/connector/duckdb_scan_base.cpp
@@ -61,18 +61,16 @@ void InitCommonState(CommonScanGlobalState& state,
   // If sdb_read_your_own_writes is false, always use a DB snapshot so reads
   // see only committed data even within an explicit transaction.
   auto& conn_ctx = GetSereneDBContext(context);
-  conn_ctx.AddRocksDBRead();
   const bool is_search_scan = bind_data.scan_source->IsSearchLike();
   if (is_search_scan && conn_ctx.GetReadYourOwnWrites() &&
-      (!context.transaction.IsAutoCommit() || conn_ctx.HasRocksDBWrite())) {
+      conn_ctx.HasRocksDBTransaction()) {
     SDB_THROW(ERROR_NOT_IMPLEMENTED,
               "querying an index within a transaction is not supported when "
               "sdb_read_your_own_writes is enabled");
   }
-  if (conn_ctx.GetReadYourOwnWrites() &&
-      (!context.transaction.IsAutoCommit() || conn_ctx.HasRocksDBWrite())) {
-    state.txn = &conn_ctx.EnsureRocksDBTransaction();
-    state.snapshot = state.txn->GetSnapshot();
+  if (conn_ctx.GetReadYourOwnWrites() && conn_ctx.HasRocksDBTransaction()) {
+    state.txn = &conn_ctx.GetRocksDBTransaction();
+    state.snapshot = &conn_ctx.GetRocksDBSnapshot();
   } else {
     state.snapshot = db->GetSnapshot();
   }

--- a/server/pg/pg_comm_task.cpp
+++ b/server/pg/pg_comm_task.cpp
@@ -608,7 +608,7 @@ void PgSQLCommTaskBase::DescribeStatement(DuckDBStatement& statement) {
       }
       dummy.emplace_back(std::move(v));
     }
-    pending = prepared.PendingQuery(dummy, true);
+    pending = PendingQueryEnsured(prepared, dummy, true);
     if (!pending->HasError()) {
       types = &pending->types;
       names = &pending->names;
@@ -1086,6 +1086,25 @@ void PgSQLCommTaskBase::ParseQuery(std::string_view packet) {
   _success_packet = true;
 }
 
+duckdb::unique_ptr<duckdb::PendingQueryResult>
+PgSQLCommTaskBase::PendingQueryEnsured(duckdb::PreparedStatement& prepared,
+                                       duckdb::vector<duckdb::Value>& values,
+                                       bool allow_stream_result) {
+  const auto& props = prepared.GetStatementProperties();
+  const auto db_name = DatabaseName();
+  _connection_ctx->EnsureCatalogSnapshot();
+  if (props.modified_databases.contains(db_name)) {
+    _connection_ctx->EnsureRocksDBTransaction();
+    _connection_ctx->EnsureRocksDBSnapshot();
+  } else if (props.read_databases.contains(db_name)) {
+    if (_connection_ctx->IsExplicitTransaction()) {
+      _connection_ctx->EnsureRocksDBTransaction();
+    }
+    _connection_ctx->EnsureRocksDBSnapshot();
+  }
+  return prepared.PendingQuery(values, allow_stream_result);
+}
+
 void PgSQLCommTaskBase::ExecutePortal(DuckDBPortal& portal) {
   SDB_ASSERT(_pop_packet);
   SDB_ASSERT(portal.stmt);
@@ -1118,7 +1137,8 @@ auto PgSQLCommTaskBase::BindStatement(DuckDBStatement& stmt,
   portal.bind_info = std::move(bind_info);
 
   auto& prepared = *stmt.prepared;
-  portal.pending = prepared.PendingQuery(portal.bind_info.param_values, true);
+  portal.pending =
+    PendingQueryEnsured(prepared, portal.bind_info.param_values, true);
   if (portal.pending->HasError()) {
     SendError(portal.pending->GetErrorObject());
     portal.pending.reset();

--- a/server/pg/pg_comm_task.h
+++ b/server/pg/pg_comm_task.h
@@ -148,6 +148,10 @@ class PgSQLCommTaskBase : public rest::CommTask {
                              const std::vector<std::string>& names,
                              const std::vector<VarFormat>& formats,
                              bool extended = true);
+  duckdb::unique_ptr<duckdb::PendingQueryResult> PendingQueryEnsured(
+    duckdb::PreparedStatement& prepared, duckdb::vector<duckdb::Value>& values,
+    bool allow_stream_result);
+
   DuckDBPortal BindStatement(DuckDBStatement& stmt, DuckDBBindInfo bind_info);
   void BuildColumnSerializers(DuckDBPortal& portal);
   void DeallocateNamedStatement(std::string_view name);

--- a/server/query/transaction.cpp
+++ b/server/query/transaction.cpp
@@ -142,20 +142,6 @@ Result Transaction::Rollback() {
   return {};
 }
 
-void Transaction::AddRocksDBRead() noexcept { _state |= State::HasRocksDBRead; }
-
-bool Transaction::HasRocksDBRead() const noexcept {
-  return (_state & State::HasRocksDBRead) != State::None;
-}
-
-void Transaction::AddRocksDBWrite() noexcept {
-  _state |= State::HasRocksDBWrite;
-}
-
-bool Transaction::HasRocksDBWrite() const noexcept {
-  return (_state & State::HasRocksDBWrite) != State::None;
-}
-
 const search::InvertedIndexSnapshot& Transaction::EnsureSearchSnapshot(
   ObjectId index_id) {
   auto it = _search_snapshots.find(index_id);
@@ -173,42 +159,36 @@ const search::InvertedIndexSnapshot& Transaction::EnsureSearchSnapshot(
   return *it->second;
 }
 
-const rocksdb::Snapshot& Transaction::EnsureRocksDBSnapshot() {
-  SDB_ASSERT(HasRocksDBRead());
-  EnsureCatalogSnapshot();
-  if (!_rocksdb_snapshot) {
-    if (HasRocksDBWrite() || IsExplicitTransaction()) {
-      EnsureRocksDBTransaction();
-    } else {
-      SDB_ASSERT(!_storage_snapshot);
-      _storage_snapshot = GetServerEngine().currentSnapshot();
-      SDB_ASSERT(_storage_snapshot);
-      _rocksdb_snapshot = _storage_snapshot->GetSnapshot();
-      SDB_ASSERT(_rocksdb_snapshot);
-    }
+void Transaction::EnsureRocksDBSnapshot() {
+  if (_rocksdb_snapshot) {
+    return;
   }
-  return *_rocksdb_snapshot;
-}
-
-rocksdb::Transaction& Transaction::EnsureRocksDBTransaction() {
-  SDB_ASSERT(HasRocksDBWrite() || IsExplicitTransaction());
-  if (!_rocksdb_transaction) [[unlikely]] {
-    SDB_ASSERT(!_rocksdb_snapshot);
-    auto* db = GetServerEngine().db();
-    SDB_ASSERT(db);
-    rocksdb::WriteOptions write_options;
-    rocksdb::TransactionOptions txn_options;
-    txn_options.skip_concurrency_control = true;
-    _rocksdb_transaction.reset(
-      db->BeginTransaction(write_options, txn_options));
-    SDB_ASSERT(_rocksdb_transaction);
-  }
-  if (!_rocksdb_snapshot) {
+  SDB_ASSERT(!_storage_snapshot);
+  if (_rocksdb_transaction) {
     _rocksdb_transaction->SetSnapshot();
     _rocksdb_snapshot = _rocksdb_transaction->GetSnapshot();
-    SDB_ASSERT(_rocksdb_snapshot);
+  } else {
+    _storage_snapshot = GetServerEngine().currentSnapshot();
+    SDB_ASSERT(_storage_snapshot);
+    _rocksdb_snapshot = _storage_snapshot->GetSnapshot();
   }
-  return *_rocksdb_transaction;
+  SDB_ASSERT(_rocksdb_snapshot);
+}
+
+void Transaction::EnsureRocksDBTransaction() {
+  SDB_ASSERT(!_storage_snapshot);
+  if (_rocksdb_transaction) {
+    return;
+  }
+  SDB_ASSERT(!_storage_snapshot);
+  SDB_ASSERT(!_rocksdb_snapshot);
+  auto* db = GetServerEngine().db();
+  SDB_ASSERT(db);
+  rocksdb::WriteOptions write_options;
+  rocksdb::TransactionOptions txn_options;
+  txn_options.skip_concurrency_control = true;
+  _rocksdb_transaction.reset(db->BeginTransaction(write_options, txn_options));
+  SDB_ASSERT(_rocksdb_transaction);
 }
 
 void Transaction::RegisterSearchFlushes() noexcept {
@@ -228,7 +208,6 @@ void Transaction::CommitSearchTransactions(uint64_t post_ingest_seq) noexcept {
 
 void Transaction::Destroy() noexcept {
   DropCatalogSnapshot();
-  _state = State::None;
   _storage_snapshot.reset();
   _rocksdb_transaction.reset();
   _rocksdb_snapshot = nullptr;

--- a/server/query/transaction.h
+++ b/server/query/transaction.h
@@ -26,7 +26,6 @@
 #include <iresearch/index/index_writer.hpp>
 #include <yaclib/async/future.hpp>
 
-#include "basics/bit_utils.hpp"
 #include "basics/containers/flat_hash_map.h"
 #include "basics/down_cast.h"
 #include "basics/result.h"
@@ -40,12 +39,6 @@ namespace sdb::query {
 class Transaction : public Config {
  public:
   using Config::Config;
-
-  enum class State : uint8_t {
-    None = 0,
-    HasRocksDBRead = 1 << 0,
-    HasRocksDBWrite = 1 << 1,
-  };
 
 #ifdef SDB_DEV
   virtual ~Transaction() {
@@ -75,26 +68,38 @@ class Transaction : public Config {
     _table_rows_deltas[table_id] += delta;
   }
 
-  void AddRocksDBRead() noexcept;
-  bool HasRocksDBRead() const noexcept;
-
-  void AddRocksDBWrite() noexcept;
-  bool HasRocksDBWrite() const noexcept;
+  bool HasRocksDBSnapshot() const noexcept {
+    return _rocksdb_snapshot != nullptr;
+  }
+  bool HasRocksDBTransaction() const noexcept {
+    return _rocksdb_transaction != nullptr;
+  }
 
   rocksdb::Transaction& GetRocksDBTransaction() const noexcept {
     SDB_ASSERT(_rocksdb_transaction);
     return *_rocksdb_transaction;
   }
 
-  rocksdb::Transaction& EnsureRocksDBTransaction();
+  const rocksdb::Snapshot& GetRocksDBSnapshot() const noexcept {
+    SDB_ASSERT(_rocksdb_snapshot);
+    return *_rocksdb_snapshot;
+  }
+
+  void EnsureRocksDBTransaction();
+  void EnsureRocksDBSnapshot();
+
+  const search::InvertedIndexSnapshot& EnsureSearchSnapshot(ObjectId index_id);
+
+  const search::InvertedIndexSnapshot& GetSearchSnapshot(
+    ObjectId index_id) const noexcept {
+    auto it = _search_snapshots.find(index_id);
+    SDB_ASSERT(it != _search_snapshots.end());
+    return *it->second;
+  }
 
   void EraseSearchTransaction(ObjectId shard_id) noexcept {
     _search_transactions.erase(shard_id);
   }
-
-  const search::InvertedIndexSnapshot& EnsureSearchSnapshot(ObjectId index_id);
-
-  const rocksdb::Snapshot& EnsureRocksDBSnapshot();
 
   void Destroy() noexcept;
 
@@ -139,7 +144,7 @@ class Transaction : public Config {
         }
         visit(*transaction, *index);
       } else {
-        visit(EnsureRocksDBTransaction(), *index);
+        visit(GetRocksDBTransaction(), *index);
       }
     }
   }
@@ -147,7 +152,6 @@ class Transaction : public Config {
  private:
   void ApplyTableStatsDiffs() noexcept;
 
-  State _state = State::None;
   std::shared_ptr<StorageSnapshot> _storage_snapshot;
   std::unique_ptr<rocksdb::Transaction> _rocksdb_transaction;
   const rocksdb::Snapshot* _rocksdb_snapshot = nullptr;
@@ -158,7 +162,5 @@ class Transaction : public Config {
     _search_snapshots;
   containers::FlatHashMap<ObjectId, int64_t> _table_rows_deltas;
 };
-
-ENABLE_BITMASK_ENUM(Transaction::State);
 
 }  // namespace sdb::query


### PR DESCRIPTION
Split `EnsureRocksDB{Transaction,Snapshot}` from `GetRocksDB{Transaction,Snapshot}`. Ensure is called eagerly in `pg_comm_task` before `PendingQuery` via `PendingQueryEnsured`, driven by the prepared statement's read/modified database sets. The physical ops (insert/update/delete/create_index/scan) then call Get, which is a non-racy lookup on already-initialised state.

The old shape used Add*Read/Add*Write flags on Transaction plus a self-promoting EnsureRocksDBTransaction that could be entered concurrently from multiple threads -- once a query reached parallel sinks, two threads could observe HasRocksDBWrite as true and race to construct the rocksdb transaction.