### PR TITLE
fix: Fixes for snapshot isolation in offsets reading and  view reading

### DIFF
--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -53,6 +53,7 @@
 #include "catalog/scorer_options.h"
 #include "catalog/table_options.h"
 #include "connector/columnstore_materializer.h"
+#include "connector/duckdb_client_state.h"
 #include "connector/duckdb_rocksdb_reader.h"
 #include "connector/duckdb_table_function.h"
 #include "connector/index_source.h"
@@ -64,6 +65,7 @@
 #include "connector/search_filter_builder.hpp"
 #include "connector/search_pk_lookup.h"
 #include "connector/search_remove_filter.hpp"
+#include "pg/connection_context.h"
 #include "query/duckdb_engine.h"
 #include "rocksdb/db.h"
 #include "rocksdb_engine_catalog/rocksdb_column_family_manager.h"
@@ -172,31 +174,19 @@ static void WriteTopkOffsets(SearchFullScanGlobalState& gstate,
 // scan_source -- promote it to a match-all SearchScan so the rest of init
 // can assume a SearchScan. Optimizer rewrites for filtered/scored queries
 // install a more specific SearchScan before init runs.
-static void EnsureDefaultMatchAllSearchScan(SereneDBScanBindData& bind_data) {
+static void EnsureDefaultMatchAllSearchScan(duckdb::ClientContext& context,
+                                            SereneDBScanBindData& bind_data) {
   if (bind_data.scan_source->Kind() == ScanSourceKind::Search) {
     return;
   }
   SDB_ASSERT(bind_data.IsInvertedIndexEntry());
   SDB_ASSERT(bind_data.inverted_index);
 
-  auto cat_snapshot = catalog::GetCatalog().GetCatalogSnapshot();
-  std::shared_ptr<search::InvertedIndexShard> shard;
-  for (auto& s : cat_snapshot->GetIndexShardsByRelation(
-         bind_data.inverted_index->GetRelationId())) {
-    if (s->GetIndexId() == bind_data.inverted_index->GetId() &&
-        s->GetType() == catalog::ObjectType::InvertedIndexShard) {
-      shard = basics::downCast<search::InvertedIndexShard>(std::move(s));
-      break;
-    }
-  }
-  SDB_ASSERT(shard);
-  auto idx_snapshot = shard->GetInvertedIndexSnapshot();
-  SDB_ASSERT(idx_snapshot);
-
   auto root = std::make_shared<irs::And>();
   root->add<irs::All>();
   auto search = std::make_unique<SearchScan>();
-  search->snapshot = std::move(idx_snapshot);
+  search->snapshot = GetSereneDBContext(context).EnsureSearchSnapshot(
+    bind_data.inverted_index->GetId());
   search->stored_filter = root;
   // `Query` is built lazily in SearchFullScanInitGlobal -- single
   // prepare site per execution.
@@ -209,7 +199,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> SearchFullScanInitGlobal(
   duckdb::ClientContext& context, duckdb::TableFunctionInitInput& input) {
   auto& bind_data = const_cast<SereneDBScanBindData&>(
     input.bind_data->Cast<SereneDBScanBindData>());
-  EnsureDefaultMatchAllSearchScan(bind_data);
+  EnsureDefaultMatchAllSearchScan(context, bind_data);
   auto state = duckdb::make_uniq<SearchFullScanGlobalState>(
     duckdb::DatabaseInstance::GetDatabase(context));
 

--- a/server/connector/functions/ts_offsets.cpp
+++ b/server/connector/functions/ts_offsets.cpp
@@ -37,12 +37,14 @@
 #include "catalog/catalog.h"
 #include "catalog/mangling.h"
 #include "catalog/table_options.h"
+ #include "connector/duckdb_client_state.h"
 #include "connector/functions/search.h"
 #include "connector/highlight/highlight_types.h"
 #include "connector/highlight/memory_index.h"
 #include "connector/offsets_collector.hpp"
 #include "connector/offsets_writer.hpp"
 #include "connector/search_filter_builder.hpp"
+#include "pg/connection_context.h"
 #include "pg/errcodes.h"
 #include "pg/sql_exception_macro.h"
 
@@ -90,7 +92,8 @@ struct OffsetsLocalState final : duckdb::FunctionLocalState {
   IndexField field;
 };
 
-auto& EnsureField(OffsetsLocalState& local_state, const OffsetsBindData& bind) {
+auto& EnsureField(duckdb::ClientContext& context,
+                  OffsetsLocalState& local_state, const OffsetsBindData& bind) {
   if (!local_state.field.tokenizer) {
     if (bind.IsStandalone()) {
       auto wrapper_or = bind.dict_tokenizer->GetTokenizer();
@@ -98,7 +101,7 @@ auto& EnsureField(OffsetsLocalState& local_state, const OffsetsBindData& bind) {
       local_state.field.Reset(kStandaloneSyntheticColumnId,
                               std::move(*wrapper_or));
     } else {
-      auto snapshot = catalog::GetCatalog().GetCatalogSnapshot();
+      auto snapshot = GetSereneDBContext(context).EnsureCatalogSnapshot();
       auto column_tokenizer =
         bind.inverted_index->GetColumnTokenizer(snapshot, bind.column_id);
       local_state.field.Reset(bind.column_id,
@@ -147,7 +150,7 @@ void OffsetsScalarFn(duckdb::DataChunk& args, duckdb::ExpressionState& state,
     return;
   }
 
-  auto& field = EnsureField(local_state, bind);
+  auto& field = EnsureField(state.GetContext(), local_state, bind);
 
   SDB_ASSERT(args.ColumnCount() >= 2);
   auto& body = args.data[1];

--- a/server/connector/functions/ts_offsets.cpp
+++ b/server/connector/functions/ts_offsets.cpp
@@ -37,7 +37,7 @@
 #include "catalog/catalog.h"
 #include "catalog/mangling.h"
 #include "catalog/table_options.h"
- #include "connector/duckdb_client_state.h"
+#include "connector/duckdb_client_state.h"
 #include "connector/functions/search.h"
 #include "connector/highlight/highlight_types.h"
 #include "connector/highlight/memory_index.h"

--- a/server/connector/index_source_factory.cpp
+++ b/server/connector/index_source_factory.cpp
@@ -25,11 +25,13 @@
 #include "catalog/pk_spec.h"
 #include "catalog/table.h"
 #include "catalog/view.h"
+#include "connector/duckdb_client_state.h"
 #include "connector/duckdb_table_function.h"
 #include "connector/index_source_rocksdb.h"
 #include "connector/index_source_view_file.h"
 #include "connector/index_source_view_rocksdb.h"
 #include "connector/view_fast_path.h"
+#include "pg/connection_context.h"
 #include "pg/errcodes.h"
 #include "pg/sql_exception_macro.h"
 #include "search/inverted_index_shard.h"
@@ -55,7 +57,7 @@ std::unique_ptr<IndexSource> MakeIndexSource(
     }
     // Re-bind must target the same manifest as CREATE INDEX did.
     if (vbd.inverted_index) {
-      auto cat_snapshot = catalog::GetCatalog().GetCatalogSnapshot();
+      auto cat_snapshot = GetSereneDBContext(context).EnsureCatalogSnapshot();
       if (auto shard =
             cat_snapshot->GetIndexShard(vbd.inverted_index->GetId())) {
         if (shard->GetType() == catalog::ObjectType::InvertedIndex) {

--- a/tests/sqllogic/sdb/pg/index/inverted_index_isolation.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_isolation.test
@@ -108,3 +108,42 @@ id
 connection reader_rc
 statement ok
 COMMIT;
+
+connection reader_bare
+statement ok
+SET sdb_read_your_own_writes = 0;
+
+
+connection reader_bare
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+
+connection reader_bare
+query
+SELECT id FROM t_idx ORDER BY id;
+----
+id
+1
+2
+3
+
+
+connection writer
+statement ok
+DROP TABLE t;
+
+
+connection reader_bare
+query
+SELECT id FROM t_idx ORDER BY id;
+----
+id
+1
+2
+3
+
+
+connection reader_bare
+statement ok
+COMMIT;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_view_isolation.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_view_isolation.test
@@ -1,0 +1,65 @@
+control substitution on
+
+
+statement count 3
+COPY (SELECT 1 AS id, 'pudge goes mid' AS body
+      UNION ALL SELECT 2, 'anchin reads manga'
+      UNION ALL SELECT 3, 'pudge plays again')
+TO '/tmp/${__DATABASE__}_view_iso.parquet' (FORMAT PARQUET);
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY view_iso_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true
+);
+
+
+statement ok
+CREATE VIEW pq_v AS SELECT * FROM read_parquet('/tmp/${__DATABASE__}_view_iso.parquet');
+
+
+statement ok
+CREATE INDEX pq_idx ON pq_v USING inverted(id, body view_iso_en);
+
+connection reader
+statement ok
+SET sdb_read_your_own_writes = 0;
+
+
+connection reader
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+
+connection reader
+query
+SELECT id, body FROM pq_idx WHERE body @@ ts_phrase('pudge') ORDER BY id;
+----
+id	body
+1	pudge goes mid
+3	pudge plays again
+
+
+connection writer
+statement ok
+DROP VIEW pq_v;
+
+
+connection reader
+query
+SELECT id, body FROM pq_idx WHERE body @@ ts_phrase('pudge') ORDER BY id;
+----
+id	body
+1	pudge goes mid
+3	pudge plays again
+
+
+connection reader
+statement ok
+COMMIT;

--- a/tests/sqllogic/sdb/pg/index/ts_offsets_isolation.test
+++ b/tests/sqllogic/sdb/pg/index/ts_offsets_isolation.test
@@ -1,0 +1,66 @@
+statement ok
+CREATE TEXT SEARCH DICTIONARY offs_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true
+);
+
+
+statement ok
+CREATE TABLE t (id INT PRIMARY KEY, body TEXT);
+
+
+statement ok
+CREATE INDEX t_idx ON t USING inverted(id, body offs_en);
+
+
+statement ok
+INSERT INTO t VALUES (1, 'the quick brown fox');
+
+
+statement ok
+VACUUM (UPDATE_INDEXES) t;
+
+connection reader
+statement ok
+SET sdb_read_your_own_writes = 0;
+
+
+connection reader
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+
+
+connection reader
+query
+SELECT id, length(ts_offsets(body)) FROM t_idx WHERE body @@ ts_phrase('quick') ORDER BY id;
+----
+id	length
+1	2
+
+
+connection writer
+statement ok
+DROP INDEX t_idx;
+
+
+connection writer
+statement ok
+DROP TEXT SEARCH DICTIONARY offs_en;
+
+
+connection reader
+query
+SELECT id, length(ts_offsets(body)) FROM t_idx WHERE body @@ ts_phrase('quick') ORDER BY id;
+----
+id	length
+1	2
+
+
+connection reader
+statement ok
+COMMIT;


### PR DESCRIPTION
Fixes of cases where search snapshot was acquired not from transaction context but from catalog entity itself that asserted/broke isolation.
1. Offsets reading
2. Plain index count
3. View access