### PR TITLE
[WIP] feat: opclass constructor

### DIFF
--- a/server/catalog/CMakeLists.txt
+++ b/server/catalog/CMakeLists.txt
@@ -23,7 +23,7 @@ target_sources(
         inverted_index.cpp
         mangling.cpp
         scorer_options.cpp
-        tokenizer.cpp
+        opclass.cpp
 )
 
 add_subdirectory(identifiers)

--- a/server/catalog/catalog.cpp
+++ b/server/catalog/catalog.cpp
@@ -57,7 +57,7 @@
 #include "catalog/sequence.h"
 #include "catalog/table.h"
 #include "catalog/table_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "catalog/types.h"
 #include "catalog/user_type.h"
 #include "catalog/view.h"
@@ -257,7 +257,7 @@ class OpenDatabase {
   Result RegisterDatabases();
   Result RegisterSchemas(ObjectId database_id);
   Result RegisterFunctions(ObjectId database_id, ObjectId schema_id);
-  Result RegisterTokenizers(ObjectId database_id, ObjectId schema_id);
+  Result RegisterOpClasses(ObjectId database_id, ObjectId schema_id);
   Result RegisterViews(ObjectId database_id, ObjectId schema_id);
   Result RegisterSequences(ObjectId database_id, ObjectId schema_id);
   Result RegisterTypes(ObjectId database_id, ObjectId schema_id);
@@ -372,17 +372,16 @@ Result OpenDatabase::RegisterFunctions(ObjectId db_id, ObjectId schema_id) {
     });
 }
 
