### PR TITLE
fix: Pass schema_id when restoring views, functions, tokenizers and t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ tests/drivers/c/harness
 
 # Matches the stuff that's gonna replace developers
 
-/.claude/
+/.claude/*
+!/.claude/skills/

--- a/server/catalog/catalog.cpp
+++ b/server/catalog/catalog.cpp
@@ -366,8 +366,12 @@ Result OpenDatabase::RegisterFunctions(ObjectId db_id, ObjectId schema_id) {
   return GetServerEngine().VisitDefinitions(
     schema_id, ObjectType::PgSqlFunction,
     [&](DefinitionKey key, vpack::Slice slice) -> Result {
-      auto function = catalog::PgSqlFunction::ReadInternal(
-        slice, {.id = key.GetObjectId(), .database_id = db_id});
+      auto function =
+        catalog::PgSqlFunction::ReadInternal(slice, {
+                                                      .id = key.GetObjectId(),
+                                                      .database_id = db_id,
+                                                      .schema_id = schema_id,
+                                                    });
       if (!function) {
         return ErrorMeta(ERROR_INTERNAL, "function",
                          "Failed to read function definition", slice);
@@ -380,8 +384,11 @@ Result OpenDatabase::RegisterTokenizers(ObjectId db_id, ObjectId schema_id) {
   return GetServerEngine().VisitDefinitions(
     schema_id, ObjectType::Tokenizer,
     [&](DefinitionKey key, vpack::Slice slice) -> Result {
-      auto tokenizer =
-        Tokenizer::ReadInternal(slice, {.id = key.GetObjectId()});
+      auto tokenizer = Tokenizer::ReadInternal(slice, {
+                                                        .id = key.GetObjectId(),
+                                                        .database_id = db_id,
+                                                        .schema_id = schema_id,
+                                                      });
       if (!tokenizer) {
         return ErrorMeta(ERROR_INTERNAL, "tokenizer",
                          "Failed to read tokenizer definition", slice);
@@ -395,8 +402,8 @@ Result OpenDatabase::RegisterViews(ObjectId db_id, ObjectId schema_id) {
     schema_id, ObjectType::PgSqlView,
     [&](DefinitionKey key, vpack::Slice slice) -> Result {
       auto view_id = key.GetObjectId();
-      auto view =
-        PgSqlView::ReadInternal(slice, {.id = view_id, .database_id = db_id});
+      auto view = PgSqlView::ReadInternal(
+        slice, {.id = view_id, .database_id = db_id, .schema_id = schema_id});
       if (!view) {
         return ErrorMeta(ERROR_INTERNAL, "view",
                          "Failed to read view definition", slice);
@@ -417,9 +424,11 @@ Result OpenDatabase::RegisterSequences(ObjectId db_id, ObjectId schema_id,
   return GetServerEngine().VisitDefinitions(
     schema_id, ObjectType::Sequence,
     [&](DefinitionKey key, vpack::Slice slice) -> Result {
-      auto seq = Sequence::ReadInternal(slice, {.id = key.GetObjectId(),
-                                                .database_id = db_id,
-                                                .schema_id = schema_id});
+      auto seq = Sequence::ReadInternal(slice, {
+                                                 .id = key.GetObjectId(),
+                                                 .database_id = db_id,
+                                                 .schema_id = schema_id,
+                                               });
       if (!seq) {
         return ErrorMeta(ERROR_INTERNAL, "sequence",
                          "Failed to read sequence definition", slice);
@@ -440,8 +449,11 @@ Result OpenDatabase::RegisterTypes(ObjectId db_id, ObjectId schema_id) {
   return GetServerEngine().VisitDefinitions(
     schema_id, ObjectType::PgSqlType,
     [&](DefinitionKey key, vpack::Slice slice) -> Result {
-      auto type = PgSqlType::ReadInternal(
-        slice, {.id = key.GetObjectId(), .database_id = db_id});
+      auto type = PgSqlType::ReadInternal(slice, {
+                                                   .id = key.GetObjectId(),
+                                                   .database_id = db_id,
+                                                   .schema_id = schema_id,
+                                                 });
       if (!type) {
         return ErrorMeta(ERROR_INTERNAL, "type",
                          "Failed to read type definition", slice);

--- a/tests/sqllogic/recovery/drop_cascade_view_recovery.test
+++ b/tests/sqllogic/recovery/drop_cascade_view_recovery.test
@@ -1,0 +1,154 @@
+control substitution on
+
+# DROP TABLE ... CASCADE after a restart must not crash when a view
+# depends on the table.
+#
+# Pre-fix, PgSqlView::ReadInternal was invoked without `schema_id` in
+# its ReadContext during catalog restore (server/catalog/catalog.cpp
+# RegisterViews), so the restored view object had a default-
+# initialised parent_id. The same buggy parent_id then fed
+# DropPlan::view_drops via PgSqlView::GetParentId(), and
+# ApplyDropPlan called RemoveFromResolution<Relation> with a
+# parent_id that was never inserted into _relations -- tripping the
+# `(it != outer.end())` assertion in ResolutionTable::RemoveObject.
+#
+# Same shape exists for PgSqlFunction, Tokenizer and PgSqlType
+# (catalog.cpp); fixed together in the same patch.
+
+
+statement ok
+CREATE TABLE pudge_base (id INTEGER PRIMARY KEY, body TEXT);
+
+
+statement ok
+INSERT INTO pudge_base VALUES (1, 'hello world'), (2, 'good evening');
+
+
+statement ok
+CREATE VIEW pudge_view AS SELECT id, body FROM pudge_base;
+
+
+# A view-backed inverted index is the original reproducer; keep it in
+# the test so a future regression takes both code paths down at once.
+statement ok
+CREATE TEXT SEARCH DICTIONARY pudge_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true
+);
+
+
+statement ok
+CREATE INDEX pudge_view_idx ON pudge_view USING inverted(id, body pudge_en);
+
+
+# Sanity pre-crash: the view resolves and the index lists.
+query
+SELECT count(*) FROM pudge_view;
+----
+count
+2
+
+
+query
+SELECT relname FROM pg_class WHERE relname = 'pudge_view_idx';
+----
+relname
+pudge_view_idx
+
+
+statement ok
+SET sdb_faults = 'crash_on_packet';
+
+
+statement error connection closed
+SELECT 1;
+
+
+# --- restart ---
+
+connection after_crash
+statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+SELECT 1;
+
+
+# Sanity post-restart: the table and the view are both visible.
+connection after_crash
+query
+SELECT count(*) FROM pudge_base;
+----
+count
+2
+
+
+connection after_crash
+query
+SELECT count(*) FROM pudge_view;
+----
+count
+2
+
+
+# The fix point: DROP TABLE ... CASCADE on a table with a dependent
+# view must NOT crash the server. Without the fix this is SIGABRT in
+# ResolutionTable::RemoveObject<Relation>.
+connection after_crash
+statement ok
+DROP TABLE pudge_base CASCADE;
+
+
+# Server is still alive (otherwise this connection would also drop).
+connection after_crash
+query
+SELECT 1 AS still_alive;
+----
+still_alive
+1
+
+
+# Cascade landed: table, view, view-backed index all gone.
+connection after_crash
+query
+SELECT count(*) FROM pg_class
+  WHERE relname IN ('pudge_base', 'pudge_view', 'pudge_view_idx');
+----
+count
+0
+
+
+# Re-create with the same names to confirm catalog isn't poisoned.
+connection after_crash
+statement ok
+CREATE TABLE pudge_base (id INTEGER PRIMARY KEY, body TEXT);
+
+
+connection after_crash
+statement ok
+CREATE VIEW pudge_view AS SELECT id, body FROM pudge_base;
+
+
+connection after_crash
+statement ok
+INSERT INTO pudge_base VALUES (1, 'reborn');
+
+
+connection after_crash
+query
+SELECT count(*) FROM pudge_view;
+----
+count
+1
+
+
+connection after_crash
+statement ok
+DROP TABLE pudge_base CASCADE;
+
+
+connection after_crash
+statement ok
+DROP TEXT SEARCH DICTIONARY pudge_en;


### PR DESCRIPTION
DROP TABLE ... CASCADE on a table with a dependent view crashed
serened after a restart - assertion `(it != outer.end())` in
ResolutionTable::RemoveObject<Relation>.

server/catalog/catalog.cpp's RegisterFunctions / RegisterTokenizers /
RegisterViews / RegisterTypes built ReadContext without `.schema_id`,
so the restored objects had a default parent_id. The resolution
table was populated correctly by the caller, but the next CASCADE
called RemoveFromResolution with the broken parent_id pulled from
view->GetParentId() and the outer map lookup missed. RegisterTables
already did this right.