### PR TITLE
fix: error messages for headline test

### DIFF
--- a/libs/iresearch/include/iresearch/utils/directory_utils.cpp
+++ b/libs/iresearch/include/iresearch/utils/directory_utils.cpp
@@ -79,6 +79,14 @@ IndexOutput::ptr TrackingDirectory::create(std::string_view name) noexcept try {
   return nullptr;
 }
 
+bool TrackingDirectory::remove(std::string_view name) noexcept {
+  if (!_impl.remove(name)) {
+    return false;
+  }
+  _files.erase(name);
+  return true;
+}
+
 bool TrackingDirectory::rename(std::string_view src,
                                std::string_view dst) noexcept {
   if (!_impl.rename(src, dst)) {

--- a/libs/iresearch/include/iresearch/utils/directory_utils.hpp
+++ b/libs/iresearch/include/iresearch/utils/directory_utils.hpp
@@ -74,10 +74,7 @@ struct TrackingDirectory final : public Directory {
     return _impl.open(name, advice);
   }
 
-  bool remove(std::string_view) noexcept final {
-    // not supported
-    return false;
-  }
+  bool remove(std::string_view name) noexcept final;
 
   bool rename(std::string_view src, std::string_view dst) noexcept final;
 

--- a/tests/libs/iresearch/utils/directory_utils_tests.cpp
+++ b/tests/libs/iresearch/utils/directory_utils_tests.cpp
@@ -339,12 +339,8 @@ TEST_F(DirectoryUtilsTests, test_tracking_dir) {
     ASSERT_EQ(1, byte_size);
     bool exists{false};
     ASSERT_TRUE(dir.exists(exists, file) && exists);
-    ASSERT_FALSE(track_dir.remove(file));
     ASSERT_TRUE(track_dir.rename(file, "def"));
-    ASSERT_FALSE(track_dir.remove(file));
     ASSERT_TRUE(dir.exists(exists, file) && !exists);
-    ASSERT_TRUE(dir.exists(exists, "def") && exists);
-    ASSERT_FALSE(track_dir.remove("def"));
     ASSERT_TRUE(dir.exists(exists, "def") && exists);
 
     byte_size = 0;
@@ -357,5 +353,29 @@ TEST_F(DirectoryUtilsTests, test_tracking_dir) {
     files = track_dir.FlushTracked(byte_size);
     ASSERT_EQ(0, files.size());
     ASSERT_EQ(0, byte_size);
+  }
+
+  // test remove forwards to impl and untracks
+  {
+    irs::MemoryDirectory dir;
+    irs::TrackingDirectory track_dir{dir};
+    const std::string_view file{"abc"};
+    {
+      auto file1 = track_dir.create(file);
+      ASSERT_FALSE(!file1);
+      file1->WriteByte(42);
+      file1->Flush();
+    }
+    bool exists{false};
+    ASSERT_TRUE(dir.exists(exists, file) && exists);
+
+    ASSERT_TRUE(track_dir.remove(file));
+    ASSERT_TRUE(dir.exists(exists, file) && !exists);
+
+    uint64_t byte_size{0};
+    auto files = track_dir.FlushTracked(byte_size);
+    ASSERT_TRUE(files.empty());
+
+    ASSERT_FALSE(track_dir.remove("def"));
   }
 }


### PR DESCRIPTION
I've faced some log errors when run `headline.test`:
```
2026-05-18T09:03:12.698952Z [2149109-15] ERROR [xxxxx] {iresearch} Failed to remove file, path: _1.csd
2026-05-18T09:03:12.703305Z [2149109-15] ERROR [xxxxx] {iresearch} Failed to remove file, path: _1.csd
2026-05-18T09:03:12.708359Z [2149109-15] ERROR [xxxxx] {iresearch} Failed to remove file, path: _1.csd
```

The reason: no columns with `store` flag -> columns are empty for writer -> column writer tries to remove file using `TrackingDir` that doesn't support removing. Current PR allows to remove with tracking dir.