-Result OpenDatabase::RegisterTokenizers(ObjectId db_id, ObjectId schema_id) {
+Result OpenDatabase::RegisterOpClasses(ObjectId db_id, ObjectId schema_id) {
   return GetServerEngine().VisitDefinitions(
-    schema_id, ObjectType::Tokenizer,
+    schema_id, ObjectType::OpClass,
     [&](DefinitionKey key, vpack::Slice slice) -> Result {
-      auto tokenizer =
-        Tokenizer::ReadInternal(slice, {.id = key.GetObjectId()});
-      if (!tokenizer) {
-        return ErrorMeta(ERROR_INTERNAL, "tokenizer",
-                         "Failed to read tokenizer definition", slice);
+      auto opclass = OpClass::ReadInternal(slice, {.id = key.GetObjectId()});
+      if (!opclass) {
+        return ErrorMeta(ERROR_INTERNAL, "opclass",
+                         "Failed to read opclass definition", slice);
       }
-      return _catalog.RegisterTokenizer(db_id, schema_id, std::move(tokenizer));
+      return _catalog.RegisterOpClass(db_id, schema_id, std::move(opclass));
     });
 }
 
@@ -638,7 +637,7 @@ Result OpenDatabase::AddSchema(ObjectId db_id, ObjectId schema_id,
     ClearDeletedDefinitions(DeletedScope::Schema);
   };
 
-  if (auto r = RegisterTokenizers(db_id, schema_id); !r.ok()) {
+  if (auto r = RegisterOpClasses(db_id, schema_id); !r.ok()) {
     return r;
   }
   if (auto r = RegisterTypes(db_id, schema_id); !r.ok()) {

--- a/server/catalog/catalog.h
+++ b/server/catalog/catalog.h
@@ -44,7 +44,7 @@
 #include "catalog/sequence.h"
 #include "catalog/table.h"
 #include "catalog/table_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "catalog/types.h"
 #include "catalog/user_type.h"
 #include "catalog/view.h"
@@ -91,8 +91,8 @@ constexpr ObjectType GetObjectType() noexcept {
     return ObjectType::SecondaryIndex;
   } else if constexpr (std::is_same_v<T, InvertedIndex>) {
     return ObjectType::InvertedIndex;
-  } else if constexpr (std::is_same_v<T, Tokenizer>) {
-    return ObjectType::Tokenizer;
+  } else if constexpr (std::is_same_v<T, OpClass>) {
+    return ObjectType::OpClass;
   } else if constexpr (std::is_same_v<T, Sequence>) {
     return ObjectType::Sequence;
   } else {
@@ -118,7 +118,7 @@ struct Snapshot {
     ObjectId database, std::string_view schema) const = 0;
   virtual std::vector<std::shared_ptr<Index>> GetIndexes(
     ObjectId database, std::string_view schema) const = 0;
-  virtual std::vector<std::shared_ptr<Tokenizer>> GetTokenizers(
+  virtual std::vector<std::shared_ptr<OpClass>> GetOpClasses(
     ObjectId database, std::string_view schema) const = 0;
   virtual std::vector<std::shared_ptr<PgSqlType>> GetTypes(
     ObjectId database, std::string_view schema) const = 0;
@@ -150,7 +150,7 @@ struct Snapshot {
   virtual std::shared_ptr<PgSqlFunction> GetFunction(
     ObjectId database, std::string_view schema,
     std::string_view name) const = 0;
-  virtual std::shared_ptr<Tokenizer> GetTokenizer(
+  virtual std::shared_ptr<OpClass> GetOpClass(
     ObjectId database, std::string_view schema,
     std::string_view name) const = 0;
   virtual std::shared_ptr<PgSqlType> GetType(ObjectId database,
@@ -235,9 +235,9 @@ struct LogicalCatalog {
   virtual Result RegisterFunction(
     ObjectId database_id, ObjectId schema_id,
     std::shared_ptr<catalog::PgSqlFunction> function) = 0;
-  virtual Result RegisterTokenizer(
+  virtual Result RegisterOpClass(
     ObjectId database_id, ObjectId schema_id,
-    std::shared_ptr<catalog::Tokenizer> tokenizer) = 0;
+    std::shared_ptr<catalog::OpClass> opclass) = 0;
   virtual Result RegisterType(ObjectId database_id, ObjectId schema_id,
                               std::shared_ptr<catalog::PgSqlType> type) = 0;
   virtual Result RegisterIndex(ObjectId database_id, ObjectId schema_id,
@@ -258,8 +258,8 @@ struct LogicalCatalog {
   virtual Result CreateFunction(
     ObjectId database_id, std::string_view schema,
     std::shared_ptr<catalog::PgSqlFunction> function, bool replace) = 0;
-  virtual Result CreateTokenizer(ObjectId database_id, std::string_view schema,
-                                 std::shared_ptr<Tokenizer> dict) = 0;
+  virtual Result CreateOpClass(ObjectId database_id, std::string_view schema,
+                               std::shared_ptr<OpClass> opclass) = 0;
   virtual Result CreateType(ObjectId database_id, std::string_view schema,
                             std::shared_ptr<PgSqlType> type) = 0;
   virtual Result CreateTable(ObjectId database_id, std::string_view schema,
@@ -308,9 +308,9 @@ struct LogicalCatalog {
   virtual Result DropFunction(std::string_view database,
                               std::string_view schema,
                               std::string_view name) = 0;
-  virtual Result DropTokenizer(std::string_view database,
-                               std::string_view schema,
-                               std::string_view name) = 0;
+  virtual Result DropOpClass(std::string_view database,
+                             std::string_view schema,
+                             std::string_view name) = 0;
   virtual Result DropView(std::string_view database, std::string_view schema,
                           std::string_view name) = 0;
   virtual Result DropSequence(std::string_view database,

--- a/server/catalog/index.cpp
+++ b/server/catalog/index.cpp
@@ -38,7 +38,7 @@
 #include "catalog/inverted_index.h"
 #include "catalog/object.h"
 #include "catalog/secondary_index.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "catalog/types.h"
 
 namespace sdb::catalog {
@@ -387,9 +387,9 @@ ResultOr<std::shared_ptr<InvertedIndex>> CreateInvertedIndex(
 
   // Resolves a text-dictionary opclass against the current snapshot. The HNSW
   // opclass is handled inline because it does not feed JSON paths.
-  auto resolve_dict =
+  auto resolve_opclass =
     [&](std::string_view col_name,
-        const std::string& opclass) -> ResultOr<std::shared_ptr<Tokenizer>> {
+        const std::string& opclass) -> ResultOr<std::shared_ptr<OpClass>> {
     auto object_name = pg::ParseObjectName(opclass, schema_name);
     // Technically nothing prevents us from allowing so.
     // But that will make schema drop more complicated as we will need to
@@ -402,8 +402,8 @@ ResultOr<std::shared_ptr<InvertedIndex>> CreateInvertedIndex(
         std::in_place, ERROR_BAD_PARAMETER,
         "Accessing text dictionary from different schema is not supported"};
     }
-    auto dict = snapshot->GetTokenizer(database_id, object_name.schema,
-                                       object_name.relation);
+    auto dict = snapshot->GetOpClass(database_id, object_name.schema,
+                                     object_name.relation);
     if (!dict) {
       return std::unexpected<Result>{std::in_place,
                                      ERROR_BAD_PARAMETER,
@@ -435,7 +435,7 @@ ResultOr<std::shared_ptr<InvertedIndex>> CreateInvertedIndex(
       }
       JsonPathInfo path_info{.path = c.json_path};
       if (!c.opclass.empty()) {
-        auto dict = resolve_dict(c.name, c.opclass);
+        auto dict = resolve_opclass(c.name, c.opclass);
         if (!dict) {
           return std::unexpected<Result>{std::move(dict.error())};
         }
@@ -493,7 +493,7 @@ ResultOr<std::shared_ptr<InvertedIndex>> CreateInvertedIndex(
                                          DescribeKnownOpclassTypes(),
                                          ")"};
         }
-        auto dict = resolve_dict(c.name, c.opclass);
+        auto dict = resolve_opclass(c.name, c.opclass);
         if (!dict) {
           return std::unexpected<Result>{std::move(dict.error())};
         }

--- a/server/catalog/index.h
+++ b/server/catalog/index.h
@@ -60,7 +60,11 @@ class Index : public SchemaObject {
     return _column_ids;
   }
 
-  virtual containers::FlatHashSet<ObjectId> GetTokenizers() const { return {}; }
+  virtual std::vector<Column::Id> GetReferencedColumnIds() const {
+    return _column_ids;
+  }
+
+  virtual containers::FlatHashSet<ObjectId> GetOpClasses() const { return {}; }
 
   // TODO(codeworse): support arguments for index shards
   virtual ResultOr<std::shared_ptr<IndexShard>> CreateIndexShard(

--- a/server/catalog/inverted_index.cpp
+++ b/server/catalog/inverted_index.cpp
@@ -43,10 +43,10 @@ ResultOr<ColumnTokenizer> BuildColumnTokenizer(
   search::Features features) {
   if (!text_dictionary.isSet()) {
     auto analyzer = std::make_unique<irs::StringTokenizer>();
-    return ColumnTokenizer{.analyzer = Tokenizer::TokenizerWrapper{
-                             analyzer.release(), Tokenizer::Deleter{nullptr}}};
+    return ColumnTokenizer{.analyzer = OpClass::TokenizerWrapper{
+                             analyzer.release(), OpClass::Deleter{nullptr}}};
   }
-  auto dict = snapshot->GetObject<Tokenizer>(text_dictionary);
+  auto dict = snapshot->GetObject<OpClass>(text_dictionary);
   if (!dict) {
     return std::unexpected<Result>{std::in_place, ERROR_INTERNAL,
                                    "Dictionary for inverted index does not "
@@ -174,7 +174,7 @@ std::optional<irs::HNSWInfo> InvertedIndex::GetColumnHNSWInfo(
   };
 }
 
-containers::FlatHashSet<ObjectId> InvertedIndex::GetTokenizers() const {
+containers::FlatHashSet<ObjectId> InvertedIndex::GetOpClasses() const {
   containers::FlatHashSet<ObjectId> res;
   for (const auto& col : _columns) {
     if (col.second.text_dictionary.isSet()) {

--- a/server/catalog/inverted_index.h
+++ b/server/catalog/inverted_index.h
@@ -30,7 +30,7 @@
 #include "catalog/index.h"
 #include "catalog/scorer_options.h"
 #include "catalog/search_analyzer_impl.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "storage_engine/index_shard.h"
 
 namespace sdb::catalog {
@@ -58,7 +58,7 @@ struct InvertedIndexColumnInfo {
 };
 
 struct ColumnTokenizer {
-  Tokenizer::TokenizerWrapper analyzer;
+  OpClass::TokenizerWrapper analyzer;
   irs::IndexFeatures features = irs::IndexFeatures::None;
 };
 
@@ -106,7 +106,7 @@ class InvertedIndex final : public Index {
     return _wand_scorer;
   }
 
-  containers::FlatHashSet<ObjectId> GetTokenizers() const final;
+  containers::FlatHashSet<ObjectId> GetOpClasses() const final;
 
  private:
   ColumnOptions _columns;

--- a/server/catalog/local_catalog.cpp
+++ b/server/catalog/local_catalog.cpp
@@ -82,7 +82,7 @@
 #include "catalog/sequence.h"
 #include "catalog/table.h"
 #include "catalog/table_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "catalog/types.h"
 #include "catalog/user_type.h"
 #include "catalog/view.h"
@@ -255,13 +255,13 @@ class SnapshotImpl : public Snapshot {
         return r;
       }
       return AddObjectDefinition(parent_id, object);
-    } else if constexpr (std::is_same_v<T, Tokenizer>) {
-      auto r = AddToResolution<ResolveType::Tokenizer>(
+    } else if constexpr (std::is_same_v<T, OpClass>) {
+      auto r = AddToResolution<ResolveType::OpClass>(
         parent_id, object->GetId(), object->GetName(), replace);
       if (!r.ok()) {
         return r;
       }
-      return AddObjectDefinition<TokenizerDependency>(parent_id, object);
+      return AddObjectDefinition<OpClassDependency>(parent_id, object);
     } else if constexpr (std::is_same_v<T, PgSqlType>) {
       auto r = AddToResolution<ResolveType::Type>(parent_id, object->GetId(),
                                                   object->GetName(), replace);
@@ -313,9 +313,9 @@ class SnapshotImpl : public Snapshot {
     } else if constexpr (std::is_same_v<T, PgSqlFunction>) {
       RemoveFromResolution<ResolveType::Function>(parent_id, object->GetName(),
                                                   maybe_not_found);
-    } else if constexpr (std::is_same_v<T, Tokenizer>) {
-      RemoveFromResolution<ResolveType::Tokenizer>(parent_id, object->GetName(),
-                                                   maybe_not_found);
+    } else if constexpr (std::is_same_v<T, OpClass>) {
+      RemoveFromResolution<ResolveType::OpClass>(parent_id, object->GetName(),
+                                                 maybe_not_found);
     } else if constexpr (std::is_same_v<T, PgSqlType>) {
       RemoveFromResolution<ResolveType::Type>(parent_id, object->GetName(),
                                               maybe_not_found);
@@ -375,9 +375,9 @@ class SnapshotImpl : public Snapshot {
         auto schema_deps = GetDependencyForWrite<SchemaDependency>(parent_id);
         schema_deps->functions.insert(object->GetId());
       } break;
-      case ObjectType::Tokenizer: {
+      case ObjectType::OpClass: {
         auto schema_deps = GetDependencyForWrite<SchemaDependency>(parent_id);
-        schema_deps->tokenizers.insert(object->GetId());
+        schema_deps->opclasses.insert(object->GetId());
       } break;
       case ObjectType::PgSqlView: {
         auto schema_deps = GetDependencyForWrite<SchemaDependency>(parent_id);
@@ -408,8 +408,8 @@ class SnapshotImpl : public Snapshot {
           GetDependencyForWrite<RelationDependency>(parent_id);
         relation_deps->indexes.insert(object->GetId());
         const auto& index = basics::downCast<Index>(*object);
-        for (auto tokenizer_id : index.GetTokenizers()) {
-          auto dep = GetDependencyForWrite<TokenizerDependency>(tokenizer_id);
+        for (auto opclass_id : index.GetOpClasses()) {
+          auto dep = GetDependencyForWrite<OpClassDependency>(opclass_id);
           SDB_ASSERT(dep);
           dep->indexes.insert(object->GetId());
         }
@@ -624,18 +624,18 @@ class SnapshotImpl : public Snapshot {
     }
   }
 
-  std::vector<std::shared_ptr<Tokenizer>> GetTokenizers(
+  std::vector<std::shared_ptr<OpClass>> GetOpClasses(
     ObjectId db_id, std::string_view schema) const final {
     return _resolution_table.ResolveObject<ResolveType::Schema>(db_id, schema)
       .transform([&](ObjectId schema_id) {
-        return _resolution_table.GetTokenizerIds(schema_id) |
+        return _resolution_table.GetOpClassIds(schema_id) |
                std::views::transform(
-                 [&](ObjectId tokenizer_id) -> std::shared_ptr<Tokenizer> {
-                   return GetObject<Tokenizer>(tokenizer_id);
+                 [&](ObjectId opclass_id) -> std::shared_ptr<OpClass> {
+                   return GetObject<OpClass>(opclass_id);
                  }) |
                std::ranges::to<std::vector>();
       })
-      .value_or(std::vector<std::shared_ptr<Tokenizer>>{});
+      .value_or(std::vector<std::shared_ptr<OpClass>>{});
   }
 
   std::vector<std::shared_ptr<PgSqlType>> GetTypes(
@@ -720,20 +720,20 @@ class SnapshotImpl : public Snapshot {
       .value_or(nullptr);
   }
 
-  std::shared_ptr<Tokenizer> GetTokenizer(ObjectId db_id,
-                                          std::string_view schema,
-                                          std::string_view name) const final {
+  std::shared_ptr<OpClass> GetOpClass(ObjectId db_id,
+                                      std::string_view schema,
+                                      std::string_view name) const final {
     auto schema_id =
       _resolution_table.ResolveObject<ResolveType::Schema>(db_id, schema);
     if (!schema_id) {
       return nullptr;
     }
     auto id =
-      _resolution_table.ResolveObject<ResolveType::Tokenizer>(*schema_id, name);
+      _resolution_table.ResolveObject<ResolveType::OpClass>(*schema_id, name);
     if (!id) {
       return nullptr;
     }
-    return GetObject<Tokenizer>(*id);
+    return GetObject<OpClass>(*id);
   }
 
   std::shared_ptr<Table> GetTable(ObjectId db_id, std::string_view schema,
@@ -811,9 +811,9 @@ class SnapshotImpl : public Snapshot {
     return _resolution_table.ResolveObject<Type>(parent_id, name);
   }
 
-  std::vector<std::shared_ptr<Index>> GetIndexesByTokenizer(
-    ObjectId tokenizer_id) const {
-    auto deps = GetDependency<TokenizerDependency>(tokenizer_id);
+  std::vector<std::shared_ptr<Index>> GetIndexesByOpClass(
+    ObjectId opclass_id) const {
+    auto deps = GetDependency<OpClassDependency>(opclass_id);
     SDB_ASSERT(deps);
     std::vector<std::shared_ptr<Index>> result;
     result.reserve(deps->indexes.size());
@@ -925,8 +925,8 @@ class SnapshotImpl : public Snapshot {
             GetDependencyForWrite<RelationDependency>(parent_id);
           relation_deps->indexes.erase(id);
           const auto& index = basics::downCast<Index>(*obj);
-          for (auto tokenizer_id : index.GetTokenizers()) {
-            auto dep = GetDependencyForWrite<TokenizerDependency>(tokenizer_id);
+          for (auto opclass_id : index.GetOpClasses()) {
+            auto dep = GetDependencyForWrite<OpClassDependency>(opclass_id);
             SDB_ASSERT(dep);
             dep->indexes.erase(obj->GetId());
           }
@@ -936,10 +936,10 @@ class SnapshotImpl : public Snapshot {
           SDB_ASSERT(schema_deps);
           schema_deps->functions.erase(id);
         } break;
-        case ObjectType::Tokenizer: {
+        case ObjectType::OpClass: {
           auto schema_deps = GetDependencyForWrite<SchemaDependency>(parent_id);
           SDB_ASSERT(schema_deps);
-          schema_deps->tokenizers.erase(id);
+          schema_deps->opclasses.erase(id);
         } break;
         case ObjectType::Table: {
           auto schema_deps = GetDependencyForWrite<SchemaDependency>(parent_id);
@@ -1035,7 +1035,7 @@ class SnapshotImpl : public Snapshot {
       } break;
       case ObjectType::PgSqlFunction:
       case ObjectType::PgSqlType:
-      case ObjectType::Tokenizer:
+      case ObjectType::OpClass:
       case ObjectType::Sequence:
         break;
       case ObjectType::TableShard:
@@ -1157,11 +1157,11 @@ Result LocalCatalog::RegisterFunction(ObjectId database_id, ObjectId schema_id,
   });
 }
 
-Result LocalCatalog::RegisterTokenizer(ObjectId database_id, ObjectId schema_id,
-                                       std::shared_ptr<Tokenizer> tokenizer) {
+Result LocalCatalog::RegisterOpClass(ObjectId database_id, ObjectId schema_id,
+                                     std::shared_ptr<OpClass> opclass) {
   absl::MutexLock lock{&_mutex};
   return Apply(_snapshot, [&](auto& clone) {
-    return clone->RegisterObject(std::move(tokenizer), schema_id, false);
+    return clone->RegisterObject(std::move(opclass), schema_id, false);
   });
 }
 
@@ -1707,9 +1707,9 @@ Result LocalCatalog::CreateTable(
     [&](auto clone) { clone->UnregisterObject(table, *schema_id, true); });
 }
 
-Result LocalCatalog::CreateTokenizer(ObjectId database_id,
-                                     std::string_view schema,
-                                     std::shared_ptr<Tokenizer> dict) {
+Result LocalCatalog::CreateOpClass(ObjectId database_id,
+                                   std::string_view schema,
+                                   std::shared_ptr<OpClass> opclass) {
   absl::MutexLock lock{&_mutex};
   auto schema_id =
     _snapshot->GetObjectId<ResolveType::Schema>(database_id, schema);
@@ -1720,18 +1720,18 @@ Result LocalCatalog::CreateTokenizer(ObjectId database_id,
   return Apply(
     _snapshot,
     [&](std::shared_ptr<SnapshotImpl>& clone) {
-      auto r = clone->RegisterObject(dict, *schema_id, false);
+      auto r = clone->RegisterObject(opclass, *schema_id, false);
       if (!r.ok()) {
         return r;
       }
       vpack::Builder b;
-      dict->WriteInternal(b);
-      return _engine->CreateDefinition(*schema_id, ObjectType::Tokenizer,
-                                       dict->GetId(),
+      opclass->WriteInternal(b);
+      return _engine->CreateDefinition(*schema_id, ObjectType::OpClass,
+                                       opclass->GetId(),
                                        [&](bool) { return b.slice(); });
     },
     [&](auto& clone) {
-      return clone->UnregisterObject(dict, *schema_id, true);
+      return clone->UnregisterObject(opclass, *schema_id, true);
     });
 }
 
@@ -2428,9 +2428,9 @@ Result LocalCatalog::DropFunction(std::string_view database,
   });
 }
 
-Result LocalCatalog::DropTokenizer(std::string_view database,
-                                   std::string_view schema,
-                                   std::string_view name) {
+Result LocalCatalog::DropOpClass(std::string_view database,
+                                 std::string_view schema,
+                                 std::string_view name) {
   absl::MutexLock lock{&_mutex};
 
   const auto database_id =
@@ -2443,13 +2443,13 @@ Result LocalCatalog::DropTokenizer(std::string_view database,
   if (!schema_id) {
     return Result{ERROR_SERVER_ILLEGAL_NAME};
   }
-  const auto tokenizer_id =
-    _snapshot->GetObjectId<ResolveType::Tokenizer>(*schema_id, name);
-  if (!tokenizer_id) {
+  const auto opclass_id =
+    _snapshot->GetObjectId<ResolveType::OpClass>(*schema_id, name);
+  if (!opclass_id) {
     return Result{ERROR_SERVER_ILLEGAL_NAME};
   }
 
-  const auto deps = _snapshot->GetIndexesByTokenizer(*tokenizer_id);
+  const auto deps = _snapshot->GetIndexesByOpClass(*opclass_id);
   if (!deps.empty()) {
     static constexpr size_t kReportIndexes = 5;
     std::vector<std::string_view> confliciting_indexes;
@@ -2470,14 +2470,14 @@ Result LocalCatalog::DropTokenizer(std::string_view database,
 
   return Apply(_snapshot, [&](std::shared_ptr<SnapshotImpl>& clone) {
     SDB_ASSERT(clone);
-    auto tokenizer = clone->GetObject<Tokenizer>(*tokenizer_id);
-    SDB_ASSERT(tokenizer);
+    auto opclass = clone->GetObject<OpClass>(*opclass_id);
+    SDB_ASSERT(opclass);
     auto r =
-      _engine->DropDefinition(*schema_id, ObjectType::Tokenizer, *tokenizer_id);
+      _engine->DropDefinition(*schema_id, ObjectType::OpClass, *opclass_id);
     if (!r.ok()) {
       return r;
     }
-    clone->UnregisterObject(std::move(tokenizer), *schema_id);
+    clone->UnregisterObject(std::move(opclass), *schema_id);
     return Result{};
   });
 }

--- a/server/catalog/local_catalog.h
+++ b/server/catalog/local_catalog.h
@@ -37,7 +37,7 @@
 #include "catalog/sequence.h"
 #include "catalog/table.h"
 #include "catalog/table_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "catalog/user_type.h"
 #include "storage_engine/table_shard.h"
 
@@ -65,8 +65,8 @@ class LocalCatalog final : public LogicalCatalog,
                           std::shared_ptr<Sequence> sequence) final;
   Result RegisterFunction(ObjectId database_id, ObjectId schema_id,
                           std::shared_ptr<PgSqlFunction> function) final;
-  Result RegisterTokenizer(ObjectId database_id, ObjectId schema_id,
-                           std::shared_ptr<Tokenizer> tokenizer) final;
+  Result RegisterOpClass(ObjectId database_id, ObjectId schema_id,
+                         std::shared_ptr<OpClass> opclass) final;
   Result RegisterType(ObjectId database_id, ObjectId schema_id,
                       std::shared_ptr<PgSqlType> type) final;
   Result RegisterTable(ObjectId database_id, ObjectId schema_id,
@@ -101,8 +101,8 @@ class LocalCatalog final : public LogicalCatalog,
                              IndexShardOptions& shard_options,
                              CreateIndexOperationOptions operation_options,
                              std::optional<ScorerOptions> wand_scorer) final;
-  Result CreateTokenizer(ObjectId database_id, std::string_view schema,
-                         std::shared_ptr<Tokenizer> dict) final;
+  Result CreateOpClass(ObjectId database_id, std::string_view schema,
+                       std::shared_ptr<OpClass> opclass) final;
   Result CreateType(ObjectId database_id, std::string_view schema,
                     std::shared_ptr<PgSqlType> type) final;
 
@@ -137,8 +137,8 @@ class LocalCatalog final : public LogicalCatalog,
                   std::string_view name) final;
   Result DropFunction(std::string_view database, std::string_view schema,
                       std::string_view name) final;
-  Result DropTokenizer(std::string_view database, std::string_view schema,
-                       std::string_view name) final;
+  Result DropOpClass(std::string_view database, std::string_view schema,
+                     std::string_view name) final;
   Result DropTable(std::string_view database, std::string_view schema,
                    std::string_view name) final;
   Result DropIndex(std::string_view database, std::string_view schema,

--- a/server/catalog/object.h
+++ b/server/catalog/object.h
@@ -49,7 +49,7 @@ enum class ObjectType : uint8_t {
   // Under database
   Schema,
   // Under schema - dependencies first
-  Tokenizer,
+  OpClass,
   PgSqlFunction,
   PgSqlType,
   PgSqlView,

--- a/server/catalog/object_dependency.h
+++ b/server/catalog/object_dependency.h
@@ -64,12 +64,12 @@ struct SchemaDependency : ObjectDependencyBase {
   containers::FlatHashSet<ObjectId> tables;
   containers::FlatHashSet<ObjectId> functions;
   containers::FlatHashSet<ObjectId> views;
-  containers::FlatHashSet<ObjectId> tokenizers;
+  containers::FlatHashSet<ObjectId> opclasses;
   containers::FlatHashSet<ObjectId> types;
   containers::FlatHashSet<ObjectId> sequences;
   bool Empty() const {
     return tables.empty() && functions.empty() && views.empty() &&
-           tokenizers.empty() && types.empty() && sequences.empty();
+           opclasses.empty() && types.empty() && sequences.empty();
   }
   std::shared_ptr<ObjectDependencyBase> Clone() const final {
     return std::make_shared<SchemaDependency>(*this);
@@ -83,10 +83,10 @@ struct DatabaseDependency : ObjectDependencyBase {
   }
 };
 
-struct TokenizerDependency : ObjectDependencyBase {
+struct OpClassDependency : ObjectDependencyBase {
   containers::FlatHashSet<ObjectId> indexes;
   std::shared_ptr<ObjectDependencyBase> Clone() const final {
-    return std::make_shared<TokenizerDependency>(*this);
+    return std::make_shared<OpClassDependency>(*this);
   }
 };
 

--- a/server/catalog/opclass.cpp
+++ b/server/catalog/opclass.cpp
@@ -18,7 +18,7 @@
 /// Copyright holder is SereneDB GmbH, Berlin, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 
 #include <vpack/builder.h>
 #include <vpack/slice.h>
@@ -34,7 +34,28 @@
 
 namespace sdb::catalog {
 
-ResultOr<Tokenizer::TokenizerWrapper> Tokenizer::GetTokenizer() {
+namespace {
+
+constexpr std::string_view kTextKindName = "text";
+
+}  // namespace
+
+std::string_view ToString(OpClassKind kind) noexcept {
+  switch (kind) {
+    case OpClassKind::Text:
+      return kTextKindName;
+  }
+  SDB_UNREACHABLE();
+}
+
+std::optional<OpClassKind> ParseOpClassKind(std::string_view name) noexcept {
+  if (name == kTextKindName) {
+    return OpClassKind::Text;
+  }
+  return std::nullopt;
+}
+
+ResultOr<OpClass::TokenizerWrapper> OpClass::GetTokenizer() {
   absl::MutexLock lock{&_m};
   if (_pool.empty()) {
     auto analyzer = CreateAnalyzer();
@@ -50,30 +71,31 @@ ResultOr<Tokenizer::TokenizerWrapper> Tokenizer::GetTokenizer() {
   return TokenizerWrapper{analyzer.release(), Deleter{this}};
 }
 
-void Tokenizer::PushTokenizer(irs::analysis::Analyzer::ptr analyzer) noexcept {
+void OpClass::PushTokenizer(irs::analysis::Analyzer::ptr analyzer) noexcept {
   SDB_ASSERT(analyzer);
   absl::MutexLock lock{&_m};
   _pool.push_back(std::move(analyzer));
 }
 
-vpack::Slice Tokenizer::Slice() const noexcept {
+vpack::Slice OpClass::Slice() const noexcept {
   return vpack::Slice{reinterpret_cast<const uint8_t*>(_data.data())};
 }
 
-irs::analysis::Analyzer::ptr Tokenizer::CreateAnalyzer() const {
+irs::analysis::Analyzer::ptr OpClass::CreateAnalyzer() const {
   irs::analysis::Analyzer::ptr output;
   irs::analysis::analyzers::MakeAnalyzer(Slice(), output);
   return output;
 }
 
-Tokenizer::Tokenizer(ObjectId id, std::string_view name,
-                     search::Features features, std::string data)
-  : SchemaObject{{}, {}, {}, id, name, ObjectType::Tokenizer},
+OpClass::OpClass(ObjectId id, std::string_view name, OpClassKind kind,
+                 search::Features features, std::string data)
+  : SchemaObject{{}, {}, {}, id, name, ObjectType::OpClass},
     _data{std::move(data)},
+    _kind{kind},
     _features{features} {}
 
-std::shared_ptr<Tokenizer> Tokenizer::ReadInternal(vpack::Slice slice,
-                                                   ReadContext ctx) {
+std::shared_ptr<OpClass> OpClass::ReadInternal(vpack::Slice slice,
+                                               ReadContext ctx) {
   auto name = slice.get("name");
   if (!name.isString()) {
     return nullptr;
@@ -83,16 +105,27 @@ std::shared_ptr<Tokenizer> Tokenizer::ReadInternal(vpack::Slice slice,
   if (auto r = features.FromVPack(features_slice); !r.ok()) {
     return nullptr;
   }
-  return std::make_shared<Tokenizer>(
-    ctx.id, name.stringView(), std::move(features),
+  // Persisted bodies written before the kind tag was introduced have no
+  // "type" key. Treat them as Text -- the only kind that existed then.
+  OpClassKind kind = OpClassKind::Text;
+  if (auto type_slice = slice.get("type"); type_slice.isString()) {
+    auto parsed = ParseOpClassKind(type_slice.stringView());
+    if (!parsed) {
+      return nullptr;
+    }
+    kind = *parsed;
+  }
+  return std::make_shared<OpClass>(
+    ctx.id, name.stringView(), kind, std::move(features),
     std::string{reinterpret_cast<const char*>(slice.getDataPtr()),
                 slice.byteSize()});
 }
 
-void Tokenizer::WriteInternal(vpack::Builder& b) const {
+void OpClass::WriteInternal(vpack::Builder& b) const {
   b.openObject();
   WriteObject(b, [&](vpack::Builder& b) {
     auto slice = vpack::Slice{reinterpret_cast<const uint8_t*>(_data.data())};
+    b.add("type", ToString(_kind));
     b.add("tokenizer", slice.get("tokenizer"));
     b.add("features");
     _features.ToVPack(b);
@@ -100,7 +133,7 @@ void Tokenizer::WriteInternal(vpack::Builder& b) const {
   b.close();
 }
 
-std::shared_ptr<Object> Tokenizer::Clone() const {
+std::shared_ptr<Object> OpClass::Clone() const {
   vpack::Builder b;
   WriteInternal(b);
   return ReadInternal(b.slice(), {.id = GetId()});

--- a/server/catalog/opclass.h
+++ b/server/catalog/opclass.h
@@ -31,6 +31,8 @@
 #include <iresearch/analysis/stemming_tokenizer.hpp>
 #include <iresearch/analysis/text_tokenizer.hpp>
 #include <memory>
+#include <optional>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -39,15 +41,25 @@
 
 namespace sdb::catalog {
 
-class Tokenizer : public SchemaObject {
+// Discriminator for opclass kinds. Persisted under the "type" key in the
+// stored vpack body. Adding new kinds is append-only; existing values must
+// never be renumbered.
+enum class OpClassKind : uint8_t {
+  Text = 0,
+};
+
+std::string_view ToString(OpClassKind kind) noexcept;
+std::optional<OpClassKind> ParseOpClassKind(std::string_view name) noexcept;
+
+class OpClass : public SchemaObject {
  public:
   struct Deleter {
-    Tokenizer* tokenizer{nullptr};
+    OpClass* opclass{nullptr};
 
     void operator()(irs::analysis::Analyzer* analyzer) {
       // TODO(mbkkt) Revert this when global identity will be available
-      if (tokenizer) {
-        tokenizer->PushTokenizer(irs::analysis::Analyzer::ptr{analyzer});
+      if (opclass) {
+        opclass->PushTokenizer(irs::analysis::Analyzer::ptr{analyzer});
       } else {
         delete analyzer;
       }
@@ -56,8 +68,8 @@ class Tokenizer : public SchemaObject {
 
   using TokenizerWrapper = std::unique_ptr<irs::analysis::Analyzer, Deleter>;
 
-  static std::shared_ptr<Tokenizer> ReadInternal(vpack::Slice slice,
-                                                 ReadContext ctx);
+  static std::shared_ptr<OpClass> ReadInternal(vpack::Slice slice,
+                                               ReadContext ctx);
 
   ResultOr<TokenizerWrapper> GetTokenizer();
 
@@ -68,9 +80,10 @@ class Tokenizer : public SchemaObject {
   void WriteInternal(vpack::Builder&) const final;
   std::shared_ptr<Object> Clone() const final;
 
-  Tokenizer(ObjectId id, std::string_view name, search::Features features,
-            std::string data);
+  OpClass(ObjectId id, std::string_view name, OpClassKind kind,
+          search::Features features, std::string data);
 
+  OpClassKind GetKind() const noexcept { return _kind; }
   const search::Features& GetFeatures() const noexcept { return _features; }
 
  private:
@@ -79,6 +92,7 @@ class Tokenizer : public SchemaObject {
   mutable absl::Mutex _m;
   std::vector<irs::analysis::Analyzer::ptr> _pool;
   std::string _data;
+  OpClassKind _kind;
   search::Features _features;
 };
 

--- a/server/catalog/resolution_table.h
+++ b/server/catalog/resolution_table.h
@@ -40,7 +40,7 @@ enum class ResolveType {
   Schema,
   Function,
   Relation,
-  Tokenizer,
+  OpClass,
   Type,
 };
 
@@ -52,7 +52,7 @@ class ResolutionTable {
     _schemas = std::make_shared<MapById<MapByNamePtr<ObjectId>>>();
     _relations = std::make_shared<MapById<MapByNamePtr<ObjectId>>>();
     _functions = std::make_shared<MapById<MapByNamePtr<ObjectId>>>();
-    _tokenizers = std::make_shared<MapById<MapByNamePtr<ObjectId>>>();
+    _opclasses = std::make_shared<MapById<MapByNamePtr<ObjectId>>>();
     _types = std::make_shared<MapById<MapByNamePtr<ObjectId>>>();
   }
   template<ResolveType Type>
@@ -84,8 +84,8 @@ class ResolutionTable {
         return resolve(_schemas, parent_id, object_name);
       } else if constexpr (Type == ResolveType::Relation) {
         return resolve(_relations, parent_id, object_name);
-      } else if constexpr (Type == ResolveType::Tokenizer) {
-        return resolve(_tokenizers, parent_id, object_name);
+      } else if constexpr (Type == ResolveType::OpClass) {
+        return resolve(_opclasses, parent_id, object_name);
       } else if constexpr (Type == ResolveType::Type) {
         return resolve(_types, parent_id, object_name);
       } else {
@@ -157,14 +157,14 @@ class ResolutionTable {
           auto [_, insert_function] =
             CloneData(_functions)
               .try_emplace(object_id, std::make_shared<MapByName<ObjectId>>());
-          auto [_, insert_tokenizer] =
-            CloneData(_tokenizers)
+          auto [_, insert_opclass] =
+            CloneData(_opclasses)
               .try_emplace(object_id, std::make_shared<MapByName<ObjectId>>());
           auto [_, insert_type] = CloneData(_types).try_emplace(
             object_id, std::make_shared<MapByName<ObjectId>>());
           SDB_ASSERT(insert_relation);
           SDB_ASSERT(insert_function);
-          SDB_ASSERT(insert_tokenizer);
+          SDB_ASSERT(insert_opclass);
           SDB_ASSERT(insert_type);
           return {};
         }
@@ -173,8 +173,8 @@ class ResolutionTable {
         return insert(_relations, parent_id, object_name, object_id)
                  ? Result{}
                  : Result{ERROR_SERVER_DUPLICATE_NAME};
-      } else if constexpr (Type == ResolveType::Tokenizer) {
-        return insert(_tokenizers, parent_id, object_name, object_id)
+      } else if constexpr (Type == ResolveType::OpClass) {
+        return insert(_opclasses, parent_id, object_name, object_id)
                  ? Result{}
                  : Result{ERROR_SERVER_DUPLICATE_NAME};
       } else if constexpr (Type == ResolveType::Type) {
@@ -202,7 +202,7 @@ class ResolutionTable {
       for (auto [_, id] : *node.mapped()) {
         CloneData(_relations).erase(id);
         CloneData(_functions).erase(id);
-        CloneData(_tokenizers).erase(id);
+        CloneData(_opclasses).erase(id);
         CloneData(_types).erase(id);
       }
       return {id};
@@ -236,14 +236,14 @@ class ResolutionTable {
         if (result) {
           CloneData(_relations).erase(*result);
           CloneData(_functions).erase(*result);
-          CloneData(_tokenizers).erase(*result);
+          CloneData(_opclasses).erase(*result);
           CloneData(_types).erase(*result);
         }
         return result;
       } else if constexpr (Type == ResolveType::Relation) {
         return remove(_relations, parent_id, object_name);
-      } else if constexpr (Type == ResolveType::Tokenizer) {
-        return remove(_tokenizers, parent_id, object_name);
+      } else if constexpr (Type == ResolveType::OpClass) {
+        return remove(_opclasses, parent_id, object_name);
       } else if constexpr (Type == ResolveType::Type) {
         return remove(_types, parent_id, object_name);
       } else {
@@ -274,9 +274,9 @@ class ResolutionTable {
     return *it->second | std::views::values;
   }
 
-  auto GetTokenizerIds(ObjectId schema_id) const {
-    auto it = _tokenizers->find(schema_id);
-    SDB_ASSERT(it != _tokenizers->end());
+  auto GetOpClassIds(ObjectId schema_id) const {
+    auto it = _opclasses->find(schema_id);
+    SDB_ASSERT(it != _opclasses->end());
     return *it->second | std::views::values;
   }
 
@@ -313,8 +313,8 @@ class ResolutionTable {
   MapByIdPtr<MapByNamePtr<ObjectId>> _relations;
   // schema_id -> (function_name -> object_id)
   MapByIdPtr<MapByNamePtr<ObjectId>> _functions;
-  // schema_id -> (tokenizer_name -> object_id)
-  MapByIdPtr<MapByNamePtr<ObjectId>> _tokenizers;
+  // schema_id -> (opclass_name -> object_id)
+  MapByIdPtr<MapByNamePtr<ObjectId>> _opclasses;
   // schema_id -> (type_name -> object_id)
   MapByIdPtr<MapByNamePtr<ObjectId>> _types;
 };

--- a/server/connector/duckdb_tokenizer_function.cpp
+++ b/server/connector/duckdb_tokenizer_function.cpp
@@ -50,10 +50,10 @@
 #include "basics/assert.h"
 #include "catalog/catalog.h"
 #include "catalog/search_analyzer_impl.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "connector/duckdb_catalog.h"
 #include "connector/duckdb_client_state.h"
-#include "pg/commands/create_tsdictionary.h"
+#include "pg/commands/create_opclass.h"
 #include "pg/connection_context.h"
 #include "pg/errcodes.h"
 #include "pg/sql_exception_macro.h"
@@ -61,17 +61,17 @@
 namespace sdb::connector {
 namespace {
 
-// PRAGMA create_text_search_dictionary('name', if_not_exists, key := value,
-// ...) Positional parameters:
+// PRAGMA create_opclass('name', if_not_exists, key := value, ...)
+// Positional parameters:
 //   [0] name (VARCHAR)  -- optionally schema-qualified as "schema.name"
 //   [1] if_not_exists (BOOLEAN)
-// Named parameters: tokenizer options (template, frequency, etc.)
-void CreateTSDictionaryPragma(duckdb::ClientContext& context,
-                              const duckdb::FunctionParameters& params) {
+// Named parameters: opclass options (type, plus per-type options).
+void CreateOpClassPragma(duckdb::ClientContext& context,
+                         const duckdb::FunctionParameters& params) {
   auto& args = params.values;
   if (args.size() < 2) {
     throw duckdb::InvalidInputException(
-      "create_text_search_dictionary requires at least name and if_not_exists");
+      "create_opclass requires at least name and if_not_exists");
   }
 
   auto dict_name = args[0].GetValue<std::string>();
@@ -79,20 +79,20 @@ void CreateTSDictionaryPragma(duckdb::ClientContext& context,
 
   auto& conn_ctx = GetSereneDBContext(context);
   auto name = pg::ParseObjectName(dict_name, StaticStrings::kPublic);
-  pg::CreateTokenizer(conn_ctx, name.relation, name.schema, if_not_exists,
-                      params.named_parameters);
+  pg::CreateOpClass(conn_ctx, name.relation, name.schema, if_not_exists,
+                    params.named_parameters);
 }
 
-// PRAGMA drop_text_search_dictionary('name', missing_ok)
+// PRAGMA drop_opclass('name', missing_ok)
 // Parameters:
 //   [0] name (VARCHAR) -- optionally schema-qualified as "schema.name"
 //   [1] missing_ok (BOOLEAN)
-void DropTSDictionaryPragma(duckdb::ClientContext& context,
-                            const duckdb::FunctionParameters& params) {
+void DropOpClassPragma(duckdb::ClientContext& context,
+                       const duckdb::FunctionParameters& params) {
   auto& args = params.values;
   if (args.size() < 2) {
     throw duckdb::InvalidInputException(
-      "drop_text_search_dictionary requires name and missing_ok");
+      "drop_opclass requires name and missing_ok");
   }
 
   const auto dict_name = args[0].GetValue<std::string>();
@@ -106,7 +106,7 @@ void DropTSDictionaryPragma(duckdb::ClientContext& context,
   auto name = pg::ParseObjectName(dict_name, StaticStrings::kPublic);
 
   auto r =
-    catalog.DropTokenizer(conn_ctx.GetDatabase(), name.schema, name.relation);
+    catalog.DropOpClass(conn_ctx.GetDatabase(), name.schema, name.relation);
 
   std::string_view object_name = "text search dictionary";
   if (r.is(ERROR_SERVER_OBJECT_TYPE_MISMATCH)) {
@@ -140,16 +140,16 @@ void DropTSDictionaryPragma(duckdb::ClientContext& context,
 
 }  // namespace
 
-void RegisterTokenizerPragma(duckdb::DatabaseInstance& db) {
+void RegisterOpClassPragma(duckdb::DatabaseInstance& db) {
   duckdb::ExtensionLoader loader(db, "serenedb");
 
   auto create_pragma = duckdb::PragmaFunction::PragmaCall(
-    "create_text_search_dictionary", CreateTSDictionaryPragma,
+    "create_opclass", CreateOpClassPragma,
     {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::BOOLEAN});
   loader.RegisterFunction(create_pragma);
 
   auto drop_pragma = duckdb::PragmaFunction::PragmaCall(
-    "drop_text_search_dictionary", DropTSDictionaryPragma,
+    "drop_opclass", DropOpClassPragma,
     {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::BOOLEAN});
   loader.RegisterFunction(drop_pragma);
 }

--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -39,7 +39,7 @@
 #include <iresearch/utils/utf8_utils.hpp>
 
 #include "catalog/scorer_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "connector/duckdb_client_state.h"
 #include "connector/functions/ts_highlight.h"
 #include "connector/functions/ts_lexize.h"
@@ -972,16 +972,16 @@ duckdb::LogicalType MakeTSQueryType() {
   return type;
 }
 
-catalog::Tokenizer::TokenizerWrapper AcquireTokenizer(
+catalog::OpClass::TokenizerWrapper AcquireTokenizer(
   duckdb::ClientContext& context, std::string_view name) {
   auto entry = ResolveCatalogTokenizer(context, name);
   if (!entry) {
     return {};
   }
-  return entry->GetTokenizer().value_or(catalog::Tokenizer::TokenizerWrapper{});
+  return entry->GetTokenizer().value_or(catalog::OpClass::TokenizerWrapper{});
 }
 
-std::shared_ptr<catalog::Tokenizer> ResolveCatalogTokenizer(
+std::shared_ptr<catalog::OpClass> ResolveCatalogTokenizer(
   duckdb::ClientContext& context, std::string_view name) {
   auto state =
     context.registered_state->Get<SereneDBClientState>(kSereneDBClientStateKey);
@@ -996,7 +996,7 @@ std::shared_ptr<catalog::Tokenizer> ResolveCatalogTokenizer(
   if (!snapshot) {
     return nullptr;
   }
-  return snapshot->GetTokenizer(db_id, qualified.schema, qualified.relation);
+  return snapshot->GetOpClass(db_id, qualified.schema, qualified.relation);
 }
 
 void RegisterSearchFunctions(duckdb::DatabaseInstance& db) {

--- a/server/connector/functions/search.h
+++ b/server/connector/functions/search.h
@@ -24,7 +24,7 @@
 #include <duckdb/main/database.hpp>
 #include <iresearch/analysis/analyzer.hpp>
 
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 
 namespace sdb::connector {
 
@@ -89,10 +89,10 @@ inline constexpr std::string_view kGeoContains = "ST_Contains";
 
 duckdb::LogicalType MakeTSQueryType();
 
-catalog::Tokenizer::TokenizerWrapper AcquireTokenizer(
+catalog::OpClass::TokenizerWrapper AcquireTokenizer(
   duckdb::ClientContext& context, std::string_view name);
 
-std::shared_ptr<catalog::Tokenizer> ResolveCatalogTokenizer(
+std::shared_ptr<catalog::OpClass> ResolveCatalogTokenizer(
   duckdb::ClientContext& context, std::string_view name);
 
 void RegisterSearchFunctions(duckdb::DatabaseInstance& db);

--- a/server/connector/functions/ts_anyall.cpp
+++ b/server/connector/functions/ts_anyall.cpp
@@ -107,7 +107,7 @@ void FromTokenizeListInAnyAllOf(
   // Hold the wrapper as a stack local so its raw pointer (used by
   // `analyzer` below) stays valid for the loop. Drops at function
   // return -> analyzer goes back to the catalog Tokenizer's pool.
-  catalog::Tokenizer::TokenizerWrapper override_wrapper;
+  catalog::OpClass::TokenizerWrapper override_wrapper;
   if (tokenize_call.children.size() == 2) {
     std::string analyzer_name;
     if (auto r = GetVarcharArg(*tokenize_call.children[1],

--- a/server/connector/functions/ts_common.hpp
+++ b/server/connector/functions/ts_common.hpp
@@ -38,7 +38,7 @@
 
 #include "basics/containers/node_hash_map.h"
 #include "basics/result.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "connector/search_filter_builder.hpp"
 
 namespace sdb::catalog {

--- a/server/connector/functions/ts_lexize.cpp
+++ b/server/connector/functions/ts_lexize.cpp
@@ -34,7 +34,7 @@
 #include <variant>
 
 #include "catalog/catalog.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "connector/duckdb_client_state.h"
 #include "connector/functions/ts_common.hpp"
 #include "pg/connection_context.h"
@@ -45,11 +45,11 @@
 namespace sdb::connector {
 namespace {
 
-std::shared_ptr<catalog::Tokenizer> LookupTokenizerDict(
+std::shared_ptr<catalog::OpClass> LookupTokenizerDict(
   const catalog::Snapshot& snapshot, sdb::ObjectId db_id,
   std::string_view current_schema, std::string_view dict_name) {
   auto name = pg::ParseObjectName(dict_name, current_schema);
-  auto dict = snapshot.GetTokenizer(db_id, name.schema, name.relation);
+  auto dict = snapshot.GetOpClass(db_id, name.schema, name.relation);
   if (!dict) {
     THROW_SQL_ERROR(
       ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -58,8 +58,8 @@ std::shared_ptr<catalog::Tokenizer> LookupTokenizerDict(
   return dict;
 }
 
-catalog::Tokenizer::TokenizerWrapper AcquireTokenizer(
-  catalog::Tokenizer& dict) {
+catalog::OpClass::TokenizerWrapper AcquireTokenizer(
+  catalog::OpClass& dict) {
   auto result = dict.GetTokenizer();
   if (!result) {
     THROW_SQL_ERROR(
@@ -81,7 +81,7 @@ struct DynamicCtx {
 };
 
 struct TsLexizeBindData final : public duckdb::FunctionData {
-  std::variant<DynamicCtx, std::shared_ptr<catalog::Tokenizer>> state;
+  std::variant<DynamicCtx, std::shared_ptr<catalog::OpClass>> state;
 
   duckdb::unique_ptr<duckdb::FunctionData> Copy() const final {
     return duckdb::make_uniq<TsLexizeBindData>(*this);
@@ -92,14 +92,14 @@ struct TsLexizeBindData final : public duckdb::FunctionData {
 };
 
 struct TsLexizeLocalState final : public duckdb::FunctionLocalState {
-  catalog::Tokenizer::TokenizerWrapper wrapper;
+  catalog::OpClass::TokenizerWrapper wrapper;
 };
 
 duckdb::unique_ptr<duckdb::FunctionLocalState> InitTsLexizeLocalState(
   duckdb::ExpressionState& /*state*/,
   const duckdb::BoundFunctionExpression& expr,
   duckdb::FunctionData* bind_data) {
-  auto& dict = std::get<std::shared_ptr<catalog::Tokenizer>>(
+  auto& dict = std::get<std::shared_ptr<catalog::OpClass>>(
     bind_data->Cast<TsLexizeBindData>().state);
   auto local = duckdb::make_uniq<TsLexizeLocalState>();
   local->wrapper = AcquireTokenizer(*dict);

--- a/server/connector/functions/ts_offsets.cpp
+++ b/server/connector/functions/ts_offsets.cpp
@@ -65,7 +65,7 @@ constexpr catalog::Column::Id kStandaloneSyntheticColumnId = 0;
 
 struct IndexField {
   void Reset(catalog::Column::Id column_id,
-             catalog::Tokenizer::TokenizerWrapper analyzer) {
+             catalog::OpClass::TokenizerWrapper analyzer) {
     tokenizer = std::move(analyzer);
     name.clear();
     MakeFieldName(column_id, name);
@@ -82,7 +82,7 @@ struct IndexField {
   void SetValue(std::string_view value) const { tokenizer->reset(value); }
 
   std::string name;
-  catalog::Tokenizer::TokenizerWrapper tokenizer;
+  catalog::OpClass::TokenizerWrapper tokenizer;
 };
 
 struct OffsetsLocalState final : duckdb::FunctionLocalState {
@@ -229,7 +229,7 @@ int64_t EvalOptionalLimit(duckdb::ClientContext& context,
 std::shared_ptr<irs::Filter> BuildFilterFromTSQuery(
   duckdb::ClientContext& context, const duckdb::Expression& tsquery_expr,
   catalog::Column::Id column_id,
-  const std::shared_ptr<catalog::Tokenizer>& dict_tokenizer) {
+  const std::shared_ptr<catalog::OpClass>& dict_tokenizer) {
   static constexpr duckdb::idx_t kSyntheticTableIdx = 0;
   static constexpr duckdb::idx_t kSyntheticColumnIdx = 0;
 

--- a/server/connector/functions/ts_offsets.h
+++ b/server/connector/functions/ts_offsets.h
@@ -29,20 +29,20 @@
 
 #include "catalog/inverted_index.h"
 #include "catalog/table_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 
 namespace sdb::connector {
 
 std::shared_ptr<irs::Filter> BuildFilterFromTSQuery(
   duckdb::ClientContext& context, const duckdb::Expression& tsquery_expr,
   catalog::Column::Id column_id,
-  const std::shared_ptr<catalog::Tokenizer>& dict_tokenizer);
+  const std::shared_ptr<catalog::OpClass>& dict_tokenizer);
 
 struct OffsetsBindData final : duckdb::FunctionData {
   std::shared_ptr<const catalog::InvertedIndex> inverted_index;
   catalog::Column::Id column_id = 0;
 
-  std::shared_ptr<catalog::Tokenizer> dict_tokenizer;
+  std::shared_ptr<catalog::OpClass> dict_tokenizer;
 
   size_t limit = 0;
   std::shared_ptr<irs::Filter> stored_filter;

--- a/server/connector/highlight/highlight_types.h
+++ b/server/connector/highlight/highlight_types.h
@@ -27,7 +27,7 @@
 #include <utility>
 
 #include "catalog/table_options.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 
 namespace sdb::connector::highlight {
 
@@ -36,7 +36,7 @@ using HitRange = std::pair<uint32_t, uint32_t>;
 struct Field {
   catalog::Column::Id column_id = 0;
   std::string field_name;
-  catalog::Tokenizer::TokenizerWrapper* analyzer = nullptr;
+  catalog::OpClass::TokenizerWrapper* analyzer = nullptr;
   size_t limit = 0;
 };
 

--- a/server/connector/search_sink_writer.hpp
+++ b/server/connector/search_sink_writer.hpp
@@ -151,7 +151,7 @@ class SearchSinkInsertBaseImpl : public ColumnSinkWriterImplBase {
     void SetNullValue();
 
     search::AnalyzerImpl::CacheType::ptr analyzer;
-    catalog::Tokenizer::TokenizerWrapper string_analyzer;
+    catalog::OpClass::TokenizerWrapper string_analyzer;
     std::string_view name;
     irs::IndexFeatures index_features;
     // For paths that don't receive a StoreAttr from an analyzer

--- a/server/pg/CMakeLists.txt
+++ b/server/pg/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(
         pg_types.cpp
         serialize.cpp
         system_catalog.cpp
+        system_opclasses.cpp
         progress_tracker.cpp
         sdb_catalog/sdb_log.cpp
         sql_utils.cpp

--- a/server/pg/commands/CMakeLists.txt
+++ b/server/pg/commands/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(sereneserver PRIVATE create_tsdictionary.cpp)
+target_sources(sereneserver PRIVATE create_opclass.cpp)

--- a/server/pg/commands/create_opclass.cpp
+++ b/server/pg/commands/create_opclass.cpp
@@ -53,7 +53,7 @@
 #include "basics/assert.h"
 #include "catalog/catalog.h"
 #include "catalog/search_analyzer_impl.h"
-#include "catalog/tokenizer.h"
+#include "catalog/opclass.h"
 #include "pg/connection_context.h"
 #include "pg/option_help.h"
 #include "pg/options_parser.h"
@@ -653,7 +653,7 @@ class CreateTSDictionaryOptions : public OptionsParser {
       OptionsParser::EraseOptionOrDefault<tokenizer_options::kFrom>(prefix);
     auto name = ParseObjectName(from, _current_schema);
     auto tokenizer =
-      _snapshot->GetTokenizer(_db_id, name.schema, name.relation);
+      _snapshot->GetOpClass(_db_id, name.schema, name.relation);
     if (!tokenizer) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_UNDEFINED_OBJECT),
@@ -691,11 +691,34 @@ class CreateTSDictionaryOptions : public OptionsParser {
   std::string_view _current_schema;
 };
 
-}  // namespace
+// Pops `type` from `options` (required, no default) and parses it into an
+// OpClassKind. Returns the parsed kind plus the remaining options.
+std::pair<catalog::OpClassKind, duckdb::named_parameter_map_t> ExtractKind(
+  const duckdb::named_parameter_map_t& options) {
+  auto type_it = options.find("type");
+  if (type_it == options.end()) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG("CREATE OPCLASS requires a 'type' option"));
+  }
+  if (type_it->second.type().id() != duckdb::LogicalTypeId::VARCHAR) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG("CREATE OPCLASS 'type' option must be a string"));
+  }
+  auto type_str = type_it->second.GetValue<std::string>();
+  auto parsed = catalog::ParseOpClassKind(type_str);
+  if (!parsed) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG("Unknown opclass type '", type_str,
+                            "' (known: text)"));
+  }
+  auto rest = options;
+  rest.erase(type_it->first);
+  return {*parsed, std::move(rest)};
+}
 
-void CreateTokenizer(ConnectionContext& conn_ctx, std::string_view name,
-                     std::string_view schema, bool if_not_exists,
-                     const duckdb::named_parameter_map_t& options) {
+void CreateTextOpClass(ConnectionContext& conn_ctx, std::string_view name,
+                       std::string_view schema, bool if_not_exists,
+                       const duckdb::named_parameter_map_t& options) {
   auto snapshot = conn_ctx.EnsureCatalogSnapshot();
   auto db_id = conn_ctx.GetDatabaseId();
   auto current_schema = conn_ctx.GetCurrentSchema();
@@ -718,7 +741,6 @@ void CreateTokenizer(ConnectionContext& conn_ctx, std::string_view name,
               reinterpret_cast<const char*>(properties_slice.getDataPtr()),
               properties_slice.byteSize()},
             false)) {
-        // If validation fails, the error should already be logged
         THROW_SQL_ERROR(
           ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
           ERR_MSG("Failed to create text search dictionary \"", name, "\""));
@@ -737,20 +759,35 @@ void CreateTokenizer(ConnectionContext& conn_ctx, std::string_view name,
     }
   }
 
-  auto tokenizer = std::make_shared<catalog::Tokenizer>(
-    ObjectId{0}, name, features,
+  auto opclass = std::make_shared<catalog::OpClass>(
+    ObjectId{0}, name, catalog::OpClassKind::Text, features,
     std::string{reinterpret_cast<const char*>(b.slice().getDataPtr()),
                 b.slice().byteSize()});
 
   auto& catalog =
     SerenedServer::Instance().getFeature<catalog::CatalogFeature>().Global();
-  auto r = catalog.CreateTokenizer(db_id, schema, std::move(tokenizer));
+  auto r = catalog.CreateOpClass(db_id, schema, std::move(opclass));
 
   if (!r.ok() && !if_not_exists) {
-    THROW_SQL_ERROR(
-      ERR_CODE(ERRCODE_DUPLICATE_OBJECT),
-      ERR_MSG("text search dictionary \"", name, "\" already exists"));
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_DUPLICATE_OBJECT),
+                    ERR_MSG("text search dictionary \"", name,
+                            "\" already exists"));
   }
+}
+
+}  // namespace
+
+void CreateOpClass(ConnectionContext& conn_ctx, std::string_view name,
+                   std::string_view schema, bool if_not_exists,
+                   const duckdb::named_parameter_map_t& options) {
+  auto [kind, kind_options] = ExtractKind(options);
+  switch (kind) {
+    case catalog::OpClassKind::Text:
+      CreateTextOpClass(conn_ctx, name, schema, if_not_exists, kind_options);
+      return;
+    // TODO(opclass): add CreateJsonOpClass when OpClassKind::Json lands.
+  }
+  SDB_UNREACHABLE();
 }
 
 }  // namespace sdb::pg

--- a/server/pg/commands/create_opclass.h
+++ b/server/pg/commands/create_opclass.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -20,12 +20,14 @@
 
 #pragma once
 
-#include <duckdb.hpp>
+#include <duckdb/common/named_parameter_map.hpp>
 
-namespace sdb::connector {
+#include "pg/connection_context.h"
 
-// Register the PRAGMA create_text_search_dictionary(...) handler.
-// Called from DuckDBEngine::Initialize().
-void RegisterOpClassPragma(duckdb::DatabaseInstance& db);
+namespace sdb::pg {
 
-}  // namespace sdb::connector
+void CreateOpClass(ConnectionContext& conn_ctx, std::string_view name,
+                   std::string_view schema, bool if_not_exists,
+                   const duckdb::named_parameter_map_t& options);
+
+}  // namespace sdb::pg

--- a/server/pg/pg_catalog/pg_ts_dict.cpp
+++ b/server/pg/pg_catalog/pg_ts_dict.cpp
@@ -40,7 +40,7 @@ catalog::MaterializedData SystemTableSnapshot<PgTsDict>::GetTableData() {
 
   for (const auto& schema : catalog->GetSchemas(GetDatabaseId())) {
     for (const auto& tokenizer :
-         catalog->GetTokenizers(GetDatabaseId(), schema->GetName())) {
+         catalog->GetOpClasses(GetDatabaseId(), schema->GetName())) {
       auto owner = tokenizer->GetOwnerId();
       if (!owner) {
         owner = id::kRootUser;

--- a/server/pg/sql_utils.h
+++ b/server/pg/sql_utils.h
@@ -47,7 +47,7 @@ constexpr std::string_view ToPgObjectTypeName(catalog::ObjectType t) noexcept {
       return "database";
     case Role:
       return "role";
-    case Tokenizer:
+    case OpClass:
       return "text search dictionary";
     case PgSqlType:
       return "type";

--- a/server/pg/system_opclasses.cpp
+++ b/server/pg/system_opclasses.cpp
@@ -1,0 +1,106 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "pg/system_opclasses.h"
+
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "basics/containers/flat_hash_map.h"
+#include "basics/static_strings.h"
+
+namespace sdb::pg {
+namespace {
+
+using SystemOpClassFactory = std::shared_ptr<catalog::OpClass> (*)();
+
+struct SystemOpClassEntry {
+  std::string_view schema;
+  std::string_view name;
+  SystemOpClassFactory factory;
+};
+
+// Built-in opclasses registered alongside the persistent catalog. Entries
+// here are constructed once at startup, are not persisted, and are visible
+// from every database.
+//
+// TODO(opclass): add `pg_catalog.text_search_dictionary` with the standard
+// text defaults so users can write
+//     CREATE INDEX i ON t USING inverted(body text_search_dictionary)
+// without first declaring a per-database TSDictionary. Empty for now --
+// follow-up commits will design the canonical body and re-use the
+// CreateTextOpClass path to produce it.
+constexpr std::span<const SystemOpClassEntry> kSystemOpClasses{};
+
+struct KeyHash {
+  using is_transparent = void;
+  size_t operator()(
+    std::pair<std::string_view, std::string_view> p) const noexcept {
+    return absl::HashOf(p);
+  }
+};
+
+struct KeyEq {
+  using is_transparent = void;
+  bool operator()(std::pair<std::string_view, std::string_view> a,
+                  std::pair<std::string_view, std::string_view> b) const noexcept {
+    return a == b;
+  }
+};
+
+using SystemOpClassMap = containers::FlatHashMap<
+  std::pair<std::string_view, std::string_view>,
+  std::shared_ptr<catalog::OpClass>, KeyHash, KeyEq>;
+
+SystemOpClassMap& Mutable() {
+  static SystemOpClassMap instance;
+  return instance;
+}
+
+}  // namespace
+
+void InitSystemOpClasses() {
+  auto& map = Mutable();
+  map.clear();
+  for (const auto& entry : kSystemOpClasses) {
+    auto opclass = entry.factory();
+    map.emplace(std::pair{entry.schema, entry.name}, std::move(opclass));
+  }
+}
+
+std::shared_ptr<catalog::OpClass> GetSystemOpClass(std::string_view schema,
+                                                   std::string_view name) {
+  const auto& map = Mutable();
+  auto it = map.find(std::pair{schema, name});
+  return it == map.end() ? nullptr : it->second;
+}
+
+void VisitSystemOpClasses(
+  std::string_view schema,
+  absl::FunctionRef<void(const catalog::OpClass&)> visitor) {
+  for (const auto& [key, opclass] : Mutable()) {
+    if (key.first == schema) {
+      visitor(*opclass);
+    }
+  }
+}
+
+}  // namespace sdb::pg

--- a/server/pg/system_opclasses.h
+++ b/server/pg/system_opclasses.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -20,14 +20,29 @@
 
 #pragma once
 
-#include <duckdb/common/named_parameter_map.hpp>
+#include <absl/functional/function_ref.h>
 
-#include "pg/connection_context.h"
+#include <memory>
+#include <string_view>
+
+#include "catalog/opclass.h"
 
 namespace sdb::pg {
 
-void CreateTokenizer(ConnectionContext& conn_ctx, std::string_view name,
-                     std::string_view schema, bool if_not_exists,
-                     const duckdb::named_parameter_map_t& options);
+// Populate the in-memory system opclass map. Mirrors InitSystemViews: the
+// entries live for the process lifetime, are not persisted, and shadow no
+// user objects. Safe to call once at startup before any connection is
+// accepted.
+void InitSystemOpClasses();
+
+// Lookup a system opclass by (schema, name). Returns nullptr if absent.
+std::shared_ptr<catalog::OpClass> GetSystemOpClass(std::string_view schema,
+                                                   std::string_view name);
+
+// Visit every system opclass in `schema`. The visitor must not retain a
+// reference past the call.
+void VisitSystemOpClasses(
+  std::string_view schema,
+  absl::FunctionRef<void(const catalog::OpClass&)> visitor);
 
 }  // namespace sdb::pg

--- a/server/query/duckdb_engine.cpp
+++ b/server/query/duckdb_engine.cpp
@@ -44,6 +44,7 @@
 #include "connector/pg_logical_types.h"
 #include "pg/pg_catalog/pg_statistic.h"
 #include "pg/system_catalog.h"
+#include "pg/system_opclasses.h"
 #include "pg/system_table.h"
 #include "query/config.h"
 
@@ -218,7 +219,7 @@ void DuckDBEngine::Initialize() {
 
   _db = std::make_unique<duckdb::DuckDB>(nullptr, &config);
 
-  connector::RegisterTokenizerPragma(*_db->instance);
+  connector::RegisterOpClassPragma(*_db->instance);
 
   connector::RegisterPgCasts(*_db->instance);
 
@@ -266,6 +267,7 @@ void DuckDBEngine::Initialize() {
   // for serving from our attached catalog.
   pg::InitSystemFunctions();
   pg::InitSystemViews();
+  pg::InitSystemOpClasses();
 }
 
 void DuckDBEngine::Shutdown() { _db.reset(); }

--- a/tests/server/connector/duckdb_search_filter_builder_test.cpp
+++ b/tests/server/connector/duckdb_search_filter_builder_test.cpp
@@ -136,8 +136,9 @@ catalog::ColumnTokenizer IdentityAnalyzerProvider(catalog::Column::Id) {
     return std::string(vpack::Slice::emptyObjectSlice().startAs<char>(),
                        vpack::Slice::emptyObjectSlice().byteSize());
   };
-  static catalog::Tokenizer gStringTokenizer(
-    ObjectId{12345}, "test_string_verbartim", {}, make_identity());
+  static catalog::OpClass gStringTokenizer(
+    ObjectId{12345}, "test_string_verbartim", catalog::OpClassKind::Text, {},
+    make_identity());
   auto tokenizer = gStringTokenizer.GetTokenizer();
   EXPECT_TRUE(tokenizer);
   return {.analyzer = *std::move(tokenizer),
@@ -152,8 +153,9 @@ catalog::ColumnTokenizer SegmentationAnalyzerProviderBase(catalog::Column::Id) {
     return std::string(builder->slice().startAs<char>(),
                        builder->slice().byteSize());
   };
-  static catalog::Tokenizer gStringTokenizer(
-    ObjectId{12346}, "test_segmentation", {}, make_segmentation());
+  static catalog::OpClass gStringTokenizer(
+    ObjectId{12346}, "test_segmentation", catalog::OpClassKind::Text, {},
+    make_segmentation());
   auto tokenizer = gStringTokenizer.GetTokenizer();
   EXPECT_TRUE(tokenizer);
   return {.analyzer = *std::move(tokenizer), .features = Features};
@@ -175,8 +177,9 @@ catalog::ColumnTokenizer SegmentationAnalyzerProviderBase(catalog::Column::Id) {
     return std::string(builder->slice().startAs<char>(),
                        builder->slice().byteSize());
   };
-  static catalog::Tokenizer gNgramTokenizer(ObjectId{12347}, "test_ngram", {},
-                                            make_ngram());
+  static catalog::OpClass gNgramTokenizer(ObjectId{12347}, "test_ngram",
+                                          catalog::OpClassKind::Text, {},
+                                          make_ngram());
   auto tokenizer = gNgramTokenizer.GetTokenizer();
   EXPECT_TRUE(tokenizer);
   return {.analyzer = *std::move(tokenizer),
@@ -193,8 +196,9 @@ catalog::ColumnTokenizer SegmentationAnalyzerProviderBase(catalog::Column::Id) {
     return std::string(builder->slice().startAs<char>(),
                        builder->slice().byteSize());
   };
-  static catalog::Tokenizer gWildcardTokenizer(ObjectId{12348}, "test_wildcard",
-                                               {}, make_wildcard());
+  static catalog::OpClass gWildcardTokenizer(ObjectId{12348}, "test_wildcard",
+                                             catalog::OpClassKind::Text, {},
+                                             make_wildcard());
   auto tokenizer = gWildcardTokenizer.GetTokenizer();
   EXPECT_TRUE(tokenizer);
   return {.analyzer = *std::move(tokenizer),
@@ -209,8 +213,9 @@ catalog::ColumnTokenizer SegmentationAnalyzerProviderBase(catalog::Column::Id) {
     return std::string(builder->slice().startAs<char>(),
                        builder->slice().byteSize());
   };
-  static catalog::Tokenizer gGeoTokenizer(ObjectId{12349}, "test_geojson", {},
-                                          make_geojson());
+  static catalog::OpClass gGeoTokenizer(ObjectId{12349}, "test_geojson",
+                                        catalog::OpClassKind::Text, {},
+                                        make_geojson());
   auto tokenizer = gGeoTokenizer.GetTokenizer();
   EXPECT_TRUE(tokenizer);
   return {.analyzer = *std::move(tokenizer),

--- a/tests/server/connector/duckdb_search_sink_writer_test.cpp
+++ b/tests/server/connector/duckdb_search_sink_writer_test.cpp
@@ -46,8 +46,10 @@ class DuckDBSearchSinkWriterTest : public ::testing::Test {
       return std::string(vpack::Slice::emptyObjectSlice().startAs<char>(),
                          vpack::Slice::emptyObjectSlice().byteSize());
     };
-    static catalog::Tokenizer gStringTokenizer(
-      ObjectId{12345}, "test_string_verbartim", {}, make_identity());
+    static catalog::OpClass gStringTokenizer(ObjectId{12345},
+                                             "test_string_verbartim",
+                                             catalog::OpClassKind::Text, {},
+                                             make_identity());
     auto tokenizer = gStringTokenizer.GetTokenizer();
     EXPECT_TRUE(tokenizer);
     return {.analyzer = *std::move(tokenizer),


### PR DESCRIPTION
We want to create any custom op class for specified type and save this preference as well as text search dictionary. For example,
```
CREATE INDEX vecs_pq_hnsw ON vecs_pq
USING inverted(emb hnsw (metric = 'l2', m = 64, ef_construction = 256));
```
Is going to become
```
CREATE HNSW my_l2(
  metric='l2',
  m=64,
  ef_construction=256
);

CREATE INDEX vecs_pq_hnsw ON vecs_pq
USING inverted(emb my_l2);
```

Also it will be useful for json (in-progress) config description: nested objects analyzing and traversing policies, how to handle non-string leafs, etc.