### PR TITLE
fix: don't lose blocked-task wakeup in pg_comm_task

### DIFF
--- a/server/pg/pg_comm_task.cpp
+++ b/server/pg/pg_comm_task.cpp
@@ -1218,9 +1218,11 @@ auto PgSQLCommTaskBase::ProcessQueryResult() -> ProcessState {
   auto& portal = *_current_portal;
   SDB_ASSERT(portal.stmt);
 
-  // If we have a pending query, drive execution
   if (portal.pending) {
-    auto status = portal.pending->ExecuteTask();
+    auto status = portal.pending->ExecuteTask(
+      [weak = weak_from_this(), feature = &_feature] {
+        feature->ScheduleProcessWakeup(weak);
+      });
     switch (status) {
       case duckdb::PendingExecutionResult::RESULT_READY: {
         // Execution complete -- get the streaming result
@@ -1240,12 +1242,7 @@ auto PgSQLCommTaskBase::ProcessQueryResult() -> ProcessState {
         // More work needed -- continue polling
         return ProcessState::More;
       case duckdb::PendingExecutionResult::BLOCKED:
-        // Blocked -- register callback and return Wait
-        duckdb::Executor::Get(*_duckdb_conn->context)
-          .SetTaskRescheduledCallback(
-            [weak = weak_from_this(), feature = &_feature] {
-              feature->ScheduleProcessWakeup(weak);
-            });
+        // Blocked -- callback was registered by ExecuteTask.
         return ProcessState::Wait;
       case duckdb::PendingExecutionResult::EXECUTION_FINISHED:
         // Same as RESULT_READY -- execution complete


### PR DESCRIPTION
Move the rescheduled-task callback from a post-BLOCKED `Executor::Set...` call into the `ExecuteTask` invocation itself. The old shape registered the callback only after the executor returned BLOCKED, leaving a window where a worker could finish its task and signal the executor before we registered the callback -- the wakeup was then dropped and the connection hung.

Pairs with the duckdb-side change at branch `v2025.05.11` (commit 6ec119ff2d) on serenedb/duckdb. The submodule bump in this PR points at it.