### PR TITLE
fix: don't drop catalog snapshot on every statement

### DIFF
--- a/server/pg/pg_comm_task.cpp
+++ b/server/pg/pg_comm_task.cpp
@@ -699,7 +699,6 @@ void PgSQLCommTaskBase::RunSimpleQuery(std::string_view query_string) {
   if (IsCancelled()) {
     return;
   }
-  _connection_ctx->DropCatalogSnapshot();
 
   // Strip trailing null bytes from PG wire protocol
   while (!query_string.empty() && query_string.back() == '\0') {
@@ -758,8 +757,6 @@ void PgSQLCommTaskBase::ExecuteNextSimpleStatement() {
   if (!_success_packet) {
     return;  // error
   }
-
-  _connection_ctx->DropCatalogSnapshot();
 
   // Advance to next statement if any
   ++stmt.current_stmt_idx;


### PR DESCRIPTION
Per-statement `DropCatalogSnapshot` calls in `RunSimpleQuery` and `ExecuteNextSimpleStatement` threw away the connection's catalog snapshot between statements inside an explicit BEGIN/COMMIT block, breaking REPEATABLE READ. The intended drop points are `Transaction::OnNewStatement` (READ_COMMITTED only) and `Transaction::Destroy` on commit/rollback.

Depends on #650 (`PendingQueryEnsured` calls `EnsureCatalogSnapshot` upfront so the snapshot is materialised before the first statement executes). Standalone this PR can crash because some paths still assume an existing snapshot.