### PR TITLE
perf: optimize intervals search (#317)

### DIFF
--- a/libs/iresearch/include/iresearch/search/common/fixed_array.hpp
+++ b/libs/iresearch/include/iresearch/search/common/fixed_array.hpp
@@ -38,6 +38,8 @@ class FixedArray {
   using value_type = T;
   using iterator = T*;
   using const_iterator = const T*;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   FixedArray() = default;
 
@@ -143,6 +145,16 @@ class FixedArray {
   const T* begin() const noexcept { return _data; }
   const T* end() const noexcept { return _data + _size; }
 
+  reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+  reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
+  const_reverse_iterator rbegin() const noexcept {
+    return const_reverse_iterator(end());
+  }
+  const_reverse_iterator rend() const noexcept {
+    return const_reverse_iterator(begin());
+  }
+
  private:
   T* _data = nullptr;
   size_t _size = 0;
@@ -154,6 +166,8 @@ class FixedRun {
   using value_type = T;
   using iterator = T*;
   using const_iterator = const T*;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   FixedRun() = default;
 
@@ -208,6 +222,16 @@ class FixedRun {
   T* end() noexcept { return _data.data() + N; }
   const T* begin() const noexcept { return _data.data(); }
   const T* end() const noexcept { return _data.data() + N; }
+
+  reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+  reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
+  const_reverse_iterator rbegin() const noexcept {
+    return const_reverse_iterator(end());
+  }
+  const_reverse_iterator rend() const noexcept {
+    return const_reverse_iterator(begin());
+  }
 
  private:
   template<typename Args, size_t... I>

--- a/libs/iresearch/include/iresearch/search/phrase_iterator.hpp
+++ b/libs/iresearch/include/iresearch/search/phrase_iterator.hpp
@@ -132,11 +132,27 @@ class SinglePositionStrategy {
     return seek == sought;
   }
 
+  bool AdvanceIterators(bool match, PosAttr::value_t sought,
+                        const Iterator& end, Iterator& it,
+                        PosAttr::value_t& lead_bound) {
+    if (!match) {
+      SDB_ASSERT(sought + Traits::Interval(*_lead_it).lead_offset >
+                 Traits::Interval(*it).lead_offset);
+      lead_bound = sought - Traits::Interval(*it).lead_offset +
+                   Traits::Interval(*_lead_it).lead_offset;
+    }
+    _base_position = sought;
+    ++it;
+    return match;
+  }
+
   bool AdvanceIterators(bool match, PosAttr::value_t sought, const Iterator&,
                         Iterator& it) {
     if (!match) {
-      SDB_ASSERT(sought > Traits::Interval(*it).lead_offset);
-      _lead_pos.seek(sought - Traits::Interval(*it).lead_offset);
+      SDB_ASSERT(sought + Traits::Interval(*_lead_it).lead_offset >
+                 Traits::Interval(*it).lead_offset);
+      _lead_pos.seek(sought - Traits::Interval(*it).lead_offset +
+                     Traits::Interval(*_lead_it).lead_offset);
     }
     _base_position = sought;
     ++it;
@@ -149,6 +165,7 @@ class SinglePositionStrategy {
   Iterator& _lead_it;
   PositionImpl& _lead_pos;
   PosAttr::value_t _base_position{pos_limits::eof()};
+  bool _reversed{false};
 };
 
 template<typename Iterator>
@@ -187,6 +204,17 @@ class IntervalPositionStrategy {
 
   bool AdvanceIterators(bool match, PosAttr::value_t sought,
                         const Iterator& end, Iterator& it) {
+    PosAttr::value_t lead_bound = 0;
+    const auto result = AdvanceIterators(match, sought, end, it, lead_bound);
+    if (!result) {
+      _lead_pos.seek(std::max(lead_bound, _lead_pos.value() + 1));
+    }
+    return result;
+  }
+
+  bool AdvanceIterators(bool match, PosAttr::value_t sought,
+                        const Iterator& end, Iterator& it,
+                        PosAttr::value_t& lead_bound) {
     const auto fail_it = it;
     _interval_delta = 0;
     if (match) {
@@ -208,7 +236,8 @@ class IntervalPositionStrategy {
     }
 
     const auto bound = _skipped ? 0 : Reach(sought, _lead_it, fail_it);
-    _lead_pos.seek(std::max(bound, _lead_pos.value() + 1));
+    lead_bound = std::max(bound, _lead_pos.value() + 1);
+
     return false;
   }
 
@@ -323,6 +352,10 @@ class PhraseFrequency {
     std::conditional_t<HasIntervals,
                        IntervalPositionStrategy<typename Positions::iterator>,
                        SinglePositionStrategy<typename Positions::iterator>>;
+  using ReverseExecutionStrategy = std::conditional_t<
+    HasIntervals,
+    IntervalPositionStrategy<typename Positions::reverse_iterator>,
+    SinglePositionStrategy<typename Positions::reverse_iterator>>;
 
   static_assert(!HasBoost || HasFreq);
 
@@ -374,7 +407,8 @@ class PhraseFrequency {
 
   uint32_t DocFreqBound() {
     OrderByDocFreq();
-    const auto freq = _pos.front().first->DocFreq();
+    FindRarestTerm();
+    const auto freq = _rarest_term_it->first->DocFreq();
     if constexpr (HasIntervals) {
       uint64_t by_window = uint64_t{freq} * _freq_scale;
       uint64_t by_occurrence = 1;
@@ -408,10 +442,14 @@ class PhraseFrequency {
     if constexpr (HasBoost) {
       _phrase_boost = 0.f;
     }
+    if constexpr (!Ordered) {
+      OrderByDocFreq();
+    }
+    FindRarestTerm();
     if constexpr (HasIntervals || Offs) {
-      return NextPositionGeneric<Ordered>();
+      return NextPositionGeneric();
     } else {
-      return NextPositionOptimized<Ordered>();
+      return NextPositionOptimized();
     }
   }
 
@@ -423,70 +461,80 @@ class PhraseFrequency {
     }
   }
 
-  template<bool Ordered = false>
   uint32_t NextPositionGeneric() {
-    if constexpr (!Ordered) {
-      OrderByDocFreq();
-    }
     uint32_t phrase_freq = 0;
-    auto& lead = *_pos.front().first;
-    lead.next();
-    auto lead_it = std::begin(_pos);
-    ExecutionStrategy strategy{lead_it, lead, _reversed};
+    auto& rarest_term = *_rarest_term_it->first;
+    ExecutionStrategy strategy_to_end{_rarest_term_it, rarest_term, false};
+
+    auto reversed_rarest_it =
+      std::reverse_iterator<decltype(_rarest_term_it)>(_rarest_term_it + 1);
+    ReverseExecutionStrategy strategy_to_start{reversed_rarest_it, rarest_term,
+                                               true};
     SDB_ASSERT(_pos.size() > 1);
 
-    for (auto end = std::end(_pos); !pos_limits::eof(lead.value());) {
-      strategy.NotifyNextLead(end);
-      bool match = true;
-      for (auto it = lead_it + 1; it != end;) {
-        auto& pos = *it->first;
+    rarest_term.next();
+    auto end = std::end(_pos);
 
-        const auto term_position = strategy.NextPosition(it);
-        if (!pos_limits::valid(term_position)) {
+    if (_rarest_term_it == _pos.begin()) {
+      while (!pos_limits::eof(rarest_term.value())) {
+        auto [freq, bound, need_break] =
+          FixedRarestTermLoop(strategy_to_end, _rarest_term_it, end);
+        phrase_freq += freq;
+        if (need_break) {
           return phrase_freq;
         }
-        const auto sought = pos.seek(term_position);
-
-        if (pos_limits::eof(sought)) {
-          if constexpr (HasFreq) {
-            if (!strategy.NextPermutation(it, end)) {
-              return phrase_freq;
-            }
-
-            if (it == end) {
-              lead.next();
-              match = false;
-            }
-            continue;
-          } else {
+        if constexpr (!HasFreq) {
+          if (phrase_freq) {
             return phrase_freq;
           }
         }
-        match = strategy.AdvanceIterators(
-          strategy.Match(term_position, sought, it), sought, end, it);
+        rarest_term.seek(std::max(bound, rarest_term.value() + 1));
+      }
+      return phrase_freq;
+    }
+    auto rend = _pos.rend();
 
-        if constexpr (HasFreq) {
-          if (it == end && match) {
-            if (!strategy.NextPermutation(it, end)) {
-              break;
-            }
-            ++phrase_freq;
-            TakeBoost();
+    if (_rarest_term_it + 1 == _pos.end()) {
+      while (!pos_limits::eof(rarest_term.value())) {
+        auto [freq, bound, need_break] =
+          FixedRarestTermLoop(strategy_to_start, reversed_rarest_it, rend);
+        phrase_freq += freq;
+        if (need_break) {
+          return phrase_freq;
+        }
+        if constexpr (!HasFreq) {
+          if (phrase_freq) {
+            return phrase_freq;
           }
         }
-        if (!match) {
+        rarest_term.seek(std::max(bound, rarest_term.value() + 1));
+      }
+      return phrase_freq;
+    }
+
+    while (!pos_limits::eof(rarest_term.value())) {
+      auto [right_freq, right_bound, need_break1] =
+        FixedRarestTermLoop(strategy_to_end, _rarest_term_it, end);
+      if (!right_freq) {
+        if (need_break1) {
           break;
         }
+        rarest_term.seek(std::max(right_bound, rarest_term.value() + 1));
+        continue;
       }
-      if (match) {
-        if constexpr (HasFreq) {
-          ++phrase_freq;
-          TakeBoost();
-          lead.next();
-        } else {
-          return 1;
+      auto [left_freq, left_bound, need_break2] =
+        FixedRarestTermLoop(strategy_to_start, reversed_rarest_it, rend);
+      phrase_freq += right_freq * left_freq;
+      if (need_break1 || need_break2) {
+        break;
+      }
+      if constexpr (!HasFreq) {
+        if (phrase_freq) {
+          return phrase_freq;
         }
       }
+      rarest_term.seek(
+        std::max(std::max(right_bound, rarest_term.value() + 1), left_bound));
     }
 
     return phrase_freq;
@@ -494,24 +542,89 @@ class PhraseFrequency {
 
  private:
   void OrderByDocFreq() {
-    if constexpr (Offs) {
-    } else if constexpr (HasIntervals) {
-      if (_pos.back().first->DocFreq() < _pos.front().first->DocFreq()) {
-        absl::c_reverse(_pos);
-        _reversed = !_reversed;
-      }
-    } else {
+    if constexpr (!Offs && !HasIntervals) {
       absl::c_sort(_pos, [](const auto& l, const auto& r) {
         return l.first->DocFreq() < r.first->DocFreq();
       });
     }
   }
 
-  template<bool Ordered = false>
-  uint32_t NextPositionOptimized() {
-    if constexpr (!Ordered) {
-      OrderByDocFreq();
+  void FindRarestTerm() {
+    _rarest_term_it = _pos.begin();
+    if constexpr (HasIntervals || Offs) {
+      auto min_term_rate = _rarest_term_it->first->DocFreq();
+      for (auto it = _rarest_term_it + 1; it != _pos.end(); ++it) {
+        const auto cand_term_rate = it->first->DocFreq();
+        if (cand_term_rate < min_term_rate) {
+          _rarest_term_it = it;
+          min_term_rate = cand_term_rate;
+        }
+      }
     }
+  }
+
+  template<typename Strategy, typename Iterator>
+  IRS_FORCE_INLINE std::tuple<uint32_t, PosAttr::value_t, bool>
+  FixedRarestTermLoop(Strategy& strategy, Iterator& lead_it,
+                      const Iterator& end) {
+    strategy.NotifyNextLead(end);
+    bool match = true;
+    uint32_t phrase_freq = 0;
+    auto it = lead_it + 1;
+    PosAttr::value_t lead_bound = 0;
+    while (it != end) {
+      auto& pos = *it->first;
+
+      const auto term_position = strategy.NextPosition(it);
+      if (!pos_limits::valid(term_position)) {
+        return {phrase_freq, lead_bound, true};
+      }
+      const auto sought = pos.seek(term_position);
+
+      if (pos_limits::eof(sought)) {
+        // exhausted
+        if constexpr (HasFreq) {
+          if (!strategy.NextPermutation(it, end)) {
+            return {phrase_freq, lead_bound, true};
+          }
+
+          if (it == end) {
+            match = false;
+          }
+          continue;
+        } else {
+          return {phrase_freq, lead_bound, true};
+        }
+      }
+      match = strategy.AdvanceIterators(
+        strategy.Match(term_position, sought, it), sought, end, it, lead_bound);
+
+      if constexpr (HasFreq) {
+        if (it == end && match) {
+          if (!strategy.NextPermutation(it, end)) {
+            break;
+          }
+          ++phrase_freq;
+          TakeBoost();
+        }
+      }
+      if (!match) {
+        break;
+      }
+    }
+    if (match) {
+      if constexpr (HasFreq) {
+        ++phrase_freq;
+        TakeBoost();
+        return {phrase_freq, lead_bound, false};
+      } else {
+        return {1, lead_bound, false};
+      }
+    }
+    return {phrase_freq, lead_bound, false};
+  }
+
+  uint32_t NextPositionOptimized() {
     auto begin = _pos.begin();
     auto end = _pos.end();
 
@@ -554,7 +667,9 @@ class PhraseFrequency {
   uint32_t _phrase_freq = 0;
   [[no_unique_address]] utils::Need<HasBoost, score_t> _phrase_boost{};
   uint32_t _freq_scale = 1;
-  bool _reversed = false;
+
+  // pointer to rarest term in _pos
+  Positions::iterator _rarest_term_it;
 };
 
 template<bool Offs, bool HasFreq, bool HasIntervals, size_t N = 0>

--- a/scripts/ci/steps/042-ci-in-docker-run-iresearch-tests.bash
+++ b/scripts/ci/steps/042-ci-in-docker-run-iresearch-tests.bash
@@ -17,6 +17,7 @@ if ! docker run --rm \
     set -o pipefail
     cd /serenedb/${BUILD_DIR}/bin
     export MALLOC_ARENA_MAX=1 # limit the number of arenas
+	python3 ../../scripts/generate_intervals_search.py --root /serenedb
     python3 ../../scripts/gtest-parallel/gtest_parallel.py ./iresearch-tests -- \
       --ires_output="xml:/serenedb/out/test-results/iresearch-tests.xml" 2>&1 | tee -a /serenedb/out/logs/iresearch-tests.log
   '; then

--- a/scripts/generate_intervals_search.py
+++ b/scripts/generate_intervals_search.py
@@ -1,0 +1,293 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import json
+import random
+import time
+import string
+
+from dataclasses import dataclass
+from typing import TextIO
+
+class Config:
+    DocCount = 20000
+    DataSize = 200
+    BigDataDocCount = 10
+    BigDataSize = 20000
+    ResourceRootPath = "resources/tests/iresearch"
+    GoldenRootPath = f"{ResourceRootPath}/phrase_filter_bench_test_golden"
+    BenchResourceFilePrefix = "interval_bench_"
+    BigDataBenchResourceFilePrefix = f"{BenchResourceFilePrefix}big_data_"
+
+    resource_types = {
+        "RepeatPhrase": "repeat.json",
+        "FreqsEqual": "freqs_equal.json",
+        "FreqsDiscrete": "freqs_discrete.json"
+    }
+
+    for resource_type, file in resource_types.items():
+        locals()[f"{resource_type}BenchResource"] = f"{ResourceRootPath}/{BenchResourceFilePrefix}{file}"
+        locals()[f"Golden{resource_type}BenchResource"] = f"{GoldenRootPath}/{BenchResourceFilePrefix}{file}.golden"
+        locals()[f"BigData{resource_type}BenchResource"] = f"{ResourceRootPath}/{BigDataBenchResourceFilePrefix}{file}"
+        locals()[f"GoldenBigData{resource_type}BenchResource"] = f"{GoldenRootPath}/{BigDataBenchResourceFilePrefix}{file}.golden"
+
+
+def parse_file(path: str):
+    with open(path) as f:
+        data = json.loads(f.read())
+    return list(map(
+        lambda x : x["phrase"],
+        data
+))
+
+class DataGenerator:
+    def __init__(self, file: TextIO, name: str, data_size: int):
+        self.file = file
+        self.name = name
+        self.data = bytearray(data_size)
+
+    def get_next_token(self) -> bytearray:
+        raise NotImplementedError()
+
+    def generate(self) -> None:
+        pos = 0
+        while pos != len(self.data):
+            token = self.get_next_token()
+            if pos + len(token) > len(self.data):
+                self.data[pos:] = token[0:(len(self.data) - pos)]
+                break
+            self.data[pos:(pos + len(token))] = token
+            pos += len(token)
+            if pos < len(self.data):
+                self.data[pos:(pos + 1)] = bytearray(' ', encoding="utf8")
+                pos += 1
+
+        print(f'\t{{"name":"{self.name}","phrase":"{self.data.decode("utf8")}"}}', file=self.file, end='')
+
+    def refresh(self, name: str) -> None:
+        self.data: bytearray = bytearray(len(self.data))
+        self.name = name
+
+
+class RepeatDataGenerator(DataGenerator):
+    def __init__(self, file: str, name: str, data_size: int, repeat_pattern: list[str]):
+        super().__init__(file, name, data_size)
+        self.pattern = list(map(lambda x: bytearray(x, encoding="utf8"), repeat_pattern))
+        self.pos = 0
+
+    def get_next_token(self):
+        token = self.pattern[self.pos]
+        self.pos = (self.pos + 1) % len(self.pattern)
+        return token
+
+
+class FreqsDataGenerator(DataGenerator):
+    def __init__(self, file: TextIO, name: str, data_size: int, tokens_with_freqs: dict[str, float]):
+        super().__init__(file, name, data_size)
+        self.pattern : list[bytearray] = []
+        self.freqs : list[float] = []
+        for token, freq in tokens_with_freqs.items():
+            self.pattern.append(bytearray(token, encoding="utf8"))
+            self.freqs.append(freq)
+        total = sum(self.freqs)
+        if abs(total - 1.0) > 0.0001:
+            raise ValueError(f"Сумма частот должна быть равна 1.0 (текущая: {total})")
+        self.rng = random.Random()
+        self.rng.seed(int(time.time() * 1_000_000))
+
+    def get_next_token(self):
+        return self.pattern[self.rng.choices(
+            population=range(len(self.freqs)),
+            weights=self.freqs,
+            k=1
+        )[0]]
+
+
+def generate_random_string(length=10, seed=None):
+    if seed is not None:
+        random.seed(seed)
+
+    characters = string.ascii_letters + string.digits
+    return ''.join(random.choice(characters) for _ in range(length))
+
+
+@dataclass
+class Term:
+    term: str
+    min_offset: int
+    max_offset: int
+
+
+@dataclass
+class Terms:
+    terms: list[Term]
+
+
+def count(terms: Terms, inp: str):
+    inp = list(inp.split())
+
+    def rec_count(cur_pos: int, cur_term: int) -> int:
+        if cur_term >= len(terms.terms):
+            return 1
+        ans = 0
+        for i in range(terms.terms[cur_term].min_offset, terms.terms[cur_term].max_offset + 1):
+            if cur_pos + i >= len(inp):
+                break
+            if inp[cur_pos + i] != terms.terms[cur_term].term:
+                continue
+            ans += rec_count(cur_pos + i, cur_term + 1)
+        return ans
+
+    res = 0
+    for i in range(len(inp)):
+        if inp[i] == terms.terms[0].term:
+            res += rec_count(i, 1)
+    return res
+
+
+
+def generation_loop(generator: type[DataGenerator], file: str, golden_file: str, doc_count: int, *args, **kwargs):
+    name = 1
+    names = set()
+
+    def gen_next_name(seed: int):
+        cand = generate_random_string(10, seed)
+        while cand in names:
+            seed += 1
+            cand = generate_random_string(10, seed)
+        names.add(cand)
+        return cand
+
+    os.makedirs(os.path.dirname(file), exist_ok=True)
+
+    with open(file, "w") as f:
+        print("[", file=f)
+        gen = generator(f, gen_next_name(name), *args, **kwargs)
+        for iter in range(doc_count - 1):
+            gen.generate()
+            print(",", file=f)
+            name += 1
+            gen.refresh(gen_next_name(name))
+        gen.generate()
+        print("\n]", file=f)
+
+    terms = Terms([
+        Term("fox", 0, 0),
+        Term("quick", 1, 3),
+        Term("brown", 1, 3),
+        Term("jumps", 1, 3)
+    ])
+
+    terms2 = Terms([
+        Term("fox", 0, 0),
+        Term("quick", 1, 10),
+        Term("brown", 1, 10),
+        Term("jumps", 1, 10)
+    ])
+
+    data = parse_file(file)
+    res1 = list(map(lambda x: count(terms, x), data))
+    res2 = list(map(lambda x: count(terms2, x), data))
+
+    os.makedirs(os.path.dirname(golden_file), exist_ok=True)
+
+    with open(golden_file, "w") as f:
+        print("Results of test 'single_search1'", file=f)
+        for i in range(len(res1)):
+            if res1[i]:
+                print(i + 1, file=f)
+        print("Results of test 'single_search2'", file=f)
+        for i in range(len(res2)):
+            if res2[i]:
+                print(i + 1, file=f)
+        print("Results of test 'freqs_search1'", file=f)
+        for i in range(len(res1)):
+            if res1[i]:
+                print(res1[i], file=f)
+        print("Results of test 'freqs_search2'", file=f)
+        for i in range(len(res2)):
+            if res2[i]:
+                print(res2[i], file=f)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate benchmark test data for interval search"
+    )
+    parser.add_argument(
+        "-r", "--root",
+        type=str,
+        required=True,
+        help="Path to the project root directory"
+    )
+    args = parser.parse_args()
+    root_path = args.root
+
+    data = ["fox", "quick", "brown", "jumps", "second", "dog"]
+    freq_eq = [0.1, 0.1, 0.1, 0.1, 0.3, 0.3]
+    custom_freqs = [0.2, 0.1, 0.05, 0.1, 0.25, 0.3]
+
+    def combine(tokens: list[str], freqs: list[float]):
+        return dict(zip(tokens, freqs))
+
+    inputs = [
+        [
+            RepeatDataGenerator,
+            Config.RepeatPhraseBenchResource,
+            Config.GoldenRepeatPhraseBenchResource,
+            Config.DocCount,
+            Config.DataSize,
+            data,
+        ],
+        [
+            FreqsDataGenerator,
+            Config.FreqsEqualBenchResource,
+            Config.GoldenFreqsEqualBenchResource,
+            Config.DocCount,
+            Config.DataSize,
+            combine(data, freq_eq),
+        ],
+        [
+            FreqsDataGenerator,
+            Config.FreqsDiscreteBenchResource,
+            Config.GoldenFreqsDiscreteBenchResource,
+            Config.DocCount,
+            Config.DataSize,
+            combine(data, custom_freqs),
+        ],
+        [
+            RepeatDataGenerator,
+            Config.BigDataRepeatPhraseBenchResource,
+            Config.GoldenBigDataRepeatPhraseBenchResource,
+            Config.BigDataDocCount,
+            Config.BigDataSize,
+            data,
+        ],
+        [
+            FreqsDataGenerator,
+            Config.BigDataFreqsEqualBenchResource,
+            Config.GoldenBigDataFreqsEqualBenchResource,
+            Config.BigDataDocCount,
+            Config.BigDataSize,
+            combine(data, freq_eq),
+        ],
+        [
+            FreqsDataGenerator,
+            Config.BigDataFreqsDiscreteBenchResource,
+            Config.GoldenBigDataFreqsDiscreteBenchResource,
+            Config.BigDataDocCount,
+            Config.BigDataSize,
+            combine(data, custom_freqs),
+        ],
+    ]
+
+    for i in range(len(inputs)):
+        inputs[i][1] = f"{root_path}/{inputs[i][1]}"
+        inputs[i][2] = f"{root_path}/{inputs[i][2]}"
+
+        generation_loop(*inputs[i])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/libs/iresearch/CMakeLists.txt
+++ b/tests/libs/iresearch/CMakeLists.txt
@@ -108,6 +108,7 @@ set(iresearch-tests_sources
     ./search/term_predicate_test.cpp
     ./search/prefix_filter_test.cpp
     ./search/range_filter_test.cpp
+    ./search/phrase_filter_bench_test.cpp
     ./search/phrase_filter_tests.cpp
     ./search/slop_phrase_gather_tests.cpp
     ./search/slop_phrase_fuzz.cpp

--- a/tests/libs/iresearch/index/index_tests.hpp
+++ b/tests/libs/iresearch/index/index_tests.hpp
@@ -257,7 +257,7 @@ class IndexTestBase : public virtual TestParamBase<index_test_context> {
                        matcher);
   }
 
-  void SetUp() final {
+  void SetUp() {
     TestBase::SetUp();
 
     // set directory

--- a/tests/libs/iresearch/search/phrase_filter_bench_test.cpp
+++ b/tests/libs/iresearch/search/phrase_filter_bench_test.cpp
@@ -1,0 +1,357 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2016 by EMC Corporation, All Rights Reserved
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is EMC Corporation
+///
+/// @author Andrey Abramov
+/// @author Vasiliy Nabatchikov
+////////////////////////////////////////////////////////////////////////////////
+
+#include <filesystem>
+
+#include "filter_test_case_base.hpp"
+#include "formats/column/test_cs_helpers.hpp"
+#include "iresearch/analysis/token_attributes.hpp"
+#include "iresearch/index/iterators.hpp"
+#include "iresearch/search/boolean_filter.hpp"
+#include "iresearch/search/multiterm_query.hpp"
+#include "iresearch/search/phrase_filter.hpp"
+#include "iresearch/search/phrase_query.hpp"
+#include "iresearch/search/term_query.hpp"
+#include "tests_shared.hpp"
+
+struct Config {
+  inline static const std::string repeat_pattern_json =
+    "interval_bench_repeat.json";
+  inline static const std::string freqs_discrete_json =
+    "interval_bench_freqs_discrete.json";
+  inline static const std::string freqs_equal_json =
+    "interval_bench_freqs_equal.json";
+  inline static const std::string big_data_repeat_pattern_json =
+    "interval_bench_big_data_repeat.json";
+  inline static const std::string big_data_freqs_discrete_json =
+    "interval_bench_big_data_freqs_discrete.json";
+  inline static const std::string big_data_freqs_equal_json =
+    "interval_bench_big_data_freqs_equal.json";
+
+  inline static const std::string time_report_dir =
+    "phrase_filter_bench_test_report";
+  inline static const std::string golden_dir =
+    "phrase_filter_bench_test_golden";
+};
+
+static const auto tab = '\t';
+static const auto double_tab = "\t\t";
+
+template<typename Func>
+void timeEstimate(const std::string& test_name, Func func, std::ostream& out,
+                  std::ostream& report) {
+  auto start = std::chrono::high_resolution_clock::now();
+  func(test_name, out);
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration =
+    std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  report << double_tab << "\"time\": " << duration.count();
+}
+
+struct BlockAttrs {
+  const irs::FreqBlockAttr* freq = nullptr;
+  const irs::BoostBlockAttr* boost = nullptr;
+};
+
+class CapturingScorer final : public irs::Scorer {
+ public:
+  CapturingScorer(const irs::Scorer& impl, BlockAttrs& attrs) noexcept
+    : _impl{impl}, _attrs{&attrs} {}
+
+  void Target(BlockAttrs& attrs) noexcept { _attrs = &attrs; }
+
+  void collect(irs::byte_type* stats, const irs::FieldCollector* field,
+               const irs::TermCollector* term) const final {
+    _impl.collect(stats, field, term);
+  }
+
+  irs::IndexFeatures GetIndexFeatures() const final {
+    return _impl.GetIndexFeatures();
+  }
+
+  irs::ScoreFunction PrepareScorer(const irs::ScoreContext& ctx) const final {
+    _attrs->freq = irs::get<irs::FreqBlockAttr>(ctx.doc_attrs);
+    _attrs->boost = irs::get<irs::BoostBlockAttr>(ctx.doc_attrs);
+    return _impl.PrepareScorer(ctx);
+  }
+
+  irs::ScoreBoundWriter::ptr PrepareScoreBoundWriter(
+    size_t max_levels) const final {
+    return _impl.PrepareScoreBoundWriter(max_levels);
+  }
+
+  irs::ScoreBoundSource::ptr PrepareScoreBoundSource() const final {
+    return _impl.PrepareScoreBoundSource();
+  }
+
+  bool Compatible(const irs::ScorerOptions& persisted) const noexcept final {
+    return _impl.Compatible(persisted);
+  }
+
+  size_t stats_size() const final { return _impl.stats_size(); }
+
+  irs::TypeInfo::type_id type() const noexcept final { return _impl.type(); }
+
+ private:
+  const irs::Scorer& _impl;
+  BlockAttrs* _attrs;
+};
+
+class PhraseFilterBenchTestCase : public tests::FilterTestCaseBase {
+  static inline constexpr irs::field_id kName = tests::FieldIdFor("name");
+  static inline constexpr irs::field_id kPhraseAnl =
+    tests::FieldIdFor("phrase_anl");
+  auto StoreName() {
+    return [](irs::IndexWriter::Document& doc, const tests::Document& src) {
+      const auto* name =
+        dynamic_cast<const tests::StringField*>(src.stored.get_by_id(kName));
+      if (name) {
+        irs::tests::StoreFieldAt(*doc.GetColWriter(), kName, doc.DocId(),
+                                 *name);
+      }
+    };
+  }
+
+  static void AnalyzedJsonFieldFactory(
+    tests::Document& doc, const std::string& name,
+    const tests::JsonDocGenerator::JsonValue& data) {
+    typedef tests::TextField<std::string> TextField;
+
+    class StringField : public tests::StringField {
+     public:
+      StringField(const std::string& name, const std::string_view& value)
+        : tests::StringField(name, value, irs::IndexFeatures::Freq) {}
+    };
+
+    if (data.is_string()) {
+      // analyzed field -- id derived per source JSON field name so different
+      // sources (e.g. "name" vs "phrase") don't collide on the same writer
+      // slot.
+      const std::string anl_name = std::string(name.data()) + "_anl";
+      auto analyzed = std::make_shared<TextField>(anl_name, data.str);
+      analyzed->id = tests::FieldIdFor(anl_name);
+      doc.indexed.push_back(std::move(analyzed));
+
+      // not analyzed field -- id derived from the raw source field name.
+      auto stringField = std::make_shared<StringField>(name, data.str);
+      stringField->id = tests::FieldIdFor(name);
+      doc.insert(std::move(stringField));
+    }
+  }
+
+ protected:
+  void SetUp() final {
+    FilterTestCaseBase::SetUp();
+    for (int i = 1; i < gArgc; ++i) {
+      const std::string arg = gArgv[i];
+      if (arg == "--report") {
+        _need_time_report = true;
+      }
+    }
+  }
+
+ public:
+  void estimateTimePhraseFilter(const std::string& input) {
+    {
+      tests::JsonDocGenerator gen(resource(input), &AnalyzedJsonFieldFactory);
+      add_segment(gen, irs::kOmCreate, irs::tests::DefaultWriterOptions(),
+                  StoreName());
+    }
+
+    auto rdr = open_reader(irs::tests::DefaultReaderOptions());
+
+    auto search_test = [&rdr](size_t off1, size_t off2,
+                              const std::string& test_name, std::ostream& out) {
+      irs::ByPhrase q;
+      *q.mutable_field_id() = kPhraseAnl;
+      q.mutable_options()->push_back<irs::ByTermOptions>().term =
+        irs::ViewCast<irs::byte_type>(std::string_view("fox"));
+      q.mutable_options()->push_back<irs::ByTermOptions>(off1, off2).term =
+        irs::ViewCast<irs::byte_type>(std::string_view("quick"));
+      q.mutable_options()->push_back<irs::ByTermOptions>(off1, off2).term =
+        irs::ViewCast<irs::byte_type>(std::string_view("brown"));
+      q.mutable_options()->push_back<irs::ByTermOptions>(off1, off2).term =
+        irs::ViewCast<irs::byte_type>(std::string_view("jumps"));
+
+      tests::PreparedFilter prepared{q, rdr};
+
+      auto docs = prepared.Execute(0);
+      docs->Advance();
+      while (!irs::doc_limits::eof(docs->Value())) {
+        out << docs->Value() << '\n';
+        docs->Advance();
+      }
+    };
+
+    auto freqs_test = [&rdr](size_t off1, size_t off2,
+                             const std::string& test_name, std::ostream& out) {
+      irs::ByPhrase q;
+      *q.mutable_field_id() = kPhraseAnl;
+      q.mutable_options()->push_back<irs::ByTermOptions>().term =
+        irs::ViewCast<irs::byte_type>(std::string_view("fox"));
+      q.mutable_options()->push_back<irs::ByTermOptions>(off1, off2).term =
+        irs::ViewCast<irs::byte_type>(std::string_view("quick"));
+      q.mutable_options()->push_back<irs::ByTermOptions>(off1, off2).term =
+        irs::ViewCast<irs::byte_type>(std::string_view("brown"));
+      q.mutable_options()->push_back<irs::ByTermOptions>(off1, off2).term =
+        irs::ViewCast<irs::byte_type>(std::string_view("jumps"));
+
+      tests::sort::CustomSort sort;
+      tests::LeadCursor* it = nullptr;
+      sort.scorer_score = [&](const irs::ScoreOperator*, irs::score_t* score,
+                              size_t n) { *score = it->Value(); };
+
+      BlockAttrs attrs;
+      BlockAttrs seek_attrs;
+      CapturingScorer capture{sort, attrs};
+      tests::PreparedFilter prepared{q, rdr, &capture};
+      irs::ColumnArgsFetcher fetcher;
+      auto docs = prepared.ExecuteScored(0, fetcher);
+      auto score = docs->PrepareScore();
+      it = docs.get();
+      capture.Target(seek_attrs);
+      irs::ColumnArgsFetcher seek_fetcher;
+      auto docs_seek = prepared.ExecuteScored(0, seek_fetcher);
+      auto seek_score = docs_seek->PrepareScore();
+      tests::sort::FrequencyScore freq_score;
+      docs->Advance();
+      const auto* freq_seek = seek_attrs.freq;
+      while (!irs::doc_limits::eof(docs->Value())) {
+        docs_seek->Seek(docs->Value());
+        docs_seek->FetchScoreArgs(0);
+        out << freq_seek->value[0] << '\n';
+        docs->Advance();
+      }
+    };
+
+    auto params = GetParam();
+    std::string test_name =
+      input + "__" +
+      PhraseFilterBenchTestCase::to_string(
+        ::testing::TestParamInfo<decltype(params)>(params, 0));
+
+    std::unique_ptr<std::ostream> out;
+    if (_update_golden) {
+      out = std::make_unique<std::ofstream>(resource(Config::golden_dir) /
+                                            (input + ".golden"));
+    } else {
+      out = std::make_unique<std::ostringstream>();
+    }
+
+    std::unique_ptr<std::ostream> report;
+    if (_need_time_report) {
+      const auto report_path = resource(Config::time_report_dir);
+      if (!std::filesystem::exists(report_path)) {
+        ASSERT_TRUE(std::filesystem::create_directory(report_path));
+      }
+      report =
+        std::make_unique<std::ofstream>(report_path / (test_name + ".json"));
+    } else {
+      report = std::make_unique<std::ostream>(nullptr);
+    }
+    *report << "[\n";
+
+    auto log_test = [](std::ostream& out, std::ostream& report,
+                       const std::string& subtest_name) {
+      report << tab << "{\n";
+      report << double_tab << "\"subtest_name\": \"" << subtest_name << "\",\n";
+      out << "Results of test '" << subtest_name << "'\n";
+    };
+
+    auto search_test1 = [search_test](const std::string& test_name,
+                                      std::ostream& out) {
+      search_test(1, 3, test_name, out);
+    };
+    log_test(*out, *report, "single_search1");
+    timeEstimate("single_search1", search_test1, *out, *report);
+    *report << '\n' << tab << "},\n";
+
+    auto search_test2 = [search_test](const std::string& test_name,
+                                      std::ostream& out) {
+      search_test(1, 10, test_name, out);
+    };
+    log_test(*out, *report, "single_search2");
+    timeEstimate("single_search2", search_test2, *out, *report);
+    *report << '\n' << tab << "},\n";
+
+    auto freqs_test1 = [freqs_test](const std::string& test_name,
+                                    std::ostream& out) {
+      freqs_test(1, 3, test_name, out);
+    };
+    log_test(*out, *report, "freqs_search1");
+    timeEstimate("freqs_search1", freqs_test1, *out, *report);
+    *report << '\n' << tab << "},\n";
+
+    auto freqs_test2 = [freqs_test](const std::string& test_name,
+                                    std::ostream& out) {
+      freqs_test(1, 10, test_name, out);
+    };
+    log_test(*out, *report, "freqs_search2");
+    timeEstimate("freqs_search2", freqs_test2, *out, *report);
+    *report << '\n' << tab << "}\n]\n";
+
+    auto test_output = static_cast<std::ostringstream&>(*out).str();
+    std::ifstream golden(resource(Config::golden_dir) / (input + ".golden"));
+    ASSERT_TRUE(golden.is_open());
+
+    std::string golden_content{std::istreambuf_iterator<char>(golden),
+                               std::istreambuf_iterator<char>()};
+    ASSERT_EQ(golden_content, test_output);
+  }
+
+ private:
+  bool _update_golden{false};
+  bool _need_time_report{false};
+};
+
+TEST_P(PhraseFilterBenchTestCase, repeated_phrase) {
+  estimateTimePhraseFilter(Config::repeat_pattern_json);
+}
+
+TEST_P(PhraseFilterBenchTestCase, freqs_equal) {
+  estimateTimePhraseFilter(Config::freqs_equal_json);
+}
+
+TEST_P(PhraseFilterBenchTestCase, discrete_freqs) {
+  estimateTimePhraseFilter(Config::freqs_discrete_json);
+}
+
+TEST_P(PhraseFilterBenchTestCase, big_data_repeated_phrase) {
+  estimateTimePhraseFilter(Config::big_data_repeat_pattern_json);
+}
+
+TEST_P(PhraseFilterBenchTestCase, big_data_freqs_equal) {
+  estimateTimePhraseFilter(Config::big_data_freqs_equal_json);
+}
+
+TEST_P(PhraseFilterBenchTestCase, big_data_discrete_freqs) {
+  estimateTimePhraseFilter(Config::big_data_freqs_discrete_json);
+}
+
+static constexpr auto kTestDirs = tests::GetDirectories<tests::kTypesDefault>();
+
+INSTANTIATE_TEST_SUITE_P(phrase_filter_bench_test, PhraseFilterBenchTestCase,
+                         ::testing::Combine(::testing::ValuesIn(kTestDirs),
+                                            ::testing::Values(tests::FormatInfo{
+                                              "1_5simd"})),
+                         PhraseFilterBenchTestCase::to_string);

--- a/tests/libs/iresearch/tests_shared.hpp
+++ b/tests/libs/iresearch/tests_shared.hpp
@@ -50,13 +50,15 @@ class TestEnv {
 
   static uint32_t iteration();
 
+ protected:
+  static int gArgc;
+  static char** gArgv;
+
  private:
   static void make_directories();
   static void parse_command_line();
   static bool prepare();
 
-  static int gArgc;
-  static char** gArgv;
   static std::string gArgvIresOutput;      // argv_ for ires_output
   static std::string gTestName;            // name of the current test //
   static std::filesystem::path gExecPath;  // path where executable resides


### PR DESCRIPTION
1. Improved interval search algorithm – The previous unidirectional traversal has been replaced with a bidirectional approach, initiating from the rarest term within the phrase. This optimization reduces the search space and improves overall matching efficiency.
2. Added golden benchmark tests for interval search – A new suite of benchmark tests has been introduced, including support for the `--report` flag. This enables detailed time-based performance reporting, facilitating regression detection and performance tracking over time.