### PR TITLE
feat: VACUUM (REFRESH_*|COMPACT_*) for inverted indexes

### DIFF
--- a/libs/basics/resource_manager.hpp
+++ b/libs/basics/resource_manager.hpp
@@ -70,7 +70,7 @@ struct ResourceManagementOptions {
 
   IResourceManager* transactions{&IResourceManager::gNoop};
   IResourceManager* readers{&IResourceManager::gNoop};
-  IResourceManager* consolidations{&IResourceManager::gNoop};
+  IResourceManager* compactions{&IResourceManager::gNoop};
   IResourceManager* file_descriptors{&IResourceManager::gNoop};
   IResourceManager* cached_columns{&IResourceManager::gNoop};
 };

--- a/libs/iresearch/README.md
+++ b/libs/iresearch/README.md
@@ -62,7 +62,7 @@ The win is a result of specific optimizations. We wrote them up as a five-post t
 
 See the [examples](examples/) directory for complete programs covering the public API, all built and exercised in CI on every PR so they stay in sync:
 
-- [basic.cpp](examples/basic.cpp) -- index documents, run term / phrase / boolean / prefix / fuzzy / top-K BM25 queries, read stored fields, delete documents, consolidate.
+- [basic.cpp](examples/basic.cpp) -- index documents, run term / phrase / boolean / prefix / fuzzy / top-K BM25 queries, read stored fields, delete documents, compact.
 - [text_filters.cpp](examples/text_filters.cpp) -- phrase search, n-gram similarity matching, regular expressions, SQL-style wildcard patterns (`%` and `_`) and fuzzy term matching with a configurable edit distance, all shown side-by-side against the same small corpus.
 - [geo.cpp](examples/geo.cpp) -- geospatial search over a GeoJSON-indexed point corpus: find everything within a radius of a center point, everything inside an annulus and everything that falls inside an arbitrary polygon.
 

--- a/libs/iresearch/examples/basic.cpp
+++ b/libs/iresearch/examples/basic.cpp
@@ -221,7 +221,7 @@ void BuildIndex(irs::IndexWriter& writer) {
   }  // Transaction commits here when ctx goes out of scope.
 
   // Commit flushes segments to disk and makes documents visible to readers.
-  writer.Commit();
+  writer.RefreshCommit();
   std::cout << "Indexed 5 documents.\n\n";
 }
 
@@ -363,7 +363,7 @@ void RemoveDocuments(irs::IndexWriter& writer,
   std::cout << "=== Remove Documents ===\n";
   auto filter = ParseQuery("databases", "title", tokenizer);
   writer.GetBatch().Remove(*filter);
-  writer.Commit();
+  writer.RefreshCommit();
 
   auto updated_reader = writer.GetSnapshot();
   std::cout << "After removal:\n";
@@ -372,28 +372,28 @@ void RemoveDocuments(irs::IndexWriter& writer,
             << "\n\n";
 }
 
-// Consolidate segments after removal to reclaim space and merge segments.
-// Deleted documents are only physically removed during consolidation.
-void ConsolidateIndex(irs::IndexWriter& writer, irs::Directory& dir) {
-  std::cout << "=== Consolidate Index ===\n";
+// Compact segments after removal to reclaim space and merge segments.
+// Deleted documents are only physically removed during compaction.
+void CompactIndex(irs::IndexWriter& writer, irs::Directory& dir) {
+  std::cout << "=== Compact Index ===\n";
 
   auto before = writer.GetSnapshot();
-  std::cout << "Before consolidation: " << before.size() << " segment(s)\n";
+  std::cout << "Before compaction: " << before.size() << " segment(s)\n";
 
-  // Tier-based consolidation merges segments of similar size.
-  irs::index_utils::ConsolidateTier tier_opts;
+  // Tier-based compaction merges segments of similar size.
+  irs::index_utils::CompactionTier tier_opts;
   tier_opts.min_segments = 1;
   tier_opts.max_segments = 10;
   auto policy = irs::index_utils::MakePolicy(tier_opts);
 
-  writer.Consolidate(policy);
-  writer.Commit();
+  writer.Compact(policy);
+  writer.RefreshCommit();
 
   // Remove files no longer referenced by any reader.
   irs::directory_utils::RemoveAllUnreferenced(dir);
 
   auto after = writer.GetSnapshot();
-  std::cout << "After consolidation:  " << after.size() << " segment(s)\n";
+  std::cout << "After compaction:  " << after.size() << " segment(s)\n";
   std::cout << "  Total documents: " << after.docs_count() << "\n";
   std::cout << "  Live documents:  " << after.live_docs_count() << "\n";
 }
@@ -446,7 +446,7 @@ int main() {
   QueryExclusion(reader, *tokenizer);
   ReadStoredFields(reader);
   RemoveDocuments(*writer, *tokenizer);
-  ConsolidateIndex(*writer, dir);
+  CompactIndex(*writer, dir);
 
   return 0;
 }

--- a/libs/iresearch/examples/geo.cpp
+++ b/libs/iresearch/examples/geo.cpp
@@ -183,7 +183,7 @@ irs::DirectoryReader BuildIndex(irs::Directory& dir,
       AppendStoredShape(*geo_cw, doc.DocId(), geo.shape_slice);
     }
   }
-  writer->Commit();
+  writer->RefreshCommit();
   return writer->GetSnapshot();
 }
 

--- a/libs/iresearch/examples/text_filters.cpp
+++ b/libs/iresearch/examples/text_filters.cpp
@@ -134,7 +134,7 @@ irs::DirectoryReader BuildIndex(irs::Directory& dir,
       names_out.emplace_back(name);
     }
   }
-  writer->Commit();
+  writer->RefreshCommit();
   return writer->GetSnapshot();
 }
 

--- a/libs/iresearch/include/iresearch/formats/formats.hpp
+++ b/libs/iresearch/include/iresearch/formats/formats.hpp
@@ -328,12 +328,12 @@ class Format {
   virtual SegmentMetaReader::ptr get_segment_meta_reader() const = 0;
 
   virtual FieldWriter::ptr get_field_writer(
-    bool consolidation, IResourceManager& resource_manager) const = 0;
+    bool compaction, IResourceManager& resource_manager) const = 0;
   virtual FieldReader::ptr get_field_reader(
     IResourceManager& resource_manager) const = 0;
 
   virtual PostingsWriter::ptr get_postings_writer(
-    bool consolidation, IResourceManager& resource_manager) const = 0;
+    bool compaction, IResourceManager& resource_manager) const = 0;
   virtual PostingsReader::ptr get_postings_reader() const = 0;
 
   virtual TypeInfo::type_id type() const noexcept = 0;

--- a/libs/iresearch/include/iresearch/formats/formats_impl.hpp
+++ b/libs/iresearch/include/iresearch/formats/formats_impl.hpp
@@ -57,10 +57,10 @@ class FormatBase : public Format {
   }
 
   FieldWriter::ptr get_field_writer(
-    bool consolidation, IResourceManager& resource_manager) const final {
+    bool compaction, IResourceManager& resource_manager) const final {
     return burst_trie::MakeWriter(
       burst_trie::Version::Min,
-      get_postings_writer(consolidation, resource_manager), consolidation,
+      get_postings_writer(compaction, resource_manager), compaction,
       resource_manager);
   }
   FieldReader::ptr get_field_reader(
@@ -84,9 +84,9 @@ class FormatImpl final : public FormatBase {
   }
 
   PostingsWriter::ptr get_postings_writer(
-    bool consolidation, IResourceManager& resource_manager) const final {
+    bool compaction, IResourceManager& resource_manager) const final {
     return std::make_unique<PostingsWriterImpl<FormatTraits>>(
-      PostingsFormat::WandSimd, consolidation, resource_manager);
+      PostingsFormat::WandSimd, compaction, resource_manager);
   }
   PostingsReader::ptr get_postings_reader() const final {
     return std::make_unique<PostingsReaderImpl<FormatTraits>>();

--- a/libs/iresearch/include/iresearch/formats/index/burst_trie.cpp
+++ b/libs/iresearch/include/iresearch/formats/index/burst_trie.cpp
@@ -564,7 +564,7 @@ class FieldWriterImpl final : public FieldWriter {
     "block_tree_terms_index";
   static constexpr std::string_view kTermsIndexExt = "ti";
 
-  FieldWriterImpl(PostingsWriter::ptr&& pw, bool consolidation,
+  FieldWriterImpl(PostingsWriter::ptr&& pw, bool compaction,
                   IResourceManager& rm,
                   burst_trie::Version version = burst_trie::Version::Max,
                   uint32_t min_block_size = kDefaultMinBlockSize,
@@ -619,7 +619,7 @@ class FieldWriterImpl final : public FieldWriter {
   const burst_trie::Version _version;
   const uint32_t _min_block_size;
   const uint32_t _max_block_size;
-  const bool _consolidation;
+  const bool _compaction;
 };
 
 void FieldWriterImpl::WriteBlock(size_t prefix, size_t begin, size_t end,
@@ -708,8 +708,7 @@ void FieldWriterImpl::WriteBlock(size_t prefix, size_t begin, size_t end,
 
   // add new block to the list of created blocks
   _blocks.emplace_back(bytes_view{_last_term.View().data(), prefix},
-                       std::move(index), block_start, meta, label,
-                       _consolidation);
+                       std::move(index), block_start, meta, label, _compaction);
 }
 
 void FieldWriterImpl::WriteBlocks(size_t prefix, size_t count) {
@@ -803,10 +802,10 @@ void FieldWriterImpl::Push(bytes_view term) {
 
   _prefixes.resize(term.size());
   std::fill(_prefixes.begin() + pos, _prefixes.end(), _stack.size());
-  _last_term.Assign(term, _consolidation);
+  _last_term.Assign(term, _compaction);
 }
 
-FieldWriterImpl::FieldWriterImpl(PostingsWriter::ptr&& pw, bool consolidation,
+FieldWriterImpl::FieldWriterImpl(PostingsWriter::ptr&& pw, bool compaction,
                                  IResourceManager& rm,
                                  burst_trie::Version version,
                                  uint32_t min_block_size,
@@ -822,7 +821,7 @@ FieldWriterImpl::FieldWriterImpl(PostingsWriter::ptr&& pw, bool consolidation,
     _version{version},
     _min_block_size{min_block_size},
     _max_block_size{max_block_size},
-    _consolidation{consolidation} {
+    _compaction{compaction} {
   SDB_ASSERT(this->_pw);
   SDB_ASSERT(min_block_size > 1);
   SDB_ASSERT(min_block_size <= max_block_size);
@@ -913,7 +912,7 @@ void FieldWriterImpl::write(const BasicTermReader& reader) {
       Push(term);
 
       // push term to the top of the stack
-      _stack.emplace_back(term, std::move(meta), _consolidation);
+      _stack.emplace_back(term, std::move(meta), _compaction);
 
       ++term_count;
     }
@@ -3095,10 +3094,10 @@ namespace irs {
 namespace burst_trie {
 
 FieldWriter::ptr MakeWriter(Version version, PostingsWriter::ptr&& writer,
-                            bool consolidation,
+                            bool compaction,
                             IResourceManager& resource_manager) {
   // Here we can parametrize field_writer via version20::TermMeta
-  return std::make_unique<::FieldWriterImpl>(std::move(writer), consolidation,
+  return std::make_unique<::FieldWriterImpl>(std::move(writer), compaction,
                                              resource_manager, version);
 }
 

--- a/libs/iresearch/include/iresearch/formats/index/burst_trie.hpp
+++ b/libs/iresearch/include/iresearch/formats/index/burst_trie.hpp
@@ -36,7 +36,7 @@ enum class Version : int32_t {
 };
 
 FieldWriter::ptr MakeWriter(Version version, PostingsWriter::ptr&& writer,
-                            bool consolidation,
+                            bool compaction,
                             IResourceManager& resource_manager);
 
 FieldReader::ptr MakeReader(PostingsReader::ptr&& reader,

--- a/libs/iresearch/include/iresearch/index/index_writer.cpp
+++ b/libs/iresearch/include/iresearch/index/index_writer.cpp
@@ -347,7 +347,7 @@ struct MapCandidatesResult {
 // candidates candidates for mapping
 // segments map against a specified segments
 MapCandidatesResult MapCandidates(CandidatesMapping& candidates_mapping,
-                                  ConsolidationView candidates,
+                                  CompactionView candidates,
                                   const auto& index) {
   size_t num_candidates = 0;
   candidates_mapping.reserve(candidates.size());
@@ -425,12 +425,12 @@ bool MapRemovals(const CandidatesMapping& candidates_mapping,
       if (!merged_itr->next()) {
         if (current_itr->next()) {
           SDB_WARN("xxxxx", sdb::Logger::IRESEARCH,
-                   "Failed to map removals for consolidated segment '",
+                   "Failed to map removals for compacted segment '",
                    old_meta.name, "' version '", old_meta.version,
                    "' from current segment '", new_meta.name, "' version '",
                    new_meta.version, "', current segment has doc_id '",
                    current_itr->value(),
-                   "' not present in the consolidated segment");
+                   "' not present in the compacted segment");
 
           return false;  // current reader has unmerged docs
         }
@@ -457,12 +457,12 @@ bool MapRemovals(const CandidatesMapping& candidates_mapping,
 
           if (!merged_itr->next()) {
             SDB_WARN("xxxxx", sdb::Logger::IRESEARCH,
-                     "Failed to map removals for consolidated segment '",
+                     "Failed to map removals for compacted segment '",
                      old_meta.name, "' version '", old_meta.version,
                      "' from current segment '", new_meta.name, "' version '",
                      new_meta.version, "', current segment has doc_id '",
                      current_itr->value(),
-                     "' not present in the consolidated segment");
+                     "' not present in the compacted segment");
 
             return false;  // current reader has unmerged docs
           }
@@ -470,12 +470,12 @@ bool MapRemovals(const CandidatesMapping& candidates_mapping,
 
         if (merged_itr->value() > current_itr->value()) {
           SDB_WARN("xxxxx", sdb::Logger::IRESEARCH,
-                   "Failed to map removals for consolidated segment '",
+                   "Failed to map removals for compacted segment '",
                    old_meta.name, "' version '", old_meta.version,
                    "' from current segment '", new_meta.name, "' version '",
                    new_meta.version, "', current segment has doc_id '",
                    current_itr->value(),
-                   "' not present in the consolidated segment");
+                   "' not present in the compacted segment");
 
           return false;  // current reader has unmerged docs
         }
@@ -484,12 +484,12 @@ bool MapRemovals(const CandidatesMapping& candidates_mapping,
         if (!merged_itr->next()) {
           if (current_itr->next()) {
             SDB_WARN("xxxxx", sdb::Logger::IRESEARCH,
-                     "Failed to map removals for consolidated segment '",
+                     "Failed to map removals for compacted segment '",
                      old_meta.name, "' version '", old_meta.version,
                      "' from current segment '", new_meta.name, "' version '",
                      new_meta.version, "', current segment has doc_id '",
                      current_itr->value(),
-                     "' not present in the consolidated segment");
+                     "' not present in the compacted segment");
 
             return false;  // current reader has unmerged docs
           }
@@ -513,14 +513,14 @@ bool MapRemovals(const CandidatesMapping& candidates_mapping,
   return true;
 }
 
-std::string ToString(ConsolidationView consolidation) {
+std::string ToString(CompactionView compaction) {
   std::string str;
 
   size_t total_size = 0;
   size_t total_docs_count = 0;
   size_t total_live_docs_count = 0;
 
-  for (const auto* segment : consolidation) {
+  for (const auto* segment : compaction) {
     auto& meta = segment->Meta();
 
     absl::StrAppend(&str, "Name='", meta.name,
@@ -533,7 +533,7 @@ std::string ToString(ConsolidationView consolidation) {
     total_size += meta.byte_size;
   }
 
-  absl::StrAppend(&str, "Total: segments=", consolidation.size(),
+  absl::StrAppend(&str, "Total: segments=", compaction.size(),
                   ", docs_count=", total_docs_count,
                   ", live_docs_count=", total_live_docs_count,
                   " size=", total_size, "");
@@ -820,17 +820,17 @@ void IndexWriter::FlushContext::Reset() noexcept {
 
 void IndexWriter::Cleanup(FlushContext& curr, FlushContext* next) noexcept {
   for (auto& import : curr.imports) {
-    auto& candidates = import.consolidation_ctx.candidates;
+    auto& candidates = import.compaction_ctx.candidates;
     for (const auto* candidate : candidates) {
-      _consolidating.segments.erase(candidate->Meta().name);
+      _compacting.segments.erase(candidate->Meta().name);
     }
   }
   for (const auto& entry : curr.cached) {
-    _consolidating.segments.erase(entry.second->Meta().name);
+    _compacting.segments.erase(entry.second->Meta().name);
   }
   if (next != nullptr) {
     for (const auto& entry : next->cached) {
-      _consolidating.segments.erase(entry.second->Meta().name);
+      _compacting.segments.erase(entry.second->Meta().name);
     }
   }
 }
@@ -1157,9 +1157,9 @@ void IndexWriter::Clear(uint64_t tick) {
   ApplyFlush(std::move(to_commit));
   Finish();
 
-  // Clear consolidating segments
-  std::lock_guard lock{_consolidating.lock};
-  _consolidating.segments.clear();
+  // Clear compacting segments
+  std::lock_guard lock{_compacting.lock};
+  _compacting.segments.clear();
 }
 
 IndexWriter::ptr IndexWriter::Make(Directory& dir, Format::ptr codec,
@@ -1269,44 +1269,44 @@ uint64_t IndexWriter::CurrentSegmentId() const noexcept {
   return _seg_counter.load(std::memory_order_relaxed);
 }
 
-ConsolidationResult IndexWriter::Consolidate(
-  const ConsolidationPolicy& policy, Format::ptr codec,
+CompactionResult IndexWriter::Compact(
+  const CompactionPolicy& policy, Format::ptr codec,
   const MergeWriter::FlushProgress& progress) {
   if (!codec) {
     // use default codec if not specified
     codec = _codec;
   }
 
-  Consolidation candidates;
+  Compaction candidates;
   const auto run_id = reinterpret_cast<uintptr_t>(&candidates);
 
   decltype(_committed_reader) committed_reader;
-  // collect a list of consolidation candidates
+  // collect a list of compaction candidates
   {
-    std::lock_guard lock{_consolidating.lock};
+    std::lock_guard lock{_compacting.lock};
     // hold a reference to the last committed state to prevent files from being
-    // deleted by a cleaner during the upcoming consolidation
+    // deleted by a cleaner during the upcoming compaction
     // use atomic_load(...) since Finish() may modify the pointer
     committed_reader = GetSnapshotImpl();
 
     if (committed_reader->size() == 0) {
-      // nothing to consolidate
-      return {0, ConsolidationError::Ok};
+      // nothing to compact
+      return {0, CompactionError::Ok};
     }
 
-    // FIXME TODO remove from 'consolidating_segments_' any segments in
+    // FIXME TODO remove from 'compacting_segments_' any segments in
     // 'committed_state_' or 'pending_state_' to avoid data duplication
-    policy(candidates, *committed_reader, _consolidating.segments);
+    policy(candidates, *committed_reader, _compacting.segments);
 
     switch (candidates.size()) {
-      case 0:  // nothing to consolidate
-        return {0, ConsolidationError::Ok};
+      case 0:  // nothing to compact
+        return {0, CompactionError::Ok};
       case 1: {
         const auto* candidate = candidates.front();
         SDB_ASSERT(candidate != nullptr);
         if (!HasRemovals(candidate->Meta())) {
-          // no removals, nothing to consolidate
-          return {0, ConsolidationError::Ok};
+          // no removals, nothing to compact
+          return {0, CompactionError::Ok};
         }
       }
     }
@@ -1314,16 +1314,16 @@ ConsolidationResult IndexWriter::Consolidate(
     for (const auto* candidate : candidates) {
       SDB_ASSERT(candidate != nullptr);
       // TODO(mbkkt) Make this check assert in future
-      if (_consolidating.segments.contains(candidate->Meta().name)) {
-        return {0, ConsolidationError::Fail};
+      if (_compacting.segments.contains(candidate->Meta().name)) {
+        return {0, CompactionError::Fail};
       }
     }
 
-    // register for consolidation
-    _consolidating.segments.reserve(_consolidating.segments.size() +
-                                    candidates.size());
+    // register for compaction
+    _compacting.segments.reserve(_compacting.segments.size() +
+                                 candidates.size());
     for (const auto* candidate : candidates) {
-      _consolidating.segments.emplace(candidate->Meta().name);
+      _compacting.segments.emplace(candidate->Meta().name);
     }
   }
 
@@ -1332,9 +1332,9 @@ ConsolidationResult IndexWriter::Consolidate(
     if (candidates.empty()) {
       return;
     }
-    std::lock_guard lock{_consolidating.lock};
+    std::lock_guard lock{_compacting.lock};
     for (const auto* candidate : candidates) {
-      _consolidating.segments.erase(candidate->Meta().name);
+      _compacting.segments.erase(candidate->Meta().name);
     }
   };
 
@@ -1352,18 +1352,18 @@ ConsolidationResult IndexWriter::Consolidate(
   }
 #endif
 
-  SDB_TRACE("xxxxx", sdb::Logger::IRESEARCH, "Starting consolidation id='",
-            run_id, "':\n", ToString(candidates));
+  SDB_TRACE("xxxxx", sdb::Logger::IRESEARCH, "Starting compaction id='", run_id,
+            "':\n", ToString(candidates));
 
   // do lock-free merge
 
-  ConsolidationResult result{candidates.size(), ConsolidationError::Fail};
+  CompactionResult result{candidates.size(), CompactionError::Fail};
 
-  IndexSegment consolidation_segment;
-  consolidation_segment.meta.codec = codec;  // Should use new codec
-  consolidation_segment.meta.version = 0;    // Reset version for new segment
+  IndexSegment compaction_segment;
+  compaction_segment.meta.codec = codec;  // Should use new codec
+  compaction_segment.meta.version = 0;    // Reset version for new segment
   // Increment active meta
-  consolidation_segment.meta.name = FileName(NextSegmentId());
+  compaction_segment.meta.name = FileName(NextSegmentId());
 
   RefTrackingDirectory dir{_dir};  // Track references for new segment
 
@@ -1371,15 +1371,15 @@ ConsolidationResult IndexWriter::Consolidate(
   merger.Reset(candidates.begin(), candidates.end());
 
   // We do not persist segment meta since some removals may come later
-  if (!merger.Flush(consolidation_segment.meta, progress)) {
-    // Nothing to consolidate or consolidation failure
+  if (!merger.Flush(compaction_segment.meta, progress)) {
+    // Nothing to compact or compaction failure
     return result;
   }
 
   auto opts = committed_reader->Options();
   opts.cs_hnsw_graphs = merger.TakeBuiltHnswGraphs();
   auto pending_reader =
-    SegmentReaderImpl::Open(_dir, consolidation_segment.meta, opts);
+    SegmentReaderImpl::Open(_dir, compaction_segment.meta, opts);
   SDB_ASSERT(pending_reader);
 
   // Commit merge, ensure no concurrent Commit/etc
@@ -1405,7 +1405,7 @@ ConsolidationResult IndexWriter::Consolidate(
               return id == s.Meta().name;
             })) {
           SDB_DEBUG("xxxxx", sdb::Logger::IRESEARCH,
-                    "Failed to start consolidation for index generation '",
+                    "Failed to start compaction for index generation '",
                     committed_reader->Meta().index_meta.gen,
                     "', not found segment ", candidate->Meta().name,
                     " in committed state");
@@ -1416,34 +1416,33 @@ ConsolidationResult IndexWriter::Consolidate(
     auto refs = dir.GetRefs();
     // Prevent concurrent imports modification
     std::lock_guard ctx_lock{ctx->pending.Mutex()};
-    // register consolidation for the next transaction
+    // register compaction for the next transaction
     ctx->imports.emplace_back(
-      std::move(consolidation_segment), writer_limits::kMaxTick,
+      std::move(compaction_segment), writer_limits::kMaxTick,
       // skip removals, will accumulate removals from existing candidates
       std::move(refs),              // do not forget to track refs
-      std::move(candidates),        // consolidation context candidates
-      std::move(pending_reader),    // consolidated reader
-      std::move(committed_reader),  // consolidation context meta
+      std::move(candidates),        // compaction context candidates
+      std::move(pending_reader),    // compacted reader
+      std::move(committed_reader),  // compaction context meta
       std::move(merger));
-    SDB_TRACE("xxxxx", sdb::Logger::IRESEARCH, "Consolidation id='", run_id,
+    SDB_TRACE("xxxxx", sdb::Logger::IRESEARCH, "Compaction id='", run_id,
               "' successfully finished: pending");
-    result.error = ConsolidationError::Pending;
+    result.error = CompactionError::Pending;
     return result;
   }
 
   // before new transaction was started:
   CandidatesMapping mappings;
   if (committed_reader != current_committed_reader) {
-    // there was a Commit(s) since consolidation was started
+    // there was a Commit(s) since compaction was started
     const auto [count, has_removals] =
       MapCandidates(mappings, candidates, *current_committed_reader);
     if (count != candidates.size()) {
-      // at least one candidate is missing can't finish consolidation
+      // at least one candidate is missing can't finish compaction
       SDB_DEBUG("xxxxx", sdb::Logger::IRESEARCH,
-                "Failed to finish consolidation id='", run_id,
-                "' for segment '", consolidation_segment.meta.name,
-                "', found only '", count, "' out of '", candidates.size(),
-                "' candidates");
+                "Failed to finish compaction id='", run_id, "' for segment '",
+                compaction_segment.meta.name, "', found only '", count,
+                "' out of '", candidates.size(), "' candidates");
       return result;
     }
 
@@ -1452,27 +1451,26 @@ ConsolidationResult IndexWriter::Consolidate(
       auto docs_mask =
         std::make_shared<DocumentMask>(*dir.ResourceManager().readers);
       if (!MapRemovals(mappings, merger, *docs_mask)) {
-        // consolidated segment has docs missing from
+        // compacted segment has docs missing from
         // current_committed_meta->segments()
         SDB_DEBUG("xxxxx", sdb::Logger::IRESEARCH,
-                  "Failed to finish consolidation id='", run_id,
-                  "' for segment '", consolidation_segment.meta.name,
+                  "Failed to finish compaction id='", run_id, "' for segment '",
+                  compaction_segment.meta.name,
                   "', due removed documents still present "
-                  "the consolidation candidates");
+                  "the compaction candidates");
 
         return result;
       }
 
       SDB_ASSERT(!docs_mask->empty());
-      consolidation_segment.meta.docs_mask = std::move(docs_mask);
+      compaction_segment.meta.docs_mask = std::move(docs_mask);
     }
   }
 
-  index_utils::FlushIndexSegment(dir, consolidation_segment, false);
+  index_utils::FlushIndexSegment(dir, compaction_segment, false);
 
-  if (consolidation_segment.meta.docs_mask) {
-    pending_reader =
-      pending_reader->UpdateMeta(dir, consolidation_segment.meta);
+  if (compaction_segment.meta.docs_mask) {
+    pending_reader = pending_reader->UpdateMeta(dir, compaction_segment.meta);
   }
 
   auto refs = dir.GetRefs();
@@ -1481,15 +1479,15 @@ ConsolidationResult IndexWriter::Consolidate(
   segment_mask.reserve(segment_mask.size() + mappings.size() +
                        candidates.size());
   const auto& pending_segment = ctx->imports.emplace_back(
-    std::move(consolidation_segment), writer_limits::kMinTick,
-    // removals must be applied to the consolidated segment
+    std::move(compaction_segment), writer_limits::kMinTick,
+    // removals must be applied to the compacted segment
     std::move(refs),              // do not forget to track refs
-    std::move(candidates),        // consolidation context candidates
-    std::move(pending_reader),    // consolidated reader
-    std::move(committed_reader),  // consolidation context meta
-    *dir.ResourceManager().consolidations);
-  // noexcept part: mask consolidated segments
-  for (const auto* candidate : pending_segment.consolidation_ctx.candidates) {
+    std::move(candidates),        // compaction context candidates
+    std::move(pending_reader),    // compacted reader
+    std::move(committed_reader),  // compaction context meta
+    *dir.ResourceManager().compactions);
+  // noexcept part: mask compacted segments
+  for (const auto* candidate : pending_segment.compaction_ctx.candidates) {
     segment_mask.emplace(candidate->Meta().name);
   }
   if (!mappings.empty()) {
@@ -1499,13 +1497,13 @@ ConsolidationResult IndexWriter::Consolidate(
       }
     }
   }
-  SDB_TRACE("xxxxx", sdb::Logger::IRESEARCH, "Consolidation id='", run_id,
+  SDB_TRACE("xxxxx", sdb::Logger::IRESEARCH, "Compaction id='", run_id,
             "' successfully finished: Name='",
             pending_segment.segment.meta.name,
             "', docs_count=", pending_segment.segment.meta.docs_count,
             ", live_docs_count=", pending_segment.segment.meta.live_docs_count,
             ", size=", pending_segment.segment.meta.byte_size);
-  result.error = ConsolidationError::Ok;
+  result.error = CompactionError::Ok;
   return result;
 }
 
@@ -1554,7 +1552,7 @@ bool IndexWriter::Import(const IndexReader& reader,
   // moving not suited import segments to the next FlushContext in PrepareFlush
   flush->imports.emplace_back(
     std::move(segment), _tick.load(std::memory_order_relaxed), std::move(refs),
-    std::move(imported_reader), *dir.ResourceManager().consolidations);
+    std::move(imported_reader), *dir.ResourceManager().compactions);
 
   return true;
 }
@@ -1652,13 +1650,13 @@ IndexWriter::ActiveSegmentContext IndexWriter::GetSegmentContext() try {
 }
 
 SegmentWriterOptions IndexWriter::GetSegmentWriterOptions(
-  bool consolidation) const noexcept {
+  bool compaction) const noexcept {
   return {
     .scorers_features = _wand_features,
     .scorer = _topk_scorer,
     .comparator = _comparator,
-    .resource_manager = consolidation ? *_dir.ResourceManager().consolidations
-                                      : *_dir.ResourceManager().transactions,
+    .resource_manager = compaction ? *_dir.ResourceManager().compactions
+                                   : *_dir.ResourceManager().transactions,
     .db = _db,
     .column_options = &_column_options,
     .norm_column_options = &_norm_column_options,
@@ -1680,7 +1678,7 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
   // are properly tracked in 'modification_queries_'
   const auto flushed_tick = ctx->FlushPending(_committed_tick, tick);
 
-  std::unique_lock cleanup_lock{_consolidating.lock, std::defer_lock};
+  std::unique_lock cleanup_lock{_compacting.lock, std::defer_lock};
   Finally cleanup = [&]() noexcept {
     if (ctx == nullptr) {
       return;
@@ -1767,7 +1765,7 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
       if (existing_segment.live_docs_count() == num_removals) {
         deleted_docs.clear();
         // It's important to mask empty segment to rollback
-        // the affected consolidations
+        // the affected compactions
 
         segment_mask.emplace(existing_segment->Meta().name);
         modified = true;
@@ -1797,44 +1795,44 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
   }
 
   // Stage 2
-  // Add pending complete segments registered by import or consolidation
+  // Add pending complete segments registered by import or compaction
 
-  // Number of candidates that have been registered for pending consolidation
+  // Number of candidates that have been registered for pending compaction
   size_t current_imports_index = 0;
   size_t import_candidates_count = 0;
   size_t partial_sync_threshold = readers.size();
 
   for (auto& import : ctx->imports) {
-    progress("Stage 2: Handling consolidated/imported segments",
+    progress("Stage 2: Handling compacted/imported segments",
              current_imports_index++, ctx->imports.size());
 
-    SDB_ASSERT(import.reader);  // Ensured by Consolidation/Import
+    SDB_ASSERT(import.reader);  // Ensured by Compaction/Import
     auto& meta = import.segment.meta;
     auto& import_reader = import.reader;
     auto import_docs_mask = CopyMask(dir, *import_reader);
 
     bool docs_mask_modified = false;
 
-    const ConsolidationView candidates{import.consolidation_ctx.candidates};
+    const CompactionView candidates{import.compaction_ctx.candidates};
 
-    const auto pending_consolidation =
-      static_cast<bool>(import.consolidation_ctx.merger);
+    const auto pending_compaction =
+      static_cast<bool>(import.compaction_ctx.merger);
 
-    if (pending_consolidation) {
-      // Pending consolidation request
+    if (pending_compaction) {
+      // Pending compaction request
       CandidatesMapping mappings;
       const auto [count, has_removals] =
         MapCandidates(mappings, candidates, readers);
 
       if (count != candidates.size()) {
         // At least one candidate is missing in pending meta can't finish
-        // consolidation
+        // compaction
         SDB_DEBUG("xxxxx", sdb::Logger::IRESEARCH,
                   "Failed to finish merge for segment '", meta.name,
                   "', found only '", count, "' out of '", candidates.size(),
                   "' candidates");
 
-        continue;  // Skip this particular consolidation
+        continue;  // Skip this particular compaction
       }
 
       // Mask mapped candidates segments from the to-be added new segment
@@ -1854,31 +1852,31 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
 
       // Have some changes, apply removals
       if (has_removals) {
-        const auto success = MapRemovals(
-          mappings, import.consolidation_ctx.merger, *import_docs_mask);
+        const auto success = MapRemovals(mappings, import.compaction_ctx.merger,
+                                         *import_docs_mask);
 
         if (!success) {
-          // Consolidated segment has docs missing from 'segments'
+          // Compacted segment has docs missing from 'segments'
           SDB_WARN("xxxxx", sdb::Logger::IRESEARCH,
                    "Failed to finish merge for segment '", meta.name,
                    "', due to removed documents still present "
-                   "the consolidation candidates");
+                   "the compaction candidates");
 
-          continue;  // Skip this particular consolidation
+          continue;  // Skip this particular compaction
         }
 
-        // We're done with removals for pending consolidation
+        // We're done with removals for pending compaction
         // they have been already applied to candidates above
-        // and successfully remapped to consolidated segment
+        // and successfully remapped to compacted segment
         docs_mask_modified |= true;
       }
 
       // We've seen at least 1 successfully applied
-      // pending consolidation request
+      // pending compaction request
       import_candidates_count += candidates.size();
     } else {
-      // During consolidation doc_mask could be already populated even for just
-      // merged segment. Pending already imported/consolidated segment, apply
+      // During compaction doc_mask could be already populated even for just
+      // merged segment. Pending already imported/compacted segment, apply
       // removals mask documents matching filters from segment_contexts
       // (i.e. from new operations)
       apply_all_queries([&](QueryContext& query) {
@@ -1902,9 +1900,8 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
       meta.docs_mask = std::move(import_docs_mask);
     }
 
-    if (docs_mask_modified || pending_consolidation) {
-      index_utils::FlushIndexSegment(dir, import.segment,
-                                     !pending_consolidation);
+    if (docs_mask_modified || pending_compaction) {
+      index_utils::FlushIndexSegment(dir, import.segment, !pending_compaction);
     }
 
     if (docs_mask_modified) {
@@ -1915,7 +1912,7 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
     pending_meta.segments.emplace_back(std::move(import.segment));
   }
 
-  // For pending consolidation we need to filter out consolidation
+  // For pending compaction we need to filter out compaction
   // candidates after applying them
   if (import_candidates_count != 0) {
     SDB_ASSERT(import_candidates_count <= readers.size());
@@ -2132,10 +2129,10 @@ IndexWriter::PendingContext IndexWriter::PrepareFlush(const CommitInfo& info) {
 
   if (!next_cached.empty()) {
     cleanup_lock.lock();
-    _consolidating.segments.reserve(_consolidating.segments.size() +
-                                    next_cached.size());
+    _compacting.segments.reserve(_compacting.segments.size() +
+                                 next_cached.size());
     for (const auto& entry : next_cached) {
-      _consolidating.segments.emplace(entry.second->Meta().name);
+      _compacting.segments.emplace(entry.second->Meta().name);
     }
   }
 
@@ -2214,7 +2211,7 @@ bool IndexWriter::Start(const CommitInfo& info) {
     }
   };
 
-  // TODO(mbkkt) error here means we don't remove cached from consolidating
+  // TODO(mbkkt) error here means we don't remove cached from compacting
   ApplyFlush(std::move(to_commit));
 
   return true;

--- a/libs/iresearch/include/iresearch/index/index_writer.hpp
+++ b/libs/iresearch/include/iresearch/index/index_writer.hpp
@@ -72,47 +72,47 @@ enum OpenMode {
 
 ENABLE_BITMASK_ENUM(OpenMode);
 
-// A set of candidates denoting an instance of consolidation
-using Consolidation = std::vector<const SubReader*>;
-using ConsolidationView = std::span<const SubReader* const>;
+// A set of candidates denoting an instance of compaction
+using Compaction = std::vector<const SubReader*>;
+using CompactionView = std::span<const SubReader* const>;
 
-// segments that are under consolidation
-using ConsolidatingSegments = absl::flat_hash_set<std::string_view>;
+// segments that are under compaction
+using CompactingSegments = absl::flat_hash_set<std::string_view>;
 
-// Mark consolidation candidate segments matching the current policy
-// candidates the segments that should be consolidated
+// Mark compaction candidate segments matching the current policy
+// candidates the segments that should be compacted
 // in: segment candidates that may be considered by this policy
 // out: actual segments selected by the current policy
 // dir the segment directory
 // meta the index meta containing segments to be considered
-// Consolidating_segments segments that are currently in progress
-// of consolidation
+// Compacting_segments segments that are currently in progress
+// of compaction
 // Final candidates are all segments selected by at least some policy
-using ConsolidationPolicy =
-  std::function<void(Consolidation& candidates, const IndexReader& index,
-                     const ConsolidatingSegments& consolidating_segments)>;
+using CompactionPolicy =
+  std::function<void(Compaction& candidates, const IndexReader& index,
+                     const CompactingSegments& compacting_segments)>;
 
-enum class ConsolidationError : uint32_t {
-  // Consolidation failed
+enum class CompactionError : uint32_t {
+  // Compaction failed
   Fail = 0,
 
-  // Consolidation successfully finished
+  // Compaction successfully finished
   Ok,
 
-  // Consolidation was scheduled for the upcoming commit
+  // Compaction was scheduled for the upcoming commit
   Pending,
 };
 
-// Represents result of a consolidation
-struct ConsolidationResult {
+// Represents result of a compaction
+struct CompactionResult {
   // Number of candidates
   size_t size{0};
 
   // Error code
-  ConsolidationError error{ConsolidationError::Fail};
+  CompactionError error{CompactionError::Fail};
 
   // intentionally implicit
-  operator bool() const noexcept { return error != ConsolidationError::Fail; }
+  operator bool() const noexcept { return error != CompactionError::Fail; }
 };
 
 // Options the the writer should use for segments
@@ -533,22 +533,22 @@ class IndexWriter : private util::Noncopyable {
   // Policy the specified defragmentation policy
   // Codec desired format that will be used for segment creation,
   // nullptr == use index_writer's codec
-  // Progress callback triggered for consolidation steps, if the
-  // callback returns false then consolidation is aborted
+  // Progress callback triggered for compaction steps, if the
+  // callback returns false then compaction is aborted
   // For deferred policies during the commit stage each policy will be
   // given the exact same index_meta containing all segments in the
   // commit, however, the resulting acceptor will only be segments not
-  // yet marked for consolidation by other policies in the same commit
-  ConsolidationResult Consolidate(
-    const ConsolidationPolicy& policy, Format::ptr codec = nullptr,
-    const MergeWriter::FlushProgress& progress = {});
+  // yet marked for compaction by other policies in the same commit
+  CompactionResult Compact(const CompactionPolicy& policy,
+                           Format::ptr codec = nullptr,
+                           const MergeWriter::FlushProgress& progress = {});
 
   // Imports index from the specified index reader into new segment
   // Reader the index reader to import.
   // Desired format that will be used for segment creation,
   // nullptr == use index_writer's codec.
-  // Progress callback triggered for consolidation steps, if the
-  // callback returns false then consolidation is aborted.
+  // Progress callback triggered for compaction steps, if the
+  // callback returns false then compaction is aborted.
   // Returns true on success.
   bool Import(const IndexReader& reader, Format::ptr codec = nullptr,
               const MergeWriter::FlushProgress& progress = {});
@@ -569,31 +569,30 @@ class IndexWriter : private util::Noncopyable {
   // nullptr == default sort order
   const Comparer* Comparator() const noexcept { return _comparator; }
 
-  // Begins the two-phase transaction.
+  // Begins the two-phase refresh (publish the in-memory writer's segment).
   // payload arbitrary user supplied data to store in the index
-  // Returns true if transaction has been successfully started.
-
-  bool Begin(const CommitInfo& info = {}) {
+  // Returns true if a refresh has been successfully started.
+  bool RefreshBegin(const CommitInfo& info = {}) {
     _commit_lock.ForgetDeadlockInfo();
     std::lock_guard lock{_commit_lock};
     return Start(info);
   }
 
-  // Rollbacks the two-phase transaction
-  void Rollback() {
+  // Discards a pending two-phase refresh.
+  void RefreshAbort() {
     _commit_lock.ForgetDeadlockInfo();
     std::lock_guard lock{_commit_lock};
     Abort();
   }
 
-  // Make all buffered changes visible for readers.
+  // Publish all buffered changes so they become visible to readers.
   // payload arbitrary user supplied data to store in the index
-  // Return whether any changes were committed.
+  // Return whether any changes were published.
   //
-  // Note that if begin() has been already called commit() is
-  // relatively lightweight operation.
-  // FIXME(gnusi): Commit() should return committed index snapshot
-  bool Commit(const CommitInfo& info = {}) {
+  // If RefreshBegin() has already been called RefreshCommit() is
+  // relatively lightweight.
+  // FIXME(gnusi): RefreshCommit() should return committed index snapshot
+  bool RefreshCommit(const CommitInfo& info = {}) {
     _commit_lock.ForgetDeadlockInfo();
     std::lock_guard lock{_commit_lock};
     const bool modified = Start(info);
@@ -612,29 +611,28 @@ class IndexWriter : private util::Noncopyable {
               std::shared_ptr<const DirectoryReaderImpl>&& committed_reader);
 
  private:
-  struct ConsolidationContext : util::Noncopyable {
-    std::shared_ptr<const DirectoryReaderImpl> consolidation_reader;
-    Consolidation candidates;
+  struct CompactionContext : util::Noncopyable {
+    std::shared_ptr<const DirectoryReaderImpl> compaction_reader;
+    Compaction candidates;
     MergeWriter merger;
   };
 
-  static_assert(std::is_nothrow_move_constructible_v<ConsolidationContext>);
+  static_assert(std::is_nothrow_move_constructible_v<CompactionContext>);
 
   struct ImportContext {
     ImportContext(
       IndexSegment&& segment, uint64_t tick, FileRefs&& refs,
-      Consolidation&& consolidation_candidates,
+      Compaction&& compaction_candidates,
       std::shared_ptr<const SegmentReaderImpl>&& reader,
-      std::shared_ptr<const DirectoryReaderImpl>&& consolidation_reader,
+      std::shared_ptr<const DirectoryReaderImpl>&& compaction_reader,
       MergeWriter&& merger) noexcept
       : tick{tick},
         segment{std::move(segment)},
         refs{std::move(refs)},
         reader{std::move(reader)},
-        consolidation_ctx{
-          .consolidation_reader = std::move(consolidation_reader),
-          .candidates = std::move(consolidation_candidates),
-          .merger = std::move(merger)} {}
+        compaction_ctx{.compaction_reader = std::move(compaction_reader),
+                       .candidates = std::move(compaction_candidates),
+                       .merger = std::move(merger)} {}
 
     ImportContext(IndexSegment&& segment, uint64_t tick, FileRefs&& refs,
                   std::shared_ptr<const SegmentReaderImpl>&& reader,
@@ -643,7 +641,7 @@ class IndexWriter : private util::Noncopyable {
         segment{std::move(segment)},
         refs{std::move(refs)},
         reader{std::move(reader)},
-        consolidation_ctx{.merger{resource_manager}} {}
+        compaction_ctx{.merger{resource_manager}} {}
 
     ImportContext(ImportContext&&) = default;
 
@@ -654,7 +652,7 @@ class IndexWriter : private util::Noncopyable {
     IndexSegment segment;
     FileRefs refs;
     std::shared_ptr<const SegmentReaderImpl> reader;
-    ConsolidationContext consolidation_ctx;
+    CompactionContext compaction_ctx;
   };
 
   static_assert(std::is_nothrow_move_constructible_v<ImportContext>);
@@ -861,7 +859,7 @@ class IndexWriter : private util::Noncopyable {
     WaitGroup pending;
 
     // set of segments to be removed from the index upon commit
-    ConsolidatingSegments segment_mask;
+    CompactingSegments segment_mask;
 
     FlushContext() = default;
 
@@ -889,7 +887,7 @@ class IndexWriter : private util::Noncopyable {
     void StartReset(IndexWriter& writer, bool keep_next = false) noexcept {
       auto* curr = ctx.get();
       if (curr != nullptr) {
-        std::lock_guard lock{writer._consolidating.lock};
+        std::lock_guard lock{writer._compacting.lock};
         writer.Cleanup(*curr, keep_next ? nullptr : curr->next);
       }
     }
@@ -940,8 +938,7 @@ class IndexWriter : private util::Noncopyable {
   ActiveSegmentContext GetSegmentContext();
 
   // Return options for SegmentWriter
-  SegmentWriterOptions GetSegmentWriterOptions(
-    bool consolidation) const noexcept;
+  SegmentWriterOptions GetSegmentWriterOptions(bool compaction) const noexcept;
 
   // Return next segment identifier
   uint64_t NextSegmentId() noexcept;
@@ -965,13 +962,13 @@ class IndexWriter : private util::Noncopyable {
   PayloadProvider _meta_payload_provider;  // provides payload for new segments
   const Comparer* _comparator;
   Format::ptr _codec;
-  // Prevent concurrent Begin/Commit/Rollback/Clear and multiple Consolidate
+  // Prevent concurrent Begin/Commit/Rollback/Clear and multiple Compact
   absl::Mutex _commit_lock;
   struct {
     std::recursive_mutex lock;  // TODO(mbkkt) make it absl::Mutex
-    // It's recursive because our tests, where consolidation policy calls commit
-    ConsolidatingSegments segments;  // segments that are under consolidation
-  } _consolidating;
+    // It's recursive because our tests, where compaction policy calls commit
+    CompactingSegments segments;  // segments that are under compaction
+  } _compacting;
   // directory used for initialization of readers
   Directory& _dir;
   // currently active context accumulating data to be

--- a/libs/iresearch/include/iresearch/store/directory.hpp
+++ b/libs/iresearch/include/iresearch/store/directory.hpp
@@ -168,7 +168,7 @@ struct Directory : private util::Noncopyable {
   explicit Directory(const ResourceManagementOptions& resource_manager) noexcept
     : _resource_manager{resource_manager} {
     SDB_ASSERT(_resource_manager.cached_columns);
-    SDB_ASSERT(_resource_manager.consolidations);
+    SDB_ASSERT(_resource_manager.compactions);
     SDB_ASSERT(_resource_manager.file_descriptors);
     SDB_ASSERT(_resource_manager.readers);
     SDB_ASSERT(_resource_manager.transactions);

--- a/libs/iresearch/include/iresearch/utils/index_utils.cpp
+++ b/libs/iresearch/include/iresearch/utils/index_utils.cpp
@@ -78,11 +78,11 @@ bool operator<(const SegmentStats& lhs, const SegmentStats& rhs) noexcept {
   return lhs.meta->name < rhs.meta->name;
 }
 
-struct ConsolidationCandidate {
+struct CompactionCandidate {
   using Iterator = std::vector<SegmentStats>::const_iterator;
   using Range = std::pair<Iterator, Iterator>;
 
-  explicit ConsolidationCandidate(Iterator i) noexcept : segments{i, i} {}
+  explicit CompactionCandidate(Iterator i) noexcept : segments{i, i} {}
 
   auto begin() const noexcept { return segments.first; }
   auto end() const noexcept { return segments.second; }
@@ -93,24 +93,24 @@ struct ConsolidationCandidate {
   double score = DBL_MIN;  // how good this permutation is
 };
 
-/// @returns score of the consolidation bucket
-double ConsolidationScore(const ConsolidationCandidate& consolidation,
-                          const size_t segments_per_tier,
-                          const size_t floor_segment_bytes) noexcept {
-  // to detect how skewed the consolidation we do the following:
+/// @returns score of the compaction bucket
+double CompactionScore(const CompactionCandidate& compaction,
+                       const size_t segments_per_tier,
+                       const size_t floor_segment_bytes) noexcept {
+  // to detect how skewed the compaction we do the following:
   // 1. evaluate coefficient of variation, less is better
   // 2. good candidates are in range [0;1]
   // 3. favor condidates where number of segments is equal to
   // 'segments_per_tier' approx
-  // 4. prefer smaller consolidations
-  // 5. prefer consolidations which clean removals
+  // 4. prefer smaller compactions
+  // 5. prefer compactions which clean removals
 
-  switch (consolidation.count) {
+  switch (compaction.count) {
     case 0:
-      // empty consolidation makes not sense
+      // empty compaction makes not sense
       return 0;
     case 1: {
-      auto& meta = *consolidation.segments.first->meta;
+      auto& meta = *compaction.segments.first->meta;
 
       if (meta.docs_count == meta.live_docs_count) {
         // singletone without removals makes no sense
@@ -123,48 +123,48 @@ double ConsolidationScore(const ConsolidationCandidate& consolidation,
     }
   }
 
-  size_t size_before_consolidation = 0;
-  size_t size_after_consolidation = 0;
-  size_t size_after_consolidation_floored = 0;
-  for (auto& segment_stat : consolidation) {
-    size_before_consolidation += segment_stat.meta->byte_size;
-    size_after_consolidation += segment_stat.size;
-    size_after_consolidation_floored +=
+  size_t size_before_compaction = 0;
+  size_t size_after_compaction = 0;
+  size_t size_after_compaction_floored = 0;
+  for (auto& segment_stat : compaction) {
+    size_before_compaction += segment_stat.meta->byte_size;
+    size_after_compaction += segment_stat.size;
+    size_after_compaction_floored +=
       std::max(segment_stat.size, floor_segment_bytes);
   }
 
   // evaluate coefficient of variation
   double sum_square_differences = 0;
-  const auto segment_size_after_consolidaton_mean =
-    static_cast<double>(size_after_consolidation_floored) /
-    static_cast<double>(consolidation.count);
-  for (auto& segment_stat : consolidation) {
+  const auto segment_size_after_compaction_mean =
+    static_cast<double>(size_after_compaction_floored) /
+    static_cast<double>(compaction.count);
+  for (auto& segment_stat : compaction) {
     const auto diff =
       static_cast<double>(std::max(segment_stat.size, floor_segment_bytes)) -
-      segment_size_after_consolidaton_mean;
+      segment_size_after_compaction_mean;
     sum_square_differences += diff * diff;
   }
 
-  const auto stdev = std::sqrt(sum_square_differences /
-                               static_cast<double>(consolidation.count));
-  const auto cv = (stdev / segment_size_after_consolidaton_mean);
+  const auto stdev =
+    std::sqrt(sum_square_differences / static_cast<double>(compaction.count));
+  const auto cv = (stdev / segment_size_after_compaction_mean);
 
   // evaluate initial score
   auto score = 1. - cv;
 
-  // favor consolidations that contain approximately the requested number of
+  // favor compactions that contain approximately the requested number of
   // segments
-  score *= std::pow(static_cast<double>(consolidation.count) /
+  score *= std::pow(static_cast<double>(compaction.count) /
                       static_cast<double>(segments_per_tier),
                     1.5);
 
   // FIXME use relative measure, e.g. cosolidation_size/total_size
-  // carefully prefer smaller consolidations over the bigger ones
-  score /= std::pow(size_after_consolidation, 0.5);
+  // carefully prefer smaller compactions over the bigger ones
+  score /= std::pow(size_after_compaction, 0.5);
 
-  // favor consolidations which clean out removals
-  score /= std::pow(static_cast<double>(size_after_consolidation) /
-                      static_cast<double>(size_before_consolidation),
+  // favor compactions which clean out removals
+  score /= std::pow(static_cast<double>(size_after_compaction) /
+                      static_cast<double>(size_before_compaction),
                     2);
 
   return score;
@@ -173,9 +173,9 @@ double ConsolidationScore(const ConsolidationCandidate& consolidation,
 }  // namespace tier
 }  // namespace
 
-ConsolidationPolicy MakePolicy(const ConsolidateBytes& options) {
-  return [options](Consolidation& candidates, const IndexReader& reader,
-                   const ConsolidatingSegments& consolidating_segments) {
+CompactionPolicy MakePolicy(const CompactionBytes& options) {
+  return [options](Compaction& candidates, const IndexReader& reader,
+                   const CompactingSegments& compacting_segments) {
     const auto byte_threshold = options.threshold;
     size_t all_segment_bytes_size = 0;
     const auto segment_count = reader.size();
@@ -193,7 +193,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateBytes& options) {
     // merge segment if: {threshold} > segment_bytes / (all_segment_bytes /
     // #segments)
     for (auto& segment : reader) {
-      if (consolidating_segments.contains(segment.Meta().name)) {
+      if (compacting_segments.contains(segment.Meta().name)) {
         continue;
       }
       const auto segment_bytes_size = segment.Meta().byte_size;
@@ -204,17 +204,17 @@ ConsolidationPolicy MakePolicy(const ConsolidateBytes& options) {
   };
 }
 
-ConsolidationPolicy MakePolicy(const ConsolidateBytesAccum& options) {
-  return [options](Consolidation& candidates, const IndexReader& reader,
-                   const ConsolidatingSegments& consolidating_segments) {
+CompactionPolicy MakePolicy(const CompactionBytesAccum& options) {
+  return [options](Compaction& candidates, const IndexReader& reader,
+                   const CompactingSegments& compacting_segments) {
     auto byte_threshold = options.threshold;
     size_t all_segment_bytes_size = 0;
     std::vector<std::pair<size_t, const SubReader*>> segments;
     segments.reserve(reader.size());
 
     for (auto& segment : reader) {
-      if (consolidating_segments.contains(segment.Meta().name)) {
-        continue;  // segment is already under consolidation
+      if (compacting_segments.contains(segment.Meta().name)) {
+        continue;  // segment is already under compaction
       }
       segments.emplace_back(SizeWithoutRemovals(segment.Meta()), &segment);
       all_segment_bytes_size += segments.back().first;
@@ -224,7 +224,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateBytesAccum& options) {
     const auto threshold_size = static_cast<float>(all_segment_bytes_size) *
                                 std::clamp(byte_threshold, 0.f, 1.f);
 
-    // prefer to consolidate smaller segments
+    // prefer to compact smaller segments
     absl::c_sort(segments, [](const auto& lhs, const auto& rhs) {
       return lhs.first < rhs.first;
     });
@@ -243,9 +243,9 @@ ConsolidationPolicy MakePolicy(const ConsolidateBytesAccum& options) {
   };
 }
 
-ConsolidationPolicy MakePolicy(const ConsolidateCount& options) {
-  return [options](Consolidation& candidates, const IndexReader& reader,
-                   const ConsolidatingSegments& /*consolidating_segments*/) {
+CompactionPolicy MakePolicy(const CompactionCount& options) {
+  return [options](Compaction& candidates, const IndexReader& reader,
+                   const CompactingSegments& /*compacting_segments*/) {
     // merge first 'threshold' segments
     for (size_t i = 0, count = std::min(options.threshold, reader.size());
          i < count; ++i) {
@@ -254,9 +254,9 @@ ConsolidationPolicy MakePolicy(const ConsolidateCount& options) {
   };
 }
 
-ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options) {
-  return [options](Consolidation& candidates, const IndexReader& reader,
-                   const ConsolidatingSegments& consolidating_segments) {
+CompactionPolicy MakePolicy(const CompactionDocsFill& options) {
+  return [options](Compaction& candidates, const IndexReader& reader,
+                   const CompactingSegments& compacting_segments) {
     auto fill_threshold = options.threshold;
     auto threshold = std::clamp(fill_threshold, 0.f, 1.f);
 
@@ -264,7 +264,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options) {
     // (#segment_docs{valid} + #segment_docs{removed})
     for (auto& segment : reader) {
       auto& meta = segment.Meta();
-      if (consolidating_segments.contains(meta.name)) {
+      if (compacting_segments.contains(meta.name)) {
         continue;
       }
       if (!meta.live_docs_count  // if no valid doc_ids left in segment
@@ -276,9 +276,9 @@ ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options) {
   };
 }
 
-ConsolidationPolicy MakePolicy(const ConsolidateDocsLive& options) {
-  return [options](Consolidation& candidates, const IndexReader& meta,
-                   const ConsolidatingSegments& consolidating_segments) {
+CompactionPolicy MakePolicy(const CompactionDocsLive& options) {
+  return [options](Compaction& candidates, const IndexReader& meta,
+                   const CompactingSegments& compacting_segments) {
     const auto docs_threshold = options.threshold;
     const auto all_segment_docs_count = meta.live_docs_count();
     const auto segment_count = meta.size();
@@ -293,7 +293,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateDocsLive& options) {
     // (all_segment_docs{valid} / #segments)
     for (auto& segment : meta) {
       auto& info = segment.Meta();
-      if (consolidating_segments.contains(info.name)) {
+      if (compacting_segments.contains(info.name)) {
         continue;
       }
       if (!info.live_docs_count  // if no valid doc_ids left in segment
@@ -304,7 +304,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateDocsLive& options) {
   };
 }
 
-ConsolidationPolicy MakePolicy(const ConsolidateTier& options) {
+CompactionPolicy MakePolicy(const CompactionTier& options) {
   // can't merge less than 1 segment
   const auto max_segments_per_tier = std::max<size_t>(1, options.max_segments);
   // can't merge less than 1 segment
@@ -315,13 +315,13 @@ ConsolidationPolicy MakePolicy(const ConsolidateTier& options) {
     std::max<size_t>(1, options.max_segments_bytes);
   const auto floor_segment_bytes =
     std::max<size_t>(1, options.floor_segment_bytes);
-  // skip consolidation that have score less than min_score
+  // skip compaction that have score less than min_score
   const auto min_score = options.min_score;
 
   return [max_segments_per_tier, min_segments_per_tier, floor_segment_bytes,
           max_segments_bytes,
-          min_score](Consolidation& candidates, const IndexReader& reader,
-                     const ConsolidatingSegments& consolidating_segments) {
+          min_score](Compaction& candidates, const IndexReader& reader,
+                     const CompactingSegments& compacting_segments) {
     // total number of documents in index
     size_t total_docs_count = 0;
     // total number of live documents in index
@@ -342,7 +342,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateTier& options) {
       }
 
       total_live_docs_count += meta.live_docs_count;
-      if (consolidating_segments.contains(meta.name)) {
+      if (compacting_segments.contains(meta.name)) {
         total_docs_count += meta.live_docs_count;
         continue;
       }
@@ -377,11 +377,11 @@ ConsolidationPolicy MakePolicy(const ConsolidateTier& options) {
 
     /// Stage 4: find proper candidates
 
-    tier::ConsolidationCandidate best(sorted_segments.begin());
+    tier::CompactionCandidate best(sorted_segments.begin());
 
     for (auto i = sorted_segments.begin(), end = sorted_segments.end();
          i != end; ++i) {
-      tier::ConsolidationCandidate candidate(i);
+      tier::CompactionCandidate candidate(i);
 
       while (candidate.segments.second != end &&
              candidate.count < max_segments_per_tier) {
@@ -400,7 +400,7 @@ ConsolidationPolicy MakePolicy(const ConsolidateTier& options) {
           continue;
         }
 
-        candidate.score = tier::ConsolidationScore(
+        candidate.score = tier::CompactionScore(
           candidate, max_segments_per_tier, floor_segment_bytes);
 
         if (candidate.score < min_score) {

--- a/libs/iresearch/include/iresearch/utils/index_utils.hpp
+++ b/libs/iresearch/include/iresearch/utils/index_utils.hpp
@@ -30,59 +30,59 @@ namespace irs::index_utils {
 
 // merge segment if:
 //   {threshold} > segment_bytes / (all_segment_bytes / #segments)
-struct ConsolidateBytes {
+struct CompactionBytes {
   float threshold = 0;
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateBytes& options);
+CompactionPolicy MakePolicy(const CompactionBytes& options);
 
 // merge segment if:
 //   {threshold} >= (segment_bytes + sum_of_merge_candidate_segment_bytes) /
 //   all_segment_bytes
-struct ConsolidateBytesAccum {
+struct CompactionBytesAccum {
   float threshold = 0;
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateBytesAccum& options);
+CompactionPolicy MakePolicy(const CompactionBytesAccum& options);
 
 // merge first {threshold} segments
-struct ConsolidateCount {
+struct CompactionCount {
   size_t threshold = std::numeric_limits<size_t>::max();
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateCount& options);
+CompactionPolicy MakePolicy(const CompactionCount& options);
 
 // merge segment if:
 //   {threshold} >= segment_docs{valid} / (all_segment_docs{valid} / #segments)
-struct ConsolidateDocsLive {
+struct CompactionDocsLive {
   float threshold = 0;
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateDocsLive& options);
+CompactionPolicy MakePolicy(const CompactionDocsLive& options);
 
 // merge segment if:
 //   {threshold} > #segment_docs{valid} / (#segment_docs{valid} +
 //   #segment_docs{removed})
-struct ConsolidateDocsFill {
+struct CompactionDocsFill {
   float threshold = 0;
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options);
+CompactionPolicy MakePolicy(const CompactionDocsFill& options);
 
-struct ConsolidateTier {
-  // minimum allowed number of segments to consolidate at once
+struct CompactionTier {
+  // minimum allowed number of segments to compact at once
   size_t min_segments = 1;
-  // maximum allowed number of segments to consolidate at once
+  // maximum allowed number of segments to compact at once
   size_t max_segments = 10;
-  // maxinum allowed size of all consolidated segments
+  // maxinum allowed size of all compacted segments
   size_t max_segments_bytes = size_t(5) * (1 << 30);
-  // treat all smaller segments as equal for consolidation selection
+  // treat all smaller segments as equal for compaction selection
   size_t floor_segment_bytes = size_t(2) * (1 << 20);
   // filter out candidates with score less than min_score
   double_t min_score = 0.;
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateTier& options);
+CompactionPolicy MakePolicy(const CompactionTier& options);
 
 // Writes segment_meta to the supplied directory
 void FlushIndexSegment(Directory& dir, IndexSegment& segment,

--- a/server/catalog/index.h
+++ b/server/catalog/index.h
@@ -44,8 +44,8 @@ class InvertedIndex;
 struct InvertedIndexOptions {
   uint32_t row_group_size = 0;
   uint32_t norm_row_group_size = 0;
-  uint32_t commit_interval_ms = 0;
-  uint32_t consolidation_interval_ms = 0;
+  uint32_t refresh_interval_ms = 0;
+  uint32_t compaction_interval_ms = 0;
   uint32_t cleanup_interval_step = 0;
   std::optional<ScorerOptions> topk_scorer;
 };

--- a/server/catalog/search_common.h
+++ b/server/catalog/search_common.h
@@ -113,23 +113,22 @@ struct StaticStrings {
   static constexpr std::string_view kOptimizeTopField = "optimizeTop";
 
   /// the name of the field in the Search View definition denoting the
-  ///        time in Ms between running consolidations
-  static constexpr std::string_view kConsolidationIntervalMsec =
-    "consolidationIntervalMsec";
+  ///        time in Ms between running compactions
+  static constexpr std::string_view kCompactionIntervalMsec =
+    "compactionIntervalMsec";
 
   /// the name of the field in the Search View definition denoting the
   ///        time in Ms between running commits
   static constexpr std::string_view kCommitIntervalMsec = "commitIntervalMsec";
 
   /// the name of the field in the Search View definition denoting the
-  ///        number of completed consolidtions before cleanup is run
+  ///        number of completed refreshes before cleanup is run
   static constexpr std::string_view kCleanupIntervalStep =
     "cleanupIntervalStep";
 
   /// the name of the field in the Search View definition denoting the
-  ///         consolidation policy properties
-  static constexpr std::string_view kConsolidationPolicy =
-    "consolidationPolicy";
+  ///         compaction policy properties
+  static constexpr std::string_view kCompactionPolicy = "compactionPolicy";
 
   /// the name of the field in the Search View definition denoting the
   ///        maximum number of concurrent active writers (segments) that perform

--- a/server/connector/duckdb_physical_create_index.cpp
+++ b/server/connector/duckdb_physical_create_index.cpp
@@ -335,8 +335,8 @@ SereneDBPhysicalCreateIndex::GetGlobalSinkState(
     catalog::InvertedIndexOptions options{
       .row_group_size = resolve_uint("row_group_size"),
       .norm_row_group_size = resolve_uint("norm_row_group_size"),
-      .commit_interval_ms = resolve_uint("commit_interval"),
-      .consolidation_interval_ms = resolve_uint("consolidation_interval"),
+      .refresh_interval_ms = resolve_uint("refresh_interval"),
+      .compaction_interval_ms = resolve_uint("compaction_interval"),
       .cleanup_interval_step = resolve_uint("cleanup_interval_step"),
     };
     if (auto* v = find_with("optimize_top_k")) {

--- a/server/connector/duckdb_schema_entry.cpp
+++ b/server/connector/duckdb_schema_entry.cpp
@@ -456,8 +456,8 @@ duckdb::optional_ptr<duckdb::CatalogEntry> SereneDBSchemaEntry::CreateIndex(
     catalog::InvertedIndexOptions options{
       .row_group_size = resolve_uint("row_group_size"),
       .norm_row_group_size = resolve_uint("norm_row_group_size"),
-      .commit_interval_ms = resolve_uint("commit_interval"),
-      .consolidation_interval_ms = resolve_uint("consolidation_interval"),
+      .refresh_interval_ms = resolve_uint("refresh_interval"),
+      .compaction_interval_ms = resolve_uint("compaction_interval"),
       .cleanup_interval_step = resolve_uint("cleanup_interval_step"),
     };
     if (auto* v = find_with("optimize_top_k")) {

--- a/server/connector/duckdb_vacuum_function.cpp
+++ b/server/connector/duckdb_vacuum_function.cpp
@@ -24,32 +24,80 @@
 #include <duckdb/main/database.hpp>
 #include <iresearch/utils/index_utils.hpp>
 
-#include "app/app_server.h"
 #include "basics/assert.h"
 #include "catalog/catalog.h"
 #include "connector/duckdb_client_state.h"
 #include "pg/connection_context.h"
+#include "search/inverted_index_shard.h"
 #include "storage_engine/engine_feature.h"
 
 namespace sdb::connector {
 namespace {
 
+enum class Scope : uint8_t {
+  Database,
+  Schema,
+  Table,
+  Index,
+  All,
+};
+
+enum class Action : uint8_t {
+  Refresh,
+  Compact,
+  SyncStats,
+  CompactRocksdb,
+};
+
+struct Verb {
+  Action action;
+  Scope scope;
+};
+
+std::optional<Verb> ParseOption(std::string_view option) {
+  static constexpr std::pair<std::string_view, Verb> kVerbs[] = {
+    {"refresh_database", {Action::Refresh, Scope::Database}},
+    {"refresh_schema", {Action::Refresh, Scope::Schema}},
+    {"refresh_table", {Action::Refresh, Scope::Table}},
+    {"refresh_index", {Action::Refresh, Scope::Index}},
+    {"refresh_all", {Action::Refresh, Scope::All}},
+    {"compact_database", {Action::Compact, Scope::Database}},
+    {"compact_schema", {Action::Compact, Scope::Schema}},
+    {"compact_table", {Action::Compact, Scope::Table}},
+    {"compact_index", {Action::Compact, Scope::Index}},
+    {"compact_all", {Action::Compact, Scope::All}},
+    {"sync_stats_table", {Action::SyncStats, Scope::Table}},
+    {"sync_stats_schema", {Action::SyncStats, Scope::Schema}},
+    {"sync_stats_database", {Action::SyncStats, Scope::Database}},
+    {"sync_stats_all", {Action::SyncStats, Scope::All}},
+    {"compact_rocksdb", {Action::CompactRocksdb, Scope::All}},
+  };
+  for (const auto& [name, verb] : kVerbs) {
+    if (option == name) {
+      return verb;
+    }
+  }
+  return std::nullopt;
+}
+
 struct VacuumBindData : public duckdb::FunctionData {
   std::string option;
-  std::string table_name;
-  std::string schema_name;
+  std::string name;
+  std::string schema;
+  std::string catalog;
 
   duckdb::unique_ptr<duckdb::FunctionData> Copy() const final {
     auto copy = duckdb::make_uniq<VacuumBindData>();
     copy->option = option;
-    copy->table_name = table_name;
-    copy->schema_name = schema_name;
+    copy->name = name;
+    copy->schema = schema;
+    copy->catalog = catalog;
     return copy;
   }
   bool Equals(const duckdb::FunctionData& other) const final {
     auto& o = other.Cast<VacuumBindData>();
-    return option == o.option && table_name == o.table_name &&
-           schema_name == o.schema_name;
+    return option == o.option && name == o.name && schema == o.schema &&
+           catalog == o.catalog;
   }
 };
 
@@ -63,16 +111,254 @@ duckdb::unique_ptr<duckdb::FunctionData> VacuumBind(
     data->option = input.inputs[0].GetValue<std::string>();
   }
   if (input.inputs.size() >= 2 && !input.inputs[1].IsNull()) {
-    data->table_name = input.inputs[1].GetValue<std::string>();
+    data->name = input.inputs[1].GetValue<std::string>();
   }
   if (input.inputs.size() >= 3 && !input.inputs[2].IsNull()) {
-    data->schema_name = input.inputs[2].GetValue<std::string>();
+    data->schema = input.inputs[2].GetValue<std::string>();
+  }
+  if (input.inputs.size() >= 4 && !input.inputs[3].IsNull()) {
+    data->catalog = input.inputs[3].GetValue<std::string>();
   }
 
-  // CALL returns empty result
   return_types.push_back(duckdb::LogicalType::BOOLEAN);
   names.push_back("ok");
   return data;
+}
+
+// BaseTableRef parses up to 3 dot-separated identifiers and packs them into
+// catalog/schema/table_name. The mapping depends on how many were given:
+//   1 -> table_name=<name>, others empty
+//   2 -> schema=<a>, table_name=<b>
+//   3 -> catalog=<a>, schema=<b>, table_name=<c>
+// For SCHEMA scope <schema> or <catalog>.<schema>, and DATABASE scope
+// <db> only, re-pack the parts into their natural slots.
+struct ResolvedName {
+  std::string database;
+  std::string schema;
+  std::string object;
+};
+
+ResolvedName ResolveName(const VacuumBindData& bind, Scope scope,
+                         const ConnectionContext& conn_ctx,
+                         const catalog::Snapshot& snapshot) {
+  ResolvedName out;
+  switch (scope) {
+    case Scope::Database: {
+      if (!bind.schema.empty() || !bind.catalog.empty()) {
+        throw duckdb::BinderException(
+          "VACUUM (REFRESH_DATABASE|COMPACT_DATABASE|SYNC_STATS_DATABASE) "
+          "expects a single database name");
+      }
+      out.database = bind.name;
+      break;
+    }
+    case Scope::Schema: {
+      if (!bind.catalog.empty()) {
+        throw duckdb::BinderException(
+          "VACUUM (REFRESH_SCHEMA|COMPACT_SCHEMA|SYNC_STATS_SCHEMA) expects "
+          "[<database>.]<schema>");
+      }
+      out.database = bind.schema;
+      out.schema = bind.name;
+      break;
+    }
+    case Scope::Table:
+    case Scope::Index: {
+      out.database = bind.catalog;
+      out.schema = bind.schema;
+      out.object = bind.name;
+      break;
+    }
+    case Scope::All:
+      break;
+  }
+
+  if (out.database.empty()) {
+    auto db = snapshot.GetDatabase(conn_ctx.GetDatabaseId());
+    if (db) {
+      out.database = std::string{db->GetName()};
+    }
+  }
+  if (out.schema.empty() && (scope == Scope::Table || scope == Scope::Index)) {
+    out.schema = conn_ctx.GetCurrentSchema();
+  }
+  return out;
+}
+
+ObjectId LookupDatabaseId(const catalog::Snapshot& snapshot,
+                          std::string_view name) {
+  auto db = snapshot.GetDatabase(name);
+  if (!db) {
+    throw duckdb::CatalogException("database '%s' does not exist.",
+                                   std::string{name});
+  }
+  return db->GetId();
+}
+
+void RefreshInvertedShard(search::InvertedIndexShard& inverted) {
+  std::ignore = std::move(inverted.CommitWait()).Get().Ok();
+}
+
+void CompactInvertedShard(search::InvertedIndexShard& inverted) {
+  static const auto kPolicy = irs::index_utils::MakePolicy(
+    irs::index_utils::CompactionCount{std::numeric_limits<size_t>::max()});
+  static const irs::MergeWriter::FlushProgress kProgress = [] { return true; };
+  RefreshInvertedShard(inverted);
+  for (size_t pass = 0; pass < 8; ++pass) {
+    bool empty_compaction = false;
+    const auto [res, _] =
+      inverted.CompactUnsafe(kPolicy, kProgress, empty_compaction);
+    if (!res.ok()) {
+      throw duckdb::InternalException("compact_index: compaction failed: %s",
+                                      res.errorMessage());
+    }
+    RefreshInvertedShard(inverted);
+    if (empty_compaction) {
+      break;
+    }
+  }
+}
+
+void ForEachInvertedShard(
+  const catalog::Snapshot& snapshot, ObjectId relation_id,
+  absl::FunctionRef<void(search::InvertedIndexShard&)> v) {
+  for (auto& shard : snapshot.GetIndexShardsByRelation(relation_id)) {
+    if (!shard || shard->GetType() != catalog::ObjectType::InvertedIndexShard) {
+      continue;
+    }
+    v(basics::downCast<search::InvertedIndexShard>(*shard));
+  }
+}
+
+void DispatchInverted(const catalog::Snapshot& snapshot, Action action,
+                      Scope scope, const ResolvedName& target) {
+  auto apply = [action](search::InvertedIndexShard& s) {
+    if (action == Action::Refresh) {
+      RefreshInvertedShard(s);
+    } else {
+      CompactInvertedShard(s);
+    }
+  };
+
+  auto walk_schema = [&](ObjectId db_id, std::string_view schema) {
+    for (auto& table : snapshot.GetTables(db_id, schema)) {
+      ForEachInvertedShard(snapshot, table->GetId(), apply);
+    }
+  };
+
+  auto walk_database = [&](ObjectId db_id) {
+    for (auto& schema : snapshot.GetSchemas(db_id)) {
+      walk_schema(db_id, schema->GetName());
+    }
+  };
+
+  switch (scope) {
+    case Scope::Index: {
+      auto db_id = LookupDatabaseId(snapshot, target.database);
+      for (auto& index : snapshot.GetIndexes(db_id, target.schema)) {
+        if (index->GetType() != catalog::ObjectType::InvertedIndex ||
+            index->GetName() != target.object) {
+          continue;
+        }
+        auto shard = snapshot.GetIndexShard(index->GetId());
+        if (!shard ||
+            shard->GetType() != catalog::ObjectType::InvertedIndexShard) {
+          continue;
+        }
+        apply(basics::downCast<search::InvertedIndexShard>(*shard));
+        return;
+      }
+      throw duckdb::CatalogException("inverted index '%s' not found.",
+                                     target.object);
+    }
+    case Scope::Table: {
+      auto db_id = LookupDatabaseId(snapshot, target.database);
+      auto table = snapshot.GetTable(db_id, target.schema, target.object);
+      if (!table) {
+        throw duckdb::CatalogException("relation '%s' not found.",
+                                       target.object);
+      }
+      ForEachInvertedShard(snapshot, table->GetId(), apply);
+      break;
+    }
+    case Scope::Schema: {
+      auto db_id = LookupDatabaseId(snapshot, target.database);
+      if (!snapshot.GetSchema(db_id, target.schema)) {
+        throw duckdb::CatalogException("schema '%s' does not exist.",
+                                       target.schema);
+      }
+      walk_schema(db_id, target.schema);
+      break;
+    }
+    case Scope::Database: {
+      walk_database(LookupDatabaseId(snapshot, target.database));
+      break;
+    }
+    case Scope::All: {
+      for (auto& db : snapshot.GetDatabases()) {
+        walk_database(db->GetId());
+      }
+      break;
+    }
+  }
+}
+
+void DispatchSyncStats(const catalog::Snapshot& snapshot, Scope scope,
+                       const ResolvedName& target) {
+  auto& engine = GetServerEngine();
+  auto sync_table = [&](ObjectId table_id) {
+    auto shard = snapshot.GetTableShard(table_id);
+    if (!shard) {
+      return;
+    }
+    if (auto r = engine.SyncTableShard(*shard); !r.ok()) {
+      throw duckdb::InternalException("SyncTableShard failed: %s",
+                                      r.errorMessage());
+    }
+  };
+  auto sync_schema = [&](ObjectId db_id, std::string_view schema) {
+    for (auto& table : snapshot.GetTables(db_id, schema)) {
+      sync_table(table->GetId());
+    }
+  };
+  auto sync_database = [&](ObjectId db_id) {
+    for (auto& schema : snapshot.GetSchemas(db_id)) {
+      sync_schema(db_id, schema->GetName());
+    }
+  };
+
+  switch (scope) {
+    case Scope::Table: {
+      auto db_id = LookupDatabaseId(snapshot, target.database);
+      auto table = snapshot.GetTable(db_id, target.schema, target.object);
+      if (!table) {
+        throw duckdb::CatalogException("relation '%s' not found.",
+                                       target.object);
+      }
+      sync_table(table->GetId());
+      break;
+    }
+    case Scope::Schema: {
+      auto db_id = LookupDatabaseId(snapshot, target.database);
+      if (!snapshot.GetSchema(db_id, target.schema)) {
+        throw duckdb::CatalogException("schema '%s' does not exist.",
+                                       target.schema);
+      }
+      sync_schema(db_id, target.schema);
+      break;
+    }
+    case Scope::Database:
+      sync_database(LookupDatabaseId(snapshot, target.database));
+      break;
+    case Scope::All:
+      for (auto& db : snapshot.GetDatabases()) {
+        sync_database(db->GetId());
+      }
+      break;
+    case Scope::Index:
+      // Unreachable: no SYNC_STATS_INDEX verb in ParseOption's table.
+      SDB_VERIFY(false);
+  }
 }
 
 void VacuumExecute(duckdb::ClientContext& context,
@@ -81,92 +367,47 @@ void VacuumExecute(duckdb::ClientContext& context,
   auto& bind_data = input.bind_data->Cast<VacuumBindData>();
   auto& conn_ctx = GetSereneDBContext(context);
   auto snapshot = conn_ctx.EnsureCatalogSnapshot();
-  auto database_id = conn_ctx.GetDatabaseId();
 
-  // Resolve tables
-  std::vector<std::shared_ptr<catalog::Table>> tables;
-  if (!bind_data.table_name.empty()) {
-    auto schema = bind_data.schema_name.empty() ? conn_ctx.GetCurrentSchema()
-                                                : bind_data.schema_name;
-    auto table = snapshot->GetTable(database_id, schema, bind_data.table_name);
-    if (!table) {
-      throw duckdb::CatalogException("relation '%s' not found.",
-                                     bind_data.table_name);
-    }
-    tables.push_back(std::move(table));
-  } else {
-    // All tables in current schema
-    tables = snapshot->GetTables(database_id, conn_ctx.GetCurrentSchema());
+  auto verb = ParseOption(bind_data.option);
+  if (!verb) {
+    throw duckdb::BinderException("unknown serenedb VACUUM option '%s'",
+                                  bind_data.option);
   }
 
-  auto option = bind_data.option;
-  std::transform(option.begin(), option.end(), option.begin(), ::tolower);
-
-  if (option == "update_indexes" || option.empty()) {
-    // Commit inverted indexes
-    for (const auto& table : tables) {
-      for (auto shard : snapshot->GetIndexShardsByRelation(table->GetId())) {
-        if (shard &&
-            shard->GetType() == catalog::ObjectType::InvertedIndexShard) {
-          auto& inverted = basics::downCast<search::InvertedIndexShard>(*shard);
-          std::ignore = std::move(inverted.CommitWait()).Get().Ok();
-        }
-      }
-    }
+  const bool needs_name = verb->scope != Scope::All;
+  if (needs_name && bind_data.name.empty()) {
+    throw duckdb::BinderException("VACUUM (%s) requires an object name",
+                                  bind_data.option);
+  }
+  if (!needs_name && !bind_data.name.empty()) {
+    throw duckdb::BinderException("VACUUM (%s) does not take an argument",
+                                  bind_data.option);
   }
 
-  if (option == "sync_stats") {
-    auto& engine = GetServerEngine();
-    for (const auto& table : tables) {
-      auto shard = snapshot->GetTableShard(table->GetId());
-      if (auto r = engine.SyncTableShard(*shard); !r.ok()) {
-        throw duckdb::InternalException("SyncTableShard failed: %s",
-                                        r.errorMessage());
-      }
+  auto target = ResolveName(bind_data, verb->scope, conn_ctx, *snapshot);
+
+  switch (verb->action) {
+    case Action::Refresh:
+    case Action::Compact:
+      DispatchInverted(*snapshot, verb->action, verb->scope, target);
+      break;
+    case Action::SyncStats:
+      DispatchSyncStats(*snapshot, verb->scope, target);
+      break;
+    case Action::CompactRocksdb: {
+      auto& engine = GetServerEngine();
+      std::ignore = std::move(engine.compactAll(true, true)).Get().Ok();
+      break;
     }
   }
 
-  if (option == "compact") {
-    auto& engine = GetServerEngine();
-    auto r = std::move(engine.compactAll(true, true)).Get().Ok();
-    std::ignore = r;
-  }
-
-  if (option == "compact_indexes") {
-    const auto policy = irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount{std::numeric_limits<size_t>::max()});
-    irs::MergeWriter::FlushProgress progress = [] { return true; };
-    for (const auto& table : tables) {
-      for (auto shard : snapshot->GetIndexShardsByRelation(table->GetId())) {
-        if (!shard ||
-            shard->GetType() != catalog::ObjectType::InvertedIndexShard) {
-          continue;
-        }
-        auto& inverted = basics::downCast<search::InvertedIndexShard>(*shard);
-        std::ignore = std::move(inverted.CommitWait()).Get().Ok();
-        for (size_t pass = 0; pass < 8; ++pass) {
-          bool empty_consolidation = false;
-          const auto [res, _] =
-            inverted.ConsolidateUnsafe(policy, progress, empty_consolidation);
-          if (!res.ok()) {
-            throw duckdb::InternalException(
-              "compact_indexes: consolidation failed: %s", res.errorMessage());
-          }
-          std::ignore = std::move(inverted.CommitWait()).Get().Ok();
-          if (empty_consolidation) {
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  // Return empty result
   output.SetCardinality(0);
 }
 
-// PRAGMA serenedb_vacuum('option', 'table_name', 'schema_name')
-// Called when DuckDB transforms VACUUM (UPDATE_INDEXES) t into this PRAGMA.
+// PRAGMA serenedb_vacuum('option', 'name', 'schema', 'catalog')
+// Called when DuckDB transforms VACUUM (REFRESH_*|COMPACT_*|...) into this
+// PRAGMA. The parameter positions mirror the BaseTableRef qualification
+// produced by the parser.
 void VacuumPragma(duckdb::ClientContext& context,
                   const duckdb::FunctionParameters& params) {
   auto& args = params.values;
@@ -175,10 +416,13 @@ void VacuumPragma(duckdb::ClientContext& context,
     bind_data.option = args[0].GetValue<std::string>();
   }
   if (args.size() >= 2) {
-    bind_data.table_name = args[1].GetValue<std::string>();
+    bind_data.name = args[1].GetValue<std::string>();
   }
   if (args.size() >= 3) {
-    bind_data.schema_name = args[2].GetValue<std::string>();
+    bind_data.schema = args[2].GetValue<std::string>();
+  }
+  if (args.size() >= 4) {
+    bind_data.catalog = args[3].GetValue<std::string>();
   }
 
   duckdb::DataChunk dummy;

--- a/server/connector/duckdb_vacuum_function.h
+++ b/server/connector/duckdb_vacuum_function.h
@@ -29,11 +29,9 @@ class DatabaseInstance;
 
 namespace sdb::connector {
 
-// Register serenedb_vacuum() table function with DuckDB.
-// Usage:
-//   CALL serenedb_vacuum('update_indexes', 'table_name');
-//   CALL serenedb_vacuum('compact');
-//   CALL serenedb_vacuum('sync_stats', 'table_name');
+// Register serenedb_vacuum() table function with DuckDB. The VACUUM grammar
+// lowers VACUUM (REFRESH_*|COMPACT_*|SYNC_STATS|COMPACT_ROCKSDB) <object>
+// into `PRAGMA serenedb_vacuum(option, name, [schema], [catalog])`.
 void RegisterVacuumFunction(duckdb::DatabaseInstance& db);
 
 }  // namespace sdb::connector

--- a/server/connector/highlight/memory_index.h
+++ b/server/connector/highlight/memory_index.h
@@ -46,7 +46,7 @@ class MemoryIndex {
       doc.NextFieldBatch();
       write_docs(doc);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     auto reader = writer->GetSnapshot();
     if (reader.size() == 0) {
       return {std::shared_ptr<const irs::SubReader>{},

--- a/server/connector/search_remove_filter.cpp
+++ b/server/connector/search_remove_filter.cpp
@@ -55,7 +55,7 @@ irs::doc_id_t SearchRemoveFilter::advance() {
     // 1. Same value PKs might exist in deleted documents and this number
     // of documents is arbitrary. So we need to check all of them.
     // In general we do not expect too many delete/insert of same PK
-    // between consolidations. So postings list should be short.
+    // between compactions. So postings list should be short.
 
     // 2. Also we might have Delete/Insert sequence in a single batch,
     // So we must check pending docs mask as well in order to not fire on

--- a/server/metrics/metrics_feature.cpp
+++ b/server/metrics/metrics_feature.cpp
@@ -247,10 +247,10 @@ constexpr containers::TrivialSet kCoordinatorMetrics = [](auto selector) {
   return selector()
     .Case("serenedb_search_num_failed_commits")
     .Case("serenedb_search_num_failed_cleanups")
-    .Case("serenedb_search_num_failed_consolidations")
+    .Case("serenedb_search_num_failed_compactions")
     .Case("serenedb_search_commit_time")
     .Case("serenedb_search_cleanup_time")
-    .Case("serenedb_search_consolidation_time");
+    .Case("serenedb_search_compaction_time");
 };
 
 void MetricsFeature::toVPack(vpack::Builder& builder,

--- a/server/query/config_variables.cpp
+++ b/server/query/config_variables.cpp
@@ -313,23 +313,23 @@ constexpr std::pair<std::string_view, VariableDescription>
       },
     },
     {
-      "commit_interval",
+      "refresh_interval",
       {
         LogicalTypeId::UINTEGER,
-        "Background commit interval (ms) for newly created inverted indexes. "
-        "Per-index WITH (commit_interval = ...) overrides. 0 disables the "
-        "commit task. Default: 1000.",
+        "Background refresh interval (ms) for newly created inverted indexes. "
+        "Per-index WITH (refresh_interval = ...) overrides. 0 disables the "
+        "refresh task. Default: 1000.",
         [] { return duckdb::Value::UINTEGER(1000); },
         [](duckdb::ClientContext&, duckdb::SetScope, duckdb::Value&) {},
       },
     },
     {
-      "consolidation_interval",
+      "compaction_interval",
       {
         LogicalTypeId::UINTEGER,
-        "Background consolidation interval (ms) for newly created inverted "
-        "indexes. Per-index WITH (consolidation_interval = ...) overrides. "
-        "0 disables the consolidation task. Default: 1000.",
+        "Background compaction interval (ms) for newly created inverted "
+        "indexes. Per-index WITH (compaction_interval = ...) overrides. "
+        "0 disables the compaction task. Default: 1000.",
         [] { return duckdb::Value::UINTEGER(1000); },
         [](duckdb::ClientContext&, duckdb::SetScope, duckdb::Value&) {},
       },

--- a/server/search/inverted_index_shard.cpp
+++ b/server/search/inverted_index_shard.cpp
@@ -129,9 +129,8 @@ InvertedIndexShard::InvertedIndexShard(ObjectId id,
     _search{GetSearchEngine()},
     _state{std::make_shared<ThreadPoolState>()} {
   const auto& options = index.GetOptions();
-  _tasks_settings.commit_interval_msec = options.commit_interval_ms;
-  _tasks_settings.consolidation_interval_msec =
-    options.consolidation_interval_ms;
+  _tasks_settings.refresh_interval_msec = options.refresh_interval_ms;
+  _tasks_settings.compaction_interval_msec = options.compaction_interval_ms;
   _tasks_settings.cleanup_interval_step = options.cleanup_interval_step;
   auto& server = SerenedServer::Instance();
 
@@ -180,7 +179,7 @@ InvertedIndexShard::InvertedIndexShard(ObjectId id,
   irs::ResourceManagementOptions resource_manager;
   resource_manager.transactions = _writers_memory;
   resource_manager.readers = _readers_memory;
-  resource_manager.consolidations = _consolidations_memory;
+  resource_manager.compactions = _compactions_memory;
   resource_manager.file_descriptors = _file_descriptors_count;
   resource_manager.cached_columns =
     &GetSearchEngine().getCachedColumnsManager();
@@ -264,7 +263,7 @@ InvertedIndexShard::InvertedIndexShard(ObjectId id,
 
   if (!path_exists) {
     // Initialize empty index
-    _writer->Commit();
+    _writer->RefreshCommit();
   }
 
   auto reader = _writer->GetSnapshot();
@@ -392,22 +391,22 @@ void InvertedIndexShard::TruncateCommit(TruncateGuard&& guard, Tick tick,
   }
 }
 
-void InvertedIndexShard::ScheduleConsolidation(absl::Duration delay) {
-  ConsolidationTask task{shared_from_this(), [] { return /* TODO */ true; }};
+void InvertedIndexShard::ScheduleCompaction(absl::Duration delay) {
+  CompactionTask task{shared_from_this(), [] { return /* TODO */ true; }};
 
-  _state->pending_consolidations.fetch_add(1, std::memory_order_release);
+  _state->pending_compactions.fetch_add(1, std::memory_order_release);
   std::move(task).Schedule(delay).Detach();
 }
 
 void InvertedIndexShard::ScheduleCommit(absl::Duration delay) {
-  CommitTask task{shared_from_this(), false};
+  RefreshTask task{shared_from_this(), false};
 
   _state->pending_commits.fetch_add(1, std::memory_order_release);
   std::move(task).Schedule(delay).Detach();
 }
 
 yaclib::Future<> InvertedIndexShard::CommitWait() {
-  CommitTask task{shared_from_this(), true};
+  RefreshTask task{shared_from_this(), true};
   _state->pending_commits.fetch_add(1, std::memory_order_release);
   return std::move(task).Schedule();
 }
@@ -467,19 +466,19 @@ Result InvertedIndexShard::CleanupUnsafeImpl() {
   return {};
 }
 
-InvertedIndexShard::ResultWithTime InvertedIndexShard::ConsolidateUnsafe(
-  const irs::ConsolidationPolicy& policy,
-  const irs::MergeWriter::FlushProgress& progress, bool& empty_consolidation) {
+InvertedIndexShard::ResultWithTime InvertedIndexShard::CompactUnsafe(
+  const irs::CompactionPolicy& policy,
+  const irs::MergeWriter::FlushProgress& progress, bool& empty_compaction) {
   auto begin = std::chrono::steady_clock::now();
-  auto result = ConsolidateUnsafeImpl(policy, progress, empty_consolidation);
+  auto result = CompactUnsafeImpl(policy, progress, empty_compaction);
   uint64_t time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                        std::chrono::steady_clock::now() - begin)
                        .count();
-  if (bool ok = result.ok(); ok && _avg_consolidation_time_ms != nullptr) {
-    _avg_consolidation_time_ms->store(
-      ComputeAvg(_consolidation_time_num, time_ms), std::memory_order_relaxed);
-  } else if (!ok && _num_failed_consolidations != nullptr) {
-    _num_failed_consolidations->fetch_add(1, std::memory_order_relaxed);
+  if (bool ok = result.ok(); ok && _avg_compaction_time_ms != nullptr) {
+    _avg_compaction_time_ms->store(ComputeAvg(_compaction_time_num, time_ms),
+                                   std::memory_order_relaxed);
+  } else if (!ok && _num_failed_compactions != nullptr) {
+    _num_failed_compactions->fetch_add(1, std::memory_order_relaxed);
   }
   return {std::move(result), time_ms};
 }
@@ -508,37 +507,37 @@ InvertedIndexShard::ResultWithTime InvertedIndexShard::CommitUnsafe(
   return {std::move(result), time_ms};
 }
 
-Result InvertedIndexShard::ConsolidateUnsafeImpl(
-  const irs::ConsolidationPolicy& policy,
-  const irs::MergeWriter::FlushProgress& progress, bool& empty_consolidation) {
-  empty_consolidation = false;
+Result InvertedIndexShard::CompactUnsafeImpl(
+  const irs::CompactionPolicy& policy,
+  const irs::MergeWriter::FlushProgress& progress, bool& empty_compaction) {
+  empty_compaction = false;
 
   if (!policy) {
     return {ERROR_BAD_PARAMETER,
-            "unset consolidation policy while executing consolidation policy "
+            "unset compaction policy while executing compaction policy "
             "on Search index '",
             GetId().id(), "'"};
   }
 
   try {
-    const auto res = _writer->Consolidate(policy, nullptr, progress);
+    const auto res = _writer->Compact(policy, nullptr, progress);
     if (!res) {
       return {ERROR_INTERNAL,
-              "failure while executing consolidation policy on Search index '",
+              "failure while executing compaction policy on Search index '",
               GetId().id(), "'"};
     }
 
-    empty_consolidation = (res.size == 0);
+    empty_compaction = (res.size == 0);
   } catch (const std::exception& e) {
     return {ERROR_INTERNAL,
-            "caught exception while executing consolidation policy ",
+            "caught exception while executing compaction policy ",
             "on Search index '",
             GetId().id(),
             "': ",
             e.what()};
   } catch (...) {
     return {ERROR_INTERNAL,
-            "caught exception while executing consolidation policy ",
+            "caught exception while executing compaction policy ",
             "on Search index '", GetId().id(), "'"};
   }
   return {};
@@ -588,7 +587,7 @@ Result InvertedIndexShard::CommitUnsafeImpl(
           return before_commit;
       }
     }();
-    const bool were_changes = _writer->Commit({
+    const bool were_changes = _writer->RefreshCommit({
       .tick = commit_tick,
       .progress = progress,
       .reopen_columnstore = /* TODO(codeworse) */ false,

--- a/server/search/inverted_index_shard.h
+++ b/server/search/inverted_index_shard.h
@@ -50,16 +50,16 @@ class InvertedIndexShard;
 struct ThreadPoolState {
   std::atomic_size_t pending_commits{0};
   std::atomic_size_t non_empty_commits{0};
-  std::atomic_size_t pending_consolidations{0};
-  std::atomic_size_t noop_consolidation_count{0};
+  std::atomic_size_t pending_compactions{0};
+  std::atomic_size_t noop_compaction_count{0};
   std::atomic_size_t noop_commit_count{0};
 };
 
 struct TasksSettings {
   size_t cleanup_interval_step{};
-  size_t commit_interval_msec{};
-  size_t consolidation_interval_msec{};
-  irs::ConsolidationPolicy consolidation_policy;
+  size_t refresh_interval_msec{};
+  size_t compaction_interval_msec{};
+  irs::CompactionPolicy compaction_policy;
   uint32_t version{};
   size_t writebuffer_active{};
   size_t writebuffer_idle{};
@@ -180,9 +180,9 @@ class InvertedIndexShard final
     return _writer->GetBatch();
   }
 
-  ResultWithTime ConsolidateUnsafe(
-    const irs::ConsolidationPolicy& policy,
-    const irs::MergeWriter::FlushProgress& progress, bool& empty_consolidation);
+  ResultWithTime CompactUnsafe(const irs::CompactionPolicy& policy,
+                               const irs::MergeWriter::FlushProgress& progress,
+                               bool& empty_compaction);
 
   ResultWithTime CommitUnsafe(bool wait,
                               const irs::ProgressReportCallback& progress,
@@ -191,7 +191,7 @@ class InvertedIndexShard final
   ResultWithTime CleanupUnsafe();
   Stats UpdateStatsUnsafe(InvertedIndexSnapshotPtr data) const;
 
-  void ScheduleConsolidation(absl::Duration delay);
+  void ScheduleCompaction(absl::Duration delay);
   void ScheduleCommit(absl::Duration delay);
 
   yaclib::Future<> CommitWait();
@@ -224,7 +224,7 @@ class InvertedIndexShard final
 
   void StartTasks() {
     ScheduleCommit({});
-    ScheduleConsolidation({});
+    ScheduleCompaction({});
   }
 
   void FinishCreation();
@@ -251,9 +251,9 @@ class InvertedIndexShard final
   int64_t GetIcebergSnapshotId() const noexcept { return _iceberg_snapshot_id; }
 
  private:
-  Result ConsolidateUnsafeImpl(const irs::ConsolidationPolicy& policy,
-                               const irs::MergeWriter::FlushProgress& progress,
-                               bool& empty_consolidation);
+  Result CompactUnsafeImpl(const irs::CompactionPolicy& policy,
+                           const irs::MergeWriter::FlushProgress& progress,
+                           bool& empty_compaction);
   Result CommitUnsafeImpl(bool wait,
                           const irs::ProgressReportCallback& progress,
                           CommitResult& code);
@@ -279,14 +279,14 @@ class InvertedIndexShard final
 
   irs::IResourceManager* _writers_memory{&irs::IResourceManager::gNoop};
   irs::IResourceManager* _readers_memory{&irs::IResourceManager::gNoop};
-  irs::IResourceManager* _consolidations_memory{&irs::IResourceManager::gNoop};
+  irs::IResourceManager* _compactions_memory{&irs::IResourceManager::gNoop};
   irs::IResourceManager* _file_descriptors_count{&irs::IResourceManager::gNoop};
 
   // Stats
   metrics::Gauge<uint64_t>* _mapped_memory{nullptr};
   metrics::Gauge<uint64_t>* _num_failed_commits{nullptr};
   metrics::Gauge<uint64_t>* _num_failed_cleanups{nullptr};
-  metrics::Gauge<uint64_t>* _num_failed_consolidations{nullptr};
+  metrics::Gauge<uint64_t>* _num_failed_compactions{nullptr};
 
   std::atomic_uint64_t _commit_time_num{0};
   metrics::Gauge<uint64_t>* _avg_commit_time_ms{nullptr};
@@ -294,8 +294,8 @@ class InvertedIndexShard final
   std::atomic_uint64_t _cleanup_time_num{0};
   metrics::Gauge<uint64_t>* _avg_cleanup_time_ms{nullptr};
 
-  std::atomic_uint64_t _consolidation_time_num{0};
-  metrics::Gauge<uint64_t>* _avg_consolidation_time_ms{nullptr};
+  std::atomic_uint64_t _compaction_time_num{0};
+  metrics::Gauge<uint64_t>* _avg_compaction_time_ms{nullptr};
   metrics::Guard<Stats>* _metric_stats{nullptr};
 
   enum class Error : uint8_t {

--- a/server/search/task.cpp
+++ b/server/search/task.cpp
@@ -33,29 +33,28 @@
 
 namespace sdb::search {
 
-void CommitTask::Finalize(
+void RefreshTask::Finalize(
   std::shared_ptr<search::InvertedIndexShard> inverted_index_shard,
   CommitResult res) {
   static constexpr size_t kMaxNonEmptyCommits = 10;
-  static constexpr size_t kMaxPendingConsolidations = 3;
+  static constexpr size_t kMaxPendingCompactions = 3;
 
   if (res != CommitResult::NoChanges) {
     _state->pending_commits.fetch_add(1, std::memory_order_release);
 
     if (res == CommitResult::Done) {
       _state->noop_commit_count.store(0, std::memory_order_release);
-      _state->noop_consolidation_count.store(0, std::memory_order_release);
+      _state->noop_compaction_count.store(0, std::memory_order_release);
 
-      if (_state->pending_consolidations.load(std::memory_order_acquire) <
-            kMaxPendingConsolidations &&
+      if (_state->pending_compactions.load(std::memory_order_acquire) <
+            kMaxPendingCompactions &&
           _state->non_empty_commits.fetch_add(1, std::memory_order_acq_rel) >=
             kMaxNonEmptyCommits) {
-        inverted_index_shard->ScheduleConsolidation(
-          _consolidation_interval_msec);
+        inverted_index_shard->ScheduleCompaction(_compaction_interval_msec);
         _state->non_empty_commits.store(0, std::memory_order_release);
       }
     }
-    ScheduleContinue(std::move(inverted_index_shard), _commit_interval_msec);
+    ScheduleContinue(std::move(inverted_index_shard), _refresh_interval_msec);
   } else {
     _state->non_empty_commits.store(0, std::memory_order_release);
     _state->noop_commit_count.fetch_add(1, std::memory_order_release);
@@ -64,15 +63,15 @@ void CommitTask::Finalize(
       if (_state->pending_commits.compare_exchange_weak(
             count, 1, std::memory_order_acq_rel)) {
         ScheduleContinue(std::move(inverted_index_shard),
-                         _commit_interval_msec);
+                         _refresh_interval_msec);
         break;
       }
     }
   }
 }
 
-void CommitTask::operator()() {
-  SDB_TRACE("xxxxx", Logger::SEARCH, "CommitTask started");
+void RefreshTask::operator()() {
+  SDB_TRACE("xxxxx", Logger::SEARCH, "RefreshTask started");
   const char run_id = 0;
   auto data = _inverted_index_shard.lock();
   absl::Cleanup set_promise = [promise = std::move(_promise)]() mutable {
@@ -100,31 +99,31 @@ void CommitTask::operator()() {
 
   // reload RuntimeState
   {
-    SDB_IF_FAILURE("SearchCommitTask::lockInvertedIndexShard") {
+    SDB_IF_FAILURE("SearchRefreshTask::lockInvertedIndexShard") {
       SDB_THROW(ERROR_DEBUG);
     }
     absl::ReaderMutexLock lock{data->GetMutex()};
     auto& settings = data->GetTasksSettings();
 
-    _commit_interval_msec = absl::Milliseconds(settings.commit_interval_msec);
-    _consolidation_interval_msec =
-      absl::Milliseconds(settings.consolidation_interval_msec);
+    _refresh_interval_msec = absl::Milliseconds(settings.refresh_interval_msec);
+    _compaction_interval_msec =
+      absl::Milliseconds(settings.compaction_interval_msec);
     _cleanup_interval_step = settings.cleanup_interval_step;
   }
 
-  // TODO(phase5-follow-up): Currently `commit_interval_ms` defaults to 0
+  // TODO(phase5-follow-up): Currently `refresh_interval_ms` defaults to 0
   // (not set on CREATE INDEX by our DuckDB path), which disables background
   // sync entirely -- inserts never become searchable. A synchronous
   // CommitWait() caller still expects a commit to happen, so always commit
   // when `_wait` is set even if background scheduling is off.
-  if (absl::ZeroDuration() == _commit_interval_msec && !_wait) {
+  if (absl::ZeroDuration() == _refresh_interval_msec && !_wait) {
     std::move(reschedule).Cancel();
     SDB_DEBUG("xxxxx", Logger::SEARCH, "sync is disabled for the index '",
               id.id(), "', runId '", size_t(&run_id), "'");
     return;
   }
 
-  SDB_IF_FAILURE("SearchCommitTask::commitUnsafe") { SDB_THROW(ERROR_DEBUG); }
+  SDB_IF_FAILURE("SearchRefreshTask::commitUnsafe") { SDB_THROW(ERROR_DEBUG); }
   auto [res, timeMs] = data->CommitUnsafe(_wait, nullptr, code);
 
   if (res.ok()) {
@@ -140,7 +139,7 @@ void CommitTask::operator()() {
   if (_cleanup_interval_step &&
       ++_cleanup_interval_count >= _cleanup_interval_step) {  // if enabled
     _cleanup_interval_count = 0;
-    SDB_IF_FAILURE("SearchCommitTask::cleanupUnsafe") {
+    SDB_IF_FAILURE("SearchRefreshTask::cleanupUnsafe") {
       SDB_THROW(ERROR_DEBUG);
     }
 
@@ -159,8 +158,8 @@ void CommitTask::operator()() {
   }
 }
 
-void ConsolidationTask::operator()() {
-  SDB_TRACE("xxxxx", Logger::SEARCH, "ConsolidationTask started");
+void CompactionTask::operator()() {
+  SDB_TRACE("xxxxx", Logger::SEARCH, "CompactionTask started");
   const char run_id = 0;
   auto data = _inverted_index_shard.lock();
   absl::Cleanup set_promise = [promise = std::move(_promise)]() mutable {
@@ -169,20 +168,20 @@ void ConsolidationTask::operator()() {
   SDB_IF_FAILURE("slow_search_task") { absl::SleepFor(absl::Seconds(5)); }
   if (!data) {
     SDB_WARN("xxxxx", Logger::SEARCH,
-             "ConsolidationTask: inverted index shard is deleted");
+             "CompactionTask: inverted index shard is deleted");
     return;
   }
   auto id = data->GetId();
-  _state->pending_consolidations.fetch_sub(1, std::memory_order_release);
+  _state->pending_compactions.fetch_sub(1, std::memory_order_release);
 
   absl::Cleanup reschedule = [this, data]() mutable noexcept {
     try {
       for (auto count =
-             _state->pending_consolidations.load(std::memory_order_acquire);
+             _state->pending_compactions.load(std::memory_order_acquire);
            count < 1;) {
-        if (_state->pending_consolidations.compare_exchange_weak(
+        if (_state->pending_compactions.compare_exchange_weak(
               count, count + 1, std::memory_order_acq_rel)) {
-          ScheduleContinue(std::move(data), _consolidation_interval_msec);
+          ScheduleContinue(std::move(data), _compaction_interval_msec);
           break;
         }
       }
@@ -193,56 +192,55 @@ void ConsolidationTask::operator()() {
 
   // reload RuntimeState
   {
-    SDB_IF_FAILURE("SearchConsolidationTask::lockInvertedIndexShard") {
+    SDB_IF_FAILURE("SearchCompactionTask::lockInvertedIndexShard") {
       SDB_THROW(ERROR_DEBUG);
     }
 
     absl::ReaderMutexLock lock{data->GetMutex()};
     auto& settings = data->GetTasksSettings();
 
-    _consolidation_policy = settings.consolidation_policy;
-    _consolidation_interval_msec =
-      absl::Milliseconds(settings.consolidation_interval_msec);
+    _compaction_policy = settings.compaction_policy;
+    _compaction_interval_msec =
+      absl::Milliseconds(settings.compaction_interval_msec);
   }
-  if (absl::ZeroDuration() == _consolidation_interval_msec ||
-      !_consolidation_policy) {
+  if (absl::ZeroDuration() == _compaction_interval_msec ||
+      !_compaction_policy) {
     std::move(reschedule).Cancel();
 
-    SDB_DEBUG("xxxxx", Logger::SEARCH,
-              "consolidation is disabled for the index '", id.id(),
-              "', runId '", size_t(&run_id), "'");
+    SDB_DEBUG("xxxxx", Logger::SEARCH, "compaction is disabled for the index '",
+              id.id(), "', runId '", size_t(&run_id), "'");
     return;
   }
   static constexpr size_t kMaxNoopCommits = 10;
-  static constexpr size_t kMaxNoopConsolidations = 10;
+  static constexpr size_t kMaxNoopCompactions = 10;
   if (_state->noop_commit_count.load(std::memory_order_acquire) <
         kMaxNoopCommits &&
-      _state->noop_consolidation_count.load(std::memory_order_acquire) <
-        kMaxNoopConsolidations) {
-    _state->pending_consolidations.fetch_add(1, std::memory_order_release);
-    ScheduleContinue(std::move(data), _consolidation_interval_msec);
+      _state->noop_compaction_count.load(std::memory_order_acquire) <
+        kMaxNoopCompactions) {
+    _state->pending_compactions.fetch_add(1, std::memory_order_release);
+    ScheduleContinue(std::move(data), _compaction_interval_msec);
     std::move(reschedule).Cancel();
   }
-  SDB_IF_FAILURE("SearchConsolidationTask::consolidateUnsafe") {
+  SDB_IF_FAILURE("SearchCompactionTask::compactUnsafe") {
     SDB_THROW(ERROR_DEBUG);
   }
 
-  bool empty_consolidation = false;
-  const auto [res, timeMs] = data->ConsolidateUnsafe(
-    _consolidation_policy, _progress, empty_consolidation);
+  bool empty_compaction = false;
+  const auto [res, timeMs] =
+    data->CompactUnsafe(_compaction_policy, _progress, empty_compaction);
 
   if (res.ok()) {
-    if (empty_consolidation) {
-      _state->noop_consolidation_count.fetch_add(1, std::memory_order_release);
+    if (empty_compaction) {
+      _state->noop_compaction_count.fetch_add(1, std::memory_order_release);
     } else {
-      _state->noop_consolidation_count.store(0, std::memory_order_release);
+      _state->noop_compaction_count.store(0, std::memory_order_release);
     }
     SDB_TRACE("xxxxx", Logger::SEARCH,
-              "successful consolidation of Search index '", id.id(),
-              "', run id '", size_t(&run_id), "', took: ", timeMs, "ms");
+              "successful compaction of Search index '", id.id(), "', run id '",
+              size_t(&run_id), "', took: ", timeMs, "ms");
   } else {
     SDB_DEBUG("xxxxx", Logger::SEARCH, "error after running for ", timeMs,
-              "ms while consolidating Search index '", id.id(), "', run id '",
+              "ms while compacting Search index '", id.id(), "', run id '",
               size_t(&run_id), "': ", res.errorNumber(), " ",
               res.errorMessage());
   }

--- a/server/search/task.h
+++ b/server/search/task.h
@@ -82,21 +82,21 @@ class Task {
   SearchEngine* _engine;
 };
 
-class CommitTask : public Task {
+class RefreshTask : public Task {
  public:
   static constexpr ThreadGroup ThreadGroup() noexcept {
-    return ThreadGroup::Commit;
+    return ThreadGroup::Refresh;
   }
-  static constexpr std::string_view TaskName() noexcept { return "Commit"; }
-  CommitTask(const std::shared_ptr<InvertedIndexShard>& inverted_index_shard,
-             bool wait)
+  static constexpr std::string_view TaskName() noexcept { return "Refresh"; }
+  RefreshTask(const std::shared_ptr<InvertedIndexShard>& inverted_index_shard,
+              bool wait)
     : Task{inverted_index_shard}, _wait{wait} {}
 
-  CommitTask GetContinuos(
+  RefreshTask GetContinuos(
     std::shared_ptr<InvertedIndexShard>&& inverted_index_shard) const {
     // continue is always no-wait as we rescheduling next background commit
     SDB_ASSERT(inverted_index_shard);
-    return CommitTask(inverted_index_shard, false);
+    return RefreshTask(inverted_index_shard, false);
   }
 
   void operator()();
@@ -105,37 +105,35 @@ class CommitTask : public Task {
     CommitResult res);
 
  private:
-  absl::Duration _commit_interval_msec{};
-  absl::Duration _consolidation_interval_msec{};
+  absl::Duration _refresh_interval_msec{};
+  absl::Duration _compaction_interval_msec{};
   size_t _cleanup_interval_step{0};
   size_t _cleanup_interval_count{0};
   bool _wait;
 };
 
-class ConsolidationTask : public Task {
+class CompactionTask : public Task {
  public:
   static constexpr ThreadGroup ThreadGroup() noexcept {
-    return ThreadGroup::Consolidation;
+    return ThreadGroup::Compaction;
   }
-  static constexpr std::string_view TaskName() noexcept {
-    return "Consolidate";
-  }
-  ConsolidationTask(
+  static constexpr std::string_view TaskName() noexcept { return "Compact"; }
+  CompactionTask(
     const std::shared_ptr<InvertedIndexShard>& inverted_index_shard,
     std::function<bool()> flush_progress)
     : Task{inverted_index_shard}, _progress{std::move(flush_progress)} {}
 
   void operator()();
-  ConsolidationTask GetContinuos(
+  CompactionTask GetContinuos(
     std::shared_ptr<InvertedIndexShard>&& inverted_index_shard) const {
     SDB_ASSERT(inverted_index_shard);
-    return ConsolidationTask(inverted_index_shard, _progress);
+    return CompactionTask(inverted_index_shard, _progress);
   }
 
  private:
   irs::MergeWriter::FlushProgress _progress;
-  irs::ConsolidationPolicy _consolidation_policy;
-  absl::Duration _consolidation_interval_msec;
+  irs::CompactionPolicy _compaction_policy;
+  absl::Duration _compaction_interval_msec;
 };
 
 }  // namespace sdb::search

--- a/server/storage_engine/search_engine.cpp
+++ b/server/storage_engine/search_engine.cpp
@@ -69,7 +69,7 @@ DECLARE_GAUGE(serenedb_search_columns_cache_size, LimitedResourceManager,
               "Search columns cache usage in bytes");
 
 const std::string kCommitThreadsParam("--search.commit-threads");
-const std::string kConsolidationThreadsParam("--search.consolidation-threads");
+const std::string kCompactionThreadsParam("--search.compaction-threads");
 const std::string kFailOnOutOfSync("--search.fail-queries-on-out-of-sync");
 const std::string kSkipRecovery("--search.skip-recovery");
 const std::string kSkipWalRecovery("--search.skip-wal-recovery");
@@ -100,18 +100,18 @@ class SearchThreadPools {
   ~SearchThreadPools() { Stop(); }
 
   ThreadPool& Get(ThreadGroup id) noexcept {
-    return ThreadGroup::Commit == id ? _commit_threads_pool
-                                     : _consolidation_threads_pool;
+    return ThreadGroup::Refresh == id ? _refresh_threads_pool
+                                      : _compaction_threads_pool;
   }
 
   void Stop() noexcept {
-    _commit_threads_pool.stop(true);
-    _consolidation_threads_pool.stop(true);
+    _refresh_threads_pool.stop(true);
+    _compaction_threads_pool.stop(true);
   }
 
  private:
-  ThreadPool _commit_threads_pool;
-  ThreadPool _consolidation_threads_pool;
+  ThreadPool _refresh_threads_pool;
+  ThreadPool _compaction_threads_pool;
 };
 
 SearchEngine::SearchEngine(Server& server)
@@ -133,13 +133,12 @@ void SearchEngine::collectOptions(
   options->addSection("search", absl::StrCat(name(), " feature"));
 
   options
-    ->addOption(
-      kConsolidationThreadsParam,
-      "The upper limit to the allowed number of consolidation threads "
-      "(0 = auto-detect).",
-      new options::UInt32Parameter(&_consolidation_threads))
+    ->addOption(kCompactionThreadsParam,
+                "The upper limit to the allowed number of compaction threads "
+                "(0 = auto-detect).",
+                new options::UInt32Parameter(&_compaction_threads))
     .setLongDescription(R"(The option value must fall in the range
-`[ 1..search.consolidation-threads ]`. Set it to `0` to automatically
+`[ 1..search.compaction-threads ]`. Set it to `0` to automatically
 choose a sensible number based on the number of cores in the system.)");
 
   options
@@ -236,8 +235,8 @@ void SearchEngine::validateOptions(
     static_cast<uint32_t>(4 * number_of_cores::GetValue());
 
   _commit_threads = ComputeThreadsCount(_commit_threads, threads_limit, 6);
-  _consolidation_threads =
-    ComputeThreadsCount(_consolidation_threads, threads_limit, 6);
+  _compaction_threads =
+    ComputeThreadsCount(_compaction_threads, threads_limit, 6);
 
   if (!args.touched(kSearchThreadsLimit)) {
     _search_execution_threads_limit =
@@ -263,9 +262,9 @@ void SearchEngine::prepare() {
   irs::compression::Init();
 
   SDB_ASSERT(std::make_tuple(size_t(0), size_t(0), size_t(0)) ==
-             stats(ThreadGroup::Commit));
+             stats(ThreadGroup::Refresh));
   SDB_ASSERT(std::make_tuple(size_t(0), size_t(0), size_t(0)) ==
-             stats(ThreadGroup::Consolidation));
+             stats(ThreadGroup::Compaction));
 }
 
 void SearchEngine::start() {
@@ -274,19 +273,19 @@ void SearchEngine::start() {
   if (ServerState::instance()->IsDBServer() ||
       ServerState::instance()->IsSingle()) {
     SDB_ASSERT(_commit_threads);
-    SDB_ASSERT(_consolidation_threads);
+    SDB_ASSERT(_compaction_threads);
 
-    _thread_pools->Get(ThreadGroup::Commit)
+    _thread_pools->Get(ThreadGroup::Refresh)
       .start(_commit_threads, IR_NATIVE_STRING("search:commit"));
-    _thread_pools->Get(ThreadGroup::Consolidation)
-      .start(_consolidation_threads, IR_NATIVE_STRING("search:compact"));
+    _thread_pools->Get(ThreadGroup::Compaction)
+      .start(_compaction_threads, IR_NATIVE_STRING("search:compact"));
 
     InitInvertedIndexes(_skip_wal_recovery);
 
     SDB_INFO("xxxxx", Logger::SEARCH, "Search maintenance: [", _commit_threads,
              "..", _commit_threads, "] commit thread(s), [",
-             _consolidation_threads, "..", _consolidation_threads,
-             "] consolidation thread(s). Search execution parallel threads "
+             _compaction_threads, "..", _compaction_threads,
+             "] compaction thread(s). Search execution parallel threads "
              "limit: ",
              _search_execution_threads_limit);
   }
@@ -351,8 +350,8 @@ std::filesystem::path SearchEngine::GetPersistedPath(
 }
 
 void SearchEngine::beginShutdown() {
-  _thread_pools->Get(ThreadGroup::Commit).stop(false);
-  _thread_pools->Get(ThreadGroup::Consolidation).stop(false);
+  _thread_pools->Get(ThreadGroup::Refresh).stop(false);
+  _thread_pools->Get(ThreadGroup::Compaction).stop(false);
 }
 
 }  // namespace sdb::search

--- a/server/storage_engine/search_engine.h
+++ b/server/storage_engine/search_engine.h
@@ -51,8 +51,8 @@ class SearchThreadPools;
 class ResourceMutex;
 
 enum class ThreadGroup : uint8_t {
-  Commit = 0,
-  Consolidation,
+  Refresh = 0,
+  Compaction,
 };
 
 SearchEngine& GetSearchEngine();
@@ -103,7 +103,7 @@ class SearchEngine final : public SerenedFeature {
   metrics::Gauge<uint64_t>& _out_of_sync_links;
   irs::IResourceManager& _columns_cache_memory_used;
 
-  uint32_t _consolidation_threads{0};
+  uint32_t _compaction_threads{0};
   uint32_t _commit_threads{0};
   uint32_t _search_execution_threads_limit{0};
   uint32_t _default_parallelism{1};

--- a/tests/bench/micro/filter_prepare.cpp
+++ b/tests/bench/micro/filter_prepare.cpp
@@ -204,7 +204,7 @@ void FilterPrepareFixture::BuildIndex(size_t num_segments) {
         doc.Insert(body_field);
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
   }
 
   _reader = irs::DirectoryReader{*_dir, _codec};

--- a/tests/bench/micro/regexp_vs_wildcard.cpp
+++ b/tests/bench/micro/regexp_vs_wildcard.cpp
@@ -360,7 +360,7 @@ Corpus BuildIndex() {
     }
     ++inserted;
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   if (inserted == 0) {
     Die("inserted 0 documents - dataset file empty?");

--- a/tests/bench/search-benchmark-game/build_index.cpp
+++ b/tests/bench/search-benchmark-game/build_index.cpp
@@ -69,10 +69,10 @@ int main(int argc, const char* argv[]) {
   bench::IndexBuilderOptions builder_options{
     .batch_size = 100000,
     .indexer_threads = 1,
-    .commit_interval_ms = 0,
-    .consolidation_interval_ms = 5000,
-    .consolidation_threads = 0,
-    .consolidate_all = true,
+    .refresh_interval_ms = 0,
+    .compaction_interval_ms = 5000,
+    .compaction_threads = 0,
+    .compact_all = true,
     .norm_row_group_size = 10'000'000,
   };
 

--- a/tests/bench/search-benchmark-game/index_builder.cpp
+++ b/tests/bench/search-benchmark-game/index_builder.cpp
@@ -82,7 +82,7 @@ IndexBuilder::IndexBuilder(std::string_view path,
 void IndexBuilder::IndexFromStream(std::istream& input,
                                    BatchHandlerFactory factory) {
   irs::async_utils::ThreadPool<> thread_pool{_opts.indexer_threads +
-                                             _opts.consolidation_threads + 1};
+                                             _opts.compaction_threads + 1};
 
   struct {
     absl::CondVar cond;
@@ -139,54 +139,53 @@ void IndexBuilder::IndexFromStream(std::istream& input,
     batch_provider.eof = true;
   });
 
-  absl::Mutex consolidation_mutex;
-  absl::CondVar consolidation_cv;
+  absl::Mutex compaction_mutex;
+  absl::CondVar compaction_cv;
 
   // commiter thread
-  if (_opts.commit_interval_ms) {
-    thread_pool.run(
-      [&consolidation_cv, &consolidation_mutex, &batch_provider, this] {
-        irs::SetThreadName(IR_NATIVE_STRING("committer"));
-
-        while (!batch_provider.done.load()) {
-          {
-            std::cout << "[COMMIT]" << std::endl;
-            _writer->Commit();
-          }
-
-          // notify consolidation threads
-          if (_opts.consolidation_threads) {
-            absl::MutexLock lock{&consolidation_mutex};
-            consolidation_cv.notify_all();
-          }
-
-          std::this_thread::sleep_for(
-            std::chrono::milliseconds(_opts.commit_interval_ms));
-        }
-      });
-  }
-
-  // consolidation threads
-  const irs::index_utils::ConsolidateTier consolidation_options;
-  auto policy = irs::index_utils::MakePolicy(consolidation_options);
-
-  for (size_t i = _opts.consolidation_threads; i; --i) {
-    thread_pool.run([&] {
-      irs::SetThreadName(IR_NATIVE_STRING("consolidater"));
+  if (_opts.refresh_interval_ms) {
+    thread_pool.run([&compaction_cv, &compaction_mutex, &batch_provider, this] {
+      irs::SetThreadName(IR_NATIVE_STRING("committer"));
 
       while (!batch_provider.done.load()) {
         {
-          absl::MutexLock lock{&consolidation_mutex};
-          if (consolidation_cv.WaitWithTimeout(
-                &consolidation_mutex,
-                absl::Milliseconds(_opts.consolidation_interval_ms))) {
+          std::cout << "[COMMIT]" << std::endl;
+          _writer->RefreshCommit();
+        }
+
+        // notify compaction threads
+        if (_opts.compaction_threads) {
+          absl::MutexLock lock{&compaction_mutex};
+          compaction_cv.notify_all();
+        }
+
+        std::this_thread::sleep_for(
+          std::chrono::milliseconds(_opts.refresh_interval_ms));
+      }
+    });
+  }
+
+  // compaction threads
+  const irs::index_utils::CompactionTier compaction_options;
+  auto policy = irs::index_utils::MakePolicy(compaction_options);
+
+  for (size_t i = _opts.compaction_threads; i; --i) {
+    thread_pool.run([&] {
+      irs::SetThreadName(IR_NATIVE_STRING("compactr"));
+
+      while (!batch_provider.done.load()) {
+        {
+          absl::MutexLock lock{&compaction_mutex};
+          if (compaction_cv.WaitWithTimeout(
+                &compaction_mutex,
+                absl::Milliseconds(_opts.compaction_interval_ms))) {
             continue;
           }
         }
 
         {
-          std::cout << "[CONSOLIDATE]" << std::flush;
-          _writer->Consolidate(policy);
+          std::cout << "[COMPACT]" << std::flush;
+          _writer->Compact(policy);
         }
 
         irs::directory_utils::RemoveAllUnreferenced(_dir);
@@ -214,20 +213,20 @@ void IndexBuilder::IndexFromStream(std::istream& input,
   thread_pool.stop();
 
   std::cout << "[COMMIT]" << std::endl;
-  _writer->Commit();
+  _writer->RefreshCommit();
 
-  if (_opts.consolidate_all) {
-    std::cout << "Consolidating all segments:" << std::endl;
-    ConsolidateAll();
-  } else if (_opts.consolidation_threads) {
+  if (_opts.compact_all) {
+    std::cout << "Compacting all segments:" << std::endl;
+    CompactAll();
+  } else if (_opts.compaction_threads) {
     irs::directory_utils::RemoveAllUnreferenced(_dir);
   }
 }
 
-void IndexBuilder::ConsolidateAll() {
-  _writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()));
-  _writer->Commit();
+void IndexBuilder::CompactAll() {
+  _writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount()));
+  _writer->RefreshCommit();
   irs::directory_utils::RemoveAllUnreferenced(_dir);
 }
 

--- a/tests/bench/search-benchmark-game/index_builder.h
+++ b/tests/bench/search-benchmark-game/index_builder.h
@@ -47,10 +47,10 @@ using BatchHandlerFactory = std::unique_ptr<IBatchHandler> (*)();
 struct IndexBuilderOptions {
   size_t batch_size = 100000;
   size_t indexer_threads = 1;
-  size_t commit_interval_ms = 0;
-  size_t consolidation_interval_ms = 5000;
-  size_t consolidation_threads = 0;
-  bool consolidate_all = true;
+  size_t refresh_interval_ms = 0;
+  size_t compaction_interval_ms = 5000;
+  size_t compaction_threads = 0;
+  bool compact_all = true;
   uint32_t row_group_size = DEFAULT_ROW_GROUP_SIZE;
   uint32_t norm_row_group_size = DEFAULT_ROW_GROUP_SIZE;
 };
@@ -66,7 +66,7 @@ class IndexBuilder {
   auto GetReader() { return _writer->GetSnapshot(); }
 
  private:
-  void ConsolidateAll();
+  void CompactAll();
 
   IndexBuilderOptions _opts;
   irs::Scorer::ptr _scorer;

--- a/tests/libs/iresearch/CMakeLists.txt
+++ b/tests/libs/iresearch/CMakeLists.txt
@@ -46,7 +46,7 @@ set(iresearch-tests_sources
     ./index/postings_tests.cpp
     ./index/segment_writer_tests.cpp
     ./index/sorted_index_tests.cpp
-    ./index/consolidation_policy_tests.cpp
+    ./index/compaction_policy_tests.cpp
     ./parser/lucene_parser_test.cpp
     ./search/empty_filter_tests.cpp
     ./search/nested_filter_test.cpp

--- a/tests/libs/iresearch/formats/column/columnstore_test.cpp
+++ b/tests/libs/iresearch/formats/column/columnstore_test.cpp
@@ -888,7 +888,7 @@ TEST_F(IRSColumnstoreTest, WriterRollbackLeavesOrphanFile) {
     w.Rollback();
   }
   // Post-Rollback: orphan file is left on disk. The IndexWriter-driven
-  // path (see index_tests `clear_writer` / `consolidate_*`) tracks the
+  // path (see index_tests `clear_writer` / `compact_*`) tracks the
   // file via `dir.attributes().refs()` and DirectoryCleaner::clean()
   // reaps it on a later pass; in this isolated columnstore-only test
   // we only assert that Rollback itself does not remove the file.

--- a/tests/libs/iresearch/formats/columnstore2_test.cpp
+++ b/tests/libs/iresearch/formats/columnstore2_test.cpp
@@ -336,7 +336,7 @@ TEST_P(Columnstore2TestCase, empty_columns) {
 // last_valid / past-end), (g) row-group transitions across many small RGs,
 // (h) seek-and-iterate (fetch K, K+1, ... K+5 sequentially), (i) seek-
 // backwards (fresh reader for the smaller doc).
-// Legacy `ColumnHint::Consolidation` / `PrevDoc` paths and the "buffered"
+// Legacy `ColumnHint::Compaction` / `PrevDoc` paths and the "buffered"
 // reader-warmup dimension are dropped (no equivalent in the new cs).
 TEST_P(Columnstore2TestCase, sparse_mask_column) {
   constexpr std::string_view kSegment = "sparse_mask";

--- a/tests/libs/iresearch/formats/formats_11_tests.cpp
+++ b/tests/libs/iresearch/formats/formats_11_tests.cpp
@@ -70,7 +70,7 @@ TEST_P(Format11TestCase, open_10_with_11) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 
@@ -130,7 +130,7 @@ TEST_P(Format11TestCase, formats_11) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 
@@ -144,7 +144,7 @@ TEST_P(Format11TestCase, formats_11) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/formats/formats_12_tests.cpp
+++ b/tests/libs/iresearch/formats/formats_12_tests.cpp
@@ -70,7 +70,7 @@ TEST_P(Format12TestCase, open_10_with_12) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -130,7 +130,7 @@ TEST_P(Format12TestCase, formats_12) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -144,7 +144,7 @@ TEST_P(Format12TestCase, formats_12) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/formats/formats_13_tests.cpp
+++ b/tests/libs/iresearch/formats/formats_13_tests.cpp
@@ -69,7 +69,7 @@ TEST_P(Format13TestCase, open_10_with_13) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -129,7 +129,7 @@ TEST_P(Format13TestCase, formats_13) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -143,7 +143,7 @@ TEST_P(Format13TestCase, formats_13) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/formats/formats_test_case_base.cpp
+++ b/tests/libs/iresearch/formats/formats_test_case_base.cpp
@@ -192,7 +192,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
 
     // initialize directory
     {
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -203,7 +203,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     {
       ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
       ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -213,7 +213,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // add second segment (creating new index_meta file, remove old)
     {
       ASSERT_TRUE(Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -224,7 +224,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // file, remove old)
     {
       writer->GetBatch().Remove(*query_doc1);
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -235,7 +235,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // remove old meta + unused segment)
     {
       writer->GetBatch().Remove(*query_doc2);
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -246,7 +246,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // remove old meta + unused segment)
     {
       writer->GetBatch().Remove(*query_doc2);
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -273,7 +273,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
 
     // initialize directory
     {
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -285,7 +285,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
       ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
       ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
       ASSERT_TRUE(Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -295,7 +295,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // delete record from first segment (creating new doc_mask file)
     {
       writer->GetBatch().Remove(*query_doc1);
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -325,7 +325,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // add second segment (creating new index_meta file, not-removing old)
     {
       ASSERT_TRUE(Insert(*writer, doc4->indexed.begin(), doc4->indexed.end()));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -336,7 +336,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // old)
     {
       writer->GetBatch().Remove(*(query_doc2));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -347,7 +347,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // remove old meta but leave first segment)
     {
       writer->GetBatch().Remove(*(query_doc3));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -358,7 +358,7 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     // remove old meta + unused segment)
     {
       writer->GetBatch().Remove(*(query_doc4));
-      writer->Commit();
+      writer->RefreshCommit();
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       irs::DirectoryCleaner::clean(*dir);  // clean unused files
@@ -391,20 +391,20 @@ TEST_P(FormatTestCase, directory_artifact_cleaner) {
     {
       auto writer = irs::IndexWriter::Make(*dir, codec(), irs::kOmCreate);
 
-      writer->Commit();  // initialize directory
+      writer->RefreshCommit();  // initialize directory
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
-      writer->Commit();  // add first segment
+      writer->RefreshCommit();  // add first segment
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
       ASSERT_TRUE(Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));
-      writer->Commit();  // add second segment
+      writer->RefreshCommit();  // add second segment
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
       writer->GetBatch().Remove(*(query_doc1));
-      writer->Commit();  // remove first segment
+      writer->RefreshCommit();  // remove first segment
       tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                     irs::DirectoryReader(*dir));
     }
@@ -1277,7 +1277,7 @@ TEST_P(FormatTestCaseWithEncryption, read_zero_block_encryption) {
 
     ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 
@@ -1380,7 +1380,7 @@ TEST_P(FormatTestCaseWithEncryption, open_ecnrypted_with_wrong_encryption) {
 
     ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 
@@ -1408,7 +1408,7 @@ TEST_P(FormatTestCaseWithEncryption, open_ecnrypted_with_non_encrypted) {
 
     ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 
@@ -1438,7 +1438,7 @@ TEST_P(FormatTestCaseWithEncryption, open_non_ecnrypted_with_encrypted) {
 
     ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/index/compaction_policy_tests.cpp
+++ b/tests/libs/iresearch/index/compaction_policy_tests.cpp
@@ -29,8 +29,8 @@
 
 namespace {
 
-[[maybe_unused]] void PrintConsolidation(
-  const irs::IndexReader& reader, const irs::ConsolidationPolicy& policy) {
+[[maybe_unused]] void PrintCompaction(const irs::IndexReader& reader,
+                                      const irs::CompactionPolicy& policy) {
   struct LessT {
     bool operator()(const irs::SubReader* lhs,
                     const irs::SubReader* rhs) const {
@@ -41,13 +41,13 @@ namespace {
                : lhs_meta.byte_size < rhs_meta.byte_size;
     }
   };
-  irs::Consolidation candidates;
-  irs::ConsolidatingSegments consolidating_segments;
+  irs::Compaction candidates;
+  irs::CompactingSegments compacting_segments;
 
   size_t i = 0;
   while (true) {
     candidates.clear();
-    policy(candidates, reader, consolidating_segments);
+    policy(candidates, reader, compacting_segments);
 
     if (candidates.empty()) {
       break;
@@ -56,7 +56,7 @@ namespace {
     std::set<const irs::SubReader*, LessT> sorted_candidates(
       candidates.begin(), candidates.end(), LessT());
 
-    std::cerr << "Consolidation " << i++ << ": ";
+    std::cerr << "Compaction " << i++ << ": ";
     for (auto* segment : sorted_candidates) {
       auto& meta = segment->Meta();
       std::cerr << meta.byte_size << " ("
@@ -64,16 +64,16 @@ namespace {
     }
     std::cerr << "\n";
 
-    // register candidates for consolidation
+    // register candidates for compaction
     for (const auto* candidate : candidates) {
-      consolidating_segments.emplace(candidate->Meta().name);
+      compacting_segments.emplace(candidate->Meta().name);
     }
   }
 }
 
 void AssertCandidates(const irs::IndexReader& reader,
                       const std::vector<size_t>& expected_candidates,
-                      const irs::Consolidation& actual_candidates) {
+                      const irs::Compaction& actual_candidates) {
   ASSERT_EQ(expected_candidates.size(), actual_candidates.size());
 
   for (const size_t expected_candidate_idx : expected_candidates) {
@@ -171,7 +171,7 @@ void AddSegment(irs::IndexMeta& meta, std::string_view name,
 
 }  // namespace
 
-TEST(ConsolidationTierTest, MaxConsolidationSize) {
+TEST(CompactionTierTest, MaxCompactSize) {
   irs::IndexMeta meta;
   for (size_t i = 0; i < 22; ++i) {
     AddSegment(meta, std::to_string(i), 1, 1, 1);
@@ -179,44 +179,44 @@ TEST(ConsolidationTierTest, MaxConsolidationSize) {
   IndexReaderMock reader{meta};
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = std::numeric_limits<size_t>::max();
     options.min_segments = 1;
     options.max_segments_bytes = 10;
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments_bytes, candidates.size());
     }
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments_bytes, candidates.size());
     }
 
     // 3rd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(reader.size() - 2 * options.max_segments_bytes,
                 candidates.size());
@@ -224,86 +224,86 @@ TEST(ConsolidationTierTest, MaxConsolidationSize) {
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // invalid options: max_segments_bytes == 0
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = std::numeric_limits<size_t>::max();
     options.min_segments = 1;
     options.max_segments_bytes = 0;
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // all segments are too big
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 }
 
-TEST(ConsolidationTierTest, EmptyMeta) {
+TEST(CompactionTierTest, EmptyMeta) {
   irs::IndexMeta meta;
   IndexReaderMock reader{meta};
 
-  irs::index_utils::ConsolidateTier options;
+  irs::index_utils::CompactionTier options;
   options.floor_segment_bytes = 1;
   options.max_segments = 10;
   options.min_segments = 1;
   options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-  irs::ConsolidatingSegments consolidating_segments;
+  irs::CompactingSegments compacting_segments;
   auto policy = irs::index_utils::MakePolicy(options);
-  irs::Consolidation candidates;
-  policy(candidates, reader, consolidating_segments);
+  irs::Compaction candidates;
+  policy(candidates, reader, compacting_segments);
   ASSERT_TRUE(candidates.empty());
 }
 
-TEST(ConsolidationTierTest, EmptyConsolidatingSegment) {
+TEST(CompactionTierTest, EmptyCompactingSegment) {
   irs::IndexMeta meta;
   AddSegment(meta, "empty", 1, 0, 1);
   IndexReaderMock reader{meta};
 
-  irs::index_utils::ConsolidateTier options;
+  irs::index_utils::CompactionTier options;
   options.floor_segment_bytes = 1;
   options.max_segments = 10;
   options.min_segments = 1;
   options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-  irs::ConsolidatingSegments consolidating_segments{reader[0].Meta().name};
+  irs::CompactingSegments compacting_segments{reader[0].Meta().name};
   auto policy = irs::index_utils::MakePolicy(options);
-  irs::Consolidation candidates;
-  policy(candidates, reader, consolidating_segments);
-  ASSERT_TRUE(candidates.empty());  // skip empty consolidating segments
+  irs::Compaction candidates;
+  policy(candidates, reader, compacting_segments);
+  ASSERT_TRUE(candidates.empty());  // skip empty compacting segments
 }
 
-TEST(ConsolidationTierTest, EmptySegment) {
+TEST(CompactionTierTest, EmptySegment) {
   irs::IndexMeta meta;
   AddSegment(meta, "empty", 0, 0, 1);
   IndexReaderMock reader{meta};
 
-  irs::index_utils::ConsolidateTier options;
+  irs::index_utils::CompactionTier options;
   options.floor_segment_bytes = 1;
   options.max_segments = 10;
   options.min_segments = 1;
   options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-  irs::ConsolidatingSegments consolidating_segments{reader[0].Meta().name};
+  irs::CompactingSegments compacting_segments{reader[0].Meta().name};
   auto policy = irs::index_utils::MakePolicy(options);
-  irs::Consolidation candidates;
-  policy(candidates, reader, consolidating_segments);
+  irs::Compaction candidates;
+  policy(candidates, reader, compacting_segments);
   ASSERT_TRUE(candidates.empty());  // skip empty segments
 }
 
-TEST(ConsolidationTierTest, MaxConsolidationCount) {
+TEST(CompactionTierTest, MaxCompactionCount) {
   // generate meta
   irs::IndexMeta meta;
   for (size_t i = 0; i < 22; ++i) {
@@ -312,148 +312,148 @@ TEST(ConsolidationTierTest, MaxConsolidationCount) {
   IndexReaderMock reader{meta};
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = 10;
     options.min_segments = 1;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 3rd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(reader.size() - 2 * options.max_segments, candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // max_segments == std::numeric_limits<size_t>::max()
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = std::numeric_limits<size_t>::max();
     options.min_segments = 1;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(reader.size(), candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // invalid options: max_segments == 0
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = 0;
     options.min_segments = 1;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // invalid options: floor_segments_bytes == 0
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 0;
     options.max_segments = 10;
     options.min_segments = 3;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 }
 
-TEST(ConsolidationTierTest, MinConsolidationCount) {
+TEST(CompactionTierTest, MinCompactionCount) {
   // generate meta
   irs::IndexMeta meta;
   for (size_t i = 0; i < 22; ++i) {
@@ -463,159 +463,159 @@ TEST(ConsolidationTierTest, MinConsolidationCount) {
 
   // min_segments == 3
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = 10;
     options.min_segments = 3;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // invalid options: min_segments == 1
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = 10;
     options.min_segments = 0;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 3rd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(reader.size() - 2 * options.max_segments, candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // invalid options: min_segments > max_segments
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = 10;
     options.min_segments = std::numeric_limits<size_t>::max();
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(options.max_segments, candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // invalid options: min_segments > max_segments
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 1;
     options.max_segments = std::numeric_limits<size_t>::max();
     options.min_segments = std::numeric_limits<size_t>::max();
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // can't find anything
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 }
 
-TEST(ConsolidationTierTest, ConsolidationFloor) {
+TEST(CompactionTierTest, CompactFloor) {
   // generate meta
   irs::IndexMeta meta;
   {
@@ -630,22 +630,22 @@ TEST(ConsolidationTierTest, ConsolidationFloor) {
   IndexReaderMock reader{meta};
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = 8;
     options.max_segments = reader.size();
     options.min_segments = 1;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(5, candidates.size());
 
@@ -657,55 +657,55 @@ TEST(ConsolidationTierTest, ConsolidationFloor) {
 
     // 2nd tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(reader.size() - 5, candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // enormous floor value, treat all segments as equal
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     options.floor_segment_bytes = std::numeric_limits<uint32_t>::max();
     options.max_segments = std::numeric_limits<size_t>::max();
     options.min_segments = 1;
     options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     auto policy = irs::index_utils::MakePolicy(options);
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
-      // register candidates for consolidation
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
       ASSERT_EQ(reader.size(), candidates.size());
     }
 
     // last empty tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 }
 
-TEST(ConsolidationTierTest, PreferSegmentsWithRemovals) {
+TEST(CompactionTierTest, PreferSegmentsWithRemovals) {
   // generate meta
   irs::IndexMeta meta;
   AddSegment(meta, "0", 10, 10, 10);
@@ -715,96 +715,96 @@ TEST(ConsolidationTierTest, PreferSegmentsWithRemovals) {
   IndexReaderMock reader{meta};
 
   // ensure policy prefers segments with removals
-  irs::index_utils::ConsolidateTier options;
+  irs::index_utils::CompactionTier options;
   options.floor_segment_bytes = 1;
   options.max_segments = 2;
   options.min_segments = 1;
   options.max_segments_bytes = std::numeric_limits<size_t>::max();
 
-  irs::ConsolidatingSegments consolidating_segments;
+  irs::CompactingSegments compacting_segments;
   auto policy = irs::index_utils::MakePolicy(options);
 
   const std::vector<std::vector<size_t>> expected_tiers{{2, 3}, {0, 1}};
 
   for (auto& expected_tier : expected_tiers) {
-    irs::Consolidation candidates;
-    policy(candidates, reader, consolidating_segments);
+    irs::Compaction candidates;
+    policy(candidates, reader, compacting_segments);
     AssertCandidates(reader, expected_tier, candidates);
     candidates.clear();
-    policy(candidates, reader, consolidating_segments);
+    policy(candidates, reader, compacting_segments);
     AssertCandidates(reader, expected_tier, candidates);
-    // register candidates for consolidation
+    // register candidates for compaction
     for (const auto* candidate : candidates) {
-      consolidating_segments.emplace(candidate->Meta().name);
+      compacting_segments.emplace(candidate->Meta().name);
     }
   }
 
-  // no more segments to consolidate
+  // no more segments to compact
   {
-    irs::Consolidation candidates;
-    policy(candidates, reader, consolidating_segments);
+    irs::Compaction candidates;
+    policy(candidates, reader, compacting_segments);
     ASSERT_TRUE(candidates.empty());
   }
 }
 
-TEST(ConsolidationTierTest, Singleton) {
-  irs::index_utils::ConsolidateTier options;
+TEST(CompactionTierTest, Singleton) {
+  irs::index_utils::CompactionTier options;
   options.floor_segment_bytes = 1;
   options.max_segments = std::numeric_limits<size_t>::max();
   options.min_segments = 1;
   options.max_segments_bytes = std::numeric_limits<size_t>::max();
   auto policy = irs::index_utils::MakePolicy(options);
 
-  // singleton consolidation without removals
+  // singleton compaction without removals
   {
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 150);
     IndexReaderMock reader{meta};
 
     // avoid having singletone merges without removals
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
-  // singleton consolidation with removals
+  // singleton compaction with removals
   {
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 99, 150);
     IndexReaderMock reader{meta};
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, {0}, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, {0}, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 }
 
-TEST(ConsolidationTierTest, Defaults) {
-  irs::index_utils::ConsolidateTier options;
+TEST(CompactionTierTest, Defaults) {
+  irs::index_utils::CompactionTier options;
   auto policy = irs::index_utils::MakePolicy(options);
 
   {
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
 
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 150);
@@ -816,28 +816,28 @@ TEST(ConsolidationTierTest, Defaults) {
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, {0, 1, 2, 3, 4}, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, {0, 1, 2, 3, 4}, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 150);
     AddSegment(meta, "1", 100, 100, 100);
@@ -854,29 +854,29 @@ TEST(ConsolidationTierTest, Defaults) {
 
     // 1st tier
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 }
 
-TEST(ConsolidationTierTest, NoCandidates) {
-  irs::index_utils::ConsolidateTier options;
+TEST(CompactionTierTest, NoCandidates) {
+  irs::index_utils::CompactionTier options;
   options.floor_segment_bytes = 2097152;
   options.max_segments_bytes = 4294967296;
   options.min_segments = 5;  // min number of segments per tier to merge at once
@@ -884,7 +884,7 @@ TEST(ConsolidationTierTest, NoCandidates) {
   options.max_segments = 10;
   auto policy = irs::index_utils::MakePolicy(options);
 
-  irs::ConsolidatingSegments consolidating_segments;
+  irs::CompactingSegments compacting_segments;
   irs::IndexMeta meta;
   AddSegment(meta, "0", 100, 100, 141747);
   AddSegment(meta, "1", 100, 100, 1548373791);
@@ -893,14 +893,14 @@ TEST(ConsolidationTierTest, NoCandidates) {
   AddSegment(meta, "4", 100, 100, 2013404723);
   IndexReaderMock reader{meta};
 
-  irs::Consolidation candidates;
-  policy(candidates, reader, consolidating_segments);
+  irs::Compaction candidates;
+  policy(candidates, reader, compacting_segments);
   ASSERT_TRUE(candidates.empty());  // candidates too large
 }
 
-TEST(ConsolidationTierTest, SkewedSegments) {
+TEST(CompactionTierTest, SkewedSegments) {
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -910,7 +910,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.floor_segment_bytes = 50;
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 10);
     AddSegment(meta, "1", 100, 100, 40);
@@ -938,28 +938,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     };
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -969,7 +969,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.floor_segment_bytes = 50;
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 10);
     AddSegment(meta, "1", 100, 100, 100);
@@ -991,28 +991,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     };
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1022,7 +1022,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.floor_segment_bytes = 50;
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 10);
     AddSegment(meta, "1", 100, 100, 100);
@@ -1040,28 +1040,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
       {0, 1}, {2, 3}, {4, 5}, {6, 7}, {8, 9}};
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 3;
     // max number of segments per tier to merge at once
@@ -1071,7 +1071,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.floor_segment_bytes = 50;
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 10);
     AddSegment(meta, "1", 100, 100, 100);
@@ -1091,28 +1091,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     };
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1122,7 +1122,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.floor_segment_bytes = 50;
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 10);
     AddSegment(meta, "1", 100, 100, 100);
@@ -1149,28 +1149,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     };
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1181,7 +1181,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.min_score = 0;  // default min score
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 1);
     AddSegment(meta, "1", 100, 100, 9886);
@@ -1190,29 +1190,29 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     const std::vector<std::vector<size_t>> expected_tiers{{0, 1}};
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
-    ASSERT_EQ(reader.size(), consolidating_segments.size());
+    ASSERT_EQ(reader.size(), compacting_segments.size());
 
-    // no segments to consolidate
+    // no segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1223,22 +1223,22 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.min_score = 0.001;  // filter out irrelevant merges
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 1);
     AddSegment(meta, "1", 100, 100, 9886);
     IndexReaderMock reader{meta};
 
-    // no segments to consolidate
+    // no segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1249,7 +1249,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.min_score = 0;  // default min score
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 1);
     AddSegment(meta, "1", 100, 100, 9886);
@@ -1261,28 +1261,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     };
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no segments to consolidate
+    // no segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1293,7 +1293,7 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     options.min_score = 0.001;  // filter our irrelevant merges
     auto policy = irs::index_utils::MakePolicy(options);
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     irs::IndexMeta meta;
     AddSegment(meta, "0", 100, 100, 1);
     AddSegment(meta, "1", 100, 100, 9886);
@@ -1305,28 +1305,28 @@ TEST(ConsolidationTierTest, SkewedSegments) {
     };
 
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
 
-    // no segments to consolidate
+    // no segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1360,32 +1360,32 @@ TEST(ConsolidationTierTest, SkewedSegments) {
       {20, 21, 23},
     };
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
-    ASSERT_EQ(reader.size(), consolidating_segments.size());
+    ASSERT_EQ(reader.size(), compacting_segments.size());
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   // enusre policy honors removals
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1420,31 +1420,31 @@ TEST(ConsolidationTierTest, SkewedSegments) {
       {22, 24},         {20, 21, 23},
     };
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
-    ASSERT_EQ(reader.size(), consolidating_segments.size());
+    ASSERT_EQ(reader.size(), compacting_segments.size());
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }
 
   {
-    irs::index_utils::ConsolidateTier options;
+    irs::index_utils::CompactionTier options;
     // min number of segments per tier to merge at once
     options.min_segments = 1;
     // max number of segments per tier to merge at once
@@ -1479,25 +1479,25 @@ TEST(ConsolidationTierTest, SkewedSegments) {
       {22, 24},         {20, 21, 23},
     };
 
-    irs::ConsolidatingSegments consolidating_segments;
+    irs::CompactingSegments compacting_segments;
     for (auto& expected_tier : expected_tiers) {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
       candidates.clear();
-      policy(candidates, reader, consolidating_segments);
+      policy(candidates, reader, compacting_segments);
       AssertCandidates(reader, expected_tier, candidates);
-      // register candidates for consolidation
+      // register candidates for compaction
       for (const auto* candidate : candidates) {
-        consolidating_segments.emplace(candidate->Meta().name);
+        compacting_segments.emplace(candidate->Meta().name);
       }
     }
-    ASSERT_EQ(reader.size(), consolidating_segments.size());
+    ASSERT_EQ(reader.size(), compacting_segments.size());
 
-    // no more segments to consolidate
+    // no more segments to compact
     {
-      irs::Consolidation candidates;
-      policy(candidates, reader, consolidating_segments);
+      irs::Compaction candidates;
+      policy(candidates, reader, compacting_segments);
       ASSERT_TRUE(candidates.empty());
     }
   }

--- a/tests/libs/iresearch/index/index_death_tests.cpp
+++ b/tests/libs/iresearch/index/index_death_tests.cpp
@@ -299,7 +299,7 @@ void OpenReader(std::string_view format,
 
     writer->GetBatch().Remove(*query_doc2);
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -389,12 +389,13 @@ TEST(index_death_test_formats_15, index_meta_write_fail_1st_phase) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // creation failure
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);  // creation failure
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);  // synchronization failure
 
     // successful attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -429,14 +430,15 @@ TEST(index_death_test_formats_15, index_meta_write_fail_1st_phase) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // creation failure
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);  // creation failure
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);  // synchronization failure
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
     // successful attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
 
     // check data
     auto reader =
@@ -503,19 +505,22 @@ TEST(index_death_test_formats_15, index_commit_fail_sync_1st_phase) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);  // synchronization failure
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);  // synchronization failure
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);  // synchronization failure
 
     // successful attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
 
     // ensure no data
     auto reader =
@@ -547,32 +552,35 @@ TEST(index_death_test_formats_15, index_commit_fail_sync_1st_phase) {
     ASSERT_NE(nullptr, writer);
 
     // initial commit
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
-    ASSERT_FALSE(writer->Begin());                // nothing to flush
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);            // synchronization failure
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to flush
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
-    ASSERT_FALSE(writer->Begin());                // nothing to flush
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);            // synchronization failure
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to flush
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);  // synchronization failure
-    ASSERT_FALSE(writer->Begin());                // nothing to flush
+    ASSERT_THROW(writer->RefreshBegin(),
+                 irs::IoError);            // synchronization failure
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to flush
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
     // successful attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
 
     // check data
     auto reader =
@@ -636,15 +644,15 @@ TEST(index_death_test_formats_15, index_meta_write_failure_2nd_phase) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_THROW(writer->Commit(), irs::IoError);
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
     ASSERT_THROW(
       (irs::DirectoryReader{dir, codec, irs::tests::DefaultReaderOptions()}),
       irs::IndexNotFound);
 
     // second attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -676,8 +684,8 @@ TEST(index_death_test_formats_15, index_meta_write_failure_2nd_phase) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_THROW(writer->Commit(), irs::IoError);
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
     ASSERT_THROW(
       (irs::DirectoryReader{dir, codec, irs::tests::DefaultReaderOptions()}),
       irs::IndexNotFound);
@@ -685,8 +693,8 @@ TEST(index_death_test_formats_15, index_meta_write_failure_2nd_phase) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
     // second attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -755,16 +763,16 @@ TEST(index_death_test_formats_15,
     // creation issue
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
 
     // synchornization issue
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
 
     // second attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -798,18 +806,18 @@ TEST(index_death_test_formats_15,
     // creation issue
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
 
     // synchornization issue
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
     // second attempt
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -848,7 +856,7 @@ TEST(index_death_test_formats_15,
 }
 
 TEST(index_death_test_formats_15,
-     segment_meta_write_fail_immediate_consolidation) {
+     segment_meta_write_fail_immediate_compaction) {
   tests::JsonDocGenerator gen(
     TestBase::resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -878,14 +886,14 @@ TEST(index_death_test_formats_15,
 
     // segment 0
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -893,24 +901,22 @@ TEST(index_death_test_formats_15,
     // register failures
     dir.RegisterFailure(
       FailingDirectory::Failure::CREATE,
-      "_3.0.sm");  // fail at segment meta creation on consolidation
+      "_3.0.sm");  // fail at segment meta creation on compaction
     dir.RegisterFailure(
       FailingDirectory::Failure::SYNC,
-      "_4.0.sm");  // fail at segment meta synchronization on consolidation
+      "_4.0.sm");  // fail at segment meta synchronization on compaction
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
     // segment meta creation failure
-    ASSERT_THROW(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)),
-      irs::IoError);
-    ASSERT_FALSE(writer->Begin());  // nothing to flush
+    ASSERT_THROW(writer->Compact(irs::index_utils::MakePolicy(compact_all)),
+                 irs::IoError);
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to flush
 
     // segment meta synchronization failure
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    ASSERT_THROW(writer->Begin(), irs::IoError);
-    ASSERT_FALSE(writer->Begin());  // nothing to flush
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to flush
 
     // check data
     auto reader =
@@ -968,8 +974,7 @@ TEST(index_death_test_formats_15,
   }
 }
 
-TEST(index_death_test_formats_15,
-     segment_meta_write_fail_deffered_consolidation) {
+TEST(index_death_test_formats_15, segment_meta_write_fail_deffered_compaction) {
   tests::JsonDocGenerator gen(
     TestBase::resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -1001,14 +1006,14 @@ TEST(index_death_test_formats_15,
 
     // segment 0
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1016,38 +1021,38 @@ TEST(index_death_test_formats_15,
     // register failures
     dir.RegisterFailure(
       FailingDirectory::Failure::CREATE,
-      "_4.0.sm");  // fail at segment meta creation on consolidation
+      "_4.0.sm");  // fail at segment meta creation on compaction
     dir.RegisterFailure(
       FailingDirectory::Failure::SYNC,
-      "_6.0.sm");  // fail at segment meta synchronization on consolidation
+      "_6.0.sm");  // fail at segment meta synchronization on compaction
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
     // segment meta creation failure
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    ASSERT_TRUE(writer->Begin());  // start transaction
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      consolidate_all)));            // register pending consolidation
-    ASSERT_FALSE(writer->Commit());  // commit started transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // start transaction
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      compact_all)));                       // register pending compaction
+    ASSERT_FALSE(writer->RefreshCommit());  // commit started transaction
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
     ASSERT_THROW(
-      writer->Begin(),
-      irs::IoError);  // start transaction to commit pending consolidation
+      writer->RefreshBegin(),
+      irs::IoError);  // start transaction to commit pending compaction
 
     // segment meta synchronization failure
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    ASSERT_TRUE(writer->Begin());  // start transaction
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      consolidate_all)));            // register pending consolidation
-    ASSERT_FALSE(writer->Commit());  // commit started transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // start transaction
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      compact_all)));                       // register pending compaction
+    ASSERT_FALSE(writer->RefreshCommit());  // commit started transaction
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
     ASSERT_THROW(
-      writer->Begin(),
-      irs::IoError);  // start transaction to commit pending consolidation
+      writer->RefreshBegin(),
+      irs::IoError);  // start transaction to commit pending compaction
 
     // check data
     auto reader =
@@ -1201,7 +1206,7 @@ TEST(index_death_test_formats_15, postings_reopen_fail) {
 
     writer->GetBatch().Remove(*query_doc2);
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1371,8 +1376,8 @@ TEST(index_death_test_formats_15,
     ASSERT_THROW(InsertWithName(*writer, *doc1), irs::IoError);
 
     // Successful follow-up attempt: failure already consumed.
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1402,8 +1407,8 @@ TEST(index_death_test_formats_15,
     ASSERT_THROW(InsertWithName(*writer, *doc2), irs::IoError);
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1452,8 +1457,8 @@ TEST(index_death_test_formats_15,
     ASSERT_NE(nullptr, writer);
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1461,8 +1466,8 @@ TEST(index_death_test_formats_15,
     ASSERT_THROW(InsertWithName(*writer, *doc2), irs::IoError);
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1562,7 +1567,7 @@ TEST(index_death_test_formats_15,
       }
       if (inserts_ok) {
         writer.GetBatch().Remove(*query_doc2);
-        ASSERT_THROW(writer.Begin(), irs::IoError);
+        ASSERT_THROW(writer.RefreshBegin(), irs::IoError);
         ASSERT_LT(dir.NumFailures(), failures_before);
       }
     }
@@ -1591,8 +1596,8 @@ TEST(index_death_test_formats_15,
     ASSERT_NE(nullptr, writer);
 
     // initial commit
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1630,8 +1635,8 @@ TEST(index_death_test_formats_15,
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1694,7 +1699,7 @@ TEST(index_death_test_formats_15,
     while (!dir.NoFailures()) {
       const auto failures_before = dir.NumFailures();
       ASSERT_TRUE(InsertWithName(writer, *doc1));
-      ASSERT_THROW(writer.Begin(), irs::IoError);
+      ASSERT_THROW(writer.RefreshBegin(), irs::IoError);
       ASSERT_LT(dir.NumFailures(), failures_before);
     }
   };
@@ -1725,8 +1730,8 @@ TEST(index_death_test_formats_15,
 
     DriveSyncFailures(dir, *writer);
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1763,8 +1768,8 @@ TEST(index_death_test_formats_15,
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1800,10 +1805,10 @@ TEST(index_death_test_formats_15,
 }
 
 TEST(index_death_test_formats_15,
-     segment_meta_write_fail_long_running_consolidation) {
-  // BlockingDirectory blocks on `_3.cs` to keep consolidation in
+     segment_meta_write_fail_long_running_compaction) {
+  // BlockingDirectory blocks on `_3.cs` to keep compaction in
   // flight while the test runs a second commit; once the lock is
-  // released the consolidation thread observes the registered failure
+  // released the compaction thread observes the registered failure
   // and the test asserts the index is still healthy.
   tests::JsonDocGenerator gen(
     TestBase::resource("simple_sequential.json"),
@@ -1820,7 +1825,7 @@ TEST(index_death_test_formats_15,
   auto codec = irs::formats::Get("1_5simd");
   ASSERT_NE(nullptr, codec);
 
-  // segment meta creation failure during consolidation
+  // segment meta creation failure during compaction
   {
     constexpr irs::IndexFeatures kAllFeatures = irs::IndexFeatures::Freq |
                                                 irs::IndexFeatures::Pos |
@@ -1836,41 +1841,40 @@ TEST(index_death_test_formats_15,
 
     // segment 0
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
-    // fail segment meta creation on the consolidated segment
+    // fail segment meta creation on the compacted segment
     failing_dir.RegisterFailure(FailingDirectory::Failure::CREATE, "_3.0.sm");
 
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
-      const irs::index_utils::ConsolidateCount consolidate_all;
-      ASSERT_THROW(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)),
-        irs::IoError);
+    std::thread compaction_thread([&writer]() {
+      const irs::index_utils::CompactionCount compact_all;
+      ASSERT_THROW(writer->Compact(irs::index_utils::MakePolicy(compact_all)),
+                   irs::IoError);
     });
 
     dir.wait_for_blocker();
 
-    // commit an intermediate segment while consolidation is blocked
+    // commit an intermediate segment while compaction is blocked
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     dir.intermediate_commits_lock.unlock();
-    consolidation_thread.join();
+    compaction_thread.join();
 
     auto reader =
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions());
@@ -1889,7 +1893,7 @@ TEST(index_death_test_formats_15,
     tests::AssertIndex(reader.GetImpl(), expected_index, kAllFeatures);
   }
 
-  // segment meta sync failure during consolidation
+  // segment meta sync failure during compaction
   {
     constexpr irs::IndexFeatures kAllFeatures = irs::IndexFeatures::Freq |
                                                 irs::IndexFeatures::Pos |
@@ -1904,13 +1908,13 @@ TEST(index_death_test_formats_15,
     ASSERT_NE(nullptr, writer);
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -1919,25 +1923,24 @@ TEST(index_death_test_formats_15,
 
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
-      const irs::index_utils::ConsolidateCount consolidate_all;
-      ASSERT_TRUE(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+    std::thread compaction_thread([&writer]() {
+      const irs::index_utils::CompactionCount compact_all;
+      ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
     });
 
     dir.wait_for_blocker();
 
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     dir.intermediate_commits_lock.unlock();
-    consolidation_thread.join();
+    compaction_thread.join();
 
-    // pending consolidation commit fails on segment-meta sync.
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    // pending compaction commit fails on segment-meta sync.
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
 
     auto reader =
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions());
@@ -1957,7 +1960,7 @@ TEST(index_death_test_formats_15,
   }
 }
 
-TEST(index_death_test_formats_15, segment_components_write_fail_consolidation) {
+TEST(index_death_test_formats_15, segment_components_write_fail_compaction) {
   // Legacy registered CREATE failures on every per-segment component
   // (`_N.doc`, `_N.cm`, `_N.ti`, `_N.tm`, `_N.pos`, `_N.pay`). The new
   // cs collapses `_N.cm` into `_N.cs`; we add `_N.cs` to the set.
@@ -1983,27 +1986,27 @@ TEST(index_death_test_formats_15, segment_components_write_fail_consolidation) {
 
     // segment 0
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
-    // Register CREATE failures across the consolidated-segment
-    // components. Each consolidation attempt allocates a fresh
+    // Register CREATE failures across the compacted-segment
+    // components. Each compaction attempt allocates a fresh
     // segment id (NextSegmentId()), so after `_3.cs` fails the next
     // attempt's segment is `_4`, the one after is `_5`, etc. Order
     // matches the order files are created during MergeWriter::Flush:
     // cs writer is opened first (in OpenColumnstoreContexts), then
     // postings, then term index/data, etc.
     dir.RegisterFailure(FailingDirectory::Failure::CREATE,
-                        "_3.cs");  // new-cs columnstore for consolidated seg
+                        "_3.cs");  // new-cs columnstore for compacted seg
     dir.RegisterFailure(FailingDirectory::Failure::CREATE,
                         "_4.doc");  // postings list (documents)
     dir.RegisterFailure(FailingDirectory::Failure::CREATE,
@@ -2015,13 +2018,12 @@ TEST(index_death_test_formats_15, segment_components_write_fail_consolidation) {
     dir.RegisterFailure(FailingDirectory::Failure::CREATE,
                         "_8.pay");  // postings list (offset + payload)
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
     while (!dir.NoFailures()) {
-      ASSERT_THROW(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)),
-        irs::IoError);
-      ASSERT_FALSE(writer->Begin());  // nothing to flush
+      ASSERT_THROW(writer->Compact(irs::index_utils::MakePolicy(compact_all)),
+                   irs::IoError);
+      ASSERT_FALSE(writer->RefreshBegin());  // nothing to flush
     }
 
     auto reader =
@@ -2071,9 +2073,9 @@ TEST(index_death_test_formats_15, segment_components_write_fail_consolidation) {
   }
 }
 
-TEST(index_death_test_formats_15, segment_components_sync_fail_consolidation) {
-  // Like the *_write_fail_consolidation* test but with SYNC failures
-  // (consolidation creates the files, then sync fails at Begin()).
+TEST(index_death_test_formats_15, segment_components_sync_fail_compaction) {
+  // Like the *_write_fail_compaction* test but with SYNC failures
+  // (compaction creates the files, then sync fails at Begin()).
   tests::JsonDocGenerator gen(TestBase::resource("simple_sequential.json"),
                               &tests::PayloadedJsonFieldFactory);
   const auto* doc1 = gen.next();
@@ -2095,18 +2097,18 @@ TEST(index_death_test_formats_15, segment_components_sync_fail_consolidation) {
     ASSERT_NE(nullptr, writer);
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
-    // Sync failures fire at Begin() (after Consolidate succeeds in
+    // Sync failures fire at Begin() (after Compact succeeds in
     // creating the files). Each iteration consumes one failure;
     // segment id advances each retry.
     dir.RegisterFailure(FailingDirectory::Failure::SYNC, "_3.cs");
@@ -2116,13 +2118,12 @@ TEST(index_death_test_formats_15, segment_components_sync_fail_consolidation) {
     dir.RegisterFailure(FailingDirectory::Failure::SYNC, "_7.pos");
     dir.RegisterFailure(FailingDirectory::Failure::SYNC, "_8.pay");
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
     while (!dir.NoFailures()) {
-      ASSERT_TRUE(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-      ASSERT_THROW(writer->Begin(), irs::IoError);
-      ASSERT_FALSE(writer->Begin());
+      ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+      ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
+      ASSERT_FALSE(writer->RefreshBegin());
     }
 
     auto reader =
@@ -2193,7 +2194,7 @@ TEST(index_death_test_formats_15, segment_components_fail_import) {
                                          irs::tests::DefaultWriterOptions());
     ASSERT_NE(nullptr, writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(src_dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2230,15 +2231,15 @@ TEST(index_death_test_formats_15, segment_components_fail_import) {
     ASSERT_NE(nullptr, writer);
 
     // initial commit
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     while (!dir.NoFailures()) {
       ASSERT_THROW(writer->Import(*src_index), irs::IoError);
-      ASSERT_FALSE(writer->Begin());  // nothing to commit
+      ASSERT_FALSE(writer->RefreshBegin());  // nothing to commit
     }
 
     auto reader =
@@ -2267,20 +2268,20 @@ TEST(index_death_test_formats_15, segment_components_fail_import) {
                                          irs::tests::DefaultWriterOptions());
     ASSERT_NE(nullptr, writer);
 
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     while (!dir.NoFailures()) {
       ASSERT_THROW(writer->Import(*src_index), irs::IoError);
-      ASSERT_FALSE(writer->Begin());  // nothing to commit
+      ASSERT_FALSE(writer->RefreshBegin());  // nothing to commit
     }
 
     ASSERT_TRUE(writer->Import(*src_index));
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2342,8 +2343,8 @@ TEST(index_death_test_formats_15,
     ASSERT_NE(nullptr, writer);
 
     // initial commit
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2360,7 +2361,7 @@ TEST(index_death_test_formats_15,
     // not at insert time.
     dir.RegisterFailure(FailingDirectory::Failure::CREATE, "_2.0.sm");
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
     ASSERT_TRUE(dir.NoFailures());
 
     (void)doc2;
@@ -2400,7 +2401,7 @@ TEST(index_death_test_formats_15,
 
     // After the failure clears, Insert + Commit proceed normally.
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2454,8 +2455,8 @@ TEST(index_death_test_formats_15,
     ASSERT_NE(nullptr, writer);
 
     // initial commit so a DirectoryReader can be opened at the end
-    ASSERT_TRUE(writer->Begin());
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshBegin());
+    ASSERT_FALSE(writer->RefreshCommit());
 
     // 1) CREATE failure on `_1.cs` -> first insert throws.
     dir.RegisterFailure(FailingDirectory::Failure::CREATE, "_1.cs");
@@ -2467,7 +2468,7 @@ TEST(index_death_test_formats_15,
     // leaves the index empty.
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     dir.RegisterFailure(FailingDirectory::Failure::SYNC, "_2.cs");
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
     ASSERT_TRUE(dir.NoFailures());
 
     auto reader =
@@ -2481,9 +2482,9 @@ TEST(index_death_test_formats_15,
   }
 }
 
-TEST(index_death_test_formats_15, fails_in_consolidate_with_removals) {
+TEST(index_death_test_formats_15, fails_in_compact_with_removals) {
   // Mixed failures around CREATE/SYNC/REMOVE on `.cs` files driven by
-  // a sequence of inserts, commits, and a consolidate. Each failing
+  // a sequence of inserts, commits, and a compact. Each failing
   // step is followed by a successful retry; final index has the full
   // dataset.
   tests::JsonDocGenerator gen(TestBase::resource("simple_sequential.json"),
@@ -2508,17 +2509,17 @@ TEST(index_death_test_formats_15, fails_in_consolidate_with_removals) {
 
     dir.RegisterFailure(FailingDirectory::Failure::CREATE,
                         "pending_segments_1");
-    ASSERT_THROW(writer->Begin(), irs::IoError);
+    ASSERT_THROW(writer->RefreshBegin(), irs::IoError);
 
     dir.RegisterFailure(FailingDirectory::Failure::RENAME,
                         "pending_segments_1");
-    ASSERT_THROW(writer->Commit(), irs::IoError);
+    ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
     ASSERT_THROW(
       (irs::DirectoryReader{dir, codec, irs::tests::DefaultReaderOptions()}),
       irs::IndexNotFound);
 
     // Now empty commit succeeds.
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2526,7 +2527,7 @@ TEST(index_death_test_formats_15, fails_in_consolidate_with_removals) {
     // Insert fails because `.cs` creation fails for the new segment.
     dir.RegisterFailure(FailingDirectory::Failure::CREATE, "_1.cs");
     ASSERT_THROW(InsertWithName(*writer, *doc1), irs::IoError);
-    ASSERT_FALSE(writer->Commit());  // nothing to commit
+    ASSERT_FALSE(writer->RefreshCommit());  // nothing to commit
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2536,32 +2537,31 @@ TEST(index_death_test_formats_15, fails_in_consolidate_with_removals) {
 
     // SYNC fails on segment 0's `.cs` -> Commit throws.
     dir.RegisterFailure(FailingDirectory::Failure::SYNC, "_2.cs");
-    ASSERT_THROW(writer->Commit(), irs::IoError);
+    ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // Nothing to commit after a failed first phase.
-    ASSERT_FALSE(writer->Commit());
+    ASSERT_FALSE(writer->RefreshCommit());
 
     // NOW IT IS OK -- insert + commit succeeds.
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2572,7 +2572,7 @@ TEST(index_death_test_formats_15, fails_in_consolidate_with_removals) {
     dir.RegisterFailure(FailingDirectory::Failure::REMOVE, "_3.cs");
     dir.RegisterFailure(FailingDirectory::Failure::REMOVE, "_5.cs");
     irs::DirectoryCleaner::clean(dir);
-    ASSERT_FALSE(writer->Commit());  // nothing changed
+    ASSERT_FALSE(writer->RefreshCommit());  // nothing changed
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2613,7 +2613,7 @@ TEST(index_death_test_formats_15, fails_in_exists) {
   // Reader::Reader probes `dir.exists(filename)` before opening the
   // `.cs`. Force the EXISTS failure on consecutive `.cs` files to
   // exercise that path. After failures clear, commits and a
-  // consolidation must still succeed.
+  // compaction must still succeed.
   tests::JsonDocGenerator gen(TestBase::resource("simple_sequential.json"),
                               &tests::PayloadedJsonFieldFactory);
 
@@ -2644,7 +2644,7 @@ TEST(index_death_test_formats_15, fails_in_exists) {
 
     while (!dir.NoFailures()) {
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
-      ASSERT_THROW(writer->Commit(), irs::IoError);
+      ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
       ASSERT_THROW(
         (irs::DirectoryReader{dir, codec, irs::tests::DefaultReaderOptions()}),
         irs::IndexNotFound);
@@ -2652,23 +2652,22 @@ TEST(index_death_test_formats_15, fails_in_exists) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2719,7 +2718,7 @@ TEST(index_death_test_formats_15, fails_in_length) {
   // `dir.length(name)` failures on per-segment files. Commit without
   // removals doesn't call `length` -- the legacy test verified the
   // failure budget stays unchanged. Then EXISTS failures on `.cs`
-  // files exercise the consolidation cleanup path.
+  // files exercise the compaction cleanup path.
   tests::JsonDocGenerator gen(
     TestBase::resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -2767,28 +2766,28 @@ TEST(index_death_test_formats_15, fails_in_length) {
 
     // segment 0
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
 
     // segment 3
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2806,26 +2805,25 @@ TEST(index_death_test_formats_15, fails_in_length) {
     ASSERT_EQ(num_failures, dir.NumFailures());
     dir.ClearFailures();
 
-    // Now register EXISTS failures on the consolidated path's `.cs`
-    // probes -- consolidation should still succeed (the cleaner
-    // tolerates the missed exists check; the post-consolidation read
-    // works because the consolidated `.cs` exists).
+    // Now register EXISTS failures on the compacted path's `.cs`
+    // probes -- compaction should still succeed (the cleaner
+    // tolerates the missed exists check; the post-compaction read
+    // works because the compacted `.cs` exists).
     for (const auto& seg : {"_1", "_2", "_3", "_4"}) {
       dir.RegisterFailure(FailingDirectory::Failure::EXISTS,
                           std::string{seg} + ".cs");
     }
 
-    const irs::index_utils::ConsolidateCount consolidate_all;
+    const irs::index_utils::CompactionCount compact_all;
 
     const auto num_failures_before = dir.NumFailures();
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    // Same number of failures: the consolidation code path doesn't
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    // Same number of failures: the compaction code path doesn't
     // probe exists on the input segment `.cs` files.
     ASSERT_EQ(num_failures_before, dir.NumFailures());
 
     irs::DirectoryCleaner::clean(dir);
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));
@@ -2903,7 +2901,7 @@ TEST(index_death_test_formats_15, columnstore_reopen_fail) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     writer->GetBatch().Remove(*query_doc2);
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec, irs::tests::DefaultReaderOptions()));

--- a/tests/libs/iresearch/index/index_profile_tests.cpp
+++ b/tests/libs/iresearch/index/index_profile_tests.cpp
@@ -157,7 +157,7 @@ class IndexProfileTestCase : public tests::IndexTestBase {
       {
         std::unique_lock commit_lock{_commit_mutex};
         REGISTER_TIMER_NAMED_DETAILED("init - commit");
-        import_writer->Commit({.tick = CommitTick()});
+        import_writer->RefreshCommit({.tick = CommitTick()});
       }
 
       REGISTER_TIMER_NAMED_DETAILED("init - open");
@@ -229,7 +229,7 @@ class IndexProfileTestCase : public tests::IndexTestBase {
 
               {
                 REGISTER_TIMER_NAMED_DETAILED("commit");
-                writer->Commit({.tick = CommitTick()});
+                writer->RefreshCommit({.tick = CommitTick()});
               }
 
               count = 0;
@@ -240,7 +240,7 @@ class IndexProfileTestCase : public tests::IndexTestBase {
           {
             std::unique_lock commit_lock{_commit_mutex};
             REGISTER_TIMER_NAMED_DETAILED("commit");
-            writer->Commit({.tick = CommitTick()});
+            writer->RefreshCommit({.tick = CommitTick()});
           }
 
           ++writer_commit_count;
@@ -367,7 +367,7 @@ class IndexProfileTestCase : public tests::IndexTestBase {
 
               {
                 REGISTER_TIMER_NAMED_DETAILED("commit");
-                writer->Commit({.tick = CommitTick()});
+                writer->RefreshCommit({.tick = CommitTick()});
               }
 
               count = 0;
@@ -378,7 +378,7 @@ class IndexProfileTestCase : public tests::IndexTestBase {
           {
             std::unique_lock commit_lock{_commit_mutex};
             REGISTER_TIMER_NAMED_DETAILED("commit");
-            writer->Commit({.tick = CommitTick()});
+            writer->RefreshCommit({.tick = CommitTick()});
           }
 
           ++writer_commit_count;
@@ -391,8 +391,8 @@ class IndexProfileTestCase : public tests::IndexTestBase {
     // ensure all data have been committed
     {
       std::unique_lock commit_lock{_commit_mutex};
-      writer->Commit({.tick = CommitTick()});
-      EXPECT_FALSE(writer->Commit());
+      writer->RefreshCommit({.tick = CommitTick()});
+      EXPECT_FALSE(writer->RefreshCommit());
     }
 
     auto path = test_dir();
@@ -499,7 +499,7 @@ class IndexProfileTestCase : public tests::IndexTestBase {
             {
               std::unique_lock commit_lock{_commit_mutex};
               REGISTER_TIMER_NAMED_DETAILED("commit");
-              writer->Commit({.tick = CommitTick()});
+              writer->RefreshCommit({.tick = CommitTick()});
             }
             ++writer_commit_count;
             std::this_thread::sleep_for(
@@ -516,11 +516,10 @@ class IndexProfileTestCase : public tests::IndexTestBase {
     thread_pool.stop();
   }
 
-  void ProfileBulkIndexDedicatedConsolidate(size_t num_threads,
-                                            size_t batch_size,
-                                            size_t consolidate_interval) {
+  void ProfileBulkIndexDedicatedCompact(size_t num_threads, size_t batch_size,
+                                        size_t compact_interval) {
     const auto policy =
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount());
     auto options = irs::tests::DefaultWriterOptions();
     std::atomic<bool> working(true);
     irs::async_utils::ThreadPool<> thread_pool(2);
@@ -530,14 +529,13 @@ class IndexProfileTestCase : public tests::IndexTestBase {
 
     auto writer = open_writer(irs::kOmCreate, options);
 
-    thread_pool.run(
-      [consolidate_interval, &working, &writer, &policy]() -> void {
-        while (working.load()) {
-          writer->Consolidate(policy);
-          std::this_thread::sleep_for(
-            std::chrono::milliseconds(consolidate_interval));
-        }
-      });
+    thread_pool.run([compact_interval, &working, &writer, &policy]() -> void {
+      while (working.load()) {
+        writer->Compact(policy);
+        std::this_thread::sleep_for(
+          std::chrono::milliseconds(compact_interval));
+      }
+    });
 
     {
       irs::Finally finalizer = [&working]() noexcept { working = false; };
@@ -545,18 +543,18 @@ class IndexProfileTestCase : public tests::IndexTestBase {
     }
 
     thread_pool.stop();
-    // ensure there are no consolidation-pending segments
-    // left in 'consolidating_segments_' before applying the final consolidation
+    // ensure there are no compaction-pending segments
+    // left in 'compacting_segments_' before applying the final compaction
     {
       std::unique_lock commit_lock{_commit_mutex};
-      writer->Commit({.tick = CommitTick()});
-      EXPECT_FALSE(writer->Commit());
+      writer->RefreshCommit({.tick = CommitTick()});
+      EXPECT_FALSE(writer->RefreshCommit());
     }
-    ASSERT_TRUE(writer->Consolidate(policy));
+    ASSERT_TRUE(writer->Compact(policy));
     {
       std::unique_lock commit_lock{_commit_mutex};
-      writer->Commit({.tick = CommitTick()});
-      EXPECT_FALSE(writer->Commit());
+      writer->RefreshCommit({.tick = CommitTick()});
+      EXPECT_FALSE(writer->RefreshCommit());
     }
 
     struct DummyDocTemplateT : public tests::CsvDocGenerator::DocTemplate {
@@ -594,9 +592,9 @@ TEST_P(IndexProfileTestCase, profile_bulk_index_multithread_cleanup_mt) {
   ProfileBulkIndexDedicatedCleanup(16, 10000, 100);
 }
 
-TEST_P(IndexProfileTestCase, profile_bulk_index_multithread_consolidate_mt) {
+TEST_P(IndexProfileTestCase, profile_bulk_index_multithread_compact_mt) {
   // a lot of threads cause a lot of contention for the segment pool
-  ProfileBulkIndexDedicatedConsolidate(8, 10000, 500);
+  ProfileBulkIndexDedicatedCompact(8, 10000, 500);
 }
 
 TEST_P(IndexProfileTestCase,
@@ -656,11 +654,10 @@ TEST_P(IndexProfileTestCase, profile_bulk_index_multithread_cleanup_mt_tick) {
   ProfileBulkIndexDedicatedCleanup(16, 10000, 100);
 }
 
-TEST_P(IndexProfileTestCase,
-       profile_bulk_index_multithread_consolidate_mt_tick) {
+TEST_P(IndexProfileTestCase, profile_bulk_index_multithread_compact_mt_tick) {
   SetOnTick(true);
   // a lot of threads cause a lot of contention for the segment pool
-  ProfileBulkIndexDedicatedConsolidate(8, 10000, 500);
+  ProfileBulkIndexDedicatedCompact(8, 10000, 500);
 }
 
 TEST_P(IndexProfileTestCase,

--- a/tests/libs/iresearch/index/index_tests.cpp
+++ b/tests/libs/iresearch/index/index_tests.cpp
@@ -337,7 +337,7 @@ void IndexTestBase::add_segment(irs::IndexWriter& writer,
                                 const StoreHook& store) {
   _index.emplace_back();
   write_segment(writer, _index.back(), gen, store);
-  writer.Commit();
+  writer.RefreshCommit();
 }
 
 void IndexTestBase::add_segments(irs::IndexWriter& writer,
@@ -346,7 +346,7 @@ void IndexTestBase::add_segments(irs::IndexWriter& writer,
     _index.emplace_back();
     write_segment(writer, _index.back(), *gen);
   }
-  writer.Commit();
+  writer.RefreshCommit();
 }
 
 void IndexTestBase::add_segment(tests::DocGeneratorBase& gen,
@@ -364,7 +364,7 @@ void IndexTestBase::add_segment_batched(
   auto writer = open_writer(mode, opts);
   _index.emplace_back();
   write_segment_batched(*writer, _index.back(), gen, batch_size);
-  writer->Commit();
+  writer->RefreshCommit();
 }
 
 }  // namespace tests
@@ -406,7 +406,7 @@ class IndexTestCase : public tests::IndexTestBase {
       auto writer =
         open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);  // create initial empty segment
 
       // populate 'import' dir
@@ -417,7 +417,7 @@ class IndexTestCase : public tests::IndexTestBase {
         ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
         ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
         ASSERT_TRUE(InsertWithName(*data_writer, *doc3));
-        data_writer->Commit();
+        data_writer->RefreshCommit();
 
         auto reader = irs::DirectoryReader(data_dir, nullptr,
                                            irs::tests::DefaultReaderOptions());
@@ -438,7 +438,7 @@ class IndexTestCase : public tests::IndexTestBase {
       {
         ASSERT_TRUE(InsertWithName(*writer, *doc4));
         ASSERT_TRUE(InsertWithName(*writer, *doc5));
-        writer->Commit();
+        writer->RefreshCommit();
         AssertSnapshotEquality(*writer);
       }
 
@@ -490,7 +490,7 @@ class IndexTestCase : public tests::IndexTestBase {
           file_count_post_clear);  // +1 extra file for new empty index meta
       }
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
 
       // should be empty after commit (no new files or uncomited changes)
@@ -555,7 +555,7 @@ class IndexTestCase : public tests::IndexTestBase {
         open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
 
       size_t file_count0 = 0;
@@ -776,7 +776,7 @@ class IndexTestCase : public tests::IndexTestBase {
                                            irs::tests::DefaultWriterOptions());
       ASSERT_NE(nullptr, writer);
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       irs::DirectoryCleaner::clean(dir());
       // can't open another writer at the same time on the same directory
@@ -840,7 +840,7 @@ class IndexTestCase : public tests::IndexTestBase {
       auto writer0 =
         irs::IndexWriter::Make(dir(), codec(), irs::kOmCreate, options0);
       ASSERT_NE(nullptr, writer0);
-      writer0->Commit();
+      writer0->RefreshCommit();
 
       // can open another writer at the same time on the same directory and
       // acquire lock
@@ -868,7 +868,7 @@ class IndexTestCase : public tests::IndexTestBase {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::kOmCreate,
                                            irs::tests::DefaultWriterOptions());
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -892,7 +892,7 @@ class IndexTestCase : public tests::IndexTestBase {
       ASSERT_EQ(0, writer->BufferedDocs());
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
       ASSERT_EQ(1, writer->BufferedDocs());
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       ASSERT_EQ(0, writer->BufferedDocs());
     }
@@ -918,7 +918,7 @@ class IndexTestCase : public tests::IndexTestBase {
       ASSERT_EQ(0, writer->BufferedDocs());
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
       ASSERT_EQ(1, writer->BufferedDocs());
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       ASSERT_EQ(0, writer->BufferedDocs());
     }
@@ -951,12 +951,12 @@ class IndexTestCase : public tests::IndexTestBase {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_EQ(1, writer->BufferedDocs());
-    writer->Begin();  // start transaction #1
+    writer->RefreshBegin();  // start transaction #1
     ASSERT_EQ(0, writer->BufferedDocs());
     ASSERT_TRUE(InsertWithName(*writer, *doc2));  // add another document while
                                                   // transaction in opened
     ASSERT_EQ(1, writer->BufferedDocs());
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);       // finish transaction #1
     ASSERT_EQ(1, writer->BufferedDocs());  // still have 1 buffered document
                                            // not included into transaction #1
@@ -971,7 +971,7 @@ class IndexTestCase : public tests::IndexTestBase {
       ASSERT_NE(reader.begin(), reader.end());
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // transaction #2
     ASSERT_EQ(0, writer->BufferedDocs());
     // check index, 2 documents in 2 segments
@@ -1038,21 +1038,22 @@ class IndexTestCase : public tests::IndexTestBase {
                                            irs::tests::DefaultWriterOptions());
 
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
-      writer->Rollback();  // does nothing
+      writer->RefreshAbort();  // does nothing
       ASSERT_EQ(1, writer->BufferedDocs());
-      ASSERT_TRUE(writer->Begin());
-      ASSERT_FALSE(writer->Begin());  // try to begin already opened transaction
+      ASSERT_TRUE(writer->RefreshBegin());
+      ASSERT_FALSE(
+        writer->RefreshBegin());  // try to begin already opened transaction
 
       // index still does not exist
       ASSERT_THROW((irs::DirectoryReader(dir(), codec(),
                                          irs::tests::DefaultReaderOptions())),
                    irs::IndexNotFound);
 
-      writer->Rollback();  // rollback transaction
-      writer->Rollback();  // does nothing
+      writer->RefreshAbort();  // rollback transaction
+      writer->RefreshAbort();  // does nothing
       ASSERT_EQ(0, writer->BufferedDocs());
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);  // commit
 
       // check index, it should be empty
@@ -1071,8 +1072,8 @@ class IndexTestCase : public tests::IndexTestBase {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::kOmCreate,
                                            irs::tests::DefaultWriterOptions());
       ASSERT_TRUE(InsertWithName(*writer, *doc2));
-      ASSERT_TRUE(writer->Begin());  // prepare for commit tx #1
-      writer->Commit();
+      ASSERT_TRUE(writer->RefreshBegin());  // prepare for commit tx #1
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);  // commit tx #1
       auto file_count = 0;
       auto dir_visitor = [&file_count](std::string_view) -> bool {
@@ -1084,8 +1085,8 @@ class IndexTestCase : public tests::IndexTestBase {
       dir().visit(dir_visitor);
       auto file_count_before = file_count;
       ASSERT_TRUE(InsertWithName(*writer, *doc3));
-      ASSERT_TRUE(writer->Begin());  // prepare for commit tx #2
-      writer->Rollback();            // rollback tx #2
+      ASSERT_TRUE(writer->RefreshBegin());  // prepare for commit tx #2
+      writer->RefreshAbort();               // rollback tx #2
       irs::directory_utils::RemoveAllUnreferenced(dir());
       file_count = 0;
       dir().visit(dir_visitor);
@@ -1163,7 +1164,7 @@ class IndexTestCase : public tests::IndexTestBase {
       // entire batch should be rollbacked
     }
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     // should be only one live doc - doc3
     auto reader =
       irs::DirectoryReader(dir(), codec(), irs::tests::DefaultReaderOptions());
@@ -1197,7 +1198,7 @@ class IndexTestCase : public tests::IndexTestBase {
       ASSERT_TRUE(InsertWithName(*writer, *doc));
       expected_docs.push_back(doc);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader = open_reader(irs::tests::DefaultReaderOptions());
@@ -1315,7 +1316,7 @@ class IndexTestCase : public tests::IndexTestBase {
         ASSERT_TRUE(doc);
       }
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -1525,7 +1526,7 @@ class IndexTestCase : public tests::IndexTestBase {
         doc.emplace_back(std::string("name"), std::string_view{});
         ASSERT_TRUE(tests::Insert(*writer, doc.begin(), doc.end()));
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -1599,7 +1600,7 @@ class IndexTestCase : public tests::IndexTestBase {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::kOmCreate,
                                            irs::tests::DefaultWriterOptions());
 
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -1623,7 +1624,7 @@ class IndexTestCase : public tests::IndexTestBase {
       ASSERT_TRUE(InsertWithName(*writer, *doc2));
       ASSERT_TRUE(InsertWithName(*writer, *doc3));
       ASSERT_TRUE(InsertWithName(*writer, *doc4));
-      ASSERT_THROW(writer->Commit(), irs::IoError);
+      ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
     }
 
     // error while commiting index (during sync in index_writer)
@@ -1651,7 +1652,7 @@ class IndexTestCase : public tests::IndexTestBase {
       ASSERT_TRUE(InsertWithName(*writer, *doc2));
       ASSERT_TRUE(InsertWithName(*writer, *doc3));
       ASSERT_TRUE(InsertWithName(*writer, *doc4));
-      ASSERT_THROW(writer->Commit(), irs::IoError);
+      ASSERT_THROW(writer->RefreshCommit(), irs::IoError);
     }
 
     // check index, it should be empty
@@ -1699,7 +1700,7 @@ void IndexTestCase::DocsBitUnion(irs::IndexFeatures features,
       ASSERT_TRUE(docs.Insert().Insert(field));
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -1784,7 +1785,7 @@ TEST_P(IndexTestCase, s2sequence) {
       sequence.emplace_back(std::move(str));
     }
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
   }
 
@@ -1894,7 +1895,7 @@ TEST_P(IndexTestCase, reopen_reader_after_writer_is_closed) {
     ASSERT_EQ(0, reader0.live_docs_count());
 
     ASSERT_TRUE(tests::Insert(*writer, *doc1));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     reader1 = writer->GetSnapshot();
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
@@ -1907,7 +1908,7 @@ TEST_P(IndexTestCase, reopen_reader_after_writer_is_closed) {
     ASSERT_EQ(1, reader1.live_docs_count());
 
     ASSERT_TRUE(tests::Insert(*writer, *doc2));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     reader2 = writer->GetSnapshot();
     ASSERT_EQ(2, reader2.size());
     ASSERT_FALSE(reader2.Meta().filename.empty());
@@ -2003,7 +2004,7 @@ TEST_P(IndexTestCase, writer_begin_clear_empty_index) {
     ASSERT_EQ(1, writer->BufferedDocs());
     writer->Clear();  // rollback started transaction and clear index
     ASSERT_EQ(0, writer->BufferedDocs());
-    ASSERT_FALSE(writer->Begin());  // nothing to commit
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to commit
 
     // check index, it should be empty
     {
@@ -2029,7 +2030,7 @@ TEST_P(IndexTestCase, writer_begin_clear) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_EQ(1, writer->BufferedDocs());
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, writer->BufferedDocs());
 
@@ -2045,12 +2046,12 @@ TEST_P(IndexTestCase, writer_begin_clear) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_EQ(1, writer->BufferedDocs());
-    ASSERT_TRUE(writer->Begin());  // start transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // start transaction
     ASSERT_EQ(0, writer->BufferedDocs());
 
     writer->Clear();  // rollback and clear index contents
     ASSERT_EQ(0, writer->BufferedDocs());
-    ASSERT_FALSE(writer->Begin());  // nothing to commit
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to commit
 
     // check index, it should be empty
     {
@@ -2076,7 +2077,7 @@ TEST_P(IndexTestCase, writer_commit_cleanup_interleaved) {
                                          irs::tests::DefaultWriterOptions());
     const auto* doc1 = gen.next();
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // check index, it should contain expected number of docs
@@ -2100,7 +2101,7 @@ TEST_P(IndexTestCase, writer_commit_clear) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_EQ(1, writer->BufferedDocs());
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, writer->BufferedDocs());
 
@@ -2116,7 +2117,7 @@ TEST_P(IndexTestCase, writer_commit_clear) {
 
     writer->Clear();  // clear index contents
     ASSERT_EQ(0, writer->BufferedDocs());
-    ASSERT_FALSE(writer->Begin());  // nothing to commit
+    ASSERT_FALSE(writer->RefreshBegin());  // nothing to commit
 
     // check index, it should be empty
     {
@@ -2290,7 +2291,7 @@ TEST_P(IndexTestCase, concurrent_add_mt) {
 
     thread0.join();
     thread1.join();
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -2349,7 +2350,7 @@ TEST_P(IndexTestCase, concurrent_add_remove_mt) {
     thread0.join();
     thread1.join();
     thread2.join();
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     std::unordered_set<std::string_view> expected = {
@@ -2414,7 +2415,7 @@ TEST_P(IndexTestCase, concurrent_add_remove_overlap_commit_mt) {
     std::atomic<bool> stop(false);
     std::thread thread([&]() -> void {
       std::lock_guard lock{mutex};
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       stop = true;
       cond.notify_all();
@@ -2423,7 +2424,7 @@ TEST_P(IndexTestCase, concurrent_add_remove_overlap_commit_mt) {
     // initial add docs
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // remove docs
@@ -2468,8 +2469,9 @@ TEST_P(IndexTestCase, concurrent_add_remove_overlap_commit_mt) {
     /* FIXME TODO add once segment_context will not block flush_all()
     ASSERT_EQ(0, reader.docs_count());
     ASSERT_EQ(0, reader.live_docs_count());
-    writer->Commit(); AssertSnapshotEquality(*writer); // commit after releasing
-    documents_context reader = irs::directory_reader::open(dir(), codec());
+    writer->RefreshCommit(); AssertSnapshotEquality(*writer); // commit after
+    releasing documents_context reader = irs::directory_reader::open(dir(),
+    codec());
     */
     ASSERT_EQ(2, reader.docs_count());
     ASSERT_EQ(2, reader.live_docs_count());
@@ -2485,7 +2487,7 @@ TEST_P(IndexTestCase, concurrent_add_remove_overlap_commit_mt) {
     // initial add docs
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // remove docs
@@ -2508,7 +2510,7 @@ TEST_P(IndexTestCase, concurrent_add_remove_overlap_commit_mt) {
     }
 
     std::thread thread([&]() -> void {
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     });
     thread.join();
@@ -2572,7 +2574,7 @@ TEST_P(IndexTestCase, document_context) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     writer->GetBatch().Remove(*query_doc3);
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     auto reader =
       irs::DirectoryReader(dir(), codec(), irs::tests::DefaultReaderOptions());
     ASSERT_EQ(1, reader.size());
@@ -2606,7 +2608,7 @@ TEST_P(IndexTestCase, document_context) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     std::thread thread1([&]() -> void {
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       auto lock = std::lock_guard{field.cond_mutex};
       field.cond.notify_all();
@@ -2655,7 +2657,7 @@ TEST_P(IndexTestCase, document_context) {
     std::atomic<bool> commit(false);  // FIXME TODO remove once segment_context
                                       // will not block flush_all()
     std::thread thread1([&]() -> void {
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       commit = true;
       auto lock = std::lock_guard{field.cond_mutex};
@@ -2687,7 +2689,8 @@ TEST_P(IndexTestCase, document_context) {
     }  // release ctx before join() in case of test failure
     thread1.join();
     // FIXME TODO add once segment_context will not block flush_all()
-    // writer->Commit(); AssertSnapshotEquality(*writer); // commit doc removal
+    // writer->RefreshCommit(); AssertSnapshotEquality(*writer); // commit doc
+    // removal
 
     auto reader =
       irs::DirectoryReader(dir(), codec(), irs::tests::DefaultReaderOptions());
@@ -2728,7 +2731,7 @@ TEST_P(IndexTestCase, document_context) {
     std::atomic<bool> commit(false);  // FIXME TODO remove once segment_context
                                       // will not block flush_all()
     std::thread thread1([&]() -> void {
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       commit = true;
       auto lock = std::lock_guard{field.cond_mutex};
@@ -2760,8 +2763,8 @@ TEST_P(IndexTestCase, document_context) {
     }  // release ctx before join() in case of test failure
     thread1.join();
     // FIXME TODO add once segment_context will not block
-    // flush_all() writer->Commit(); AssertSnapshotEquality(*writer); // commit
-    // doc replace
+    // flush_all() writer->RefreshCommit(); AssertSnapshotEquality(*writer); //
+    // commit doc replace
 
     auto reader =
       irs::DirectoryReader(dir(), codec(), irs::tests::DefaultReaderOptions());
@@ -2797,7 +2800,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -2836,7 +2839,7 @@ TEST_P(IndexTestCase, document_context) {
       ctx.Reset();
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -2878,7 +2881,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -2928,7 +2931,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -2981,7 +2984,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3037,7 +3040,7 @@ TEST_P(IndexTestCase, document_context) {
       ctx.Reset();
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3078,7 +3081,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3135,7 +3138,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3195,7 +3198,7 @@ TEST_P(IndexTestCase, document_context) {
       ctx.Reset();
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3241,7 +3244,7 @@ TEST_P(IndexTestCase, document_context) {
       ASSERT_TRUE(ctx.Commit());
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3298,7 +3301,7 @@ TEST_P(IndexTestCase, document_context) {
       // implicit commit and flush
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3373,7 +3376,7 @@ TEST_P(IndexTestCase, document_context) {
       ctx.Commit();
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3437,7 +3440,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3500,7 +3503,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3561,7 +3564,7 @@ TEST_P(IndexTestCase, document_context) {
             ASSERT_TRUE(doc.Insert(doc2->indexed.begin(), doc2->indexed.end()));
             CaptureNameLikeFields(doc, doc2->indexed);
           }
-          writer->Commit(); AssertSnapshotEquality(*writer);
+          writer->RefreshCommit(); AssertSnapshotEquality(*writer);
           {
             auto doc = ctx.Insert();
             ASSERT_TRUE(doc.Insert(doc3->indexed.begin(), doc3->indexed.end()));
@@ -3569,7 +3572,7 @@ TEST_P(IndexTestCase, document_context) {
           }
         }
 
-        writer->Commit(); AssertSnapshotEquality(*writer);
+        writer->RefreshCommit(); AssertSnapshotEquality(*writer);
 
         auto reader = irs::directory_reader::open(dir(), codec());
         ASSERT_EQ(3, reader.size());
@@ -3660,7 +3663,7 @@ TEST_P(IndexTestCase, document_context) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -3720,7 +3723,7 @@ TEST_P(IndexTestCase, document_context) {
             ASSERT_TRUE(doc.Insert(doc2->indexed.begin(), doc2->indexed.end()));
             CaptureNameLikeFields(doc, doc2->indexed);
           }
-          writer->Commit(); AssertSnapshotEquality(*writer);
+          writer->RefreshCommit(); AssertSnapshotEquality(*writer);
           {
             auto doc = ctx.Insert();
             ASSERT_TRUE(doc.Insert(doc3->indexed.begin(), doc3->indexed.end()));
@@ -3728,7 +3731,7 @@ TEST_P(IndexTestCase, document_context) {
           }
         }
 
-        writer->Commit(); AssertSnapshotEquality(*writer);
+        writer->RefreshCommit(); AssertSnapshotEquality(*writer);
 
         auto reader = irs::directory_reader::open(dir(), codec());
         ASSERT_EQ(3, reader.size());
@@ -4036,7 +4039,7 @@ TEST_P(IndexTestCase, doc_removal) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4066,7 +4069,7 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     writer->GetBatch().Remove(*(query_doc1.get()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4096,7 +4099,7 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     writer->GetBatch().Remove(std::move(query_doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4127,7 +4130,7 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     writer->GetBatch().Remove(
       std::shared_ptr<irs::Filter>(std::move(query_doc1)));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4157,7 +4160,7 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     writer->GetBatch().Remove(std::move(query_doc2));  // not present yet
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4190,7 +4193,7 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     writer->GetBatch().Remove(std::move(query_doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4222,10 +4225,10 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     writer->GetBatch().Remove(std::move(query_doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // document mask with 'doc3' created
     writer->GetBatch().Remove(std::move(query_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // new document mask with 'doc2','doc3' created
 
@@ -4255,11 +4258,11 @@ TEST_P(IndexTestCase, doc_removal) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4288,11 +4291,11 @@ TEST_P(IndexTestCase, doc_removal) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     writer->GetBatch().Remove(std::move(query_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4341,12 +4344,12 @@ TEST_P(IndexTestCase, doc_removal) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4403,18 +4406,18 @@ TEST_P(IndexTestCase, doc_removal) {
     ASSERT_TRUE(InsertWithName(*writer, *doc3));  // C
     ASSERT_TRUE(InsertWithName(*writer, *doc4));  // D
     writer->GetBatch().Remove(std::move(query_doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc5));  // E
     ASSERT_TRUE(InsertWithName(*writer, *doc6));  // F
     ASSERT_TRUE(InsertWithName(*writer, *doc7));  // G
     writer->GetBatch().Remove(std::move(query_doc3_doc7));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc8));  // H
     ASSERT_TRUE(InsertWithName(*writer, *doc9));  // I
     writer->GetBatch().Remove(std::move(query_doc2_doc6_doc9));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4542,7 +4545,7 @@ TEST_P(IndexTestCase, doc_update) {
     trx4.Commit();
     trx2.Commit();
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4559,7 +4562,7 @@ TEST_P(IndexTestCase, doc_update) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc1.get()), *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4588,7 +4591,7 @@ TEST_P(IndexTestCase, doc_update) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc1), *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4618,7 +4621,7 @@ TEST_P(IndexTestCase, doc_update) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(UpdateWithName(
       *writer, std::shared_ptr<irs::Filter>(std::move(query_doc1)), *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4647,10 +4650,10 @@ TEST_P(IndexTestCase, doc_update) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc1), *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4704,7 +4707,7 @@ TEST_P(IndexTestCase, doc_update) {
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc1), *doc2));
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc2), *doc3));
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc3), *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4734,16 +4737,16 @@ TEST_P(IndexTestCase, doc_update) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc1), *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc2), *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc3), *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4771,11 +4774,11 @@ TEST_P(IndexTestCase, doc_update) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, std::move(query_doc2),
                                *doc2));  // non-existent document
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4806,7 +4809,7 @@ TEST_P(IndexTestCase, doc_update) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc2), *doc3));
     writer->GetBatch().Remove(*(query_doc2));  // remove no longer existent
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4838,13 +4841,13 @@ TEST_P(IndexTestCase, doc_update) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc2), *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(*(query_doc2));  // remove no longer existent
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4897,7 +4900,7 @@ TEST_P(IndexTestCase, doc_update) {
     writer->GetBatch().Remove(*(query_doc2));
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc2),
                                *doc3));  // update no longer existent
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4926,14 +4929,14 @@ TEST_P(IndexTestCase, doc_update) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(*(query_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc2),
                                *doc3));  // update no longer existent
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4967,7 +4970,7 @@ TEST_P(IndexTestCase, doc_update) {
     writer->GetBatch().Remove(*(query_doc2));
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc2), *doc3));
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc3), *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -4998,16 +5001,16 @@ TEST_P(IndexTestCase, doc_update) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(*(query_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc2), *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(UpdateWithName(*writer, *(query_doc3), *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5096,7 +5099,7 @@ TEST_P(IndexTestCase, doc_update) {
     ASSERT_FALSE(InsertWithName(*writer, *doc3));  // serializer returs false
     ASSERT_FALSE(InsertWithName(*writer, *doc4));  // index features differ
     ASSERT_FALSE(UpdateWithName(*writer, *(query_doc1.get()), *doc3));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5147,7 +5150,7 @@ TEST_P(IndexTestCase, import_reader) {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // ensure the writer has an initial
                                       // completed state
 
@@ -5162,10 +5165,10 @@ TEST_P(IndexTestCase, import_reader) {
       ASSERT_EQ(0, meta.seg_counter);
     }
 
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5176,7 +5179,7 @@ TEST_P(IndexTestCase, import_reader) {
     // insert a document and check the meta counter again
     {
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
 
       irs::IndexMeta meta;
@@ -5198,7 +5201,7 @@ TEST_P(IndexTestCase, import_reader) {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // ensure the writer has an initial
                                       // completed state
 
@@ -5214,15 +5217,15 @@ TEST_P(IndexTestCase, import_reader) {
     }
 
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     data_writer->GetBatch().Remove(std::move(query_doc1));
-    data_writer->Commit();
-    writer->Commit();
+    data_writer->RefreshCommit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // ensure the writer has an initial
                                       // completed state
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5233,7 +5236,7 @@ TEST_P(IndexTestCase, import_reader) {
     // insert a document and check the meta counter again
     {
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
 
       irs::IndexMeta meta;
@@ -5256,10 +5259,10 @@ TEST_P(IndexTestCase, import_reader) {
 
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5296,10 +5299,10 @@ TEST_P(IndexTestCase, import_reader) {
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
     data_writer->GetBatch().Remove(std::move(query_doc1));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5331,13 +5334,13 @@ TEST_P(IndexTestCase, import_reader) {
 
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(InsertWithName(*data_writer, *doc3));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc4));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5379,14 +5382,14 @@ TEST_P(IndexTestCase, import_reader) {
 
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(InsertWithName(*data_writer, *doc3));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc4));
     data_writer->GetBatch().Remove(std::move(query_doc2_doc3));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5422,14 +5425,14 @@ TEST_P(IndexTestCase, import_reader) {
 
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(InsertWithName(*data_writer, *doc3));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc4));
     data_writer->GetBatch().Remove(std::move(query_doc4));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5468,13 +5471,13 @@ TEST_P(IndexTestCase, import_reader) {
 
     ASSERT_TRUE(InsertWithName(*data_writer, *doc1));
     ASSERT_TRUE(InsertWithName(*data_writer, *doc2));
-    data_writer->Commit();
+    data_writer->RefreshCommit();
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     writer->GetBatch().Remove(
       std::move(query_doc2));  // should not match any documents
     ASSERT_TRUE(writer->Import(irs::DirectoryReader(
       data_dir, codec(), irs::tests::DefaultReaderOptions())));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -5542,7 +5545,7 @@ TEST_P(IndexTestCase, refresh_reader) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5578,7 +5581,7 @@ TEST_P(IndexTestCase, refresh_reader) {
     auto query_doc2 = MakeByTerm("name", "B");
 
     writer->GetBatch().Remove(std::move(query_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
   // validate state pre/post refresh (existing segment changed)
@@ -5631,7 +5634,7 @@ TEST_P(IndexTestCase, refresh_reader) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5700,7 +5703,7 @@ TEST_P(IndexTestCase, refresh_reader) {
     auto query_doc1 = MakeByTerm("name", "A");
 
     writer->GetBatch().Remove(std::move(query_doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5779,7 +5782,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
     index_ref.emplace_back();
     gen0.reset();
     write_segment(*writer, index_ref.back(), gen0);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5788,7 +5791,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
     index_ref.emplace_back();
     gen1.reset();
     write_segment(*writer, index_ref.back(), gen1);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5800,7 +5803,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
     write_segment(*writer, index_ref.back(), gen0);
     gen1.reset();
     write_segment(*writer, index_ref.back(), gen1);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5816,7 +5819,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
       write_segment(*writer, index_ref.back(), gen1);
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5843,7 +5846,7 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
       }
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -5851,9 +5854,9 @@ TEST_P(IndexTestCase, reuse_segment_writer) {
 
   // merge all segments
   {
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 }
@@ -5891,7 +5894,7 @@ TEST_P(IndexTestCase, segment_column_user_system) {
   ASSERT_TRUE(Insert(*writer, doc0.indexed.begin(), doc0.indexed.end()));
   ASSERT_TRUE(InsertWithName(*writer, *doc1));
   ASSERT_TRUE(InsertWithName(*writer, *doc2));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   std::unordered_set<std::string_view> expected_name = {"A", "B"};
@@ -5942,7 +5945,7 @@ TEST_P(IndexTestCase, import_concurrent) {
       : dir(std::make_unique<irs::MemoryDirectory>()) {
       writer = irs::IndexWriter::Make(*dir, codec, irs::kOmCreate,
                                       irs::tests::DefaultWriterOptions());
-      writer->Commit();
+      writer->RefreshCommit();
       reader =
         irs::DirectoryReader(*dir, nullptr, irs::tests::DefaultReaderOptions());
     }
@@ -5992,7 +5995,7 @@ TEST_P(IndexTestCase, import_concurrent) {
 
       ASSERT_TRUE(InsertWithName(*store.writer, *doc));
     }
-    store.writer->Commit();
+    store.writer->RefreshCommit();
     store.reader = irs::DirectoryReader(*store.dir, nullptr,
                                         irs::tests::DefaultReaderOptions());
     tests::AssertSnapshotEquality(store.writer->GetSnapshot(), store.reader);
@@ -6033,7 +6036,7 @@ TEST_P(IndexTestCase, import_concurrent) {
     worker.join();
   }
 
-  writer->Commit();  // commit changes
+  writer->RefreshCommit();  // commit changes
 
   auto reader =
     irs::DirectoryReader(dir, nullptr, irs::tests::DefaultReaderOptions());
@@ -6063,10 +6066,10 @@ TEST_P(IndexTestCase, import_concurrent) {
   ASSERT_TRUE(names.empty());
 }
 
-static void ConsolidateRange(irs::Consolidation& candidates,
-                             const irs::ConsolidatingSegments& segments,
-                             const irs::IndexReader& reader, size_t begin,
-                             size_t end) {
+static void CompactRange(irs::Compaction& candidates,
+                         const irs::CompactingSegments& segments,
+                         const irs::IndexReader& reader, size_t begin,
+                         size_t end) {
   if (begin > reader.size() || end > reader.size()) {
     return;
   }
@@ -6079,7 +6082,7 @@ static void ConsolidateRange(irs::Consolidation& candidates,
   }
 }
 
-TEST_P(IndexTestCase, concurrent_consolidation) {
+TEST_P(IndexTestCase, concurrent_compaction) {
   auto writer =
     open_writer(dir(), irs::kOmCreate, irs::tests::DefaultWriterOptions());
   ASSERT_NE(nullptr, writer);
@@ -6102,7 +6105,7 @@ TEST_P(IndexTestCase, concurrent_consolidation) {
   size_t size = 0;
   while (const auto* doc = gen.next()) {
     ASSERT_TRUE(InsertWithName(*writer, *doc));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ++size;
   }
@@ -6131,15 +6134,15 @@ TEST_P(IndexTestCase, concurrent_consolidation) {
 
       while (num_segments > 1) {
         auto policy = [&i, &num_segments](
-                        irs::Consolidation& candidates,
+                        irs::Compaction& candidates,
                         const irs::IndexReader& reader,
-                        const irs::ConsolidatingSegments& segments) mutable {
+                        const irs::CompactingSegments& segments) mutable {
           num_segments = reader.size();
-          ConsolidateRange(candidates, segments, reader, i, i + 2);
+          CompactRange(candidates, segments, reader, i, i + 2);
         };
 
-        if (writer->Consolidate(policy)) {
-          writer->Commit();
+        if (writer->Compact(policy)) {
+          writer->RefreshCommit();
         }
 
         i = (i + 1) % num_segments;
@@ -6158,7 +6161,7 @@ TEST_P(IndexTestCase, concurrent_consolidation) {
     thread.join();
   }
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   auto reader = irs::DirectoryReader(this->dir(), codec(),
@@ -6189,7 +6192,7 @@ TEST_P(IndexTestCase, concurrent_consolidation) {
   ASSERT_TRUE(names.empty());
 }
 
-TEST_P(IndexTestCase, concurrent_consolidation_dedicated_commit) {
+TEST_P(IndexTestCase, concurrent_compaction_dedicated_commit) {
   auto writer =
     open_writer(dir(), irs::kOmCreate, irs::tests::DefaultWriterOptions());
   ASSERT_NE(nullptr, writer);
@@ -6212,7 +6215,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_dedicated_commit) {
   size_t size = 0;
   while (const auto* doc = gen.next()) {
     ASSERT_TRUE(InsertWithName(*writer, *doc));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ++size;
   }
@@ -6241,14 +6244,14 @@ TEST_P(IndexTestCase, concurrent_consolidation_dedicated_commit) {
 
       while (num_segments > 1) {
         auto policy = [&i, &num_segments](
-                        irs::Consolidation& candidates,
+                        irs::Compaction& candidates,
                         const irs::IndexReader& reader,
-                        const irs::ConsolidatingSegments& segments) mutable {
+                        const irs::CompactingSegments& segments) mutable {
           num_segments = reader.size();
-          ConsolidateRange(candidates, segments, reader, i, i + 2);
+          CompactRange(candidates, segments, reader, i, i + 2);
         };
 
-        writer->Consolidate(policy);
+        writer->Compact(policy);
 
         i = (i + 1) % num_segments;
       }
@@ -6261,7 +6264,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_dedicated_commit) {
     wait_for_all();
 
     while (!shutdown.load()) {
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       std::this_thread::sleep_for(100ms);
     }
@@ -6282,7 +6285,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_dedicated_commit) {
   shutdown = true;
   commit_thread.join();
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   auto reader = irs::DirectoryReader(this->dir(), codec(),
@@ -6313,7 +6316,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_dedicated_commit) {
   ASSERT_TRUE(names.empty());
 }
 
-TEST_P(IndexTestCase, concurrent_consolidation_two_phase_dedicated_commit) {
+TEST_P(IndexTestCase, concurrent_compaction_two_phase_dedicated_commit) {
   auto writer =
     open_writer(dir(), irs::kOmCreate, irs::tests::DefaultWriterOptions());
   ASSERT_NE(nullptr, writer);
@@ -6336,7 +6339,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_two_phase_dedicated_commit) {
   size_t size = 0;
   while (const auto* doc = gen.next()) {
     ASSERT_TRUE(InsertWithName(*writer, *doc));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ++size;
   }
@@ -6365,14 +6368,14 @@ TEST_P(IndexTestCase, concurrent_consolidation_two_phase_dedicated_commit) {
 
       while (num_segments > 1) {
         auto policy = [&i, &num_segments](
-                        irs::Consolidation& candidates,
+                        irs::Compaction& candidates,
                         const irs::IndexReader& meta,
-                        const irs::ConsolidatingSegments& segments) mutable {
+                        const irs::CompactingSegments& segments) mutable {
           num_segments = meta.size();
-          ConsolidateRange(candidates, segments, meta, i, i + 2);
+          CompactRange(candidates, segments, meta, i, i + 2);
         };
 
-        writer->Consolidate(policy);
+        writer->Compact(policy);
 
         i = (i + 1) % num_segments;
       }
@@ -6385,9 +6388,9 @@ TEST_P(IndexTestCase, concurrent_consolidation_two_phase_dedicated_commit) {
     wait_for_all();
 
     while (!shutdown.load()) {
-      writer->Begin();
+      writer->RefreshBegin();
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
       std::this_thread::sleep_for(100ms);
     }
@@ -6408,7 +6411,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_two_phase_dedicated_commit) {
   shutdown = true;
   commit_thread.join();
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   auto reader = irs::DirectoryReader(this->dir(), codec(),
@@ -6439,7 +6442,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_two_phase_dedicated_commit) {
   ASSERT_TRUE(names.empty());
 }
 
-TEST_P(IndexTestCase, concurrent_consolidation_cleanup) {
+TEST_P(IndexTestCase, concurrent_compaction_cleanup) {
   auto writer =
     open_writer(dir(), irs::kOmCreate, irs::tests::DefaultWriterOptions());
   ASSERT_NE(nullptr, writer);
@@ -6462,7 +6465,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_cleanup) {
   size_t size = 0;
   while (const auto* doc = gen.next()) {
     ASSERT_TRUE(InsertWithName(*writer, *doc));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ++size;
   }
@@ -6490,15 +6493,15 @@ TEST_P(IndexTestCase, concurrent_consolidation_cleanup) {
       size_t num_segments = std::numeric_limits<size_t>::max();
 
       while (num_segments > 1) {
-        auto policy = [&](irs::Consolidation& candidates,
+        auto policy = [&](irs::Compaction& candidates,
                           const irs::IndexReader& reader,
-                          const irs::ConsolidatingSegments& segments) mutable {
+                          const irs::CompactingSegments& segments) mutable {
           num_segments = reader.size();
-          ConsolidateRange(candidates, segments, reader, i, i + 2);
+          CompactRange(candidates, segments, reader, i, i + 2);
         };
 
-        if (writer->Consolidate(policy)) {
-          writer->Commit();
+        if (writer->Compact(policy)) {
+          writer->RefreshCommit();
           irs::DirectoryCleaner::clean(this->dir());
         }
 
@@ -6518,7 +6521,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_cleanup) {
     thread.join();
   }
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   irs::DirectoryCleaner::clean(dir());
 
@@ -6550,7 +6553,7 @@ TEST_P(IndexTestCase, concurrent_consolidation_cleanup) {
   ASSERT_TRUE(names.empty());
 }
 
-TEST_P(IndexTestCase, consolidate_single_segment) {
+TEST_P(IndexTestCase, compact_single_segment) {
   tests::JsonDocGenerator gen(
     resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -6567,17 +6570,17 @@ TEST_P(IndexTestCase, consolidate_single_segment) {
                                               irs::IndexFeatures::Pos |
                                               irs::IndexFeatures::Offs;
 
-  std::vector<size_t> expected_consolidating_segments;
-  auto check_consolidating_segments =
-    [&expected_consolidating_segments](
-      irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-      const irs::ConsolidatingSegments& consolidating_segments) {
-      ASSERT_EQ(expected_consolidating_segments.size(),
-                consolidating_segments.size());
-      for (auto i : expected_consolidating_segments) {
-        auto& expected_consolidating_segment = reader[i];
-        ASSERT_TRUE(consolidating_segments.contains(
-          expected_consolidating_segment.Meta().name));
+  std::vector<size_t> expected_compacting_segments;
+  auto check_compacting_segments =
+    [&expected_compacting_segments](
+      irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+      const irs::CompactingSegments& compacting_segments) {
+      ASSERT_EQ(expected_compacting_segments.size(),
+                compacting_segments.size());
+      for (auto i : expected_compacting_segments) {
+        auto& expected_compacting_segment = reader[i];
+        ASSERT_TRUE(compacting_segments.contains(
+          expected_compacting_segment.Meta().name));
       }
     };
 
@@ -6589,16 +6592,16 @@ TEST_P(IndexTestCase, consolidate_single_segment) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
-    ASSERT_TRUE(writer->Consolidate(
-      check_consolidating_segments));  // check segments registered for
-                                       // consolidation
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // nothing to compact
+    ASSERT_TRUE(
+      writer->Compact(check_compacting_segments));  // check segments registered
+                                                    // for compaction
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
   }
@@ -6619,11 +6622,11 @@ TEST_P(IndexTestCase, consolidate_single_segment) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     auto query_doc1 = MakeByTerm("name", "A");
     writer->GetBatch().Remove(*query_doc1);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(
       3,
@@ -6637,14 +6640,14 @@ TEST_P(IndexTestCase, consolidate_single_segment) {
     count = 0;
     dir().visit(get_number_of_files_in_segments);
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
-    expected_consolidating_segments = {
-      0};  // expect first segment to be marked for consolidation
-    ASSERT_TRUE(writer->Consolidate(
-      check_consolidating_segments));  // check segments registered for
-                                       // consolidation
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // nothing to compact
+    expected_compacting_segments = {
+      0};  // expect first segment to be marked for compaction
+    ASSERT_TRUE(
+      writer->Compact(check_compacting_segments));  // check segments registered
+                                                    // for compaction
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1 + count,
               irs::DirectoryCleaner::clean(dir()));  // +1 for segments_2
@@ -6679,10 +6682,10 @@ TEST_P(IndexTestCase, consolidate_single_segment) {
   }
 }
 
-TEST_P(IndexTestCase, segment_consolidate_long_running) {
+TEST_P(IndexTestCase, segment_compact_long_running) {
   // The new cs writes `<segment>.cs` for every committed segment. Use the
   // third segment's expected `.cs` file as the BlockingDirectory trigger;
-  // the test gates consolidation on its create().
+  // the test gates compaction on its create().
   const auto blocker = std::string{"_3.cs"};
 
   tests::JsonDocGenerator gen(
@@ -6719,42 +6722,42 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));  // segments_1
 
     // retrieve total number of segment files
     dir.visit(get_number_of_files_in_segments);
 
-    // acquire directory lock, and block consolidation
+    // acquire directory lock, and block compaction
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
-      // consolidate
-      ASSERT_TRUE(writer->Consolidate(
-        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{})));
+    std::thread compaction_thread([&writer]() {
+      // compact
+      ASSERT_TRUE(writer->Compact(
+        irs::index_utils::MakePolicy(irs::index_utils::CompactionCount{})));
 
-      const std::vector<size_t> expected_consolidating_segments{0, 1};
-      auto check_consolidating_segments =
-        [&expected_consolidating_segments](
-          irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-          const irs::ConsolidatingSegments& consolidating_segments) {
-          ASSERT_EQ(expected_consolidating_segments.size(),
-                    consolidating_segments.size());
-          for (auto i : expected_consolidating_segments) {
-            const auto& expected_consolidating_segment = reader[i];
-            ASSERT_TRUE(consolidating_segments.contains(
-              expected_consolidating_segment.Meta().name));
+      const std::vector<size_t> expected_compacting_segments{0, 1};
+      auto check_compacting_segments =
+        [&expected_compacting_segments](
+          irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+          const irs::CompactingSegments& compacting_segments) {
+          ASSERT_EQ(expected_compacting_segments.size(),
+                    compacting_segments.size());
+          for (auto i : expected_compacting_segments) {
+            const auto& expected_compacting_segment = reader[i];
+            ASSERT_TRUE(compacting_segments.contains(
+              expected_compacting_segment.Meta().name));
           }
         };
-      // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      // check segments registered for compaction
+      ASSERT_TRUE(writer->Compact(check_compacting_segments));
     });
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
@@ -6775,24 +6778,24 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
     // add several segments in background
     // segment 3
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);                  // commit transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));  // segments_2
 
     // add several segments in background
     // segment 4
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);                  // commit transaction
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));  // segments_3
 
-    dir.intermediate_commits_lock.unlock();  // finish consolidation
-    consolidation_thread.join();  // wait for the consolidation to complete
+    dir.intermediate_commits_lock.unlock();  // finish compaction
+    compaction_thread.join();  // wait for the compaction to complete
 
-    // finished consolidation holds a reference to segments_3
+    // finished compaction holds a reference to segments_3
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
-    writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit consolidation
+    writer->RefreshCommit();
+    AssertSnapshotEquality(*writer);  // commit compaction
 
     // +1 for segments_4, +1 for segments_3
     ASSERT_EQ(1 + 1 + count, irs::DirectoryCleaner::clean(dir));
@@ -6882,7 +6885,7 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
 
@@ -6892,25 +6895,25 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));  // segments_1
 
-    // acquire directory lock, and block consolidation
+    // acquire directory lock, and block compaction
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
-      // consolidation will fail because of
-      ASSERT_FALSE(writer->Consolidate(irs::index_utils::MakePolicy(
-        irs::index_utils::ConsolidateCount())));  // consolidate
+    std::thread compaction_thread([&writer]() {
+      // compaction will fail because of
+      ASSERT_FALSE(writer->Compact(irs::index_utils::MakePolicy(
+        irs::index_utils::CompactionCount())));  // compact
 
-      auto check_consolidating_segments =
-        [](irs::Consolidation& /*candidates*/, const irs::IndexReader& /*meta*/,
-           const irs::ConsolidatingSegments& consolidating_segments) {
-          ASSERT_TRUE(consolidating_segments.empty());
+      auto check_compacting_segments =
+        [](irs::Compaction& /*candidates*/, const irs::IndexReader& /*meta*/,
+           const irs::CompactingSegments& compacting_segments) {
+          ASSERT_TRUE(compacting_segments.empty());
         };
-      // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      // check segments registered for compaction
+      ASSERT_TRUE(writer->Compact(check_compacting_segments));
     });
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
@@ -6932,27 +6935,27 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
     // segment 3
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     writer->GetBatch().Remove(*query_doc1);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);                  // commit transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));  // segments_2
 
     // add several segments in background
     // segment 4
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);                  // commit transaction
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));  // segments_3
 
-    dir.intermediate_commits_lock.unlock();  // finish consolidation
-    consolidation_thread.join();  // wait for the consolidation to complete
+    dir.intermediate_commits_lock.unlock();  // finish compaction
+    compaction_thread.join();  // wait for the compaction to complete
     ASSERT_EQ(2 * count - 1 + 1,
               irs::DirectoryCleaner::clean(
                 dir));  // files from segment 1 and 3 (without segment meta)
                         // + segments_3
-    writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit consolidation
+    writer->RefreshCommit();
+    AssertSnapshotEquality(*writer);  // commit compaction
     ASSERT_EQ(0,
-              irs::DirectoryCleaner::clean(dir));  // consolidation failed
+              irs::DirectoryCleaner::clean(dir));  // compaction failed
 
     // validate structure
     tests::index_t expected;
@@ -7036,13 +7039,13 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));  // segments_1
 
@@ -7050,29 +7053,29 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
     count = 0;
     dir.visit(get_number_of_files_in_segments);
 
-    // acquire directory lock, and block consolidation
+    // acquire directory lock, and block compaction
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
-      // consolidation will fail because of
-      ASSERT_TRUE(writer->Consolidate(
-        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    std::thread compaction_thread([&writer]() {
+      // compaction will fail because of
+      ASSERT_TRUE(writer->Compact(
+        irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-      const std::vector<size_t> expected_consolidating_segments{0, 1};
-      auto check_consolidating_segments =
-        [&expected_consolidating_segments](
-          irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-          const irs::ConsolidatingSegments& consolidating_segments) {
-          ASSERT_EQ(expected_consolidating_segments.size(),
-                    consolidating_segments.size());
-          for (auto i : expected_consolidating_segments) {
-            const auto& expected_consolidating_segment = reader[i];
-            ASSERT_TRUE(consolidating_segments.contains(
-              expected_consolidating_segment.Meta().name));
+      const std::vector<size_t> expected_compacting_segments{0, 1};
+      auto check_compacting_segments =
+        [&expected_compacting_segments](
+          irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+          const irs::CompactingSegments& compacting_segments) {
+          ASSERT_EQ(expected_compacting_segments.size(),
+                    compacting_segments.size());
+          for (auto i : expected_compacting_segments) {
+            const auto& expected_compacting_segment = reader[i];
+            ASSERT_TRUE(compacting_segments.contains(
+              expected_compacting_segment.Meta().name));
           }
         };
-      // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      // check segments registered for compaction
+      ASSERT_TRUE(writer->Compact(check_compacting_segments));
     });
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
@@ -7092,17 +7095,17 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // remove doc1 in background
     writer->GetBatch().Remove(*query_doc1);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
     // unused column store
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));
 
-    dir.intermediate_commits_lock.unlock();  // finish consolidation
-    consolidation_thread.join();  // wait for the consolidation to complete
-    // Consolidation still holds a reference to the snapshot segment_2
+    dir.intermediate_commits_lock.unlock();  // finish compaction
+    compaction_thread.join();  // wait for the compaction to complete
+    // Compaction still holds a reference to the snapshot segment_2
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
-    writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit consolidation
+    writer->RefreshCommit();
+    AssertSnapshotEquality(*writer);  // commit compaction
     // files from segments 1 and 2, segment_3
     // segment_2 + stale segment 1 meta
     ASSERT_EQ(count + 2 + 1, irs::DirectoryCleaner::clean(dir));
@@ -7178,14 +7181,14 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));  // segments_1
 
@@ -7194,28 +7197,28 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
     dir.visit(get_number_of_files_in_segments);
 
     dir.intermediate_commits_lock
-      .lock();  // acquire directory lock, and block consolidation
+      .lock();  // acquire directory lock, and block compaction
 
-    std::thread consolidation_thread([&writer]() {
-      // consolidation will fail because of
-      ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-        irs::index_utils::ConsolidateCount())));  // consolidate
+    std::thread compaction_thread([&writer]() {
+      // compaction will fail because of
+      ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+        irs::index_utils::CompactionCount())));  // compact
 
-      const std::vector<size_t> expected_consolidating_segments{0, 1};
-      auto check_consolidating_segments =
-        [&expected_consolidating_segments](
-          irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-          const irs::ConsolidatingSegments& consolidating_segments) {
-          ASSERT_EQ(expected_consolidating_segments.size(),
-                    consolidating_segments.size());
-          for (auto i : expected_consolidating_segments) {
-            const auto& expected_consolidating_segment = reader[i];
-            ASSERT_TRUE(consolidating_segments.contains(
-              expected_consolidating_segment.Meta().name));
+      const std::vector<size_t> expected_compacting_segments{0, 1};
+      auto check_compacting_segments =
+        [&expected_compacting_segments](
+          irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+          const irs::CompactingSegments& compacting_segments) {
+          ASSERT_EQ(expected_compacting_segments.size(),
+                    compacting_segments.size());
+          for (auto i : expected_compacting_segments) {
+            const auto& expected_compacting_segment = reader[i];
+            ASSERT_TRUE(compacting_segments.contains(
+              expected_compacting_segment.Meta().name));
           }
         };
-      // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      // check segments registered for compaction
+      ASSERT_TRUE(writer->Compact(check_compacting_segments));
     });
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
@@ -7235,18 +7238,18 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
 
     // remove doc1 in background
     writer->GetBatch().Remove(*query_doc1_doc4);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
     //  unused column store
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir));
 
-    dir.intermediate_commits_lock.unlock();  // finish consolidation
-    consolidation_thread.join();  // wait for the consolidation to complete
-    // consolidation still holds a reference to the snapshot pointed by
+    dir.intermediate_commits_lock.unlock();  // finish compaction
+    compaction_thread.join();  // wait for the compaction to complete
+    // compaction still holds a reference to the snapshot pointed by
     // segments_2
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir));
-    writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit consolidation
+    writer->RefreshCommit();
+    AssertSnapshotEquality(*writer);  // commit compaction
 
     // files from segments 1 and 2,
     // segment_3
@@ -7316,18 +7319,18 @@ TEST_P(IndexTestCase, segment_consolidate_long_running) {
   }
 }
 
-TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
-  std::vector<size_t> expected_consolidating_segments;
-  auto check_consolidating_segments =
-    [&expected_consolidating_segments](
-      irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-      const irs::ConsolidatingSegments& consolidating_segments) {
-      ASSERT_EQ(expected_consolidating_segments.size(),
-                consolidating_segments.size());
-      for (auto i : expected_consolidating_segments) {
-        const auto& expected_consolidating_segment = reader[i];
-        ASSERT_TRUE(consolidating_segments.contains(
-          expected_consolidating_segment.Meta().name));
+TEST_P(IndexTestCase, segment_compact_clear_commit) {
+  std::vector<size_t> expected_compacting_segments;
+  auto check_compacting_segments =
+    [&expected_compacting_segments](
+      irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+      const irs::CompactingSegments& compacting_segments) {
+      ASSERT_EQ(expected_compacting_segments.size(),
+                compacting_segments.size());
+      for (auto i : expected_compacting_segments) {
+        const auto& expected_compacting_segment = reader[i];
+        ASSERT_TRUE(compacting_segments.contains(
+          expected_compacting_segment.Meta().name));
       }
     };
 
@@ -7344,7 +7347,7 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
   const tests::Document* doc2 = gen.next();
   const tests::Document* doc3 = gen.next();
 
-  // 2-phase: clear + consolidate
+  // 2-phase: clear + compact
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7352,22 +7355,22 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 3
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
 
-    writer->Begin();
+    writer->RefreshBegin();
     writer->Clear();
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
     auto reader =
@@ -7375,7 +7378,7 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
     ASSERT_EQ(0, reader.size());
   }
 
-  // 2-phase: consolidate + clear
+  // 2-phase: compact + clear
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7383,22 +7386,22 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 3
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
 
-    writer->Begin();
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    writer->RefreshBegin();
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
     writer->Clear();
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
     auto reader =
@@ -7406,7 +7409,7 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
     ASSERT_EQ(0, reader.size());
   }
 
-  // consolidate + clear
+  // compact + clear
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7414,28 +7417,28 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     writer->Clear();
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
     auto reader =
@@ -7443,7 +7446,7 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
     ASSERT_EQ(0, reader.size());
   }
 
-  // clear + consolidate
+  // clear + compact
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7451,23 +7454,23 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     writer->Clear();
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
     auto reader =
@@ -7476,18 +7479,18 @@ TEST_P(IndexTestCase, segment_consolidate_clear_commit) {
   }
 }
 
-TEST_P(IndexTestCase, segment_consolidate_commit) {
-  std::vector<size_t> expected_consolidating_segments;
-  auto check_consolidating_segments =
-    [&expected_consolidating_segments](
-      irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-      const irs::ConsolidatingSegments& consolidating_segments) {
-      ASSERT_EQ(expected_consolidating_segments.size(),
-                consolidating_segments.size());
-      for (auto i : expected_consolidating_segments) {
-        const auto& expected_consolidating_segment = reader[i];
-        ASSERT_TRUE(consolidating_segments.contains(
-          expected_consolidating_segment.Meta().name));
+TEST_P(IndexTestCase, segment_compact_commit) {
+  std::vector<size_t> expected_compacting_segments;
+  auto check_compacting_segments =
+    [&expected_compacting_segments](
+      irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+      const irs::CompactingSegments& compacting_segments) {
+      ASSERT_EQ(expected_compacting_segments.size(),
+                compacting_segments.size());
+      for (auto i : expected_compacting_segments) {
+        const auto& expected_compacting_segment = reader[i];
+        ASSERT_TRUE(compacting_segments.contains(
+          expected_compacting_segment.Meta().name));
       }
     };
 
@@ -7517,7 +7520,7 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
       return true;
     };
 
-  // consolidate without deletes
+  // compact without deletes
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7525,12 +7528,12 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
@@ -7539,33 +7542,33 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
     count = 0;
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
-
-    ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-
-    // all segments are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    writer->Commit();
+    // all segments are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
+
+    ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
+
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit nothing)
     ASSERT_EQ(1 + count, irs::DirectoryCleaner::clean(
                            dir()));  // +1 for corresponding segments_* file
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // nothing to compact
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit nothing)
 
@@ -7602,7 +7605,7 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
     }
   }
 
-  // consolidate without deletes
+  // compact without deletes
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7610,13 +7613,13 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -7629,25 +7632,25 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction (will commit segment
-                                      // 3 + consolidation)
+                                      // 3 + compaction)
     ASSERT_EQ(1 + count,
               irs::DirectoryCleaner::clean(dir()));  // +1 for segments_*
 
@@ -7708,7 +7711,7 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
     }
   }
 
-  // consolidate without deletes
+  // compact without deletes
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -7716,13 +7719,13 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -7735,29 +7738,29 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));  // segments_1
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));  // segments_1
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction (will commit segment
-                                      // 3 + consolidation)
+                                      // 3 + compaction)
     ASSERT_EQ(count + 1,
               irs::DirectoryCleaner::clean(dir()));  // +1 for segments_*
 
@@ -7824,7 +7827,7 @@ TEST_P(IndexTestCase, segment_consolidate_commit) {
   }
 }
 
-TEST_P(IndexTestCase, consolidate_check_consolidating_segments) {
+TEST_P(IndexTestCase, compact_check_compacting_segments) {
   tests::JsonDocGenerator gen(
     resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -7837,63 +7840,63 @@ TEST_P(IndexTestCase, consolidate_check_consolidating_segments) {
   auto writer = open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
   ASSERT_NE(nullptr, writer);
 
-  // ensure consolidating segments is empty
+  // ensure compacting segments is empty
   {
-    auto check_consolidating_segments =
-      [](irs::Consolidation& /*candidates*/, const irs::IndexReader& /*reader*/,
-         const irs::ConsolidatingSegments& consolidating_segments) {
-        ASSERT_TRUE(consolidating_segments.empty());
+    auto check_compacting_segments =
+      [](irs::Compaction& /*candidates*/, const irs::IndexReader& /*reader*/,
+         const irs::CompactingSegments& compacting_segments) {
+        ASSERT_TRUE(compacting_segments.empty());
       };
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
   }
 
   const size_t segments_count = 10;
   for (size_t i = 0; i < segments_count; ++i) {
     const auto* doc = gen.next();
     ASSERT_TRUE(InsertWithName(*writer, *doc));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
-  // register 'SEGMENTS_COUNT/2' consolidations
+  // register 'SEGMENTS_COUNT/2' compactions
   for (size_t i = 0, j = 0; i < segments_count / 2; ++i) {
     auto merge_adjacent =
-      [&j](irs::Consolidation& candidates, const irs::IndexReader& reader,
-           const irs::ConsolidatingSegments& /*consolidating_segments*/) {
+      [&j](irs::Compaction& candidates, const irs::IndexReader& reader,
+           const irs::CompactingSegments& /*compacting_segments*/) {
         ASSERT_TRUE(j < reader.size());
         candidates.emplace_back(&reader[j++]);
         ASSERT_TRUE(j < reader.size());
         candidates.emplace_back(&reader[j++]);
       };
 
-    ASSERT_TRUE(writer->Consolidate(merge_adjacent));
+    ASSERT_TRUE(writer->Compact(merge_adjacent));
   }
 
   // check all segments registered
   {
-    auto check_consolidating_segments =
-      [](irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-         const irs::ConsolidatingSegments& consolidating_segments) {
-        ASSERT_EQ(reader.size(), consolidating_segments.size());
-        for (auto& expected_consolidating_segment : reader) {
-          ASSERT_TRUE(consolidating_segments.contains(
-            expected_consolidating_segment.Meta().name));
+    auto check_compacting_segments =
+      [](irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+         const irs::CompactingSegments& compacting_segments) {
+        ASSERT_EQ(reader.size(), compacting_segments.size());
+        for (auto& expected_compacting_segment : reader) {
+          ASSERT_TRUE(compacting_segments.contains(
+            expected_compacting_segment.Meta().name));
         }
       };
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
   }
 
-  writer->Commit();
-  AssertSnapshotEquality(*writer);  // commit pending consolidations
+  writer->RefreshCommit();
+  AssertSnapshotEquality(*writer);  // commit pending compactions
 
-  // ensure consolidating segments is empty
+  // ensure compacting segments is empty
   {
-    auto check_consolidating_segments =
-      [](irs::Consolidation& /*candidates*/, const irs::IndexReader& /*reader*/,
-         const irs::ConsolidatingSegments& consolidating_segments) {
-        ASSERT_TRUE(consolidating_segments.empty());
+    auto check_compacting_segments =
+      [](irs::Compaction& /*candidates*/, const irs::IndexReader& /*reader*/,
+         const irs::CompactingSegments& compacting_segments) {
+        ASSERT_TRUE(compacting_segments.empty());
       };
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
   }
 
   // validate structure
@@ -7942,31 +7945,31 @@ TEST_P(IndexTestCase, consolidate_check_consolidating_segments) {
   }
 }
 
-TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
-  std::vector<size_t> expected_consolidating_segments;
-  auto check_consolidating_segments =
-    [&expected_consolidating_segments](
-      irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-      const irs::ConsolidatingSegments& consolidating_segments) {
-      ASSERT_EQ(expected_consolidating_segments.size(),
-                consolidating_segments.size());
-      for (auto i : expected_consolidating_segments) {
-        const auto& expected_consolidating_segment = reader[i];
-        ASSERT_TRUE(consolidating_segments.contains(
-          expected_consolidating_segment.Meta().name));
+TEST_P(IndexTestCase, segment_compact_pending_commit) {
+  std::vector<size_t> expected_compacting_segments;
+  auto check_compacting_segments =
+    [&expected_compacting_segments](
+      irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+      const irs::CompactingSegments& compacting_segments) {
+      ASSERT_EQ(expected_compacting_segments.size(),
+                compacting_segments.size());
+      for (auto i : expected_compacting_segments) {
+        const auto& expected_compacting_segment = reader[i];
+        ASSERT_TRUE(compacting_segments.contains(
+          expected_compacting_segment.Meta().name));
       }
     };
 
-  auto check_consolidating_segments_name_only =
-    [&expected_consolidating_segments](
-      irs::Consolidation& /*candidates*/, const irs::IndexReader& reader,
-      const irs::ConsolidatingSegments& consolidating_segments) {
-      ASSERT_EQ(expected_consolidating_segments.size(),
-                consolidating_segments.size());
-      for (auto i : expected_consolidating_segments) {
-        const auto& expected_consolidating_segment = reader[i];
-        ASSERT_TRUE(consolidating_segments.contains(
-          expected_consolidating_segment.Meta().name));
+  auto check_compacting_segments_name_only =
+    [&expected_compacting_segments](
+      irs::Compaction& /*candidates*/, const irs::IndexReader& reader,
+      const irs::CompactingSegments& compacting_segments) {
+      ASSERT_EQ(expected_compacting_segments.size(),
+                compacting_segments.size());
+      for (auto i : expected_compacting_segments) {
+        const auto& expected_compacting_segment = reader[i];
+        ASSERT_TRUE(compacting_segments.contains(
+          expected_compacting_segment.Meta().name));
       }
     };
 
@@ -7997,7 +8000,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
       return true;
     };
 
-  // consolidate without deletes
+  // compact without deletes
   {
     auto writer =
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
@@ -8005,13 +8008,13 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
@@ -8021,43 +8024,44 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
     ASSERT_FALSE(
-      writer->Begin());  // begin transaction (will not start transaction)
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      writer
+        ->RefreshBegin());  // begin transaction (will not start transaction)
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
-
-    ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    // all segments are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
+    // all segments are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    writer->Commit();
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
+
+    ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
+
+    writer->RefreshCommit();
     AssertSnapshotEquality(
-      *writer);  // commit transaction (will commit consolidation)
+      *writer);  // commit transaction (will commit compaction)
     ASSERT_EQ(1 + count, irs::DirectoryCleaner::clean(
                            dir()));  // +1 for corresponding segments_* file
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // nothing to compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit nothing)
 
@@ -8095,7 +8099,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate without deletes
+  // compact without deletes
   {
     SetUp();
     auto writer =
@@ -8104,13 +8108,13 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -8122,49 +8126,49 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
 
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit segment 3)
 
     // writer still holds a reference to segments_2
-    // because it's under consolidation
+    // because it's under compaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit pending merge
     ASSERT_EQ(1 + 1 + count,
               irs::DirectoryCleaner::clean(dir()));  // segments_2
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure
     tests::index_t expected;
@@ -8224,7 +8228,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate without deletes
+  // compact without deletes
   {
     SetUp();
     auto writer =
@@ -8233,13 +8237,13 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -8252,56 +8256,56 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit segment 3)
 
     // writer still holds a reference to segments_3
-    // because it's under consolidation
+    // because it's under compaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);               // commit pending merge, segment 4 (doc5 + doc6)
     ASSERT_EQ(count + 1 + 1,  // +1 for segments_3
               irs::DirectoryCleaner::clean(dir()));  // +1 for segments
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure
     tests::index_t expected;
@@ -8386,7 +8390,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate with deletes
+  // compact with deletes
   {
     SetUp();
     auto query_doc1 = MakeByTerm("name", "A");
@@ -8398,13 +8402,13 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -8414,52 +8418,52 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
     writer->GetBatch().Remove(*query_doc1);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit removal)
 
     // writer still holds a reference to segments_2
-    // because it's under consolidation
+    // because it's under compaction
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // unused column store
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
 
     // Check name only because of removals
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    ASSERT_TRUE(writer->Compact(check_compacting_segments_name_only));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit pending merge
     ASSERT_EQ(count + 2 + 1,  // +2 for  segments_2 + stale segment 1 meta
               irs::DirectoryCleaner::clean(dir()));  // +1 for segments
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -8521,7 +8525,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate with deletes
+  // compact with deletes
   {
     SetUp();
     auto query_doc1_doc4 = MakeByTermOrByTerm("name", "A", "name", "D");
@@ -8533,14 +8537,14 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -8550,48 +8554,48 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
     writer->GetBatch().Remove(*query_doc1_doc4);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    writer->Commit();
+    writer->RefreshCommit();
     // commit transaction (will commit removal)
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // unused column store
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments_name_only));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit pending merge
 
     // segments_2 + stale segment 1 meta + stale segment 2 meta +1 for segments,
     ASSERT_EQ(count + 4, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -8657,7 +8661,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate with delete committed and pending
+  // compact with delete committed and pending
   {
     SetUp();
     auto query_doc1 = MakeByTerm("name", "A");
@@ -8669,14 +8673,14 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -8686,42 +8690,42 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
     writer->GetBatch().Remove(*query_doc1);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    auto do_commit_and_consolidate_count =
-      [&](irs::Consolidation& candidates, const irs::IndexReader& reader,
-          const irs::ConsolidatingSegments& consolidating_segments) {
+    auto do_commit_and_compact_count =
+      [&](irs::Compaction& candidates, const irs::IndexReader& reader,
+          const irs::CompactingSegments& compacting_segments) {
         auto sub_policy =
-          irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
-        sub_policy(candidates, reader, consolidating_segments);
-        writer->Commit();
+          irs::index_utils::MakePolicy(irs::index_utils::CompactionCount());
+        sub_policy(candidates, reader, compacting_segments);
+        writer->RefreshCommit();
         AssertSnapshotEquality(*writer);
       };
 
-    ASSERT_TRUE(writer->Consolidate(do_commit_and_consolidate_count));
+    ASSERT_TRUE(writer->Compact(do_commit_and_compact_count));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments_name_only));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
     writer->GetBatch().Remove(*query_doc4);
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit pending merge + delete
     ASSERT_EQ(count + 6, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -8792,7 +8796,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 5
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // remove one doc from new and old segment to make conolidation do
@@ -8801,15 +8805,15 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     auto query_doc5 = MakeByTerm("name", "E");
     writer->GetBatch().Remove(*query_doc3);
     writer->GetBatch().Remove(*query_doc5);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     count = 0;
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // check all old segments are deleted (no old version of segments is
@@ -8818,7 +8822,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
               irs::DirectoryCleaner::clean(dir()));  // +3 segment files
   }
 
-  // repeatable consolidation of already consolidated segment
+  // repeatable compaction of already compacted segment
   {
     SetUp();
     auto query_doc1 = MakeByTerm("name", "A");
@@ -8829,7 +8833,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
@@ -8840,48 +8844,48 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     writer->GetBatch().Remove(*query_doc1);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // this consolidation will be postponed
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-    // check consolidating segments are pending
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // this compaction will be postponed
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+    // check compacting segments are pending
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    auto do_commit_and_consolidate_count =
-      [&](irs::Consolidation& candidates, const irs::IndexReader& reader,
-          const irs::ConsolidatingSegments& consolidating_segments) {
-        writer->Commit();
+    auto do_commit_and_compact_count =
+      [&](irs::Compaction& candidates, const irs::IndexReader& reader,
+          const irs::CompactingSegments& compacting_segments) {
+        writer->RefreshCommit();
         AssertSnapshotEquality(*writer);
-        writer->Begin();  // another commit to process pending
-                          // consolidating_segments
-        writer->Commit();
+        writer->RefreshBegin();  // another commit to process pending
+                                 // compacting_segments
+        writer->RefreshCommit();
         AssertSnapshotEquality(*writer);
         auto sub_policy =
-          irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
-        sub_policy(candidates, reader, consolidating_segments);
+          irs::index_utils::MakePolicy(irs::index_utils::CompactionCount());
+        sub_policy(candidates, reader, compacting_segments);
       };
 
-    // this should fail as segments 1 and 0 are actually consolidated on
+    // this should fail as segments 1 and 0 are actually compacted on
     // previous  commit inside our test policy
-    ASSERT_FALSE(writer->Consolidate(do_commit_and_consolidate_count));
+    ASSERT_FALSE(writer->Compact(do_commit_and_compact_count));
     ASSERT_NE(0, irs::DirectoryCleaner::clean(dir()));
     // check all data is deleted
     const auto one_segment_count = count;
@@ -8891,7 +8895,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_EQ(one_segment_count, count);
   }
 
-  // repeatable consolidation of already consolidated segment during two
+  // repeatable compaction of already compacted segment during two
   // phase commit
   {
     SetUp();
@@ -8904,7 +8908,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
@@ -8915,52 +8919,52 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     writer->GetBatch().Remove(*query_doc1);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // this consolidation will be postponed
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-    // check consolidating segments are pending
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // this compaction will be postponed
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+    // check compacting segments are pending
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    auto do_commit_and_consolidate_count =
-      [&](irs::Consolidation& candidates, const irs::IndexReader& reader,
-          const irs::ConsolidatingSegments& consolidating_segments) {
-        writer->Commit();
+    auto do_commit_and_compact_count =
+      [&](irs::Compaction& candidates, const irs::IndexReader& reader,
+          const irs::CompactingSegments& compacting_segments) {
+        writer->RefreshCommit();
         AssertSnapshotEquality(*writer);
-        writer->Begin();  // another commit to process pending
-                          // consolidating_segments
-        writer->Commit();
+        writer->RefreshBegin();  // another commit to process pending
+                                 // compacting_segments
+        writer->RefreshCommit();
         AssertSnapshotEquality(*writer);
         // new transaction with passed 1st phase
         writer->GetBatch().Remove(*query_doc4);
-        writer->Begin();
+        writer->RefreshBegin();
         auto sub_policy =
-          irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
-        sub_policy(candidates, reader, consolidating_segments);
+          irs::index_utils::MakePolicy(irs::index_utils::CompactionCount());
+        sub_policy(candidates, reader, compacting_segments);
       };
 
-    // this should fail as segments 1 and 0 are actually consolidated on
+    // this should fail as segments 1 and 0 are actually compacted on
     // previous  commit inside our test policy
-    ASSERT_FALSE(writer->Consolidate(do_commit_and_consolidate_count));
-    writer->Commit();
+    ASSERT_FALSE(writer->Compact(do_commit_and_compact_count));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_NE(0, irs::DirectoryCleaner::clean(dir()));
     // check all data is deleted
@@ -8971,7 +8975,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_EQ(one_segment_count, count);
   }
 
-  // check commit rollback and consolidation
+  // check commit rollback and compaction
   {
     SetUp();
     auto query_doc1 = MakeByTerm("name", "A");
@@ -8982,48 +8986,48 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));
 
     writer->GetBatch().Remove(*query_doc1);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
-    // this consolidation will be postponed
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-    // check consolidating segments are pending
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
+    // this compaction will be postponed
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+    // check compacting segments are pending
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    writer->Rollback();
+    writer->RefreshAbort();
 
     // leftovers cleanup
     ASSERT_EQ(2, irs::DirectoryCleaner::clean(dir()));
 
     // still pending
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     writer->GetBatch().Remove(*query_doc1);
     // make next commit
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
-    // now no consolidating should be present
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // now no compacting should be present
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // could consolidate successfully
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // could compact successfully
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
     // cleanup should remove old files
     ASSERT_NE(0, irs::DirectoryCleaner::clean(dir()));
@@ -9039,11 +9043,11 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     auto reader =
       irs::DirectoryReader(dir(), codec(), irs::tests::DefaultReaderOptions());
     ASSERT_TRUE(reader);
-    ASSERT_EQ(1, reader.size());  // should be one consolidated segment
+    ASSERT_EQ(1, reader.size());  // should be one compacted segment
     ASSERT_EQ(3, reader.live_docs_count());
   }
 
-  // consolidate with deletes + inserts
+  // compact with deletes + inserts
   {
     SetUp();
     auto query_doc1_doc4 = MakeByTermOrByTerm("name", "A", "name", "D");
@@ -9055,14 +9059,14 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -9072,49 +9076,49 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
     writer->GetBatch().Remove(*query_doc1_doc4);
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     // commit transaction (will commit removal)
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  //  unused column store
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments_name_only));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit pending merge
 
     // segments_2 + stale segment 1 meta + stale segment 2 meta +1 for segments,
     ASSERT_EQ(count + 4, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -9201,7 +9205,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate with deletes + inserts
+  // compact with deletes + inserts
   {
     SetUp();
     auto query_doc1_doc4 = MakeByTermOrByTerm("name", "A", "name", "D");
@@ -9213,14 +9217,14 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
     // segment 2
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -9231,42 +9235,42 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
-    ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(
+      irs::index_utils::CompactionCount())));  // compact
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
     // writer still holds a reference to segments_2
-    // because it's under consolidation
+    // because it's under compaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));  // segments_2
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     writer->GetBatch().Remove(*query_doc1_doc4);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit pending merge + removal
 
     // +1 for segments,
@@ -9275,9 +9279,9 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // +1 for segments_2
     ASSERT_EQ(count + 5, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -9364,7 +9368,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     }
   }
 
-  // consolidate with deletes + inserts
+  // compact with deletes + inserts
   {
     SetUp();
     auto query_doc3_doc4 = MakeOr({{"name", "C"}, {"name", "D"}});
@@ -9376,7 +9380,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     // segment 1
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
@@ -9386,7 +9390,7 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(1, irs::DirectoryCleaner::clean(dir()));  // segments_1
 
@@ -9398,68 +9402,68 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    ASSERT_TRUE(writer->Begin());  // begin transaction
+    ASSERT_TRUE(writer->RefreshBegin());  // begin transaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // count number of files in segments
     count = 0;
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    // can't consolidate segments that are already marked for consolidation
-    ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    // can't compact segments that are already marked for compaction
+    ASSERT_FALSE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
-    size_t num_files_consolidation_segment = count;
+    size_t num_files_compaction_segment = count;
     count = 0;
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
-    num_files_consolidation_segment = count - num_files_consolidation_segment;
+    num_files_compaction_segment = count - num_files_compaction_segment;
 
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
     // writer still holds a reference to segments_2
-    // because it's under consolidation
+    // because it's under compaction
     ASSERT_EQ(0, irs::DirectoryCleaner::clean(dir()));  // segments_2
 
-    // check consolidating segments
-    expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {0, 1};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     writer->GetBatch().Remove(*query_doc3_doc4);
 
     // commit pending merge + removal
-    // pending consolidation will fail (because segment 2 will have no live
+    // pending compaction will fail (because segment 2 will have no live
     // docs after applying removals)
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
-    // check consolidating segments
-    expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    // check compacting segments
+    expected_compacting_segments = {};
+    ASSERT_TRUE(writer->Compact(check_compacting_segments));
 
     // +2 for segments_2 + unused column store, +1 for segments_2
-    ASSERT_EQ(num_files_consolidation_segment + num_files_segment_2 + 2 + 1,
+    ASSERT_EQ(num_files_compaction_segment + num_files_segment_2 + 2 + 1,
               irs::DirectoryCleaner::clean(dir()));
 
     // validate structure (doesn't take removals into account)
@@ -9521,13 +9525,13 @@ TEST_P(IndexTestCase, segment_consolidate_pending_commit) {
   }
 }
 
-TEST_P(IndexTestCase, consolidate_progress) {
+TEST_P(IndexTestCase, compact_progress) {
   tests::JsonDocGenerator gen(TestBase::resource("simple_sequential.json"),
                               &tests::GenericJsonFieldFactory);
   auto* doc1 = gen.next();
   auto* doc2 = gen.next();
   auto policy =
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount());
 
   // test default progress (false)
   {
@@ -9535,13 +9539,13 @@ TEST_P(IndexTestCase, consolidate_progress) {
     auto writer = irs::IndexWriter::Make(dir, get_codec(), irs::kOmCreate,
                                          irs::tests::DefaultWriterOptions());
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();  // create segment0
+    writer->RefreshCommit();  // create segment0
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, get_codec(),
                            irs::tests::DefaultReaderOptions()));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();  // create segment1
+    writer->RefreshCommit();  // create segment1
 
     auto reader = writer->GetSnapshot();
     tests::AssertSnapshotEquality(
@@ -9554,8 +9558,8 @@ TEST_P(IndexTestCase, consolidate_progress) {
 
     irs::MergeWriter::FlushProgress progress;
 
-    ASSERT_TRUE(writer->Consolidate(policy, get_codec(), progress));
-    writer->Commit();  // write consolidated segment
+    ASSERT_TRUE(writer->Compact(policy, get_codec(), progress));
+    writer->RefreshCommit();  // write compacted segment
     reader = irs::DirectoryReader(dir, get_codec(),
                                   irs::tests::DefaultReaderOptions());
 
@@ -9571,13 +9575,13 @@ TEST_P(IndexTestCase, consolidate_progress) {
     auto writer = irs::IndexWriter::Make(dir, get_codec(), irs::kOmCreate,
                                          irs::tests::DefaultWriterOptions());
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();  // create segment0
+    writer->RefreshCommit();  // create segment0
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, get_codec(),
                            irs::tests::DefaultReaderOptions()));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();  // create segment1
+    writer->RefreshCommit();  // create segment1
 
     auto reader = writer->GetSnapshot();
     tests::AssertSnapshotEquality(
@@ -9590,8 +9594,8 @@ TEST_P(IndexTestCase, consolidate_progress) {
 
     irs::MergeWriter::FlushProgress progress = []() -> bool { return false; };
 
-    ASSERT_FALSE(writer->Consolidate(policy, get_codec(), progress));
-    writer->Commit();  // write consolidated segment
+    ASSERT_FALSE(writer->Compact(policy, get_codec(), progress));
+    writer->RefreshCommit();  // write compacted segment
     reader = writer->GetSnapshot();
     tests::AssertSnapshotEquality(
       reader, irs::DirectoryReader(dir, get_codec(),
@@ -9615,7 +9619,7 @@ TEST_P(IndexTestCase, consolidate_progress) {
     for (size_t size = 0; size < max_docs; ++size) {
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
     }
-    writer->Commit();  // create segment0
+    writer->RefreshCommit();  // create segment0
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, get_codec(),
@@ -9624,7 +9628,7 @@ TEST_P(IndexTestCase, consolidate_progress) {
     for (size_t size = 0; size < max_docs; ++size) {
       ASSERT_TRUE(InsertWithName(*writer, *doc2));
     }
-    writer->Commit();  // create segment1
+    writer->RefreshCommit();  // create segment1
     auto reader = irs::DirectoryReader(dir, get_codec(),
                                        irs::tests::DefaultReaderOptions());
     tests::AssertSnapshotEquality(writer->GetSnapshot(), reader);
@@ -9639,8 +9643,8 @@ TEST_P(IndexTestCase, consolidate_progress) {
       return true;
     };
 
-    ASSERT_TRUE(writer->Consolidate(policy, get_codec(), progress));
-    writer->Commit();  // write consolidated segment
+    ASSERT_TRUE(writer->Compact(policy, get_codec(), progress));
+    writer->RefreshCommit();  // write compacted segment
     reader = writer->GetSnapshot();
     tests::AssertSnapshotEquality(
       reader, irs::DirectoryReader(dir, get_codec(),
@@ -9663,7 +9667,7 @@ TEST_P(IndexTestCase, consolidate_progress) {
     for (size_t size = 0; size < max_docs; ++size) {
       ASSERT_TRUE(InsertWithName(*writer, *doc1));
     }
-    writer->Commit();  // create segment0
+    writer->RefreshCommit();  // create segment0
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, get_codec(),
@@ -9672,7 +9676,7 @@ TEST_P(IndexTestCase, consolidate_progress) {
     for (size_t size = 0; size < max_docs; ++size) {
       ASSERT_TRUE(InsertWithName(*writer, *doc2));
     }
-    writer->Commit();  // create segment0
+    writer->RefreshCommit();  // create segment0
     auto reader = irs::DirectoryReader(dir, get_codec(),
                                        irs::tests::DefaultReaderOptions());
     tests::AssertSnapshotEquality(writer->GetSnapshot(), reader);
@@ -9685,8 +9689,8 @@ TEST_P(IndexTestCase, consolidate_progress) {
       return --call_count;
     };
 
-    ASSERT_FALSE(writer->Consolidate(policy, get_codec(), progress));
-    writer->Commit();  // write consolidated segment
+    ASSERT_FALSE(writer->Compact(policy, get_codec(), progress));
+    writer->RefreshCommit();  // write compacted segment
 
     reader = irs::DirectoryReader(dir, get_codec(),
                                   irs::tests::DefaultReaderOptions());
@@ -9698,7 +9702,7 @@ TEST_P(IndexTestCase, consolidate_progress) {
   }
 }
 
-TEST_P(IndexTestCase, segment_consolidate) {
+TEST_P(IndexTestCase, segment_compact) {
   tests::JsonDocGenerator gen(
     resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -9716,7 +9720,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
   const tests::Document* doc6 = gen.next();
 
   auto always_merge =
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount());
   constexpr irs::IndexFeatures kAllFeatures = irs::IndexFeatures::Freq |
                                               irs::IndexFeatures::Pos |
                                               irs::IndexFeatures::Offs;
@@ -9729,7 +9733,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     writer->GetBatch().Remove(std::move(query_doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -9744,10 +9748,10 @@ TEST_P(IndexTestCase, segment_consolidate) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -9762,16 +9766,16 @@ TEST_P(IndexTestCase, segment_consolidate) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -9806,15 +9810,15 @@ TEST_P(IndexTestCase, segment_consolidate) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -9849,17 +9853,17 @@ TEST_P(IndexTestCase, segment_consolidate) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -9894,17 +9898,17 @@ TEST_P(IndexTestCase, segment_consolidate) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -9932,9 +9936,9 @@ TEST_P(IndexTestCase, segment_consolidate) {
     ASSERT_FALSE(docs_itr->next());
   }
 
-  auto merge_if_masked = [](irs::Consolidation& candidates,
+  auto merge_if_masked = [](irs::Compaction& candidates,
                             const irs::IndexReader& reader,
-                            const irs::ConsolidatingSegments&) -> void {
+                            const irs::CompactingSegments&) -> void {
     for (auto& segment : reader) {
       if (segment.Meta().live_docs_count != segment.Meta().docs_count) {
         candidates.emplace_back(&segment);
@@ -9951,13 +9955,13 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(merge_if_masked));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(merge_if_masked));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     {
@@ -9978,11 +9982,11 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1));
-    ASSERT_TRUE(writer->Consolidate(merge_if_masked));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(merge_if_masked));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     {
@@ -9993,9 +9997,9 @@ TEST_P(IndexTestCase, segment_consolidate) {
       ASSERT_EQ(2, segment.docs_count());  // total count of documents
     }
 
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       merge_if_masked));  // previous removal now committed and considered
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     {
@@ -10015,15 +10019,15 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -10063,15 +10067,15 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -10111,17 +10115,17 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -10161,17 +10165,17 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -10212,21 +10216,21 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc3_doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -10271,21 +10275,21 @@ TEST_P(IndexTestCase, segment_consolidate) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1_doc3_doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate structure
@@ -10329,7 +10333,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // add 2nd segment
@@ -10350,10 +10354,10 @@ TEST_P(IndexTestCase, segment_consolidate) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1_3));
 
     // defragment segments
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate merged segment
@@ -10408,7 +10412,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // add 2nd segment
@@ -10427,12 +10431,12 @@ TEST_P(IndexTestCase, segment_consolidate) {
     ASSERT_TRUE(InsertWithName(*writer, *doc1_1));
     ASSERT_TRUE(InsertWithName(*writer, *doc1_2));
     ASSERT_TRUE(InsertWithName(*writer, *doc1_3));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // defragment segments
-    ASSERT_TRUE(writer->Consolidate(always_merge));
-    writer->Commit();
+    ASSERT_TRUE(writer->Compact(always_merge));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     // validate merged segment
@@ -10480,7 +10484,7 @@ TEST_P(IndexTestCase, segment_consolidate) {
   }
 }
 
-TEST_P(IndexTestCase, segment_consolidate_policy) {
+TEST_P(IndexTestCase, segment_compact_policy) {
   tests::JsonDocGenerator gen(
     resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -10506,19 +10510,19 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc6));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateBytes options;
+    irs::index_utils::CompactionBytes options;
     options.threshold = 1;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -10583,16 +10587,16 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateBytes options;
+    irs::index_utils::CompactionBytes options;
     options.threshold = 0;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -10654,16 +10658,16 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateBytesAccum options;
+    irs::index_utils::CompactionBytesAccum options;
     options.threshold = 1;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     // segments merged because segment[0] is a candidate and needs to be
     // merged with something
@@ -10700,16 +10704,16 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateBytesAccum options;
+    irs::index_utils::CompactionBytesAccum options;
     options.threshold = 0;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -10775,17 +10779,17 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc2_doc3_doc4));
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateDocsLive options;
+    irs::index_utils::CompactionDocsLive options;
     options.threshold = 1;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     std::unordered_set<std::string_view> expected_name = {"A", "E"};
@@ -10825,17 +10829,17 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc2_doc3_doc4));
     ASSERT_TRUE(InsertWithName(*writer, *doc5));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateDocsLive options;
+    irs::index_utils::CompactionDocsLive options;
     options.threshold = 0;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -10901,20 +10905,20 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc2_doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateDocsFill options;
+    irs::index_utils::CompactionDocsFill options;
     options.threshold = 1;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     std::unordered_set<std::string_view> expected_name = {"A", "C"};
@@ -10951,20 +10955,20 @@ TEST_P(IndexTestCase, segment_consolidate_policy) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc1));
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(InsertWithName(*writer, *doc3));
     ASSERT_TRUE(InsertWithName(*writer, *doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc2_doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
-    irs::index_utils::ConsolidateDocsFill options;
+    irs::index_utils::CompactionDocsFill options;
     options.threshold = 0;
-    ASSERT_TRUE(writer->Consolidate(
+    ASSERT_TRUE(writer->Compact(
       irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -11086,7 +11090,7 @@ TEST_P(IndexTestCase, segment_options) {
     thread.join();
     ASSERT_TRUE(stop);
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -11131,7 +11135,7 @@ TEST_P(IndexTestCase, segment_options) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -11200,7 +11204,7 @@ TEST_P(IndexTestCase, segment_options) {
 
     ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -11277,7 +11281,7 @@ TEST_P(IndexTestCase, segment_options) {
       CaptureNameLikeFields(doc, doc2->indexed);
     }
 
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
     AssertSnapshotEquality(*writer);
 
     auto reader =
@@ -11322,7 +11326,7 @@ TEST_P(IndexTestCase, writer_close) {
       open_writer(irs::kOmCreate, irs::tests::DefaultWriterOptions());
 
     ASSERT_TRUE(InsertWithName(*writer, *doc));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }  // ensure writer is closed
 
@@ -11360,7 +11364,7 @@ TEST_P(IndexTestCase, writer_insert_immediate_remove) {
 
   ASSERT_TRUE(InsertWithName(*writer, *doc3));
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);  // index should be non-empty
 
   size_t count = 0;
@@ -11379,22 +11383,22 @@ TEST_P(IndexTestCase, writer_insert_immediate_remove) {
 
   auto query_doc1 = MakeByTerm("name", "A");
   writer->GetBatch().Remove(*(query_doc1.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
-  // remove for initial segment to trigger consolidation
-  // consolidation is needed to force opening all file handles and make
+  // remove for initial segment to trigger compaction
+  // compaction is needed to force opening all file handles and make
   // cached readers indeed hold reference to a file
   auto query_doc3 = MakeByTerm("name", "C");
   writer->GetBatch().Remove(*(query_doc3.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
-  // this consolidation should bring us to one consolidated segment without
+  // this compaction should bring us to one compacted segment without
   // removals.
-  ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-  writer->Commit();
+  ASSERT_TRUE(writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   // file removal should pass for all files (especially valid for Microsoft
@@ -11422,7 +11426,7 @@ TEST_P(IndexTestCase, writer_insert_immediate_remove_all) {
 
   ASSERT_TRUE(InsertWithName(*writer, *doc3));
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);  // index should be non-empty
   size_t count = 0;
   auto get_number_of_files_in_segments =
@@ -11443,22 +11447,22 @@ TEST_P(IndexTestCase, writer_insert_immediate_remove_all) {
   writer->GetBatch().Remove(*(query_doc1.get()));
   auto query_doc2 = MakeByTerm("name", "B");
   writer->GetBatch().Remove(*(query_doc2.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
-  // remove for initial segment to trigger consolidation
-  // consolidation is needed to force opening all file handles and make
+  // remove for initial segment to trigger compaction
+  // compaction is needed to force opening all file handles and make
   // cached readers indeed hold reference to a file
   auto query_doc3 = MakeByTerm("name", "C");
   writer->GetBatch().Remove(*(query_doc3.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
-  // this consolidation should bring us to one consolidated segment without
+  // this compaction should bring us to one compacted segment without
   // removes.
-  ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-  writer->Commit();
+  ASSERT_TRUE(writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   // file removal should pass for all files (especially valid for Microsoft
@@ -11484,7 +11488,7 @@ TEST_P(IndexTestCase, writer_remove_all_from_last_segment) {
 
   ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);  // index should be non-empty
   size_t count = 0;
   auto get_number_of_files_in_segments =
@@ -11500,7 +11504,7 @@ TEST_P(IndexTestCase, writer_remove_all_from_last_segment) {
   writer->GetBatch().Remove(*(query_doc1.get()));
   auto query_doc2 = MakeByTerm("name", "B");
   writer->GetBatch().Remove(*(query_doc2.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   {
     auto reader =
@@ -11516,14 +11520,14 @@ TEST_P(IndexTestCase, writer_remove_all_from_last_segment) {
     ASSERT_EQ(count, 0);
   }
 
-  // this consolidation should still be ok
-  ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-  writer->Commit();
+  // this compaction should still be ok
+  ASSERT_TRUE(writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 }
 
-TEST_P(IndexTestCase, writer_remove_all_from_last_segment_consolidation) {
+TEST_P(IndexTestCase, writer_remove_all_from_last_segment_compaction) {
   tests::JsonDocGenerator gen(resource("simple_sequential.json"),
                               &tests::GenericJsonFieldFactory);
   auto& directory = dir();
@@ -11538,33 +11542,33 @@ TEST_P(IndexTestCase, writer_remove_all_from_last_segment_consolidation) {
 
   ASSERT_TRUE(InsertWithName(*writer, *doc2));
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);  // segment 1
 
   ASSERT_TRUE(InsertWithName(*writer, *doc3));
 
   ASSERT_TRUE(InsertWithName(*writer, *doc4));
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);  //  segment 2
 
   auto query_doc1 = MakeByTerm("name", "A");
   writer->GetBatch().Remove(*(query_doc1.get()));
   auto query_doc3 = MakeByTerm("name", "C");
   writer->GetBatch().Remove(*(query_doc3.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
-  // this consolidation should bring us to one consolidated segment without
+  // this compaction should bring us to one compacted segment without
   // removes.
-  ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+  ASSERT_TRUE(writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
   // Remove all documents from 'new' segment
   auto query_doc4 = MakeByTerm("name", "D");
   writer->GetBatch().Remove(*(query_doc4.get()));
   auto query_doc2 = MakeByTerm("name", "B");
   writer->GetBatch().Remove(*(query_doc2.get()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   {
     auto reader =
@@ -11585,10 +11589,10 @@ TEST_P(IndexTestCase, writer_remove_all_from_last_segment_consolidation) {
     ASSERT_EQ(count, 0);
   }
 
-  // this consolidation should still be ok
-  ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-  writer->Commit();
+  // this compaction should still be ok
+  ASSERT_TRUE(writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 }
 
@@ -11652,7 +11656,7 @@ TEST_P(IndexTestCase, ensure_no_empty_norms_written) {
       ASSERT_TRUE(doc.Insert(field));
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -11686,7 +11690,7 @@ TEST_P(IndexTestCase, ensure_no_empty_norms_written) {
 
 class IndexTestCase11 : public tests::IndexTestBase {};
 
-TEST_P(IndexTestCase11, consolidate_old_format) {
+TEST_P(IndexTestCase11, compact_old_format) {
   tests::JsonDocGenerator gen(
     resource("simple_sequential.json"),
     [](tests::Document& doc, const std::string& name,
@@ -11713,20 +11717,20 @@ TEST_P(IndexTestCase11, consolidate_old_format) {
   auto writer = open_writer(irs::kOmCreate, writer_options);
   // 1st segment
   ASSERT_TRUE(InsertWithName(*writer, *doc1));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   validate_codec(codec(), 1);
   // 2nd segment
   ASSERT_TRUE(InsertWithName(*writer, *doc2));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   validate_codec(codec(), 2);
-  // consolidate
+  // compact
   auto old_codec = irs::formats::Get("1_5simd");
-  irs::index_utils::ConsolidateCount consolidate_all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all),
-                                  old_codec));
-  writer->Commit();
+  irs::index_utils::CompactionCount compact_all;
+  ASSERT_TRUE(
+    writer->Compact(irs::index_utils::MakePolicy(compact_all), old_codec));
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   validate_codec(old_codec, 1);
 }
@@ -11758,7 +11762,7 @@ TEST_P(IndexTestCase11, clean_writer_with_payload) {
   auto writer = open_writer(irs::kOmCreate, writer_options);
 
   ASSERT_TRUE(InsertWithName(*writer, *doc1));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   size_t file_count0 = 0;
@@ -11800,11 +11804,11 @@ TEST_P(IndexTestCase11, initial_two_phase_commit_no_payload) {
   };
   auto writer = open_writer(irs::kOmCreate, writer_options);
 
-  ASSERT_TRUE(writer->Begin());
+  ASSERT_TRUE(writer->RefreshBegin());
 
   // transaction is already started
   payload_calls_count = 0;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
 
@@ -11813,7 +11817,7 @@ TEST_P(IndexTestCase11, initial_two_phase_commit_no_payload) {
   ASSERT_TRUE(irs::IsNull(irs::GetPayload(reader.Meta().index_meta)));
 
   // no changes
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
   ASSERT_EQ(reader, reader.Reopen());
@@ -11834,7 +11838,7 @@ TEST_P(IndexTestCase11, initial_commit_no_payload) {
   };
   auto writer = open_writer(irs::kOmCreate, writer_options);
 
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   auto reader = irs::DirectoryReader(directory, nullptr,
@@ -11843,7 +11847,7 @@ TEST_P(IndexTestCase11, initial_commit_no_payload) {
 
   // no changes
   payload_calls_count = 0;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
   ASSERT_EQ(reader, reader.Reopen());
@@ -11872,13 +11876,13 @@ TEST_P(IndexTestCase11, initial_two_phase_commit_payload_revert) {
 
   input_payload = irs::ViewCast<irs::byte_type>(std::string_view("init"));
   payload_committed_tick = 42;
-  ASSERT_TRUE(writer->Begin());
+  ASSERT_TRUE(writer->RefreshBegin());
   ASSERT_EQ(0, payload_committed_tick);
 
   payload_provider_result = true;
   // transaction is already started
   payload_calls_count = 0;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
 
@@ -11887,7 +11891,7 @@ TEST_P(IndexTestCase11, initial_two_phase_commit_payload_revert) {
   ASSERT_TRUE(irs::IsNull(irs::GetPayload(reader.Meta().index_meta)));
 
   // no changes
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
   ASSERT_EQ(reader, reader.Reopen());
@@ -11916,7 +11920,7 @@ TEST_P(IndexTestCase11, initial_commit_payload_revert) {
 
   input_payload = irs::ViewCast<irs::byte_type>(std::string_view("init"));
   payload_committed_tick = 42;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_committed_tick);
 
@@ -11927,7 +11931,7 @@ TEST_P(IndexTestCase11, initial_commit_payload_revert) {
   payload_provider_result = true;
   // no changes
   payload_calls_count = 0;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
   ASSERT_EQ(reader, reader.Reopen());
@@ -11955,12 +11959,12 @@ TEST_P(IndexTestCase11, initial_two_phase_commit_payload) {
 
   input_payload = irs::ViewCast<irs::byte_type>(std::string_view("init"));
   payload_committed_tick = 42;
-  ASSERT_TRUE(writer->Begin());
+  ASSERT_TRUE(writer->RefreshBegin());
   ASSERT_EQ(0, payload_committed_tick);
 
   // transaction is already started
   payload_calls_count = 0;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
 
@@ -11969,7 +11973,7 @@ TEST_P(IndexTestCase11, initial_two_phase_commit_payload) {
   ASSERT_EQ(input_payload, irs::GetPayload(reader.Meta().index_meta));
 
   // no changes
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
   ASSERT_EQ(reader, reader.Reopen());
@@ -11997,7 +12001,7 @@ TEST_P(IndexTestCase11, initial_commit_payload) {
 
   input_payload = irs::ViewCast<irs::byte_type>(std::string_view("init"));
   payload_committed_tick = 42;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_committed_tick);
 
@@ -12007,7 +12011,7 @@ TEST_P(IndexTestCase11, initial_commit_payload) {
 
   // no changes
   payload_calls_count = 0;
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(0, payload_calls_count);
   ASSERT_EQ(reader, reader.Reopen());
@@ -12036,15 +12040,16 @@ TEST_P(IndexTestCase11, commit_payload) {
   auto writer = open_writer(irs::kOmCreate, writer_options);
 
   payload_provider_result = false;
-  ASSERT_TRUE(writer->Begin());  // initial commit
-  writer->Commit();
+  ASSERT_TRUE(writer->RefreshBegin());  // initial commit
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   auto reader = irs::DirectoryReader(directory, nullptr,
                                      irs::tests::DefaultReaderOptions());
   ASSERT_TRUE(irs::IsNull(irs::GetPayload(reader.Meta().index_meta)));
 
-  ASSERT_FALSE(writer->Begin());  // transaction hasn't been started, no changes
-  writer->Commit();
+  ASSERT_FALSE(
+    writer->RefreshBegin());  // transaction hasn't been started, no changes
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(reader, reader.Reopen());
   payload_provider_result = true;
@@ -12080,13 +12085,13 @@ TEST_P(IndexTestCase11, commit_payload) {
 
     input_payload =
       irs::ViewCast<irs::byte_type>(std::string_view(reader.Meta().filename));
-    ASSERT_TRUE(writer->Begin());
+    ASSERT_TRUE(writer->RefreshBegin());
     ASSERT_EQ(expected_tick, payload_committed_tick);
 
     // transaction is already started
     ASSERT_NE(0, payload_calls_count);
     payload_calls_count = 0;
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, payload_calls_count);
 
@@ -12129,10 +12134,10 @@ TEST_P(IndexTestCase11, commit_payload) {
 
     input_payload =
       irs::ViewCast<irs::byte_type>(std::string_view(reader.Meta().filename));
-    ASSERT_TRUE(writer->Begin());
+    ASSERT_TRUE(writer->RefreshBegin());
     ASSERT_EQ(expected_tick, payload_committed_tick);
 
-    writer->Rollback();
+    writer->RefreshAbort();
 
     // check payload
     {
@@ -12172,12 +12177,12 @@ TEST_P(IndexTestCase11, commit_payload) {
     input_payload =
       irs::ViewCast<irs::byte_type>(std::string_view(reader.Meta().filename));
     payload_provider_result = false;
-    ASSERT_TRUE(writer->Begin());
+    ASSERT_TRUE(writer->RefreshBegin());
     ASSERT_EQ(expected_tick, payload_committed_tick);
 
     // transaction is already started
     payload_calls_count = 0;
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, payload_calls_count);
 
@@ -12220,13 +12225,13 @@ TEST_P(IndexTestCase11, commit_payload) {
     input_payload.clear();
     payload_provider_result = true;
 
-    ASSERT_TRUE(writer->Begin());
+    ASSERT_TRUE(writer->RefreshBegin());
     ASSERT_EQ(expected_tick, payload_committed_tick);
 
     // transaction is already started
     payload_calls_count = 0;
     input_payload.clear();
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, payload_calls_count);
 
@@ -12255,7 +12260,7 @@ TEST_P(IndexTestCase11, commit_payload) {
       ASSERT_TRUE(doc);
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
@@ -12267,8 +12272,9 @@ TEST_P(IndexTestCase11, commit_payload) {
     reader = new_reader;
   }
 
-  ASSERT_FALSE(writer->Begin());  // transaction hasn't been started, no changes
-  writer->Commit();
+  ASSERT_FALSE(
+    writer->RefreshBegin());  // transaction hasn't been started, no changes
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_EQ(reader, reader.Reopen());
 }
@@ -12307,8 +12313,8 @@ TEST_P(IndexTestCase11, testExternalGeneration) {
     }
     trx.Commit(3);
   }
-  ASSERT_TRUE(writer->Begin());
-  writer->Commit();
+  ASSERT_TRUE(writer->RefreshBegin());
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   auto reader = irs::DirectoryReader(directory, nullptr,
                                      irs::tests::DefaultReaderOptions());
@@ -12359,8 +12365,8 @@ TEST_P(IndexTestCase11, testExternalGenerationDifferentStart) {
     }
     trx.Commit(3);
   }
-  ASSERT_TRUE(writer->Begin());
-  writer->Commit();
+  ASSERT_TRUE(writer->RefreshBegin());
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   writer.reset();
   auto reader = irs::DirectoryReader(directory, nullptr,
@@ -12417,8 +12423,8 @@ TEST_P(IndexTestCase11, testExternalGenerationRemoveBeforeInsert) {
     }
     trx.Commit(4);
   }
-  ASSERT_TRUE(writer->Begin());
-  writer->Commit();
+  ASSERT_TRUE(writer->RefreshBegin());
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   auto reader = irs::DirectoryReader(directory, nullptr,
                                      irs::tests::DefaultReaderOptions());
@@ -12440,7 +12446,7 @@ TEST_P(IndexTestCase14, write_field_with_multiple_stored_features) {
   GTEST_SKIP() << "format-14 codec is no longer registered";
 }
 
-TEST_P(IndexTestCase14, consolidate_multiple_stored_features) {
+TEST_P(IndexTestCase14, compact_multiple_stored_features) {
   GTEST_SKIP() << "format-14 codec is no longer registered";
 }
 

--- a/tests/libs/iresearch/index/merge_writer_tests.cpp
+++ b/tests/libs/iresearch/index/merge_writer_tests.cpp
@@ -174,7 +174,7 @@ void MergeWriterTestCase::EnsureDocBlocksNotMixed(bool primary_sort) {
     insert_documents(segment2, 20, 30);
   }
 
-  ASSERT_TRUE(writer->Commit());
+  ASSERT_TRUE(writer->RefreshCommit());
   AssertSnapshotEquality(
     writer->GetSnapshot(),
     irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
@@ -193,10 +193,10 @@ void MergeWriterTestCase::EnsureDocBlocksNotMixed(bool primary_sort) {
   // 0: 1..10
   // 1: 11..20
   // 2: 21..30
-  const irs::index_utils::ConsolidateCount consolidate_all;
+  const irs::index_utils::CompactionCount compact_all;
   ASSERT_EQ(!primary_sort || SupportsSort(),
-            writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-  ASSERT_EQ(!primary_sort || SupportsSort(), writer->Commit());
+            writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+  ASSERT_EQ(!primary_sort || SupportsSort(), writer->RefreshCommit());
   AssertSnapshotEquality(
     writer->GetSnapshot(),
     irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
@@ -264,7 +264,7 @@ TEST_P(MergeWriterTestCase, test_merge_writer_add_segments) {
     for (auto* doc : docs) {
       ASSERT_NE(nullptr, doc);
       ASSERT_TRUE(Insert(*writer, doc->indexed.begin(), doc->indexed.end()));
-      writer->Commit();  // create segmentN
+      writer->RefreshCommit();  // create segmentN
       AssertSnapshotEquality(writer->GetSnapshot(),
                              irs::DirectoryReader(data_dir, codec_ptr));
     }
@@ -309,11 +309,11 @@ TEST_P(MergeWriterTestCase, test_merge_writer_flush_progress) {
     auto* doc2 = gen.next();
     auto writer = irs::IndexWriter::Make(data_dir, codec_ptr, irs::kOmCreate);
     ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
-    writer->Commit();  // create segment0
+    writer->RefreshCommit();  // create segment0
     AssertSnapshotEquality(writer->GetSnapshot(),
                            irs::DirectoryReader(data_dir, codec_ptr));
     ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
-    writer->Commit();  // create segment1
+    writer->RefreshCommit();  // create segment1
     AssertSnapshotEquality(writer->GetSnapshot(),
                            irs::DirectoryReader(data_dir, codec_ptr));
   }
@@ -454,11 +454,11 @@ TEST_P(MergeWriterTestCase, test_merge_writer_field_features) {
   {
     auto writer = irs::IndexWriter::Make(dir, codec_ptr, irs::kOmCreate);
     ASSERT_TRUE(Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(writer->GetSnapshot(),
                            irs::DirectoryReader(dir, codec_ptr));
     ASSERT_TRUE(Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(writer->GetSnapshot(),
                            irs::DirectoryReader(dir, codec_ptr));
   }
@@ -712,18 +712,18 @@ TEST_P(MergeWriterTestCase, test_merge_writer) {
 
     ASSERT_TRUE(Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
     ASSERT_TRUE(Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
     ASSERT_TRUE(Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
     ASSERT_TRUE(Insert(*writer, doc4.indexed.begin(), doc4.indexed.end()));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
     writer->GetBatch().Remove(std::move(query_doc4));
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
@@ -1669,7 +1669,7 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns) {
         irs::tests::StoreFieldAt(*doc.Columnstore(), kTextId, doc.DocId(), t);
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     {
       auto seg = writer->GetBatch();
       for (size_t i = 2; i < 4; ++i) {
@@ -1685,7 +1685,7 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns) {
         irs::tests::StoreFieldAt(*doc.Columnstore(), kTextId, doc.DocId(), t);
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
   }
 
   // Pre-merge source-segment verification: each of the two segments
@@ -1764,9 +1764,9 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns) {
   {
     auto writer = irs::IndexWriter::Make(dir, codec_ptr, irs::kOmAppend,
                                          irs::tests::DefaultWriterOptions());
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{})));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount{})));
+    ASSERT_TRUE(writer->RefreshCommit());
   }
 
   auto merged_reader =
@@ -1927,7 +1927,7 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns) {
 }
 
 // Three docs share doc_int + doc_string columns; the fourth doc has an
-// exclusive `another_column`. Removing doc4 before consolidation must
+// exclusive `another_column`. Removing doc4 before compaction must
 // either drop `another_column` from the merged segment or keep the
 // slot with all-null rows -- in any case every surviving live doc must
 // continue to read its doc_string + doc_int payload intact. Mirrors
@@ -1967,7 +1967,7 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns_remove) {
         irs::tests::StoreFieldAt(*doc.Columnstore(), kIntId, doc.DocId(), n);
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     // Segment 1: doc2 (string + int) and doc4 (string + another_column).
     {
       auto seg = writer->GetBatch();
@@ -1991,9 +1991,9 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns_remove) {
                                  a);
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     writer->GetBatch().Remove(MakeByTerm("doc_string", "string4_data"));
-    writer->Commit();
+    writer->RefreshCommit();
   }
 
   // Pre-merge inspection. Track which segment doc3 ended up in -- the
@@ -2083,13 +2083,13 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns_remove) {
     }
   }
 
-  // Consolidate to a single segment.
+  // Compact to a single segment.
   {
     auto writer = irs::IndexWriter::Make(dir, codec_ptr, irs::kOmAppend,
                                          irs::tests::DefaultWriterOptions());
-    ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{})));
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->Compact(
+      irs::index_utils::MakePolicy(irs::index_utils::CompactionCount{})));
+    ASSERT_TRUE(writer->RefreshCommit());
   }
 
   auto merged_reader =
@@ -2229,7 +2229,7 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns_remove) {
           irs::tests::StoreFieldAt(*d.Columnstore(), kAnotherId, d.DocId(), a);
         }
       }
-      writer->Commit();
+      writer->RefreshCommit();
       // Segment 1: doc3, doc4 -- same shape.
       {
         auto seg = writer->GetBatch();
@@ -2247,20 +2247,20 @@ TEST_P(MergeWriterTestCase, test_merge_writer_columns_remove) {
           irs::tests::StoreFieldAt(*d.Columnstore(), kAnotherId, d.DocId(), a);
         }
       }
-      writer->Commit();
+      writer->RefreshCommit();
       // Remove doc2 -- still leaves the other two columns (doc_int,
       // another_column) populated in every remaining live doc.
       writer->GetBatch().Remove(MakeByTerm("doc_string", "string2_data"));
-      writer->Commit();
+      writer->RefreshCommit();
     }
 
-    // Consolidate.
+    // Compact.
     {
       auto writer = irs::IndexWriter::Make(dir2, codec_ptr, irs::kOmAppend,
                                            irs::tests::DefaultWriterOptions());
-      ASSERT_TRUE(writer->Consolidate(
-        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{})));
-      ASSERT_TRUE(writer->Commit());
+      ASSERT_TRUE(writer->Compact(
+        irs::index_utils::MakePolicy(irs::index_utils::CompactionCount{})));
+      ASSERT_TRUE(writer->RefreshCommit());
     }
 
     auto reader2 =

--- a/tests/libs/iresearch/index/norm_test.cpp
+++ b/tests/libs/iresearch/index/norm_test.cpp
@@ -199,7 +199,7 @@ TEST_P(NormTestCase, CheckNorms) {
   ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   // Create expected index
@@ -309,7 +309,7 @@ TEST_P(NormTestCase, CheckNormsBatched) {
   for (const auto* d : docs) {
     ASSERT_TRUE(Insert(*writer, d->indexed.begin(), d->indexed.end()));
   }
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   // Create expected index
@@ -371,7 +371,7 @@ TEST_P(NormTestCase, CheckNormsBatched) {
   }
 }
 
-TEST_P(NormTestCase, CheckNormsConsolidation) {
+TEST_P(NormTestCase, CheckNormsCompaction) {
   const absl::flat_hash_map<std::string_view, uint32_t> seed_mapping{
     {"name", uint32_t{1}},
     {"same", uint32_t{1} << 5},
@@ -417,12 +417,12 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
   ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_TRUE(Insert(*writer, doc4->indexed.begin(), doc4->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc5->indexed.begin(), doc5->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc6->indexed.begin(), doc6->indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   // Create expected index
@@ -533,15 +533,14 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
     }
   }
 
-  // Consolidate segments
+  // Compact segments
   {
-    const irs::index_utils::ConsolidateCount consolidate_all;
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    writer->Commit();
+    const irs::index_utils::CompactionCount compact_all;
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
-    // Simulate consolidation
+    // Simulate compaction
     index().clear();
     index().emplace_back();
     expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
@@ -622,7 +621,7 @@ TEST_P(NormTestCase, CheckNormsConsolidation) {
   }
 }
 
-TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
+TEST_P(NormTestCase, CheckNormsCompactionWithRemovals) {
   const absl::flat_hash_map<std::string_view, uint32_t> seed_mapping{
     {"name", uint32_t{1}},
     {"same", uint32_t{1} << 5},
@@ -668,12 +667,12 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
   ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
   ASSERT_TRUE(Insert(*writer, doc4->indexed.begin(), doc4->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc5->indexed.begin(), doc5->indexed.end()));
   ASSERT_TRUE(Insert(*writer, doc6->indexed.begin(), doc6->indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
   // Create expected index
@@ -788,19 +787,18 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
   {
     auto query_doc3 = MakeByTerm("name", "D");
     writer->GetBatch().Remove(*query_doc3);
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 
-  // Consolidate segments
+  // Compact segments
   {
-    const irs::index_utils::ConsolidateCount consolidate_all;
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    writer->Commit();
+    const irs::index_utils::CompactionCount compact_all;
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
 
-    // Simulate consolidation
+    // Simulate compaction
     index().clear();
     index().emplace_back();
     expected_index.back().insert(doc0->indexed.begin(), doc0->indexed.end(),
@@ -878,15 +876,14 @@ TEST_P(NormTestCase, CheckNormsConsolidationWithRemovals) {
   }
 
   ASSERT_TRUE(Insert(*writer, doc0->indexed.begin(), doc0->indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
   AssertSnapshotEquality(*writer);
 
-  // Consolidate segments
+  // Compact segments
   {
-    const irs::index_utils::ConsolidateCount consolidate_all;
-    ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-    writer->Commit();
+    const irs::index_utils::CompactionCount compact_all;
+    ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/index/sorted_index_tests.cpp
+++ b/tests/libs/iresearch/index/sorted_index_tests.cpp
@@ -52,7 +52,7 @@ TEST_P(SortedIndexTestCase, reader_components) {
   GTEST_SKIP() << kSortedReason;
 }
 
-TEST_P(SortedIndexTestCase, simple_sequential_consolidate) {
+TEST_P(SortedIndexTestCase, simple_sequential_compact) {
   GTEST_SKIP() << kSortedReason;
 }
 
@@ -70,12 +70,12 @@ TEST_P(SortedIndexTestCase, multi_valued_sorting_field) {
   GTEST_SKIP() << kSortedReason;
 }
 
-TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_dense) {
+TEST_P(SortedIndexTestCase, check_document_order_after_compaction_dense) {
   GTEST_SKIP() << kSortedReason;
 }
 
 TEST_P(SortedIndexTestCase,
-       check_document_order_after_consolidation_dense_with_removals) {
+       check_document_order_after_compaction_dense_with_removals) {
   GTEST_SKIP() << kSortedReason;
 }
 
@@ -88,21 +88,21 @@ TEST_P(SortedIndexTestCase, doc_removal_same_key_within_trx_flush) {
 }
 
 TEST_P(SortedIndexTestCase,
-       check_document_order_after_consolidation_sparse_with_gaps) {
+       check_document_order_after_compaction_sparse_with_gaps) {
   GTEST_SKIP() << kSortedReason;
 }
 
-TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_sparse) {
-  GTEST_SKIP() << kSortedReason;
-}
-
-TEST_P(SortedIndexTestCase,
-       check_document_order_after_consolidation_sparse_already_sorted) {
+TEST_P(SortedIndexTestCase, check_document_order_after_compaction_sparse) {
   GTEST_SKIP() << kSortedReason;
 }
 
 TEST_P(SortedIndexTestCase,
-       check_document_order_after_consolidation_sparse_with_removals) {
+       check_document_order_after_compaction_sparse_already_sorted) {
+  GTEST_SKIP() << kSortedReason;
+}
+
+TEST_P(SortedIndexTestCase,
+       check_document_order_after_compaction_sparse_with_removals) {
   GTEST_SKIP() << kSortedReason;
 }
 

--- a/tests/libs/iresearch/search/block_scoring_test.cpp
+++ b/tests/libs/iresearch/search/block_scoring_test.cpp
@@ -246,7 +246,7 @@ class BlockScoringTestCase : public IndexTestBase {
       index.emplace_back();
       write_segment(writer, index.back(), gen, &StoreScoringFields);
     }
-    writer.Commit();
+    writer.RefreshCommit();
   }
 
   // Create single segment from multiple JSON files (420 total docs)
@@ -281,7 +281,7 @@ class BlockScoringTestCase : public IndexTestBase {
                                   &BlockScoringFieldFactory);
       index_ref.emplace_back();
       write_segment(*writer, index_ref.back(), gen, &StoreScoringFields);
-      writer->Commit();
+      writer->RefreshCommit();
     }
 
     // Segment 2
@@ -290,7 +290,7 @@ class BlockScoringTestCase : public IndexTestBase {
                                   &BlockScoringFieldFactory);
       index_ref.emplace_back();
       write_segment(*writer, index_ref.back(), gen, &StoreScoringFields);
-      writer->Commit();
+      writer->RefreshCommit();
     }
 
     // Segment 3
@@ -299,7 +299,7 @@ class BlockScoringTestCase : public IndexTestBase {
                                   &BlockScoringFieldFactory);
       index_ref.emplace_back();
       write_segment(*writer, index_ref.back(), gen, &StoreScoringFields);
-      writer->Commit();
+      writer->RefreshCommit();
     }
 
     auto reader =

--- a/tests/libs/iresearch/search/bm25_test.cpp
+++ b/tests/libs/iresearch/search/bm25_test.cpp
@@ -654,7 +654,7 @@ TEST_P(Bm25TestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -669,7 +669,7 @@ TEST_P(Bm25TestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -765,7 +765,7 @@ TEST_P(Bm25TestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -780,7 +780,7 @@ TEST_P(Bm25TestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -885,7 +885,7 @@ TEST_P(Bm25TestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -900,7 +900,7 @@ TEST_P(Bm25TestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -1426,7 +1426,7 @@ TEST_P(Bm25TestCase, test_collector_serialization) {
       store_seq(d, *doc);
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/search/boolean_filter_tests.cpp
+++ b/tests/libs/iresearch/search/boolean_filter_tests.cpp
@@ -15082,7 +15082,7 @@ TEST_P(BooleanFilterTestCase, or_sequential_multiple_segments) {
       Insert(*writer, doc3->indexed.begin(), doc3->indexed.end()));  // C
     ASSERT_TRUE(
       Insert(*writer, doc4->indexed.begin(), doc4->indexed.end()));  // D
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(
       Insert(*writer, doc5->indexed.begin(), doc5->indexed.end()));  // E
@@ -15090,13 +15090,13 @@ TEST_P(BooleanFilterTestCase, or_sequential_multiple_segments) {
       Insert(*writer, doc6->indexed.begin(), doc6->indexed.end()));  // F
     ASSERT_TRUE(
       Insert(*writer, doc7->indexed.begin(), doc7->indexed.end()));  // G
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
     ASSERT_TRUE(
       Insert(*writer, doc8->indexed.begin(), doc8->indexed.end()));  // H
     ASSERT_TRUE(
       Insert(*writer, doc9->indexed.begin(), doc9->indexed.end()));  // I
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/search/boost_query_test.cpp
+++ b/tests/libs/iresearch/search/boost_query_test.cpp
@@ -104,7 +104,7 @@ class BoostQueryTestCase : public tests::IndexTestBase {
     insert("open source software");
     insert("source software");
 
-    writer->Commit();
+    writer->RefreshCommit();
 
     auto reader = irs::DirectoryReader(dir(), codec());
     EXPECT_EQ(1, reader.size());

--- a/tests/libs/iresearch/search/dfi_test.cpp
+++ b/tests/libs/iresearch/search/dfi_test.cpp
@@ -117,7 +117,7 @@ void DFIIndexTest::BuildFixture() {
   ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
 }
 
 TEST_P(DFIIndexTest, scores_nonnegative_and_only_fire_above_expected) {

--- a/tests/libs/iresearch/search/doc_collector_test.cpp
+++ b/tests/libs/iresearch/search/doc_collector_test.cpp
@@ -237,7 +237,7 @@ TEST_P(DocCollectorTestCase, test_execute_topk_multi_segment) {
         ASSERT_TRUE(Insert(*writer, doc->indexed.begin(), doc->indexed.end()));
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -249,7 +249,7 @@ TEST_P(DocCollectorTestCase, test_execute_topk_multi_segment) {
         ASSERT_TRUE(Insert(*writer, doc->indexed.begin(), doc->indexed.end()));
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
   }

--- a/tests/libs/iresearch/search/geo_distance_filter_test.cpp
+++ b/tests/libs/iresearch/search/geo_distance_filter_test.cpp
@@ -455,7 +455,7 @@ TEST(GeoDistanceFilterTest, query) {
         }
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     reader = writer->GetSnapshot();
   }
 
@@ -993,7 +993,7 @@ TEST(GeoDistanceFilterTest, checkScorer) {
         }
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     reader = writer->GetSnapshot();
   }
 

--- a/tests/libs/iresearch/search/geo_filter_test.cpp
+++ b/tests/libs/iresearch/search/geo_filter_test.cpp
@@ -365,7 +365,7 @@ TEST(GeoFilterTest, query) {
         }
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     reader = writer->GetSnapshot();
   }
 
@@ -752,7 +752,7 @@ TEST(GeoFilterTest, checkScorer) {
         }
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     reader = writer->GetSnapshot();
   }
 

--- a/tests/libs/iresearch/search/granular_range_filter_tests.cpp
+++ b/tests/libs/iresearch/search/granular_range_filter_tests.cpp
@@ -1936,7 +1936,7 @@ TEST_P(GranularRangeFilterTestCase, by_range_order_multiple_sorts) {
 
       write_segment(*writer, segment, gen);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/search/index_reader_test.cpp
+++ b/tests/libs/iresearch/search/index_reader_test.cpp
@@ -80,7 +80,7 @@ TEST(directory_reader_test, open_empty_index) {
   // Create empty index
   {
     auto writer = irs::IndexWriter::Make(dir, codec, irs::kOmCreate);
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
   }
 
   auto rdr = irs::DirectoryReader(dir, codec);
@@ -129,7 +129,7 @@ TEST(directory_reader_test, open_newest_index) {
       return nullptr;
     }
     irs::PostingsWriter::ptr get_postings_writer(
-      bool consolidation, irs::IResourceManager&) const final {
+      bool compaction, irs::IResourceManager&) const final {
       return nullptr;
     }
     irs::PostingsReader::ptr get_postings_reader() const final {
@@ -241,7 +241,7 @@ TEST(directory_reader_test, open) {
       ASSERT_TRUE(d.Insert(doc3->indexed.begin(), doc3->indexed.end()));
       StoreName()(d, *doc3);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
@@ -271,7 +271,7 @@ TEST(directory_reader_test, open) {
       ASSERT_TRUE(d.Insert(doc7->indexed.begin(), doc7->indexed.end()));
       StoreName()(d, *doc7);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
@@ -289,7 +289,7 @@ TEST(directory_reader_test, open) {
       ASSERT_TRUE(d.Insert(doc9->indexed.begin(), doc9->indexed.end()));
       StoreName()(d, *doc9);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     tests::AssertSnapshotEquality(
       writer->GetSnapshot(),
       irs::DirectoryReader(dir, codec_ptr, irs::tests::DefaultReaderOptions()));
@@ -532,7 +532,7 @@ TEST(segment_reader_test, open) {
       ASSERT_TRUE(d.Insert(doc5->indexed.begin(), doc5->indexed.end()));
       StoreName()(d, *doc5);
     }
-    writer->Commit();
+    writer->RefreshCommit();
     writer_snapshot = writer->GetSnapshot();
   }
 

--- a/tests/libs/iresearch/search/indri_dirichlet_test.cpp
+++ b/tests/libs/iresearch/search/indri_dirichlet_test.cpp
@@ -103,7 +103,7 @@ void IndriDirichletIndexTest::BuildFixture() {
   ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
 }
 
 TEST_P(IndriDirichletIndexTest, scores_are_finite) {

--- a/tests/libs/iresearch/search/lm_test.cpp
+++ b/tests/libs/iresearch/search/lm_test.cpp
@@ -192,7 +192,7 @@ void LMIndexTest::BuildFixture() {
   ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
 }
 
 namespace {

--- a/tests/libs/iresearch/search/nested_filter_test.cpp
+++ b/tests/libs/iresearch/search/nested_filter_test.cpp
@@ -440,7 +440,7 @@ void NestedFilterTestCase::InitDataSet() {
                          {"CPU", 1000, 2},
                          {"RAM", 5000, 2}}});
 
-  ASSERT_TRUE(writer->Commit());
+  ASSERT_TRUE(writer->RefreshCommit());
   AssertSnapshotEquality(*writer);
 
   auto reader = open_reader(irs::tests::DefaultReaderOptions());

--- a/tests/libs/iresearch/search/proxy_filter_test.cpp
+++ b/tests/libs/iresearch/search/proxy_filter_test.cpp
@@ -149,7 +149,7 @@ class ProxyFilterTestCase : public ::testing::TestWithParam<size_t> {
         doc.Insert(*field);
       }
     }
-    writer->Commit();
+    writer->RefreshCommit();
     _index = irs::DirectoryReader(_dir, codec);
     AssertSnapshotEquality(writer->GetSnapshot(), _index);
   }

--- a/tests/libs/iresearch/search/raw_tf_test.cpp
+++ b/tests/libs/iresearch/search/raw_tf_test.cpp
@@ -92,7 +92,7 @@ void RawTfIndexTest::BuildFixture() {
   ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
   ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
-  writer->Commit();
+  writer->RefreshCommit();
 }
 
 TEST_P(RawTfIndexTest, scores_match_freq) {

--- a/tests/libs/iresearch/search/regexp_filter_test.cpp
+++ b/tests/libs/iresearch/search/regexp_filter_test.cpp
@@ -995,9 +995,9 @@ TEST_P(RegexpFilterTestCase, by_regexp_two_segments) {
   CheckQuery(MakeFilter("nonexistent", ".*"), Docs{}, rdr);
 }
 
-// Consolidation
+// Compaction
 
-TEST_P(RegexpFilterTestCase, by_regexp_consolidation) {
+TEST_P(RegexpFilterTestCase, by_regexp_compaction) {
   auto writer = open_writer();
   {
     tests::JsonDocGenerator gen(resource("simple_sequential.json"),
@@ -1018,9 +1018,9 @@ TEST_P(RegexpFilterTestCase, by_regexp_consolidation) {
     }
     CheckQuery(MakeFilter("same", ".*"), all, rdr);
   }
-  ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
-  writer->Commit();
+  ASSERT_TRUE(writer->Compact(
+    irs::index_utils::MakePolicy(irs::index_utils::CompactionCount())));
+  writer->RefreshCommit();
   {
     auto rdr = open_reader();
     ASSERT_EQ(1, rdr.size());

--- a/tests/libs/iresearch/search/search_bench_test.cpp
+++ b/tests/libs/iresearch/search/search_bench_test.cpp
@@ -424,10 +424,10 @@ void BuildIndex(const std::string& corpus_path,
   bench::IndexBuilderOptions builder_options{
     .batch_size = 100000,
     .indexer_threads = 1,
-    .commit_interval_ms = 0,
-    .consolidation_interval_ms = 5000,
-    .consolidation_threads = 0,
-    .consolidate_all = true,
+    .refresh_interval_ms = 0,
+    .compaction_interval_ms = 5000,
+    .compaction_threads = 0,
+    .compact_all = true,
     .norm_row_group_size = 10'000'000,
   };
 

--- a/tests/libs/iresearch/search/tfidf_test.cpp
+++ b/tests/libs/iresearch/search/tfidf_test.cpp
@@ -666,7 +666,7 @@ TEST_P(TfidfTestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -681,7 +681,7 @@ TEST_P(TfidfTestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -775,7 +775,7 @@ TEST_P(TfidfTestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -790,7 +790,7 @@ TEST_P(TfidfTestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -897,7 +897,7 @@ TEST_P(TfidfTestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -912,7 +912,7 @@ TEST_P(TfidfTestCase, test_query) {
         store_seq(d, *doc);
         gen.next();  // skip 1 doc
       }
-      writer->Commit();
+      writer->RefreshCommit();
       AssertSnapshotEquality(*writer);
     }
 
@@ -1444,7 +1444,7 @@ TEST_P(TfidfTestCase, test_collector_serialization) {
       store_seq(d, *doc);
     }
 
-    writer->Commit();
+    writer->RefreshCommit();
     AssertSnapshotEquality(*writer);
   }
 

--- a/tests/libs/iresearch/search/wand_norm_merge_test.cpp
+++ b/tests/libs/iresearch/search/wand_norm_merge_test.cpp
@@ -23,12 +23,12 @@
 // adds the shapes the bench is likely actually hitting:
 //   * multi-row-group norm columns (small `norm_row_group_size`),
 //   * RGs with mixed byte_size on the same column,
-//   * mismatched per-source byte widths during consolidation,
-//   * removals before consolidation (mask-filter on the norm merge),
+//   * mismatched per-source byte widths during compaction,
+//   * removals before compaction (mask-filter on the norm merge),
 //   * multiple norm-bearing fields in one segment.
 //
 // Each test exercises: write -> read-norm -> BM25 wand vs no-wand -> ...
-// optional consolidate -> read-norm -> BM25 wand vs no-wand.
+// optional compact -> read-norm -> BM25 wand vs no-wand.
 
 #include <gtest/gtest.h>
 
@@ -297,7 +297,7 @@ class WandNormMergeCase : public tests::IndexTestBase {
 // Baseline that already passed before this round of expansion. Kept to
 // catch regressions on the simplest end of the surface.
 // -------------------------------------------------------------------------
-TEST_P(WandNormMergeCase, BasicBM25WandRoundTripAcrossConsolidate) {
+TEST_P(WandNormMergeCase, BasicBM25WandRoundTripAcrossCompact) {
   static constexpr uint32_t kCountsA[] = {1, 2, 3, 4};
   static constexpr uint32_t kCountsB[] = {5, 6, 7, 8};
 
@@ -309,11 +309,11 @@ TEST_P(WandNormMergeCase, BasicBM25WandRoundTripAcrossConsolidate) {
   for (auto c : kCountsA) {
     ASSERT_TRUE(InsertNormDoc(*writer, "a", c));
   }
-  writer->Commit();
+  writer->RefreshCommit();
   for (auto c : kCountsB) {
     ASSERT_TRUE(InsertNormDoc(*writer, "b", c));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   std::vector<irs::score_t> pre_scores;
   {
@@ -328,9 +328,9 @@ TEST_P(WandNormMergeCase, BasicBM25WandRoundTripAcrossConsolidate) {
     pre_scores = Scores(RunBM25(reader, *bm25, kBody, 8));
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   {
     auto reader = open_reader(MakeReaderOpts(bm25.get()));
@@ -368,7 +368,7 @@ TEST_P(WandNormMergeCase, NormMultiRgInOneSegment) {
   for (size_t i = 0; i < std::size(kCounts); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("doc_", i), kCounts[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -397,7 +397,7 @@ TEST_P(WandNormMergeCase, NormMultiRgInOneSegment) {
 }
 
 // -------------------------------------------------------------------------
-// Multi-RG per segment + consolidation. The merge writes a single output
+// Multi-RG per segment + compaction. The merge writes a single output
 // norm column built from per-source byte spans; if the merge mishandles
 // RG boundaries or row offsets, per-doc Get(row) returns stale data.
 // -------------------------------------------------------------------------
@@ -413,11 +413,11 @@ TEST_P(WandNormMergeCase, NormMultiRgAcrossMerge) {
   for (size_t i = 0; i < std::size(kA); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("a_", i), kA[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
   for (size_t i = 0; i < std::size(kB); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("b_", i), kB[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   std::vector<irs::score_t> pre_scores;
   {
@@ -426,9 +426,9 @@ TEST_P(WandNormMergeCase, NormMultiRgAcrossMerge) {
     pre_scores = Scores(RunBM25(reader, *bm25, kBody, 16));
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -447,7 +447,7 @@ TEST_P(WandNormMergeCase, NormMultiRgAcrossMerge) {
 
   auto post_scores = Scores(RunBM25(reader, *bm25, kBody, 16));
   ASSERT_EQ(pre_scores, post_scores)
-    << "BM25 score set diverged across multi-RG consolidation";
+    << "BM25 score set diverged across multi-RG compaction";
 }
 
 // -------------------------------------------------------------------------
@@ -468,11 +468,11 @@ TEST_P(WandNormMergeCase, NormMixedByteWidthsMerge) {
   for (size_t i = 0; i < std::size(kA); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("a_", i), kA[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
   for (size_t i = 0; i < std::size(kB); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("b_", i), kB[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   // Read pre-merge norms.
   {
@@ -483,9 +483,9 @@ TEST_P(WandNormMergeCase, NormMixedByteWidthsMerge) {
     AssertNorms(reader[1], kBody, {{1, kB[0]}, {2, kB[1]}, {3, kB[2]}});
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -502,7 +502,7 @@ TEST_P(WandNormMergeCase, NormMixedByteWidthsMerge) {
 }
 
 // -------------------------------------------------------------------------
-// Deletes before consolidation: MergeNormColumnFromSources's mask filter
+// Deletes before compaction: MergeNormColumnFromSources's mask filter
 // must skip the per-row bytes of removed docs and produce a compacted
 // merged column. If the mask path mis-counts bytes, post-merge norms
 // shift by the wrong offset.
@@ -518,7 +518,7 @@ TEST_P(WandNormMergeCase, NormMergeWithMask) {
   for (size_t i = 0; i < std::size(kA); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("a_", i), kA[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   // Remove "a_1" (count=2) and "a_3" (count=4) from segment A. The
   // filter must outlive Commit() per IndexWriter::Transaction::Remove
@@ -527,12 +527,12 @@ TEST_P(WandNormMergeCase, NormMergeWithMask) {
   auto rm2 = MakeByTerm(kId, "a_3");
   writer->GetBatch().Remove(*rm1);
   writer->GetBatch().Remove(*rm2);
-  writer->Commit();
+  writer->RefreshCommit();
 
   for (size_t i = 0; i < std::size(kB); ++i) {
     ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("b_", i), kB[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   // Pre-merge: segment A still has 5 docs but live_count=3.
   {
@@ -543,9 +543,9 @@ TEST_P(WandNormMergeCase, NormMergeWithMask) {
     ASSERT_EQ(3, reader[1].docs_count());
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -579,12 +579,12 @@ TEST_P(WandNormMergeCase, NormTwoFieldsAcrossMerge) {
     ASSERT_TRUE(
       InsertDualNormDoc(*writer, absl::StrCat("a_", i), kBodyA[i], kBody2A[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
   for (size_t i = 0; i < std::size(kBodyB); ++i) {
     ASSERT_TRUE(
       InsertDualNormDoc(*writer, absl::StrCat("b_", i), kBodyB[i], kBody2B[i]));
   }
-  writer->Commit();
+  writer->RefreshCommit();
 
   // Pre-merge: each field's norm column is independent per segment.
   {
@@ -598,9 +598,9 @@ TEST_P(WandNormMergeCase, NormTwoFieldsAcrossMerge) {
     AssertNorms(reader[1], kBody2, {{1, kBody2B[0]}, {2, kBody2B[1]}});
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -622,14 +622,14 @@ TEST_P(WandNormMergeCase, NormTwoFieldsAcrossMerge) {
 }
 
 // -------------------------------------------------------------------------
-// 16 source segments consolidated in one shot. Mirrors the
+// 16 source segments compacted in one shot. Mirrors the
 // search-benchmark-game ingest pattern: ~15-17 commit-per-batch segments,
-// then a single `ConsolidateCount` merges them all. If any cross-source
+// then a single `CompactionCount` merges them all. If any cross-source
 // state in the norm merge (running merged_row, byte_size promotion,
 // per-source NormColumnReader cache) gets confused with more than 2
 // sources, this is where it surfaces.
 // -------------------------------------------------------------------------
-TEST_P(WandNormMergeCase, NormMultiSegmentConsolidate) {
+TEST_P(WandNormMergeCase, NormMultiSegmentCompact) {
   static constexpr size_t kSegments = 16;
   static constexpr size_t kDocsPerSeg = 5;
 
@@ -652,7 +652,7 @@ TEST_P(WandNormMergeCase, NormMultiSegmentConsolidate) {
       expected_counts.push_back(count);
       ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("s", s, "_d", d), count));
     }
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
   }
 
   // Pre-merge: kSegments separate segments, each with its own NormColumn.
@@ -671,17 +671,17 @@ TEST_P(WandNormMergeCase, NormMultiSegmentConsolidate) {
     pre_scores = Scores(RunBM25(reader, *bm25, kBody, kSegments * kDocsPerSeg));
   }
 
-  // Single-shot ConsolidateCount with default max merges everything.
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  // Single-shot CompactionCount with default max merges everything.
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   // Post-merge: ONE segment, per-doc norms equal to expected_counts in
   // source-iteration order (no deletes -> identity remap, doc ids
   // contiguous 1..N).
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size())
-    << "consolidate-all did not produce a single merged segment";
+    << "compact-all did not produce a single merged segment";
   const auto& seg = reader[0];
   ASSERT_EQ(expected_counts.size(), seg.docs_count());
 
@@ -693,15 +693,15 @@ TEST_P(WandNormMergeCase, NormMultiSegmentConsolidate) {
 
   auto post_scores =
     Scores(RunBM25(reader, *bm25, kBody, kSegments * kDocsPerSeg));
-  ASSERT_EQ(pre_scores, post_scores) << "BM25 score multiset diverged after "
-                                     << kSegments << "-way consolidate-all";
+  ASSERT_EQ(pre_scores, post_scores)
+    << "BM25 score multiset diverged after " << kSegments << "-way compact-all";
 }
 
 // -------------------------------------------------------------------------
 // 16 sources, multi-RG per source, AND cross-byte-width: the combination
 // the bench actually drives.
 // -------------------------------------------------------------------------
-TEST_P(WandNormMergeCase, NormMultiSegmentMultiRgMixedWidthsConsolidate) {
+TEST_P(WandNormMergeCase, NormMultiSegmentMultiRgMixedWidthsCompact) {
   static constexpr size_t kSegments = 16;
   static constexpr size_t kDocsPerSeg = 7;  // multi-RG with RG=3
   static constexpr size_t kRgSize = 3;
@@ -723,7 +723,7 @@ TEST_P(WandNormMergeCase, NormMultiSegmentMultiRgMixedWidthsConsolidate) {
       expected_counts.push_back(count);
       ASSERT_TRUE(InsertNormDoc(*writer, absl::StrCat("s", s, "_d", d), count));
     }
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
   }
 
   std::vector<irs::score_t> pre_scores;
@@ -741,9 +741,9 @@ TEST_P(WandNormMergeCase, NormMultiSegmentMultiRgMixedWidthsConsolidate) {
     pre_scores = Scores(RunBM25(reader, *bm25, kBody, kSegments * kDocsPerSeg));
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -800,7 +800,7 @@ TEST_P(WandNormMergeCase, BenchShape16SegmentsRealisticTfDl) {
       ASSERT_TRUE(
         InsertMixedDoc(*writer, absl::StrCat("s", s, "_d", d), tf, filler));
     }
-    ASSERT_TRUE(writer->Commit());
+    ASSERT_TRUE(writer->RefreshCommit());
   }
 
   // Pre-merge: norms match (tf, dl) per doc on each segment.
@@ -820,9 +820,9 @@ TEST_P(WandNormMergeCase, BenchShape16SegmentsRealisticTfDl) {
     pre_scores = Scores(RunBM25(reader, *bm25, kBody, 50));
   }
 
-  const irs::index_utils::ConsolidateCount all;
-  ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(all)));
-  ASSERT_TRUE(writer->Commit());
+  const irs::index_utils::CompactionCount all;
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(all)));
+  ASSERT_TRUE(writer->RefreshCommit());
 
   auto reader = open_reader(MakeReaderOpts(bm25.get()));
   ASSERT_EQ(1, reader.size());
@@ -839,7 +839,7 @@ TEST_P(WandNormMergeCase, BenchShape16SegmentsRealisticTfDl) {
 
   auto post_scores = Scores(RunBM25(reader, *bm25, kBody, 50));
   ASSERT_EQ(pre_scores, post_scores)
-    << "BM25 score multiset diverged on bench-shaped consolidation with"
+    << "BM25 score multiset diverged on bench-shaped compaction with"
     << " independent tf/dl";
 }
 

--- a/tests/libs/iresearch/search/wand_scoring_test.cpp
+++ b/tests/libs/iresearch/search/wand_scoring_test.cpp
@@ -87,7 +87,7 @@ class WandScoringTestCase : public IndexTestBase {
       index.emplace_back();
       write_segment(writer, index.back(), gen);
     }
-    writer.Commit();
+    writer.RefreshCommit();
   }
 
   // Single segment with multiplier * 420 docs.
@@ -132,7 +132,7 @@ class WandScoringTestCase : public IndexTestBase {
         index_ref.emplace_back();
         write_segment(*writer, index_ref.back(), gen);
       }
-      writer->Commit();
+      writer->RefreshCommit();
     }
 
     return writer->GetSnapshot();

--- a/tests/libs/iresearch/search/wand_test.cpp
+++ b/tests/libs/iresearch/search/wand_test.cpp
@@ -88,7 +88,7 @@ class WandTestCase : public tests::IndexTestBase {
   void GenerateSegment(irs::ScorerPtr scorer, bool write_norms,
                        bool append_data = false);
   void GenerateSegmentMinNorm(irs::ScorerPtr scorer);
-  void ConsolidateAll(irs::ScorerPtr scorer, bool write_norms);
+  void CompactAll(irs::ScorerPtr scorer, bool write_norms);
 
   void AssertFilters(irs::ScorerPtr scorer, bool disjunction = true) {
     auto apply = [&](auto assert_filter) {
@@ -211,13 +211,12 @@ void WandTestCase::AssertResults(const irs::DirectoryReader& index,
   ASSERT_EQ(result, wand_result);
 }
 
-void WandTestCase::ConsolidateAll(irs::ScorerPtr scorer, bool write_norms) {
-  const irs::index_utils::ConsolidateCount consolidate_all;
+void WandTestCase::CompactAll(irs::ScorerPtr scorer, bool write_norms) {
+  const irs::index_utils::CompactionCount compact_all;
   auto writer =
     open_writer(irs::kOmAppend, GetWriterOptions(scorer, write_norms));
-  ASSERT_TRUE(
-    writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
-  ASSERT_TRUE(writer->Commit());
+  ASSERT_TRUE(writer->Compact(irs::index_utils::MakePolicy(compact_all)));
+  ASSERT_TRUE(writer->RefreshCommit());
   ASSERT_EQ(1, writer->GetSnapshot().size());
 }
 
@@ -382,7 +381,7 @@ void WandTestCase::AssertWithNewSegmentsDense(irs::Scorer* scorer) {
   AssertFilters(scorer, false);
 
   GenerateSegment(scorer, true, true);  // Add another segment
-  ConsolidateAll(scorer, true);
+  CompactAll(scorer, true);
   AssertFilters(scorer, false);
 
   GenerateSegment(scorer, true, true);  // Add another segment
@@ -394,7 +393,7 @@ void WandTestCase::AssertWithNewSegmentsDense(irs::Scorer* scorer) {
   GenerateSegment(scorer, true, true);  // Add another segment
   AssertFilters(scorer, false);
 
-  ConsolidateAll(scorer, true);
+  CompactAll(scorer, true);
   AssertFilters(scorer, false);
 }
 
@@ -405,7 +404,7 @@ void WandTestCase::AssertWithNewSegmentsSparse(irs::Scorer* scorer) {
   GenerateSegment(scorer, false, true);  // Add another segment
   AssertFilters(scorer, false);
 
-  ConsolidateAll(scorer, false);
+  CompactAll(scorer, false);
   AssertFilters(scorer, false);
 }
 

--- a/tests/libs/iresearch/search/wildcard_ngram_filter_test.cpp
+++ b/tests/libs/iresearch/search/wildcard_ngram_filter_test.cpp
@@ -220,7 +220,7 @@ TEST(WildcardNgramFilterTest, query) {
       irs::tests::StoreFieldAt(*cs, kStoreId, doc.DocId(), field);
     }
     ctx.Commit();
-    writer->Commit();
+    writer->RefreshCommit();
   }
 
   irs::DirectoryReader reader{dir, irs::formats::Get("1_5simd"),

--- a/tests/libs/iresearch/store/directory_cleaner_tests.cpp
+++ b/tests/libs/iresearch/store/directory_cleaner_tests.cpp
@@ -264,7 +264,7 @@ TEST(directory_cleaner_tests, test_directory_cleaner_current_segment) {
     auto writer = irs::IndexWriter::Make(dir, codec_ptr, irs::kOmCreate);
 
     ASSERT_TRUE(Insert(*writer, doc1->indexed.begin(), doc1->indexed.end()));
-    writer->Commit();
+    writer->RefreshCommit();
     tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                   irs::DirectoryReader(dir, codec_ptr));
 
@@ -280,7 +280,7 @@ TEST(directory_cleaner_tests, test_directory_cleaner_current_segment) {
 
     writer->GetBatch().Remove(std::move(query_doc1));
     ASSERT_TRUE(Insert(*writer, doc2->indexed.begin(), doc2->indexed.end()));
-    writer->Commit();
+    writer->RefreshCommit();
     tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                   irs::DirectoryReader(dir, codec_ptr));
 

--- a/tests/libs/iresearch/tests_shared.hpp
+++ b/tests/libs/iresearch/tests_shared.hpp
@@ -120,14 +120,14 @@ struct MaxMemoryCounter final : irs::IResourceManager {
 
 struct TestResourceManager {
   SimpleMemoryAccounter cached_columns;
-  SimpleMemoryAccounter consolidations;
+  SimpleMemoryAccounter compactions;
   SimpleMemoryAccounter file_descriptors;
   SimpleMemoryAccounter readers;
   SimpleMemoryAccounter transactions;
 
   irs::ResourceManagementOptions options{.transactions = &transactions,
                                          .readers = &readers,
-                                         .consolidations = &consolidations,
+                                         .compactions = &compactions,
                                          .file_descriptors = &file_descriptors,
                                          .cached_columns = &cached_columns};
 };

--- a/tests/server/connector/duckdb_search_sink_writer_test.cpp
+++ b/tests/server/connector/duckdb_search_sink_writer_test.cpp
@@ -211,7 +211,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteMultipleColumns) {
   sink.Write({rocksdb::Slice(big_data[3])}, pk[3]);
   sink.Finish();
   ASSERT_TRUE(trx.Commit());
-  _data_writer->Commit();
+  _data_writer->RefreshCommit();
 
   auto validate_row = [](const irs::SubReader& segment, std::string_view pk,
                          int32_t col1, std::string_view col2, bool col3,
@@ -320,7 +320,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteMultipleColumns) {
     delete_sink.Finish();
     ASSERT_TRUE(delete_trx.Commit());
   }
-  _data_writer->Commit();
+  _data_writer->RefreshCommit();
 
   {
     auto reader = irs::DirectoryReader(_dir, _codec, {.db = &TestDb()});
@@ -370,7 +370,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertNullsColumns) {
   sink.Write({{}}, pk[3]);  // null
   sink.Finish();
   ASSERT_TRUE(trx.Commit());
-  _data_writer->Commit();
+  _data_writer->RefreshCommit();
 
   auto reader = irs::DirectoryReader(_dir, _codec, {.db = &TestDb()});
   ASSERT_EQ(1, reader.size());
@@ -521,7 +521,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertStringPrefix) {
 
   sink.Finish();
   ASSERT_TRUE(trx.Commit());
-  _data_writer->Commit();
+  _data_writer->RefreshCommit();
   auto reader = irs::DirectoryReader(_dir, _codec, {.db = &TestDb()});
   ASSERT_EQ(1, reader.size());
   ASSERT_EQ(1, reader.docs_count());
@@ -574,7 +574,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteInsertWithExisting) {
     sink.Finish();
     trx.Commit();
     // That would be our "existing" segment
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
   }
   {
     auto delete_trx = _data_writer->GetBatch();
@@ -625,7 +625,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteInsertWithExisting) {
     sink.Finish();
     trx.Commit();
     // eventually commit. value3 would be visible
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
   }
   auto reader = irs::DirectoryReader(_dir, _codec, {.db = &TestDb()});
   ASSERT_EQ(2, reader.size());
@@ -752,7 +752,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteInsertOnePending) {
     sink.Finish();
     trx.Commit();
     // eventually commit. value3 would be visible
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
   }
   auto reader = irs::DirectoryReader(_dir, _codec, {.db = &TestDb()});
   ASSERT_EQ(1, reader.size());
@@ -892,7 +892,7 @@ TEST_F(DuckDBSearchSinkWriterTest, InsertDeleteInsertOnePendingWithFlush) {
       sink.Finish();
       trx.Commit();
       // eventually commit. value3 would be visible
-      limited_data_writer->Commit();
+      limited_data_writer->RefreshCommit();
     }
     auto reader = irs::DirectoryReader(dir, _codec, {.db = &TestDb()});
     ASSERT_EQ(3, reader.size());
@@ -975,7 +975,7 @@ TEST_F(DuckDBSearchSinkWriterTest, DeleteNotMissedWithExisting) {
     sink.Finish();
     trx.Commit();
     // That would be our "existing" segment
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
   }
   {
     // this delete should not fire at value2 during new segment processing
@@ -1001,7 +1001,7 @@ TEST_F(DuckDBSearchSinkWriterTest, DeleteNotMissedWithExisting) {
     sink.Write({rocksdb::Slice("value2", 6)}, kPk);
     sink.Finish();
     trx.Commit();
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
     // Intentionally do not commit data writer to force several same PKs in one
     // writer commit
   }
@@ -1069,7 +1069,7 @@ TEST_F(DuckDBSearchSinkWriterTest, UpdateWithExisting) {
     sink.Write({rocksdb::Slice("value2", 6)}, kPk2);
     sink.Finish();
     ASSERT_TRUE(trx.Commit());
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
   }
   // Phase 2: update pk1's value using the combined update writer.
   // Update == delete old + insert new for the same PK.
@@ -1088,7 +1088,7 @@ TEST_F(DuckDBSearchSinkWriterTest, UpdateWithExisting) {
     sink.Write({rocksdb::Slice("value1_new", 10)}, kPk1);
     sink.Finish();
     ASSERT_TRUE(trx.Commit());
-    _data_writer->Commit();
+    _data_writer->RefreshCommit();
   }
 
   auto reader = irs::DirectoryReader(_dir, _codec, {.db = &TestDb()});

--- a/tests/sqllogic/recovery/index.test
+++ b/tests/sqllogic/recovery/index.test
@@ -83,7 +83,7 @@ SET sdb_faults = 'slow_search_task';
 
 connection new2
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 statement async ok
@@ -158,7 +158,7 @@ wait
 
 connection new2
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 connection new2
@@ -197,7 +197,7 @@ INSERT INTO t VALUES ('one'), ('two'), ('three');
 # with the INSERTs.
 connection new2
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 connection new2
@@ -242,5 +242,5 @@ query
 SELECT * FROM sdb_search_tasks_status;
 ----
 task_type	active_tasks	pending_tasks	threads
-Commit	0	0	<slt:ignore>
-Consolidation	0	0	<slt:ignore>
+Refresh	0	0	<slt:ignore>
+Compaction	0	0	<slt:ignore>

--- a/tests/sqllogic/recovery/index_backfill.test
+++ b/tests/sqllogic/recovery/index_backfill.test
@@ -68,7 +68,7 @@ SELECT 1;
 
 connection bf_after_5
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) idx_bf_t;
+VACUUM (REFRESH_TABLE) idx_bf_t;
 
 connection bf_after_5
 query

--- a/tests/sqllogic/recovery/indexonly_no_double_apply.test
+++ b/tests/sqllogic/recovery/indexonly_no_double_apply.test
@@ -39,7 +39,7 @@ statement ok
 SET sdb_faults = 'Search::CrashAfterCommit';
 
 statement error connection closed
-VACUUM (UPDATE_INDEXES) indexonly_no_double;
+VACUUM (REFRESH_TABLE) indexonly_no_double;
 
 # After restart, the inverted index already contains the row -- recovery
 # must NOT add it again. If the committed_tick filter is wrong, we'd see

--- a/tests/sqllogic/recovery/indexonly_replay.test
+++ b/tests/sqllogic/recovery/indexonly_replay.test
@@ -52,7 +52,7 @@ RESET sdb_faults;
 
 connection after_replay
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_replay;
+VACUUM (REFRESH_TABLE) indexonly_replay;
 
 connection after_replay
 query
@@ -83,7 +83,7 @@ INSERT INTO indexonly_replay VALUES (4, 'doomed phrase about to vanish');
 
 connection after_replay
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_replay;
+VACUUM (REFRESH_TABLE) indexonly_replay;
 
 connection after_replay
 query
@@ -106,7 +106,7 @@ RESET sdb_faults;
 
 connection after_delete
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_replay;
+VACUUM (REFRESH_TABLE) indexonly_replay;
 
 # Row 4 must be gone from the inverted index.
 connection after_delete
@@ -160,7 +160,7 @@ INSERT INTO indexonly_update VALUES
 # AFTER it -- the [CP] from the UPDATE batch is what must be replayed.
 connection after_delete
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_update;
+VACUUM (REFRESH_TABLE) indexonly_update;
 
 # Sanity: original phrase searchable.
 connection after_delete
@@ -184,7 +184,7 @@ RESET sdb_faults;
 
 connection after_update
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_update;
+VACUUM (REFRESH_TABLE) indexonly_update;
 
 # New phrase must be searchable -- wal_recovery replayed the [CP] for
 # the post-update value.

--- a/tests/sqllogic/recovery/indexonly_truncate_replay.test
+++ b/tests/sqllogic/recovery/indexonly_truncate_replay.test
@@ -35,7 +35,7 @@ INSERT INTO indexonly_trunc VALUES
   (2, 'pre truncate charlie delta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_trunc;
+VACUUM (REFRESH_TABLE) indexonly_trunc;
 
 # Sanity: rows are searchable before TRUNCATE.
 query
@@ -90,7 +90,7 @@ INSERT INTO indexonly_trunc VALUES
 
 connection after_truncate
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_trunc;
+VACUUM (REFRESH_TABLE) indexonly_trunc;
 
 connection after_truncate
 query

--- a/tests/sqllogic/recovery/inverted_index_fault_isolation.test
+++ b/tests/sqllogic/recovery/inverted_index_fault_isolation.test
@@ -49,7 +49,7 @@ INSERT INTO doc VALUES (3, 'beta three', 'c', 300, 'x-three')
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) doc
+VACUUM (REFRESH_TABLE) doc
 
 
 # Baseline: no fault armed, every shape works.

--- a/tests/sqllogic/recovery/inverted_index_json_crash.test
+++ b/tests/sqllogic/recovery/inverted_index_json_crash.test
@@ -18,7 +18,7 @@ statement ok
 INSERT INTO jc_t VALUES (1, '{"host":"server-01"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) jc_t;
+VACUUM (REFRESH_TABLE) jc_t;
 
 query
 SELECT id FROM jc_idx WHERE content->>'host' @@ ts_like('server-01');
@@ -42,7 +42,7 @@ RESET sdb_faults;
 
 connection jc_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_t;
+VACUUM (REFRESH_TABLE) jc_t;
 
 # Seed row still indexed.
 connection jc_after
@@ -96,7 +96,7 @@ INSERT INTO jc_patch_t VALUES (1, 'alpha', '{"host":"hp1"}'::json);
 
 connection jc_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_patch_t;
+VACUUM (REFRESH_TABLE) jc_patch_t;
 
 connection jc_after
 statement ok
@@ -112,7 +112,7 @@ RESET sdb_faults;
 
 connection jc_patch_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_patch_t;
+VACUUM (REFRESH_TABLE) jc_patch_t;
 
 # UPDATE took effect on the plain indexed column.
 connection jc_patch_after
@@ -166,7 +166,7 @@ RESET sdb_faults;
 
 connection jc_multi_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_multi_t;
+VACUUM (REFRESH_TABLE) jc_multi_t;
 
 connection jc_multi_after
 query
@@ -210,7 +210,7 @@ RESET sdb_faults;
 
 connection jc_hash_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_hash_t;
+VACUUM (REFRESH_TABLE) jc_hash_t;
 
 connection jc_hash_after
 query
@@ -237,7 +237,7 @@ INSERT INTO jc_seq_t VALUES (1, '{"host":"orig"}'::json);
 
 connection jc_hash_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_seq_t;
+VACUUM (REFRESH_TABLE) jc_seq_t;
 
 connection jc_hash_after
 statement ok
@@ -269,7 +269,7 @@ RESET sdb_faults;
 
 connection jc_seq_after
 statement ok
-VACUUM (UPDATE_INDEXES) jc_seq_t;
+VACUUM (REFRESH_TABLE) jc_seq_t;
 
 # Seed row survived (it was sealed pre-crash).
 connection jc_seq_after

--- a/tests/sqllogic/recovery/inverted_index_rollback.test
+++ b/tests/sqllogic/recovery/inverted_index_rollback.test
@@ -55,7 +55,7 @@ INSERT INTO doc_rb VALUES (1, 'baseline alpha', 'a', 100)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) doc_rb
+VACUUM (REFRESH_TABLE) doc_rb
 
 
 # Aborted txn: INSERTs go to the cs writer but ROLLBACK must drop the segment
@@ -95,7 +95,7 @@ INSERT INTO doc_rb VALUES (4, 'delta', 'd', 400)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) doc_rb
+VACUUM (REFRESH_TABLE) doc_rb
 
 
 query
@@ -136,7 +136,7 @@ INSERT INTO doc_pre VALUES (1, 'alpha one', 'a', 100)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) doc_pre
+VACUUM (REFRESH_TABLE) doc_pre
 
 
 # Arm the crash: serened will exit(1) before RocksDB persists the next COMMIT.
@@ -193,7 +193,7 @@ INSERT INTO doc_pre VALUES (4, 'delta four', 'd', 400)
 
 connection pre_after
 statement ok
-VACUUM (UPDATE_INDEXES) doc_pre
+VACUUM (REFRESH_TABLE) doc_pre
 
 
 connection pre_after
@@ -243,7 +243,7 @@ INSERT INTO doc_post VALUES (1, 'alpha one', 'a', 100)
 
 connection pre_after
 statement ok
-VACUUM (UPDATE_INDEXES) doc_post
+VACUUM (REFRESH_TABLE) doc_post
 
 
 # Arm: crash *after* RocksDB commit -- the next COMMIT persists then dies.
@@ -281,7 +281,7 @@ pk	body	label	tag
 # INCLUDE columns).
 connection post_after
 statement ok
-VACUUM (UPDATE_INDEXES) doc_post
+VACUUM (REFRESH_TABLE) doc_post
 
 
 connection post_after

--- a/tests/sqllogic/recovery/inverted_index_wand_compaction.test
+++ b/tests/sqllogic/recovery/inverted_index_wand_compaction.test
@@ -1,7 +1,7 @@
 hash-threshold 100
 
 # ---------------------------------------------------------------------------
-# Verify that WAND metadata survives index consolidation. A review pass on
+# Verify that WAND metadata survives index compaction. A review pass on
 # `merge_writer.cpp` flagged that `Flush` builds a `FlushState` with
 # `norms = nullptr` (the new field on `FlushState` was added for the initial
 # flush; merge never sets it). If true, `PostingsWriterBase::PrepareWriters`
@@ -14,7 +14,7 @@ hash-threshold 100
 #      VACUUM, insert, VACUUM).
 #   2. Pre-merge: arm `irs::WandIterator` fault -- query trips, proving
 #      both initial-flush segments wrote wand metadata.
-#   3. PRAGMA serenedb_vacuum('compact_indexes', ...) -- merges into one
+#   3. VACUUM (COMPACT_TABLE) <table> -- merges into one
 #      segment via MergeWriter::Flush.
 #   4. Post-merge: arm `irs::WandIterator` fault -- if wand metadata is in
 #      the merged segment, the fault trips again. If not, the query
@@ -59,7 +59,7 @@ INSERT INTO wand_cons SELECT i, CASE i % 5
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_cons;
+VACUUM (REFRESH_TABLE) wand_cons;
 
 
 # Segment 2: 100 more rows under a disjoint pk range.
@@ -75,7 +75,7 @@ INSERT INTO wand_cons SELECT i, CASE i % 5
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_cons;
+VACUUM (REFRESH_TABLE) wand_cons;
 
 
 # === Pre-merge sanity: WAND fires on the initial-flush segments. ===
@@ -94,10 +94,10 @@ statement ok
 SET sdb_faults = '-irs::WandIterator';
 
 
-# === Force consolidation into one merged segment. ===
+# === Force compaction into one merged segment. ===
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'wand_cons');
+VACUUM (COMPACT_TABLE) wand_cons;
 
 
 # Correctness sanity: the merged segment returns the right docs.

--- a/tests/sqllogic/recovery/inverted_index_wand_faults.test
+++ b/tests/sqllogic/recovery/inverted_index_wand_faults.test
@@ -64,11 +64,11 @@ CREATE INDEX plain_docs_idx ON plain_docs USING inverted(id, body en_wand);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_docs;
+VACUUM (REFRESH_TABLE) wand_docs;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) plain_docs;
+VACUUM (REFRESH_TABLE) plain_docs;
 
 
 # === Positive: shapes that should engage WAND ===

--- a/tests/sqllogic/recovery/table_size.test
+++ b/tests/sqllogic/recovery/table_size.test
@@ -37,7 +37,7 @@ CREATE INDEX t_idx ON t USING inverted(name test_english);
 
 
 statement ok
-VACUUM (SYNC_STATS) t;
+VACUUM (SYNC_STATS_TABLE) t;
 
 
 statement ok

--- a/tests/sqllogic/recovery/table_size.test
+++ b/tests/sqllogic/recovery/table_size.test
@@ -41,7 +41,7 @@ VACUUM (SYNC_STATS) t;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 query

--- a/tests/sqllogic/recovery/vacuum_global.test
+++ b/tests/sqllogic/recovery/vacuum_global.test
@@ -1,0 +1,176 @@
+control substitution on
+
+# Instance-wide VACUUM scopes: REFRESH_ALL / COMPACT_ALL / SYNC_STATS_ALL /
+# COMPACT_ROCKSDB. These walk every database / the whole rocksdb engine, so they
+# need their own serened instance -- under the shared sqllogic runner they would
+# touch other tests' per-test databases. Per-scope variants and the error paths
+# are covered in tests/sqllogic/sdb/pg/index/vacuum_options.test.
+
+statement ok
+CREATE SCHEMA s1;
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY public.en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false,
+    accent = false, frequency = true, position = true, norm = true);
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY s1.en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false,
+    accent = false, frequency = true, position = true, norm = true);
+
+
+statement ok
+CREATE TABLE public.docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX docs_idx ON public.docs USING inverted(id, body en);
+
+
+statement ok
+CREATE TABLE s1.notes (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX notes_idx ON s1.notes USING inverted(id, body en);
+
+
+# REFRESH_ALL publishes pending writes across every database + schema at once.
+statement ok
+INSERT INTO public.docs VALUES (1, 'alpha across schemas');
+
+
+statement ok
+INSERT INTO s1.notes VALUES (1, 'alpha across schemas');
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('alpha');
+----
+count
+0
+
+
+statement ok
+VACUUM (REFRESH_ALL);
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('alpha');
+----
+count
+1
+
+
+query
+SELECT count(*) FROM s1.notes_idx WHERE body @@ ts_phrase('alpha');
+----
+count
+1
+
+
+# Inflate both indexes to several segments, then COMPACT_ALL to a fixpoint.
+statement ok
+INSERT INTO public.docs VALUES (2, 'beta one');
+
+
+statement ok
+VACUUM (REFRESH_ALL);
+
+
+statement ok
+INSERT INTO public.docs VALUES (3, 'beta two');
+
+
+statement ok
+INSERT INTO s1.notes VALUES (2, 'beta two');
+
+
+statement ok
+VACUUM (REFRESH_ALL);
+
+
+statement ok
+INSERT INTO public.docs VALUES (4, 'beta three');
+
+
+statement ok
+VACUUM (REFRESH_ALL);
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('beta');
+----
+count
+3
+
+
+statement ok
+VACUUM (COMPACT_ALL);
+
+
+# Compaction must not change query results in any database.
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('beta');
+----
+count
+3
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('alpha');
+----
+count
+1
+
+
+query
+SELECT count(*) FROM s1.notes_idx WHERE body @@ ts_phrase('beta');
+----
+count
+1
+
+
+# COMPACT_ALL again is idempotent.
+statement ok
+VACUUM (COMPACT_ALL);
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('beta');
+----
+count
+3
+
+
+# SYNC_STATS_ALL and COMPACT_ROCKSDB are whole-instance maintenance ops that
+# must run without error.
+statement ok
+VACUUM (SYNC_STATS_ALL);
+
+
+statement ok
+VACUUM (COMPACT_ROCKSDB);
+
+
+# Data is still intact after the rocksdb compaction.
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('beta');
+----
+count
+3
+
+
+statement ok
+DROP TABLE public.docs;
+
+
+statement ok
+DROP TEXT SEARCH DICTIONARY public.en;
+
+
+statement ok
+DROP SCHEMA s1 CASCADE;

--- a/tests/sqllogic/recovery/wal_index_recovery.test
+++ b/tests/sqllogic/recovery/wal_index_recovery.test
@@ -31,7 +31,7 @@ CREATE INDEX wal_rec_idx ON wal_rec_t USING inverted(a, b wal_dict);
 
 # Seed row must be searchable before we break anything
 statement ok
-VACUUM (UPDATE_INDEXES) wal_rec_t;
+VACUUM (REFRESH_TABLE) wal_rec_t;
 
 query
 SELECT a, b FROM wal_rec_idx WHERE b @@ ts_phrase('alpha bravo');
@@ -58,7 +58,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_rec_t;
+VACUUM (REFRESH_TABLE) wal_rec_t;
 
 # Pre-crash row survives
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_bulk.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_bulk.test
@@ -24,7 +24,7 @@ statement ok
 CREATE INDEX wal_bulk_idx ON wal_bulk_t USING inverted(a, b bulk_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_bulk_t;
+VACUUM (REFRESH_TABLE) wal_bulk_t;
 
 query
 SELECT COUNT(*) FROM wal_bulk_idx WHERE b @@ ts_phrase('seed');
@@ -51,7 +51,7 @@ SELECT 1;
 
 connection bulk_after
 statement ok retry 60 backoff 1s
-VACUUM (UPDATE_INDEXES) wal_bulk_t;
+VACUUM (REFRESH_TABLE) wal_bulk_t;
 
 connection bulk_after
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_chain.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_chain.test
@@ -31,7 +31,7 @@ statement ok
 CREATE INDEX chain_idx ON chain_t USING inverted(a, b chain_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) chain_t;
+VACUUM (REFRESH_TABLE) chain_t;
 
 # Initial sanity
 query
@@ -189,7 +189,7 @@ SELECT 1;
 
 connection final
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) chain_t;
+VACUUM (REFRESH_TABLE) chain_t;
 
 connection final
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_delete.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_delete.test
@@ -31,7 +31,7 @@ statement ok
 CREATE INDEX wal_del_idx ON wal_del_t USING inverted(a, b del_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_del_t;
+VACUUM (REFRESH_TABLE) wal_del_t;
 
 query
 SELECT a FROM wal_del_idx WHERE b @@ ts_phrase('apple');
@@ -61,7 +61,7 @@ SELECT 1;
 
 connection del_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_del_t;
+VACUUM (REFRESH_TABLE) wal_del_t;
 
 # Deleted rows are gone from the index
 connection del_after

--- a/tests/sqllogic/recovery/wal_index_recovery_delete_then_insert.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_delete_then_insert.test
@@ -33,7 +33,7 @@ CREATE INDEX del_then_insert_idx ON del_then_insert_t
   USING inverted(a, b del_then_insert_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) del_then_insert_t;
+VACUUM (REFRESH_TABLE) del_then_insert_t;
 
 # Block iresearch commit so all subsequent ops only land in the WAL.
 statement ok
@@ -58,7 +58,7 @@ SELECT 1;
 
 connection after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) del_then_insert_t;
+VACUUM (REFRESH_TABLE) del_then_insert_t;
 
 # The stale token must NOT be searchable: if Delete didn't clear indexed_cols
 # in the recovery accumulator, the pre-delete Put would leak through.

--- a/tests/sqllogic/recovery/wal_index_recovery_drop_database.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_drop_database.test
@@ -30,7 +30,7 @@ statement ok
 CREATE INDEX dd_idx ON dd_t USING inverted(id, body dd_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dd_t;
+VACUUM (REFRESH_TABLE) dd_t;
 
 # Block search commits.
 statement ok
@@ -64,7 +64,7 @@ SELECT 1;
 
 connection dd_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) dd_t;
+VACUUM (REFRESH_TABLE) dd_t;
 
 # Transient database really is gone.
 connection dd_after

--- a/tests/sqllogic/recovery/wal_index_recovery_drop_index.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_drop_index.test
@@ -30,7 +30,7 @@ statement ok
 CREATE INDEX di_idx ON di_t USING inverted(id, body di_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) di_t;
+VACUUM (REFRESH_TABLE) di_t;
 
 # Sanity: the seed row is searchable before we touch anything.
 query
@@ -99,7 +99,7 @@ CREATE INDEX di_idx ON di_t USING inverted(id, body di_dict);
 
 connection di_after
 statement ok
-VACUUM (UPDATE_INDEXES) di_t;
+VACUUM (REFRESH_TABLE) di_t;
 
 connection di_after
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_drop_schema.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_drop_schema.test
@@ -54,10 +54,10 @@ statement ok
 CREATE INDEX ds_drop_idx ON ds_drop.t USING inverted(id, body ds_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ds_keep.t;
+VACUUM (REFRESH_TABLE) ds_keep.t;
 
 statement ok
-VACUUM (UPDATE_INDEXES) ds_drop.t;
+VACUUM (REFRESH_TABLE) ds_drop.t;
 
 # Block search commits.
 statement ok
@@ -97,7 +97,7 @@ SELECT 1;
 
 connection ds_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ds_keep.t;
+VACUUM (REFRESH_TABLE) ds_keep.t;
 
 # Dropped schema is gone.
 connection ds_after

--- a/tests/sqllogic/recovery/wal_index_recovery_drop_table.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_drop_table.test
@@ -37,10 +37,10 @@ statement ok
 CREATE INDEX dt_drop_idx ON dt_drop USING inverted(id, body dt_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dt_keep;
+VACUUM (REFRESH_TABLE) dt_keep;
 
 statement ok
-VACUUM (UPDATE_INDEXES) dt_drop;
+VACUUM (REFRESH_TABLE) dt_drop;
 
 # Block search commits — rocksdb keeps advancing.
 statement ok
@@ -80,7 +80,7 @@ SELECT 1;
 
 connection dt_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) dt_keep;
+VACUUM (REFRESH_TABLE) dt_keep;
 
 # Dropped table and its index are gone.
 connection dt_after

--- a/tests/sqllogic/recovery/wal_index_recovery_empty_to_full.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_empty_to_full.test
@@ -21,7 +21,7 @@ CREATE TABLE ef_t(id INTEGER PRIMARY KEY, body TEXT);
 statement ok
 CREATE INDEX ef_idx ON ef_t USING inverted(id, body ef_dict);
 
-# No VACUUM (UPDATE_INDEXES) needed — table is empty, index has 0 docs.
+# No VACUUM (REFRESH_TABLE) needed — table is empty, index has 0 docs.
 
 # Initial sanity: index is empty.
 query
@@ -47,7 +47,7 @@ SELECT 1;
 
 connection ef_after
 statement ok retry 60 backoff 1s
-VACUUM (UPDATE_INDEXES) ef_t;
+VACUUM (REFRESH_TABLE) ef_t;
 
 connection ef_after
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_geo.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_geo.test
@@ -35,7 +35,7 @@ CREATE INDEX wal_geo_idx ON wal_geo_t
   INCLUDE (geo);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_geo_t;
+VACUUM (REFRESH_TABLE) wal_geo_t;
 
 # Plan check: geo distance + projection both served by the inverted index.
 query
@@ -98,7 +98,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_geo_t;
+VACUUM (REFRESH_TABLE) wal_geo_t;
 
 # Pre-crash row still queryable.
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_geo_no_include.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_geo_no_include.test
@@ -25,7 +25,7 @@ CREATE INDEX wal_geo_ni_idx ON wal_geo_ni_t
   USING inverted(geo wal_geo_ni_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_geo_ni_t;
+VACUUM (REFRESH_TABLE) wal_geo_ni_t;
 
 # Plan: filter served by inverted-index posting + analyzer-output cs aux
 # column; `geo` projection falls back to RocksDB lookup (no INCLUDE).
@@ -97,7 +97,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_geo_ni_t;
+VACUUM (REFRESH_TABLE) wal_geo_ni_t;
 
 # Pre-crash row still queryable.
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_hnsw.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_hnsw.test
@@ -24,7 +24,7 @@ CREATE INDEX wal_hnsw_idx ON wal_hnsw_t
   USING inverted(emb hnsw (metric = 'l2'));
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_hnsw_t;
+VACUUM (REFRESH_TABLE) wal_hnsw_t;
 
 # Plan check: ANN top-K served by the HNSW graph in the inverted index.
 query
@@ -71,7 +71,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_hnsw_t;
+VACUUM (REFRESH_TABLE) wal_hnsw_t;
 
 # Pre-crash row still queryable.
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_huge.test_slow
+++ b/tests/sqllogic/recovery/wal_index_recovery_huge.test_slow
@@ -23,10 +23,10 @@ statement ok
 CREATE TABLE huge_t(id INTEGER PRIMARY KEY, body TEXT);
 
 statement ok
-CREATE INDEX huge_idx ON huge_t USING inverted(id, body huge_dict) WITH (commit_interval = 0);
+CREATE INDEX huge_idx ON huge_t USING inverted(id, body huge_dict) WITH (refresh_interval = 0);
 
 statement ok
-VACUUM (UPDATE_INDEXES) huge_t;
+VACUUM (REFRESH_TABLE) huge_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -52,7 +52,7 @@ SELECT 1;
 
 connection huge_after
 statement ok retry 60 backoff 1s
-VACUUM (UPDATE_INDEXES) huge_t;
+VACUUM (REFRESH_TABLE) huge_t;
 
 # Counts: 100_000 - 100 (deleted at every multiple of 1000) = 99_900.
 connection huge_after

--- a/tests/sqllogic/recovery/wal_index_recovery_include.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_include.test
@@ -67,7 +67,7 @@ CREATE INDEX wal_inc_idx ON wal_inc_t
   INCLUDE (pk, v, dual, ints, triple, pt, m, nest);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_inc_t;
+VACUUM (REFRESH_TABLE) wal_inc_t;
 
 # All projections served from the inverted index (cs for INCLUDE columns,
 # inverted-index for txt filter, RocksDB for nothing).
@@ -152,7 +152,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_inc_t;
+VACUUM (REFRESH_TABLE) wal_inc_t;
 
 # Pre-crash row's INCLUDE'd values still served from cs.
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_interleaved_writes.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_interleaved_writes.test
@@ -38,7 +38,7 @@ statement ok
 CREATE INDEX iw_idx ON iw_idx_t USING inverted(id, body iw_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) iw_idx_t;
+VACUUM (REFRESH_TABLE) iw_idx_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -124,7 +124,7 @@ SELECT 1;
 
 connection iw_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) iw_idx_t;
+VACUUM (REFRESH_TABLE) iw_idx_t;
 
 # Final pks in iw_idx_t:
 #  pre seeds: 1 was deleted, 2 updated → kept as id=2

--- a/tests/sqllogic/recovery/wal_index_recovery_keep_other_cols.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_keep_other_cols.test
@@ -33,7 +33,7 @@ CREATE INDEX ko_idx ON ko_t
   USING inverted(id, a ko_dict, b ko_dict, c ko_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ko_t;
+VACUUM (REFRESH_TABLE) ko_t;
 
 # Pre-crash: every token searchable.
 query
@@ -75,7 +75,7 @@ SELECT 1;
 
 connection ko_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ko_t;
+VACUUM (REFRESH_TABLE) ko_t;
 
 # Updated columns: new tokens findable, old gone.
 

--- a/tests/sqllogic/recovery/wal_index_recovery_long_strings.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_long_strings.test
@@ -21,7 +21,7 @@ statement ok
 CREATE INDEX ls_idx ON ls_t USING inverted(id, body ls_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ls_t;
+VACUUM (REFRESH_TABLE) ls_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -48,7 +48,7 @@ SELECT 1;
 
 connection ls_after
 statement ok retry 60 backoff 1s
-VACUUM (UPDATE_INDEXES) ls_t;
+VACUUM (REFRESH_TABLE) ls_t;
 
 connection ls_after
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_many_tables_mixed.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_many_tables_mixed.test
@@ -77,13 +77,13 @@ statement ok
 CREATE INDEX mt_epsilon_inv ON mt_epsilon USING inverted(id, body mt_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) mt_alpha;
+VACUUM (REFRESH_TABLE) mt_alpha;
 
 statement ok
-VACUUM (UPDATE_INDEXES) mt_beta;
+VACUUM (REFRESH_TABLE) mt_beta;
 
 statement ok
-VACUUM (UPDATE_INDEXES) mt_epsilon;
+VACUUM (REFRESH_TABLE) mt_epsilon;
 
 # === Block search commits and start the heavy interleaved workload. ===
 # mt_epsilon must NOT receive any writes — it stays caught up.
@@ -152,15 +152,15 @@ SELECT 1;
 
 connection mt_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) mt_alpha;
+VACUUM (REFRESH_TABLE) mt_alpha;
 
 connection mt_after
 statement ok
-VACUUM (UPDATE_INDEXES) mt_beta;
+VACUUM (REFRESH_TABLE) mt_beta;
 
 connection mt_after
 statement ok
-VACUUM (UPDATE_INDEXES) mt_epsilon;
+VACUUM (REFRESH_TABLE) mt_epsilon;
 
 # === mt_alpha: 5 rows — id ∈ {1, 2, 5, 40} after deletes, plus id=2 modified.
 #   Wait: started with 1,2,3, added 4,5, deleted 3, pk-renamed 4→40.

--- a/tests/sqllogic/recovery/wal_index_recovery_mixed.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_mixed.test
@@ -32,7 +32,7 @@ statement ok
 CREATE INDEX wal_mix_idx ON wal_mix_t USING inverted(a, b mix_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_mix_t;
+VACUUM (REFRESH_TABLE) wal_mix_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -69,7 +69,7 @@ SELECT 1;
 
 connection mix_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_mix_t;
+VACUUM (REFRESH_TABLE) wal_mix_t;
 
 # pk=1 untouched
 connection mix_after

--- a/tests/sqllogic/recovery/wal_index_recovery_multi_index.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_multi_index.test
@@ -34,10 +34,10 @@ statement ok
 CREATE INDEX wal_mi_b_idx ON wal_mi_b USING inverted(id, txt mi_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_mi_a;
+VACUUM (REFRESH_TABLE) wal_mi_a;
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_mi_b;
+VACUUM (REFRESH_TABLE) wal_mi_b;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -61,11 +61,11 @@ SELECT 1;
 
 connection mi_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_mi_a;
+VACUUM (REFRESH_TABLE) wal_mi_a;
 
 connection mi_after
 statement ok
-VACUUM (UPDATE_INDEXES) wal_mi_b;
+VACUUM (REFRESH_TABLE) wal_mi_b;
 
 # Table A: id=1 deleted, id=2 and id=3 added by recovery
 connection mi_after

--- a/tests/sqllogic/recovery/wal_index_recovery_multicolumn.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_multicolumn.test
@@ -26,7 +26,7 @@ statement ok
 CREATE INDEX wal_mc_idx ON wal_mc_t USING inverted(pk, name mc_dict, score, ts);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_mc_t;
+VACUUM (REFRESH_TABLE) wal_mc_t;
 
 # All 3 columns searchable pre-crash
 query
@@ -66,7 +66,7 @@ SELECT 1;
 
 connection mc_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_mc_t;
+VACUUM (REFRESH_TABLE) wal_mc_t;
 
 # TEXT column recovered
 connection mc_after

--- a/tests/sqllogic/recovery/wal_index_recovery_no_index_tables.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_no_index_tables.test
@@ -44,7 +44,7 @@ statement ok
 CREATE INDEX ni2_main_idx ON ni2_main USING inverted(id, body ni2_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ni2_main;
+VACUUM (REFRESH_TABLE) ni2_main;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -94,7 +94,7 @@ SELECT 1;
 
 connection ni2_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ni2_main;
+VACUUM (REFRESH_TABLE) ni2_main;
 
 # Inverted index counts only the indexed table.
 connection ni2_after

--- a/tests/sqllogic/recovery/wal_index_recovery_non_indexed_update.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_non_indexed_update.test
@@ -32,7 +32,7 @@ statement ok
 CREATE INDEX ni_idx ON ni_t USING inverted(id, note ni_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ni_t;
+VACUUM (REFRESH_TABLE) ni_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -60,7 +60,7 @@ SELECT 1;
 
 connection ni_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ni_t;
+VACUUM (REFRESH_TABLE) ni_t;
 
 # Indexed column unchanged for rows 1 and 2.
 connection ni_after

--- a/tests/sqllogic/recovery/wal_index_recovery_noop.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_noop.test
@@ -26,7 +26,7 @@ CREATE INDEX wal_nop_idx ON wal_nop_t USING inverted(a, b nop_dict);
 
 # Flush iresearch so its persisted tick matches rocksdb's tail
 statement ok
-VACUUM (UPDATE_INDEXES) wal_nop_t;
+VACUUM (REFRESH_TABLE) wal_nop_t;
 
 query
 SELECT COUNT(*) FROM wal_nop_idx WHERE b @@ ts_phrase('caught');

--- a/tests/sqllogic/recovery/wal_index_recovery_only_non_indexed_writes.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_only_non_indexed_writes.test
@@ -37,7 +37,7 @@ CREATE INDEX oni_inv_idx ON oni_inv_t USING inverted(id, body oni_dict);
 
 # Get inverted index fully caught up — nothing pending.
 statement ok
-VACUUM (UPDATE_INDEXES) oni_inv_t;
+VACUUM (REFRESH_TABLE) oni_inv_t;
 
 # === Block search commits, but never write to the indexed table. ===
 statement ok
@@ -68,7 +68,7 @@ SELECT 1;
 
 connection oni_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) oni_inv_t;
+VACUUM (REFRESH_TABLE) oni_inv_t;
 
 # Inverted index is exactly as before the crash.
 connection oni_after

--- a/tests/sqllogic/recovery/wal_index_recovery_partial_lag.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_partial_lag.test
@@ -41,10 +41,10 @@ CREATE INDEX pl_lagging_idx ON pl_lagging
   USING inverted(id, body pl_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) pl_caught_up;
+VACUUM (REFRESH_TABLE) pl_caught_up;
 
 statement ok
-VACUUM (UPDATE_INDEXES) pl_lagging;
+VACUUM (REFRESH_TABLE) pl_lagging;
 
 # Both indexes are caught up. Block search commits and write to the lagging
 # table only.
@@ -76,11 +76,11 @@ SELECT 1;
 
 connection pl_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) pl_caught_up;
+VACUUM (REFRESH_TABLE) pl_caught_up;
 
 connection pl_after
 statement ok
-VACUUM (UPDATE_INDEXES) pl_lagging;
+VACUUM (REFRESH_TABLE) pl_lagging;
 
 # Caught-up table is unchanged.
 connection pl_after

--- a/tests/sqllogic/recovery/wal_index_recovery_pk_update.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_pk_update.test
@@ -34,7 +34,7 @@ statement ok
 CREATE INDEX pku_idx ON pku_t USING inverted(id, name pku_dict, data pku_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) pku_t;
+VACUUM (REFRESH_TABLE) pku_t;
 
 # Sanity: pre-PK-update everything findable
 query
@@ -65,7 +65,7 @@ SELECT 1;
 
 connection pku_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) pku_t;
+VACUUM (REFRESH_TABLE) pku_t;
 
 # Old pks (1, 2) — gone from index.
 connection pku_after

--- a/tests/sqllogic/recovery/wal_index_recovery_populate_crash.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_populate_crash.test
@@ -32,7 +32,7 @@ CREATE INDEX pop_idx ON pop_t USING inverted(c, a pop_dict, b pop_dict);
 
 # Make sure index is fully caught up before we block commits.
 statement ok
-VACUUM (UPDATE_INDEXES) pop_t;
+VACUUM (REFRESH_TABLE) pop_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -56,7 +56,7 @@ SELECT 1;
 
 connection pop_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) pop_t;
+VACUUM (REFRESH_TABLE) pop_t;
 
 # All 10001 rows must be retrievable through iresearch (count goes via
 # IRESEARCH_COUNT operator → reads iresearch reader directly).

--- a/tests/sqllogic/recovery/wal_index_recovery_revival.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_revival.test
@@ -30,7 +30,7 @@ statement ok
 CREATE INDEX rv_idx ON rv_t USING inverted(id, body rv_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) rv_t;
+VACUUM (REFRESH_TABLE) rv_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -73,7 +73,7 @@ SELECT 1;
 
 connection rv_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) rv_t;
+VACUUM (REFRESH_TABLE) rv_t;
 
 # pk=1 untouched
 connection rv_after

--- a/tests/sqllogic/recovery/wal_index_recovery_stress_loop.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_stress_loop.test
@@ -56,10 +56,10 @@ CREATE TABLE stress_t(id INTEGER PRIMARY KEY, body TEXT);
 
 statement ok
 CREATE INDEX stress_idx ON stress_t USING inverted(id, body stress_dict)
-  WITH (commit_interval = 0);
+  WITH (refresh_interval = 0);
 
 statement ok
-VACUUM (UPDATE_INDEXES) stress_t;
+VACUUM (REFRESH_TABLE) stress_t;
 
 ###############################################################################
 # Round 1
@@ -1004,7 +1004,7 @@ SELECT 1;
 
 connection final
 statement ok retry 60 backoff 1s
-VACUUM (UPDATE_INDEXES) stress_t;
+VACUUM (REFRESH_TABLE) stress_t;
 
 # Per-sandbox surviving rows: 341.  10 sandboxes → 3410.
 connection final

--- a/tests/sqllogic/recovery/wal_index_recovery_tick_in_past.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_tick_in_past.test
@@ -35,7 +35,7 @@ statement ok
 CREATE INDEX past_idx ON past_t USING inverted(value1, value2 past_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) past_t;
+VACUUM (REFRESH_TABLE) past_t;
 
 # At this point past_idx has _recovery_tick == engine.recoveryTick(). Everything
 # below now goes into WAL but the iresearch tick stays where it is.
@@ -64,7 +64,7 @@ SELECT 1;
 
 connection past_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) past_t;
+VACUUM (REFRESH_TABLE) past_t;
 
 # Row counts:
 #  seed 0..999      1000

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate.test
@@ -32,7 +32,7 @@ statement ok
 CREATE INDEX babsky_idx ON babsky_t USING inverted(id, body babsky_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) babsky_t;
+VACUUM (REFRESH_TABLE) babsky_t;
 
 # Sanity: seed rows searchable before we touch anything.
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate_chain.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate_chain.test
@@ -28,7 +28,7 @@ statement ok
 CREATE INDEX gayazov_idx ON gayazov_t USING inverted(id, body gayazov_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) gayazov_t;
+VACUUM (REFRESH_TABLE) gayazov_t;
 
 # Block search commits. Everything below this stays in the WAL until restart.
 statement ok

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate_isolated_tables.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate_isolated_tables.test
@@ -38,10 +38,10 @@ statement ok
 CREATE INDEX vedernikoff_drop_idx ON vedernikoff_drop USING inverted(id, body vedernikoff_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) vedernikoff_keep;
+VACUUM (REFRESH_TABLE) vedernikoff_keep;
 
 statement ok
-VACUUM (UPDATE_INDEXES) vedernikoff_drop;
+VACUUM (REFRESH_TABLE) vedernikoff_drop;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate_multiple_indexes.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate_multiple_indexes.test
@@ -33,7 +33,7 @@ statement ok
 CREATE INDEX abramov_tag_idx ON abramov_t USING inverted(id, tag abramov_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) abramov_t;
+VACUUM (REFRESH_TABLE) abramov_t;
 
 # Sanity: both shards return seed rows.
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate_stress.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate_stress.test
@@ -31,7 +31,7 @@ statement ok
 CREATE INDEX ivanov_idx ON ivanov_t USING inverted(id, body ivanov_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ivanov_t;
+VACUUM (REFRESH_TABLE) ivanov_t;
 
 # Sanity before stress.
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate_then_inserts.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate_then_inserts.test
@@ -31,7 +31,7 @@ statement ok
 CREATE INDEX mironov_idx ON mironov_t USING inverted(id, body mironov_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) mironov_t;
+VACUUM (REFRESH_TABLE) mironov_t;
 
 # Sanity: pre-truncate rows are searchable.
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_truncate_then_vacuum.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_truncate_then_vacuum.test
@@ -1,6 +1,6 @@
 control substitution on
 
-# WAL index recovery: VACUUM (UPDATE_INDEXES) AFTER a TRUNCATE, then crash.
+# WAL index recovery: VACUUM (REFRESH_TABLE) AFTER a TRUNCATE, then crash.
 #
 # Sequence inside the recovery range:
 #   1) seed + VACUUM            -> on-disk iresearch holds the seed.
@@ -39,7 +39,7 @@ CREATE INDEX gnusi_idx ON gnusi_t USING inverted(id, body gnusi_dict);
 
 # Phase 1: seed -> publish via vacuum.
 statement ok
-VACUUM (UPDATE_INDEXES) gnusi_t;
+VACUUM (REFRESH_TABLE) gnusi_t;
 
 # Phase 2: write more, then publish via vacuum -- iresearch on-disk now holds
 # {phase1, phase2}.
@@ -47,7 +47,7 @@ statement ok
 INSERT INTO gnusi_t VALUES (3, 'phase2 charlie'), (4, 'phase2 delta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) gnusi_t;
+VACUUM (REFRESH_TABLE) gnusi_t;
 
 query
 SELECT count(*) FROM gnusi_idx WHERE body @@ ts_phrase('phase1 alpha');

--- a/tests/sqllogic/recovery/wal_index_recovery_types.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_types.test
@@ -39,7 +39,7 @@ CREATE INDEX ty_idx ON ty_t
   USING inverted(id, txt ty_dict, small_i, big_i, flt, dbl, flag, d);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ty_t;
+VACUUM (REFRESH_TABLE) ty_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -62,7 +62,7 @@ SELECT 1;
 
 connection ty_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ty_t;
+VACUUM (REFRESH_TABLE) ty_t;
 
 # Total row count
 connection ty_after

--- a/tests/sqllogic/recovery/wal_index_recovery_unicode.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_unicode.test
@@ -26,7 +26,7 @@ statement ok
 CREATE INDEX uni_idx ON uni_t USING inverted(id, body uni_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) uni_t;
+VACUUM (REFRESH_TABLE) uni_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -51,7 +51,7 @@ SELECT 1;
 
 connection uni_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) uni_t;
+VACUUM (REFRESH_TABLE) uni_t;
 
 connection uni_after
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_update.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_update.test
@@ -31,7 +31,7 @@ statement ok
 CREATE INDEX wal_upd_idx ON wal_upd_t USING inverted(a, b upd_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_upd_t;
+VACUUM (REFRESH_TABLE) wal_upd_t;
 
 query
 SELECT a FROM wal_upd_idx WHERE b @@ ts_phrase('old cat');
@@ -61,7 +61,7 @@ SELECT 1;
 
 connection upd_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_upd_t;
+VACUUM (REFRESH_TABLE) wal_upd_t;
 
 # Old values for updated rows must be gone
 connection upd_after

--- a/tests/sqllogic/recovery/wal_index_recovery_update_all_cols.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_update_all_cols.test
@@ -30,7 +30,7 @@ CREATE INDEX ua_idx ON ua_t
   USING inverted(id, a ua_dict, b ua_dict, c ua_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ua_t;
+VACUUM (REFRESH_TABLE) ua_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -58,7 +58,7 @@ SELECT 1;
 
 connection ua_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ua_t;
+VACUUM (REFRESH_TABLE) ua_t;
 
 connection ua_after
 query

--- a/tests/sqllogic/recovery/wal_index_recovery_wildcard.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_wildcard.test
@@ -36,7 +36,7 @@ CREATE INDEX wal_wild_idx ON wal_wild_t
   INCLUDE (b);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_wild_t;
+VACUUM (REFRESH_TABLE) wal_wild_t;
 
 # Plan check: ts_like filter served by the inverted index.
 query
@@ -101,7 +101,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_wild_t;
+VACUUM (REFRESH_TABLE) wal_wild_t;
 
 # Pre-crash row queryable.
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_wildcard_no_include.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_wildcard_no_include.test
@@ -27,7 +27,7 @@ CREATE INDEX wal_wild_ni_idx ON wal_wild_ni_t
   USING inverted(b wal_wild_ni_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) wal_wild_ni_t;
+VACUUM (REFRESH_TABLE) wal_wild_ni_t;
 
 # Plan: ts_like filter consults analyzer-output cs aux column;
 # `b` projection falls back to RocksDB lookup (no INCLUDE).
@@ -104,7 +104,7 @@ SELECT 1;
 
 connection wal_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) wal_wild_ni_t;
+VACUUM (REFRESH_TABLE) wal_wild_ni_t;
 
 # Pre-crash row queryable.
 connection wal_after

--- a/tests/sqllogic/recovery/wal_index_recovery_with_secondary.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_with_secondary.test
@@ -35,7 +35,7 @@ statement ok
 CREATE INDEX ws_score_idx ON ws_t(score);
 
 statement ok
-VACUUM (UPDATE_INDEXES) ws_t;
+VACUUM (REFRESH_TABLE) ws_t;
 
 statement ok
 SET sdb_faults = 'SearchCommitTask::commitUnsafe';
@@ -75,7 +75,7 @@ SELECT 1;
 
 connection ws_after
 statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
-VACUUM (UPDATE_INDEXES) ws_t;
+VACUUM (REFRESH_TABLE) ws_t;
 
 # Total row count.
 connection ws_after

--- a/tests/sqllogic/sdb/pg/ddl/column_store_mode.test
+++ b/tests/sqllogic/sdb/pg/ddl/column_store_mode.test
@@ -184,7 +184,7 @@ INSERT INTO indexonly_search VALUES
   (3, 'pudge carries team again');
 
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_search;
+VACUUM (REFRESH_TABLE) indexonly_search;
 
 # Search predicate against the IndexOnly column passes through the inverted
 # index. Only `id` is projected; `body` is consumed by the predicate and
@@ -234,7 +234,7 @@ CREATE INDEX indexonly_late_idx
   ON indexonly_late USING inverted(body indexonly_english);
 
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_late;
+VACUUM (REFRESH_TABLE) indexonly_late;
 
 # The two pre-index rows are not searchable -- their `body` was never
 # persisted anywhere.
@@ -251,7 +251,7 @@ INSERT INTO indexonly_late VALUES
   (4, 'anchin after index');
 
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_late;
+VACUUM (REFRESH_TABLE) indexonly_late;
 
 query
 SELECT id FROM indexonly_late_idx WHERE body @@ ts_phrase('pudge') ORDER BY id;
@@ -290,7 +290,7 @@ CREATE INDEX indexonly_composite_idx
   ON indexonly_composite USING inverted(id, body indexonly_english);
 
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_composite;
+VACUUM (REFRESH_TABLE) indexonly_composite;
 
 # Pre-existing rows are not in the index (backfill was a no-op).
 query
@@ -303,7 +303,7 @@ statement ok
 INSERT INTO indexonly_composite VALUES (3, 'fresh row');
 
 statement ok
-VACUUM (UPDATE_INDEXES) indexonly_composite;
+VACUUM (REFRESH_TABLE) indexonly_composite;
 
 query
 SELECT id FROM indexonly_composite_idx WHERE body @@ ts_phrase('fresh') ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/basic.test
+++ b/tests/sqllogic/sdb/pg/index/basic.test
@@ -12,7 +12,7 @@ CREATE TEXT SEARCH DICTIONARY test_english(
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 statement ok
@@ -54,16 +54,16 @@ c
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 statement error
-VACUUM (UPDATE_INDEXES) wrong_t_name;
+VACUUM (REFRESH_TABLE) wrong_t_name;
 ----
 db error: ERROR: relation 'wrong_t_name' not found.
 
 
 statement error
-VACUUM (UPDATE_INDEXES) index_t;
+VACUUM (REFRESH_TABLE) index_t;
 ----
 db error: ERROR: relation 'index_t' not found.
 
@@ -284,7 +284,7 @@ statement ok
 INSERT INTO table_numeric_idx VALUES (1,1), (2,3), (4,5);
 
 statement ok
-VACUUM (UPDATE_INDEXES) table_numeric_idx;
+VACUUM (REFRESH_TABLE) table_numeric_idx;
 
 query
 SELECT * FROM test_index_numeric WHERE a = 1 OR b = 3 OR a = 17 ORDER BY a;
@@ -301,7 +301,7 @@ statement count 3
 INSERT INTO table_numeric_idx VALUES (3,1), (7,3), (17,5);
 
 statement ok
-VACUUM (UPDATE_INDEXES) table_numeric_idx;
+VACUUM (REFRESH_TABLE) table_numeric_idx;
 
 statement ok
 SET sdb_read_your_own_writes = 1;
@@ -324,7 +324,7 @@ statement ok
 COMMIT;
 
 statement ok
-VACUUM (UPDATE_INDEXES) table_numeric_idx;
+VACUUM (REFRESH_TABLE) table_numeric_idx;
 
 statement ok
 SET sdb_read_your_own_writes = 0;
@@ -471,8 +471,8 @@ Explain:
     oneline (boolean) [default: false] - One-line output format for physical plan
     cost (boolean) [default: false] - Show estimated costs in physical plan
 Index:
-  commit_interval (integer) [default: 1000] - Commit interval in milliseconds
-  consolidation_interval (integer) [default: 1000] - Consolidation interval in milliseconds
+  refresh_interval (integer) [default: 1000] - Refresh interval in milliseconds
+  compaction_interval (integer) [default: 1000] - Compaction interval in milliseconds
   cleanup_interval_step (integer) [default: 1] - Cleanup interval step
 
 

--- a/tests/sqllogic/sdb/pg/index/geo_search.test
+++ b/tests/sqllogic/sdb/pg/index/geo_search.test
@@ -58,7 +58,7 @@ statement ok
 INSERT INTO geo_data VALUES (6, '{"type":"Polygon","coordinates":[[[37.614323,55.705898],[37.615825,55.705898],[37.615825,55.706520],[37.614323,55.706520],[37.614323,55.705898]]]}')
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_data
+VACUUM (REFRESH_TABLE) geo_data
 
 
 # --- ST_Intersects ---
@@ -202,7 +202,7 @@ statement ok
 INSERT INTO geo_data VALUES (7, '{"type":"Point","coordinates":[37.614800,55.704500]}')
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_data
+VACUUM (REFRESH_TABLE) geo_data
 
 
 # New point [37.6148, 55.7045] is inside both large_poly and medium_poly.
@@ -362,7 +362,7 @@ statement ok
 INSERT INTO geo_plain VALUES (1, '{"type":"Point","coordinates":[0,0]}')
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_plain
+VACUUM (REFRESH_TABLE) geo_plain
 
 
 statement error
@@ -418,7 +418,7 @@ statement ok
 INSERT INTO geo_data_g VALUES (6, 'POLYGON((37.614323 55.705898, 37.615825 55.705898, 37.615825 55.706520, 37.614323 55.706520, 37.614323 55.705898))'::GEOMETRY('OGC:CRS84'))
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_data_g
+VACUUM (REFRESH_TABLE) geo_data_g
 
 
 # --- GEOMETRY field + JSON (GeoJSON) shape ---
@@ -638,7 +638,7 @@ statement ok
 INSERT INTO geo_data_g VALUES (7, 'POINT(37.614800 55.704500)'::GEOMETRY('OGC:CRS84'))
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_data_g
+VACUUM (REFRESH_TABLE) geo_data_g
 
 
 query
@@ -818,7 +818,7 @@ statement ok
 INSERT INTO places VALUES (7, '{"type":"Point","coordinates":[37.701645,55.832144]}', 'blue restaurant outpost')
 
 statement ok
-VACUUM (UPDATE_INDEXES) places
+VACUUM (REFRESH_TABLE) places
 
 
 # --- AND: geo predicate AND text @@ ---
@@ -1244,7 +1244,7 @@ statement ok
 INSERT INTO geo_pt VALUES (6, '{"name":"orphan"}')
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_pt
+VACUUM (REFRESH_TABLE) geo_pt
 
 
 # --- ST_Intersects + path-mode geopoint ---
@@ -1357,7 +1357,7 @@ statement ok
 INSERT INTO geo_pt_arr VALUES (6, '[55.704,37.616,0.0]')
 
 statement ok
-VACUUM (UPDATE_INDEXES) geo_pt_arr
+VACUUM (REFRESH_TABLE) geo_pt_arr
 
 
 # --- ST_Distance_Centroid + array-mode geopoint ---

--- a/tests/sqllogic/sdb/pg/index/headline.test
+++ b/tests/sqllogic/sdb/pg/index/headline.test
@@ -217,7 +217,7 @@ INSERT INTO hl_docs VALUES
     (5, 'lorem ipsum dolor sit amet quick consectetur adipiscing elit fox sed do')
 
 statement ok
-VACUUM (UPDATE_INDEXES) hl_docs
+VACUUM (REFRESH_TABLE) hl_docs
 
 
 # Single-term match: search scan emits ts_offsets(body); piped into
@@ -339,7 +339,7 @@ INSERT INTO hl_corpus VALUES
     (30, 'fox in socks by dr seuss is a classic')
 
 statement ok
-VACUUM (UPDATE_INDEXES) hl_corpus
+VACUUM (REFRESH_TABLE) hl_corpus
 
 # BM25 ORDER BY + LIMIT: top-3 most relevant snippets. Pure-fox doc (5)
 # scores highest by raw frequency. We take top 3 and render with
@@ -547,7 +547,7 @@ statement ok
 INSERT INTO hl_no_offs_docs VALUES (1, 'the quick brown fox')
 
 statement ok
-VACUUM (UPDATE_INDEXES) hl_no_offs_docs
+VACUUM (REFRESH_TABLE) hl_no_offs_docs
 
 query
 SELECT id, ts_highlight(body)
@@ -568,7 +568,7 @@ INSERT INTO hl_no_offs_docs VALUES
     (4, 'a slow brown bear')
 
 statement ok
-VACUUM (UPDATE_INDEXES) hl_no_offs_docs
+VACUUM (REFRESH_TABLE) hl_no_offs_docs
 
 query
 SELECT id, ts_highlight(body)
@@ -778,7 +778,7 @@ INSERT INTO hl_multi VALUES
     (2, 'cat news', 'cat is here')
 
 statement ok
-VACUUM (UPDATE_INDEXES) hl_multi
+VACUUM (REFRESH_TABLE) hl_multi
 
 # Two ts_offsets() projections on different columns with different
 # limits. The per-FieldEntry cap in FillRowOffsets keeps the

--- a/tests/sqllogic/sdb/pg/index/inverted_index.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index.test
@@ -30,7 +30,7 @@ statement ok
 INSERT INTO foo values (2, 'quick red fox jumps over lazy dog', 'value a');
 
 statement ok
-VACUUM (UPDATE_INDEXES) foo;
+VACUUM (REFRESH_TABLE) foo;
 
 query
 SELECT a, b FROM foo_idx WHERE b @@ ts_phrase('over lazy dog') ORDER BY a;
@@ -43,7 +43,7 @@ statement ok
 UPDATE foo SET c = 'value abc' WHERE a = 1;
 
 statement ok
-VACUUM (UPDATE_INDEXES) foo;
+VACUUM (REFRESH_TABLE) foo;
 
 query
 SELECT a, b, c FROM foo_idx WHERE c @@ ts_phrase('value abc') AND b @@ ts_phrase('over lazy dog');
@@ -58,7 +58,7 @@ statement ok
 INSERT INTO foo values (4, 'quick brown fox jumps over big dog', 'value b');
 
 statement ok
-VACUUM (UPDATE_INDEXES) foo;
+VACUUM (REFRESH_TABLE) foo;
 
 query
 SELECT a, b FROM foo_idx WHERE b @@ ts_phrase('over big dog') OR b @@ ts_phrase('red fox') ORDER BY a;
@@ -89,7 +89,7 @@ statement ok
 INSERT INTO foo values (6, 'quick fox over big dog', 'value c');
 
 statement ok
-VACUUM (UPDATE_INDEXES) foo;
+VACUUM (REFRESH_TABLE) foo;
 
 # Exact gap: 1 word between 'quick' and 'fox' -- matches rows with 'quick brown fox' and 'quick red fox'
 query
@@ -302,7 +302,7 @@ UPDATE vedernikoff SET c = 'deadinside' WHERE a = 3;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vedernikoff;
+VACUUM (REFRESH_TABLE) vedernikoff;
 
 
 query
@@ -772,13 +772,13 @@ statement ok
 CREATE INDEX multi_seg_idx ON multi_seg USING inverted(a, b score_en);
 
 statement ok
-VACUUM (UPDATE_INDEXES) multi_seg;
+VACUUM (REFRESH_TABLE) multi_seg;
 
 statement ok
 INSERT INTO multi_seg VALUES (3, 'gamma fox'), (4, 'delta fox');
 
 statement ok
-VACUUM (UPDATE_INDEXES) multi_seg;
+VACUUM (REFRESH_TABLE) multi_seg;
 
 query
 SELECT a, BM25(multi_seg_idx.tableoid) > 0 AS has_score FROM multi_seg_idx WHERE b @@ ts_phrase('fox') ORDER BY a;
@@ -1129,7 +1129,7 @@ statement ok
 CREATE INDEX dense_multi_idx ON dense_multi USING inverted(a, b test_english);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_multi;
+VACUUM (REFRESH_TABLE) dense_multi;
 
 statement ok
 INSERT INTO dense_multi VALUES
@@ -1139,7 +1139,7 @@ INSERT INTO dense_multi VALUES
   (8, 'universal token theta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_multi;
+VACUUM (REFRESH_TABLE) dense_multi;
 
 query
 SELECT a, b FROM dense_multi_idx WHERE b @@ ts_phrase('universal token') ORDER BY a;
@@ -1180,7 +1180,7 @@ INSERT INTO dense_multi VALUES
   (10, 'universal token kappa');
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_multi;
+VACUUM (REFRESH_TABLE) dense_multi;
 
 query
 SELECT a, b FROM dense_multi_idx WHERE b @@ ts_phrase('universal token') ORDER BY a;

--- a/tests/sqllogic/sdb/pg/index/inverted_index.test_slow
+++ b/tests/sqllogic/sdb/pg/index/inverted_index.test_slow
@@ -356,7 +356,7 @@ statement ok
 CREATE INDEX dense_pk_slow_idx ON dense_pk_slow USING inverted(a, b test_english);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_pk_slow;
+VACUUM (REFRESH_TABLE) dense_pk_slow;
 
 statement count 5000
 INSERT INTO dense_pk_slow
@@ -364,7 +364,7 @@ SELECT n, 'every row shares universal phrase number ' || n::text
 FROM generate_series(5001, 10000) AS s(n);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_pk_slow;
+VACUUM (REFRESH_TABLE) dense_pk_slow;
 
 query
 SELECT * FROM dense_pk_slow_idx WHERE b @@ ts_phrase('every row shares') ORDER BY a;
@@ -409,7 +409,7 @@ statement ok
 CREATE INDEX dense_no_pk_slow_idx ON dense_no_pk_slow USING inverted(a, b test_english, c test_english);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_no_pk_slow;
+VACUUM (REFRESH_TABLE) dense_no_pk_slow;
 
 # intentional insert out of order to test generated score column reading
 statement count 5000
@@ -431,7 +431,7 @@ SELECT n, 'every row shares universal phrase number ' || n::text,
 FROM generate_series(201, 5000) AS s(n);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dense_no_pk_slow;
+VACUUM (REFRESH_TABLE) dense_no_pk_slow;
 
 # same hash as for table with PK
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_analyzer_cs_split.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_analyzer_cs_split.test
@@ -35,7 +35,7 @@ CREATE INDEX t_geo_inc_idx ON t_geo_inc
   USING inverted(geo g_dict) INCLUDE (geo);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_geo_inc;
+VACUUM (REFRESH_TABLE) t_geo_inc;
 
 query
 EXPLAIN SELECT pk, geo FROM t_geo_inc_idx
@@ -86,7 +86,7 @@ statement ok
 CREATE INDEX t_geo_noi_idx ON t_geo_noi USING inverted(geo g_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_geo_noi;
+VACUUM (REFRESH_TABLE) t_geo_noi;
 
 query
 EXPLAIN SELECT pk, geo FROM t_geo_noi_idx
@@ -138,7 +138,7 @@ CREATE INDEX t_wild_inc_idx ON t_wild_inc
   USING inverted(b w_dict) INCLUDE (b);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_wild_inc;
+VACUUM (REFRESH_TABLE) t_wild_inc;
 
 query
 EXPLAIN SELECT pk, b FROM t_wild_inc_idx
@@ -196,7 +196,7 @@ statement ok
 CREATE INDEX t_wild_noi_idx ON t_wild_noi USING inverted(b w_dict);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_wild_noi;
+VACUUM (REFRESH_TABLE) t_wild_noi;
 
 query
 EXPLAIN SELECT pk, b FROM t_wild_noi_idx

--- a/tests/sqllogic/sdb/pg/index/inverted_index_ann_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_ann_include.test
@@ -38,7 +38,7 @@ INSERT INTO vec_t VALUES (4, [10, 10, 10]::FLOAT[3], 'delta', 400, 'body-four')
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vec_t
+VACUUM (REFRESH_TABLE) vec_t
 
 
 # All-INCLUDE projection: label + tag are both INCLUDE'd, so the

--- a/tests/sqllogic/sdb/pg/index/inverted_index_array_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_array_include.test
@@ -42,7 +42,7 @@ INSERT INTO arr_t VALUES (3, 'third',  [-1.0, 0.0, 1.0])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) arr_t
+VACUUM (REFRESH_TABLE) arr_t
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_array_nulls.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_array_nulls.test
@@ -46,7 +46,7 @@ INSERT INTO arr_n VALUES (3, 'third',  [-1.0, 0.0, 1.0])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) arr_n
+VACUUM (REFRESH_TABLE) arr_n
 
 
 # Sanity: the ARRAY column is served by the iresearch columnstore (i),

--- a/tests/sqllogic/sdb/pg/index/inverted_index_column_existence.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_column_existence.test
@@ -53,7 +53,7 @@ INSERT INTO ce VALUES (4, 'delta', NULL)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) ce
+VACUUM (REFRESH_TABLE) ce
 
 
 # ---- 1. ts_is_null() pushes down as NOT[EXISTS[col_id]] ----

--- a/tests/sqllogic/sdb/pg/index/inverted_index_columnstore.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_columnstore.test
@@ -68,12 +68,12 @@ pk	big_int	dbl
 5	500	5.25
 
 # Insert into existing index, flush, query: hits a fresh segment with
-# columnstore data merged with the original on consolidation.
+# columnstore data merged with the original on compaction.
 statement ok
 INSERT INTO foo VALUES (6, 66, 600, 6.5, 6.25, TRUE, 'fresh');
 
 statement ok
-VACUUM (UPDATE_INDEXES) foo;
+VACUUM (REFRESH_TABLE) foo;
 
 query
 SELECT pk, small_int, big_int, flag FROM foo_idx WHERE txt @@ ts_phrase('fresh');
@@ -86,7 +86,7 @@ statement ok
 UPDATE foo SET big_int = 999, flag = FALSE WHERE pk = 6;
 
 statement ok
-VACUUM (UPDATE_INDEXES) foo;
+VACUUM (REFRESH_TABLE) foo;
 
 query
 SELECT pk, big_int, flag FROM foo_idx WHERE txt @@ ts_phrase('fresh');
@@ -94,7 +94,7 @@ SELECT pk, big_int, flag FROM foo_idx WHERE txt @@ ts_phrase('fresh');
 pk	big_int	flag
 6	999	f
 
-# After multiple consolidation cycles, columnstore data from older segments
+# After multiple compaction cycles, columnstore data from older segments
 # survives the merge: original 5 rows still materialize correctly.
 query
 SELECT pk, big_int, dbl FROM foo_idx ORDER BY pk;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_columnstore_codecs.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_columnstore_codecs.test
@@ -175,7 +175,7 @@ SELECT seq_int, step_int FROM codec_seq_idx WHERE txt @@ ts_phrase('five');
 seq_int	step_int
 1004	50
 
-# --- 5. Insert + VACUUM-driven consolidation across codec mixes -----------
+# --- 5. Insert + VACUUM-driven compaction across codec mixes -----------
 # Forces a merge that has to bring together row groups whose chosen codec
 # differs (constant marker vs. mixed marker). The merged segment must read
 # back identical values.
@@ -185,7 +185,7 @@ INSERT INTO codec_const VALUES
   (6, TRUE,  9, 'zeta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) codec_const;
+VACUUM (REFRESH_TABLE) codec_const;
 
 query
 SELECT pk, flag, marker FROM codec_const_idx ORDER BY pk;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_compact.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_compact.test
@@ -2,9 +2,9 @@ hash-threshold 100
 
 # End-to-end test: BM25 ordering must remain correct after the inverted
 # index is compacted. We force the index into a multi-segment shape by
-# inserting in three batches with VACUUM (UPDATE_INDEXES) between each
-# batch (each VACUUM commits a fresh segment). Then we drive consolidation
-# to a fixpoint via the new compact_indexes handler and re-run the same
+# inserting in three batches with VACUUM (REFRESH_TABLE) between each
+# batch (each VACUUM commits a fresh segment). Then we drive compaction
+# to a fixpoint via the COMPACT_TABLE handler and re-run the same
 # BM25 queries. Norms feed BM25, so this also covers the norm read path
 # across pre- and post-merge segments.
 
@@ -39,7 +39,7 @@ INSERT INTO docs VALUES (2, 'the quick fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # Batch 2 — segment B
@@ -52,7 +52,7 @@ INSERT INTO docs VALUES (4, 'a fox is a fox is a fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # Batch 3 — segment C
@@ -65,7 +65,7 @@ INSERT INTO docs VALUES (6, 'nothing here');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # Snapshot the pre-compaction BM25 ordering for 'fox'. The expected
@@ -92,10 +92,10 @@ id
 1
 
 
-# Drive consolidation to a fixpoint. After this, all live docs should be
+# Drive compaction to a fixpoint. After this, all live docs should be
 # in a single merged segment.
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'docs');
+VACUUM (COMPACT_TABLE) docs;
 
 
 # Same BM25 queries must give the same ordering after compaction.
@@ -130,7 +130,7 @@ id	has_score
 
 # Compacting again should be a no-op (idempotent).
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'docs');
+VACUUM (COMPACT_TABLE) docs;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_compression_option.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_compression_option.test
@@ -208,7 +208,7 @@ INSERT INTO hnsw_comp VALUES
   (3, [0.0, 0.0, 1.0]::FLOAT[3]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hnsw_comp;
+VACUUM (REFRESH_TABLE) hnsw_comp;
 
 query
 SELECT id FROM hnsw_comp_unc ORDER BY emb <-> [1.0, 0.0, 0.0]::FLOAT[3] LIMIT 1;
@@ -231,7 +231,7 @@ INSERT INTO hnsw_mat VALUES
   (2, [4.0, 5.0, 6.0]::FLOAT[3]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hnsw_mat;
+VACUUM (REFRESH_TABLE) hnsw_mat;
 
 query
 SELECT id, emb FROM hnsw_mat_idx ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_dfi.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_dfi.test
@@ -40,7 +40,7 @@ CREATE INDEX docs_idx ON docs USING inverted(id, body en);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # DFI with default measure (standardized): never negative. At least one

--- a/tests/sqllogic/sdb/pg/index/inverted_index_document_length.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_document_length.test
@@ -34,7 +34,7 @@ INSERT INTO docs VALUES (3, 'the lazy dog');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 query
@@ -84,7 +84,7 @@ INSERT INTO docs VALUES (5, 'a quick brown rabbit and a fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 query
@@ -243,7 +243,7 @@ INSERT INTO sparse_norm VALUES (6, '{"body":"x"}'::json);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) sparse_norm;
+VACUUM (REFRESH_TABLE) sparse_norm;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_explain_source.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_explain_source.test
@@ -219,7 +219,7 @@ QUERY PLAN
 # Confirms that when EXPLAIN says (i) for emb, the value really comes
 # back through the index path (not garbage / not empty).
 statement ok
-VACUUM (UPDATE_INDEXES) src_hnsw_only;
+VACUUM (REFRESH_TABLE) src_hnsw_only;
 
 query
 SELECT id, emb FROM src_hnsw_only_idx ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_expressions.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_expressions.test
@@ -17,7 +17,7 @@ statement ok
 INSERT INTO num1 VALUES (1, 10), (2, 41), (3, -5);
 
 statement ok
-VACUUM (UPDATE_INDEXES) num1;
+VACUUM (REFRESH_TABLE) num1;
 
 query
 SELECT id FROM num1_idx WHERE a + 1 = 42;
@@ -45,7 +45,7 @@ statement ok
 INSERT INTO vc1 VALUES (1, 'HELLO'), (2, 'World'), (3, 'mixed');
 
 statement ok
-VACUUM (UPDATE_INDEXES) vc1;
+VACUUM (REFRESH_TABLE) vc1;
 
 query
 SELECT id FROM vc1_idx WHERE LOWER(s) = 'hello';
@@ -78,7 +78,7 @@ statement ok
 INSERT INTO b1 VALUES (1, 5), (2, -3), (3, 0), (4, 7);
 
 statement ok
-VACUUM (UPDATE_INDEXES) b1;
+VACUUM (REFRESH_TABLE) b1;
 
 query
 SELECT id FROM b1_idx WHERE (x > 0) = true ORDER BY id;
@@ -108,7 +108,7 @@ statement ok
 INSERT INTO b1d VALUES (1, 5), (2, -3), (3, 0), (4, 7);
 
 statement ok
-VACUUM (UPDATE_INDEXES) b1d;
+VACUUM (REFRESH_TABLE) b1d;
 
 query
 SELECT id FROM b1d_idx WHERE (x > 0) = true ORDER BY id;
@@ -130,7 +130,7 @@ statement ok
 INSERT INTO num2 VALUES (1, 10, 20), (2, 5, 5), (3, 7, 13);
 
 statement ok
-VACUUM (UPDATE_INDEXES) num2;
+VACUUM (REFRESH_TABLE) num2;
 
 query
 SELECT id FROM num2_idx WHERE a + b = 30;
@@ -158,7 +158,7 @@ statement ok
 INSERT INTO vc2 VALUES (1, 'foo', 'bar'), (2, 'hello', 'world'), (3, 'a', 'b');
 
 statement ok
-VACUUM (UPDATE_INDEXES) vc2;
+VACUUM (REFRESH_TABLE) vc2;
 
 query
 SELECT id FROM vc2_idx WHERE s1 || s2 = 'foobar';
@@ -185,7 +185,7 @@ statement ok
 INSERT INTO b2 VALUES (1, 10, 5), (2, 3, 7), (3, 4, 4);
 
 statement ok
-VACUUM (UPDATE_INDEXES) b2;
+VACUUM (REFRESH_TABLE) b2;
 
 query
 SELECT id FROM b2_idx WHERE (a > b) = true ORDER BY id;
@@ -213,7 +213,7 @@ statement ok
 INSERT INTO num3 VALUES (1, 1, 2, 3), (2, 10, 20, 30), (3, 0, 0, 0);
 
 statement ok
-VACUUM (UPDATE_INDEXES) num3;
+VACUUM (REFRESH_TABLE) num3;
 
 query
 SELECT id FROM num3_idx WHERE a + b + c = 6;
@@ -240,7 +240,7 @@ statement ok
 INSERT INTO vc3 VALUES (1, 'x', 'y', 'z'), (2, 'foo', 'bar', 'baz');
 
 statement ok
-VACUUM (UPDATE_INDEXES) vc3;
+VACUUM (REFRESH_TABLE) vc3;
 
 query
 SELECT id FROM vc3_idx WHERE CONCAT(a, '-', b, '-', c) = 'x-y-z';
@@ -267,7 +267,7 @@ statement ok
 INSERT INTO b3 VALUES (1, 1, 2, 10), (2, 10, 20, 5), (3, 4, 4, 8);
 
 statement ok
-VACUUM (UPDATE_INDEXES) b3;
+VACUUM (REFRESH_TABLE) b3;
 
 query
 SELECT id FROM b3_idx WHERE (a + b > c) = true ORDER BY id;
@@ -297,7 +297,7 @@ INSERT INTO mix VALUES
     (1, 'foo', 'bar'), (2, 'hello', 'world'), (3, 'foo', 'baz');
 
 statement ok
-VACUUM (UPDATE_INDEXES) mix;
+VACUUM (REFRESH_TABLE) mix;
 
 query
 SELECT id FROM mix_idx WHERE a = 'foo' ORDER BY id;
@@ -382,13 +382,13 @@ statement ok
 INSERT INTO dml VALUES (1, 10, 20), (2, 1, 1);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dml;
+VACUUM (REFRESH_TABLE) dml;
 
 statement ok
 UPDATE dml SET a = 100 WHERE id = 1;
 
 statement ok
-VACUUM (UPDATE_INDEXES) dml;
+VACUUM (REFRESH_TABLE) dml;
 
 query
 SELECT id FROM dml_idx WHERE a + b = 30;
@@ -405,7 +405,7 @@ statement ok
 DELETE FROM dml WHERE id = 2;
 
 statement ok
-VACUUM (UPDATE_INDEXES) dml;
+VACUUM (REFRESH_TABLE) dml;
 
 query
 SELECT id FROM dml_idx ORDER BY id;
@@ -426,7 +426,7 @@ statement ok
 INSERT INTO n1 VALUES (1, 1, 2), (2, NULL, 5), (3, 7, NULL);
 
 statement ok
-VACUUM (UPDATE_INDEXES) n1;
+VACUUM (REFRESH_TABLE) n1;
 
 query
 SELECT id FROM n1_idx WHERE a + b IS NULL ORDER BY id;
@@ -455,7 +455,7 @@ statement ok
 INSERT INTO poly VALUES (1, 3), (2, 0), (3, 5);
 
 statement ok
-VACUUM (UPDATE_INDEXES) poly;
+VACUUM (REFRESH_TABLE) poly;
 
 query
 SELECT id FROM poly_idx WHERE a * a + a = 12;
@@ -490,7 +490,7 @@ statement ok
 INSERT INTO sgn VALUES (1, 5), (2, -3), (3, 0), (4, 7);
 
 statement ok
-VACUUM (UPDATE_INDEXES) sgn;
+VACUUM (REFRESH_TABLE) sgn;
 
 query
 SELECT id FROM sgn_idx
@@ -529,13 +529,13 @@ statement ok
 INSERT INTO mu1 VALUES (1, 10, 20), (2, 5, 25);
 
 statement ok
-VACUUM (UPDATE_INDEXES) mu1;
+VACUUM (REFRESH_TABLE) mu1;
 
 statement ok
 UPDATE mu1 SET b = 100;
 
 statement ok
-VACUUM (UPDATE_INDEXES) mu1;
+VACUUM (REFRESH_TABLE) mu1;
 
 query
 SELECT id FROM mu1_idx WHERE a + b = 110;
@@ -562,13 +562,13 @@ statement ok
 INSERT INTO mu2 VALUES (1, 10, 20, 'x'), (2, 5, 5, 'y');
 
 statement ok
-VACUUM (UPDATE_INDEXES) mu2;
+VACUUM (REFRESH_TABLE) mu2;
 
 statement ok
 UPDATE mu2 SET extra = 'z' WHERE id = 1;
 
 statement ok
-VACUUM (UPDATE_INDEXES) mu2;
+VACUUM (REFRESH_TABLE) mu2;
 
 query
 SELECT id FROM mu2_idx WHERE a + b = 30;
@@ -596,13 +596,13 @@ statement ok
 INSERT INTO mu3 VALUES (1, 'foo', 'bar'), (2, 'hello', 'world');
 
 statement ok
-VACUUM (UPDATE_INDEXES) mu3;
+VACUUM (REFRESH_TABLE) mu3;
 
 statement ok
 UPDATE mu3 SET a = 'baz' WHERE id = 1;
 
 statement ok
-VACUUM (UPDATE_INDEXES) mu3;
+VACUUM (REFRESH_TABLE) mu3;
 
 query
 SELECT id FROM mu3_idx WHERE a = 'foo';
@@ -638,13 +638,13 @@ statement ok
 INSERT INTO md VALUES (1, 10), (2, 41), (3, -5), (4, 100);
 
 statement ok
-VACUUM (UPDATE_INDEXES) md;
+VACUUM (REFRESH_TABLE) md;
 
 statement ok
 DELETE FROM md WHERE a > 10;
 
 statement ok
-VACUUM (UPDATE_INDEXES) md;
+VACUUM (REFRESH_TABLE) md;
 
 query
 SELECT id FROM md_idx ORDER BY id;
@@ -677,13 +677,13 @@ statement ok
 INSERT INTO md2 VALUES (1, 'foo', 'bar'), (2, 'baz', 'qux');
 
 statement ok
-VACUUM (UPDATE_INDEXES) md2;
+VACUUM (REFRESH_TABLE) md2;
 
 statement ok
 DELETE FROM md2;
 
 statement ok
-VACUUM (UPDATE_INDEXES) md2;
+VACUUM (REFRESH_TABLE) md2;
 
 query
 SELECT id FROM md2_idx;
@@ -758,7 +758,7 @@ INSERT INTO tx_v VALUES
     (3, 'foo', 'baz');
 
 statement ok
-VACUUM (UPDATE_INDEXES) tx_v;
+VACUUM (REFRESH_TABLE) tx_v;
 
 # TERM_EQ
 query
@@ -803,7 +803,7 @@ statement ok
 INSERT INTO tx_n VALUES (1, 10, 20), (2, 5, 5), (3, 7, 13), (4, 50, 50);
 
 statement ok
-VACUUM (UPDATE_INDEXES) tx_n;
+VACUUM (REFRESH_TABLE) tx_n;
 
 # TERM_EQ
 query
@@ -842,7 +842,7 @@ statement ok
 INSERT INTO tx_b VALUES (1, 10, 5), (2, 3, 7), (3, 4, 4);
 
 statement ok
-VACUUM (UPDATE_INDEXES) tx_b;
+VACUUM (REFRESH_TABLE) tx_b;
 
 query
 SELECT id FROM tx_b_idx WHERE (a > b) = true;
@@ -874,7 +874,7 @@ INSERT INTO tx_mix VALUES
     (3, 'foo', 'baz');
 
 statement ok
-VACUUM (UPDATE_INDEXES) tx_mix;
+VACUUM (REFRESH_TABLE) tx_mix;
 
 # Direct-column @@.
 query
@@ -975,7 +975,7 @@ statement ok
 INSERT INTO strange_json VALUES (1, 10, 20), (2, 5, 5), (3, 7, 8);
 
 statement ok
-VACUUM (UPDATE_INDEXES) strange_json;
+VACUUM (REFRESH_TABLE) strange_json;
 
 query
 SELECT id FROM strange_json_idx WHERE ((a + b)::json) = '30'::json;
@@ -1013,7 +1013,7 @@ statement ok
 INSERT INTO types_smoke VALUES (1, 1), (2, 2);
 
 statement ok
-VACUUM (UPDATE_INDEXES) types_smoke;
+VACUUM (REFRESH_TABLE) types_smoke;
 
 query
 SELECT id FROM types_smoke_idx WHERE (a + 1)::TINYINT = 2::TINYINT;
@@ -1073,7 +1073,7 @@ statement ok
 INSERT INTO null_expr VALUES (1, 1), (2, -1);
 
 statement ok
-VACUUM (UPDATE_INDEXES) null_expr;
+VACUUM (REFRESH_TABLE) null_expr;
 
 query
 SELECT id FROM null_expr_idx ORDER BY id;
@@ -1104,7 +1104,7 @@ statement ok
 INSERT INTO null_col VALUES (1, NULL), (2, NULL);
 
 statement ok
-VACUUM (UPDATE_INDEXES) null_col;
+VACUUM (REFRESH_TABLE) null_col;
 
 query
 SELECT id FROM null_col_idx ORDER BY id;
@@ -1133,7 +1133,7 @@ statement ok
 INSERT INTO inc_e_num VALUES (1, 10, 20), (2, 5, 5), (3, 100, 1);
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_e_num;
+VACUUM (REFRESH_TABLE) inc_e_num;
 
 query
 SELECT id, a + b AS s FROM inc_e_num_idx WHERE id = 1;
@@ -1154,7 +1154,7 @@ statement ok
 UPDATE inc_e_num SET a = 50 WHERE id = 1;
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_e_num;
+VACUUM (REFRESH_TABLE) inc_e_num;
 
 query
 SELECT id, a + b AS s FROM inc_e_num_idx ORDER BY id;
@@ -1176,7 +1176,7 @@ statement ok
 INSERT INTO inc_e_str VALUES (1, 'FOO', 'Bar'), (2, 'X', 'Y');
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_e_str;
+VACUUM (REFRESH_TABLE) inc_e_str;
 
 query
 SELECT id, LOWER(a) || '-' || LOWER(b) AS s FROM inc_e_str_idx ORDER BY id;
@@ -1197,7 +1197,7 @@ statement ok
 INSERT INTO inc_e_zstd VALUES (1, 'foo', 'bar'), (2, 'baz', 'qux');
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_e_zstd;
+VACUUM (REFRESH_TABLE) inc_e_zstd;
 
 query
 SELECT id, a || b AS s FROM inc_e_zstd_idx ORDER BY id;
@@ -1224,7 +1224,7 @@ statement ok
 INSERT INTO inc_e_rgs VALUES (1, 1), (2, 5), (3, 12);
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_e_rgs;
+VACUUM (REFRESH_TABLE) inc_e_rgs;
 
 query
 SELECT id, a * 2 AS s FROM inc_e_rgs_idx ORDER BY id;
@@ -1267,7 +1267,7 @@ INSERT INTO hnsw_e VALUES
     (4, 0, 0, 0);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hnsw_e;
+VACUUM (REFRESH_TABLE) hnsw_e;
 
 query
 SELECT id FROM hnsw_e_idx ORDER BY array_value(x, y, z) <-> [1,2,3]::FLOAT[3] LIMIT 2;
@@ -1307,7 +1307,7 @@ statement ok
 INSERT INTO hnsw_e2 VALUES (1, 1, 0, 0), (2, 0, 1, 0), (3, 0, 0, 1);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hnsw_e2;
+VACUUM (REFRESH_TABLE) hnsw_e2;
 
 # `hnsw` requires options.
 
@@ -1357,7 +1357,7 @@ CREATE INDEX inc_expr_idx ON inc_expr
   INCLUDE (payload);
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_expr;
+VACUUM (REFRESH_TABLE) inc_expr;
 
 query
 SELECT id, payload FROM inc_expr_idx WHERE a + b = 30 ORDER BY id;
@@ -1391,7 +1391,7 @@ CREATE INDEX inc_expr2_idx ON inc_expr2
   INCLUDE (big included (compression = 'uncompressed'));
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_expr2;
+VACUUM (REFRESH_TABLE) inc_expr2;
 
 query
 SELECT id, big FROM inc_expr2_idx WHERE a + b = 4 ORDER BY id;
@@ -1419,7 +1419,7 @@ CREATE INDEX inc_expr3_idx ON inc_expr3
   INCLUDE (label);
 
 statement ok
-VACUUM (UPDATE_INDEXES) inc_expr3;
+VACUUM (REFRESH_TABLE) inc_expr3;
 
 query
 SELECT id, label FROM inc_expr3_idx WHERE s1 || s2 = 'fooqux' ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_hnsw_cache_pressure.test_slow
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_hnsw_cache_pressure.test_slow
@@ -33,7 +33,7 @@ FROM generate_series(1, 6000) i;
 # Forces HNSWWriter::Build to run; ASan trips here on the unfixed
 # code if the dangling read fires during build.
 statement ok
-VACUUM (UPDATE_INDEXES) vec;
+VACUUM (REFRESH_TABLE) vec;
 
 # Sanity: index is queryable and returns the requested top-K.
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_hnsw_nulls.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_hnsw_nulls.test
@@ -9,7 +9,7 @@ hash-threshold 100
 #  2. DELETE flagged rows in docs_mask but the HNSW graph kept their
 #     node ids; the next HNSW search returned a deleted doc and the
 #     downstream PK fetch failed with "Missing row for PK in RocksDB".
-#  3. PRAGMA serenedb_vacuum('compact_indexes', ...) rebuilds HNSW
+#  3. VACUUM (COMPACT_TABLE) <table> rebuilds HNSW
 #     over the merged vector column; without the NULL skip, ANN
 #     search on the merged segment also returned NULL rows.
 #
@@ -52,7 +52,7 @@ INSERT INTO vec_n VALUES (5, [0, 0, 1]::FLOAT[3], 'unit-z')
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vec_n
+VACUUM (REFRESH_TABLE) vec_n
 
 
 # ---- Full scan returns every row, NULL emb materialises as NULL ----
@@ -123,7 +123,7 @@ DELETE FROM vec_n WHERE pk = 3
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vec_n
+VACUUM (REFRESH_TABLE) vec_n
 
 
 # pk=3 was the closest match to [0, 0.9, 0.1]; with the docs_mask
@@ -138,9 +138,9 @@ pk	label
 1	unit-x
 
 
-# ---- Consolidation rebuilds HNSW; NULL skip applies to merge too ----
+# ---- Compaction rebuilds HNSW; NULL skip applies to merge too ----
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'vec_n');
+VACUUM (COMPACT_TABLE) vec_n;
 
 
 # Pre-fix this returned pk=4, pk=2 (the two NULL rows) because the

--- a/tests/sqllogic/sdb/pg/index/inverted_index_indexed_vs_included.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_indexed_vs_included.test
@@ -65,7 +65,7 @@ INSERT INTO m VALUES (4, 'delta',      400,  'note four',  40, 'red leaf')
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
 # ---- 1. INDEXED-only column projection: pushdown filter + rocksdb lookup ----

--- a/tests/sqllogic/sdb/pg/index/inverted_index_indri_dirichlet.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_indri_dirichlet.test
@@ -42,7 +42,7 @@ CREATE INDEX docs_idx ON docs USING inverted(id, body en);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # Indri Dirichlet with small mu: log((tf + mu*P(t|C)) / (dl + mu)) is finite

--- a/tests/sqllogic/sdb/pg/index/inverted_index_insert_conflict_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_insert_conflict_include.test
@@ -37,7 +37,7 @@ statement ok
 INSERT INTO t VALUES (1, 'fox', 11);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 # Three-row chunk with conflict in the FIRST position. The cs vector
 # arrives as [chunk[0]=conflict, chunk[1]=survivor, chunk[2]=survivor]
@@ -46,7 +46,7 @@ statement count 2
 INSERT INTO t VALUES (1, 'conflict', 99), (2, 'fox bird', 22), (3, 'fox cat', 33);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 # Read INCLUDE values back through cs. Each surviving doc's (id, val)
 # must be self-consistent and match the source row.
@@ -64,13 +64,13 @@ statement ok
 INSERT INTO t VALUES (4, 'fox eagle', 44);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 statement count 2
 INSERT INTO t VALUES (5, 'fox bee', 55), (1, 'conflict', 999), (6, 'fox jay', 66);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 query
 SELECT id, val FROM idx WHERE body @@ ts_phrase('fox') ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_isolation.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_isolation.test
@@ -23,7 +23,7 @@ INSERT INTO t VALUES (1, 'foo');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 connection reader
 statement ok
@@ -50,7 +50,7 @@ INSERT INTO t VALUES (2, 'foo');
 
 connection writer
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 # Same query in the reader's transaction must return the pinned result.
@@ -92,7 +92,7 @@ INSERT INTO t VALUES (3, 'foo');
 
 connection writer
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 connection reader_rc

--- a/tests/sqllogic/sdb/pg/index/inverted_index_json.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_json.test
@@ -22,7 +22,7 @@ INSERT INTO logs VALUES
     (4, '{"host":"server-14","status":"warning"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) logs;
+VACUUM (REFRESH_TABLE) logs;
 
 
 
@@ -62,7 +62,7 @@ INSERT INTO evts VALUES
     (3, '{"host":"a","status":"error"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) evts;
+VACUUM (REFRESH_TABLE) evts;
 
 query
 SELECT id FROM evts_idx WHERE content->>'host' @@ ts_like('a') ORDER BY id;
@@ -104,7 +104,7 @@ INSERT INTO preds VALUES
     (3, '{"host":"server-03","msg":"the quick fox jumps"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) preds;
+VACUUM (REFRESH_TABLE) preds;
 
 # TERM_EQ on a JSON path
 query
@@ -154,7 +154,7 @@ INSERT INTO lev VALUES
     (3, '{"tag":"unrelated"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) lev;
+VACUUM (REFRESH_TABLE) lev;
 
 query
 SELECT id FROM lev_idx WHERE content->>'tag' @@ ts_levenshtein('urgent', 1) ORDER BY id;
@@ -179,7 +179,7 @@ INSERT INTO arr_logs VALUES
     (3, '{"tags":["alpha","epsilon"]}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) arr_logs;
+VACUUM (REFRESH_TABLE) arr_logs;
 
 query
 SELECT id FROM arr_idx WHERE content->'tags'->>0 = 'alpha' ORDER BY id;
@@ -207,7 +207,7 @@ INSERT INTO jonly VALUES
     (2, '{"host":"server-02"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) jonly;
+VACUUM (REFRESH_TABLE) jonly;
 
 # Sanity check: the ->> form claims the predicate and returns rows.
 query
@@ -320,7 +320,7 @@ id
 7
 
 statement ok
-VACUUM (UPDATE_INDEXES) prim_types;
+VACUUM (REFRESH_TABLE) prim_types;
 
 # String leaf is searchable through TERM_EQ via the ->> form.
 query
@@ -396,7 +396,7 @@ INSERT INTO str_lookalike VALUES
     (3, '{"val":"  {leading ws"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) str_lookalike;
+VACUUM (REFRESH_TABLE) str_lookalike;
 
 query
 SELECT id FROM str_lookalike_idx
@@ -429,7 +429,7 @@ INSERT INTO num_str_split VALUES
     (4, '{"val":true}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) num_str_split;
+VACUUM (REFRESH_TABLE) num_str_split;
 
 query
 SELECT id FROM num_str_split_idx WHERE (content->'val')::int = 42;
@@ -593,7 +593,7 @@ INSERT INTO mixed_tok VALUES
     (4, '{"val":7}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) mixed_tok;
+VACUUM (REFRESH_TABLE) mixed_tok;
 
 # Keyword tokenizer side: exact-match string lookup hits the string-mangled
 # field.
@@ -639,7 +639,7 @@ INSERT INTO hashpath_single VALUES
     (3, '{"host":"server-03","status":"err"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hashpath_single;
+VACUUM (REFRESH_TABLE) hashpath_single;
 
 query
 SELECT id FROM hashpath_single_idx
@@ -676,7 +676,7 @@ INSERT INTO hashpath_multi VALUES
     (3, '{"user":{"name":"alice","age":40}}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hashpath_multi;
+VACUUM (REFRESH_TABLE) hashpath_multi;
 
 query
 SELECT id FROM hashpath_multi_idx
@@ -704,7 +704,7 @@ INSERT INTO hashpath_chain VALUES
     (3, '{"user":{"name":"carol","role":"user"}}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) hashpath_chain;
+VACUUM (REFRESH_TABLE) hashpath_chain;
 
 query
 SELECT id FROM hashpath_chain_idx
@@ -730,7 +730,7 @@ INSERT INTO chain_to_hash VALUES
     (2, '{"user":{"name":"frank"}}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) chain_to_hash;
+VACUUM (REFRESH_TABLE) chain_to_hash;
 
 query
 SELECT id FROM chain_to_hash_idx
@@ -753,13 +753,13 @@ INSERT INTO dml_t VALUES
     (2, '{"host":"beta"}'::json);
 
 statement ok
-VACUUM (UPDATE_INDEXES) dml_t;
+VACUUM (REFRESH_TABLE) dml_t;
 
 statement ok
 UPDATE dml_t SET content = '{"host":"gamma"}'::json WHERE id = 1;
 
 statement ok
-VACUUM (UPDATE_INDEXES) dml_t;
+VACUUM (REFRESH_TABLE) dml_t;
 
 query
 SELECT id FROM dml_idx WHERE content->>'host' = 'alpha';
@@ -778,7 +778,7 @@ statement ok
 DELETE FROM dml_t WHERE id = 2;
 
 statement ok
-VACUUM (UPDATE_INDEXES) dml_t;
+VACUUM (REFRESH_TABLE) dml_t;
 
 query
 SELECT id FROM dml_idx WHERE content->>'host' = 'beta';
@@ -812,7 +812,7 @@ CREATE INDEX jp_inc_idx ON jp_inc
   INCLUDE (label);
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_inc;
+VACUUM (REFRESH_TABLE) jp_inc;
 
 query
 SELECT id, label FROM jp_inc_idx WHERE doc->>'host' = 'a' ORDER BY id;
@@ -847,7 +847,7 @@ CREATE INDEX jp_inc2_idx ON jp_inc2
   INCLUDE (label);
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_inc2;
+VACUUM (REFRESH_TABLE) jp_inc2;
 
 query
 SELECT id, label FROM jp_inc2_idx WHERE (doc->'val')::int = 42 ORDER BY id;
@@ -884,7 +884,7 @@ CREATE INDEX jp_inc_mixed_idx ON jp_inc_mixed
   INCLUDE (label);
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_inc_mixed;
+VACUUM (REFRESH_TABLE) jp_inc_mixed;
 
 query
 SELECT id, label FROM jp_inc_mixed_idx ORDER BY id;
@@ -914,7 +914,7 @@ CREATE INDEX jp_inc3_idx ON jp_inc3
   INCLUDE (big included (compression = 'uncompressed'));
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_inc3;
+VACUUM (REFRESH_TABLE) jp_inc3;
 
 query
 SELECT id, big FROM jp_inc3_idx WHERE doc->>'host' = 'x' ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_json_path_synthetic.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_json_path_synthetic.test
@@ -43,7 +43,7 @@ INSERT INTO jp_wild VALUES (3, '{"host":"router-15"}'::json);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_wild;
+VACUUM (REFRESH_TABLE) jp_wild;
 
 
 query
@@ -81,7 +81,7 @@ INSERT INTO jp_geo VALUES (2, '{"where":"{\"type\":\"Point\",\"coordinates\":[37
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_geo;
+VACUUM (REFRESH_TABLE) jp_geo;
 
 
 # Just confirm the rows are reachable -- the geo predicate language
@@ -162,7 +162,7 @@ INSERT INTO jp_norm VALUES (3, '{"body":"alpha"}'::json);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) jp_norm;
+VACUUM (REFRESH_TABLE) jp_norm;
 
 
 # Norm-bearing dictionary should not crash the norm-callback path -- the

--- a/tests/sqllogic/sdb/pg/index/inverted_index_json_sparse_norm.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_json_sparse_norm.test
@@ -48,7 +48,7 @@ INSERT INTO sparse_norm VALUES (6, '{"body":"x"}'::json);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) sparse_norm;
+VACUUM (REFRESH_TABLE) sparse_norm;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_lazy_seek.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_lazy_seek.test
@@ -62,7 +62,7 @@ statement ok
 CREATE INDEX lz_idx ON lz_docs USING inverted(id, body lz_en);
 
 statement ok
-VACUUM (UPDATE_INDEXES) lz_docs;
+VACUUM (REFRESH_TABLE) lz_docs;
 
 
 # ============================================================================

--- a/tests/sqllogic/sdb/pg/index/inverted_index_lazy_seek.test_slow
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_lazy_seek.test_slow
@@ -65,7 +65,7 @@ statement ok
 CREATE INDEX lzs_idx ON lzs USING inverted(id, body lzs_en);
 
 statement ok
-VACUUM (UPDATE_INDEXES) lzs;
+VACUUM (REFRESH_TABLE) lzs;
 
 
 # ============================================================================

--- a/tests/sqllogic/sdb/pg/index/inverted_index_list_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_list_include.test
@@ -46,7 +46,7 @@ INSERT INTO list_t VALUES (4, 'fourth', [])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) list_t
+VACUUM (REFRESH_TABLE) list_t
 
 
 # Materialize the LIST column through the new-cs columnstore materializer.

--- a/tests/sqllogic/sdb/pg/index/inverted_index_list_nulls.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_list_nulls.test
@@ -56,7 +56,7 @@ INSERT INTO list_n VALUES (4, 'fourth', [])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) list_n
+VACUUM (REFRESH_TABLE) list_n
 
 
 # Sanity: the LIST column is served by the iresearch columnstore (i), so

--- a/tests/sqllogic/sdb/pg/index/inverted_index_lm.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_lm.test
@@ -42,7 +42,7 @@ CREATE INDEX docs_idx ON docs USING inverted(id, body en);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # LM Jelinek-Mercer with default lambda (0.1): strictly positive for matches.
@@ -136,7 +136,7 @@ INSERT INTO docs VALUES (7, 'fox runs fast fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # LM JM across segments: positive for every match, doc 7 (higher tf) strictly

--- a/tests/sqllogic/sdb/pg/index/inverted_index_map_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_map_include.test
@@ -56,7 +56,7 @@ INSERT INTO map_t VALUES (5, 'fifth',  MAP {'e': NULL, 'f': 5})
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) map_t
+VACUUM (REFRESH_TABLE) map_t
 
 
 # Sanity: the MAP column is served by the iresearch columnstore (i),

--- a/tests/sqllogic/sdb/pg/index/inverted_index_merge.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_merge.test
@@ -14,8 +14,8 @@ hash-threshold 100
 #       * == 4096     -> two full chunks, no partial in either
 #       * boundary+/- 1 cases for off-by-one in tail-bit masking
 #
-# Driven via `PRAGMA serenedb_vacuum('compact_indexes', ...)` after several
-# VACUUM (UPDATE_INDEXES) segment-creating batches.
+# Driven via `VACUUM (COMPACT_TABLE) <table>` after several
+# VACUUM (REFRESH_TABLE) segment-creating batches.
 
 statement ok
 CREATE TABLE m (
@@ -67,7 +67,7 @@ INSERT INTO m VALUES (4, 'delta', 40, 'note-4')
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
 # ---------------- Segment 2: exactly STANDARD_VECTOR_SIZE (== 2048) -----
@@ -85,7 +85,7 @@ FROM generate_series(100, 2147) AS s(i)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
 # ---------------- Segment 3: 2048 + 1 (partial last word in last chunk) -
@@ -101,7 +101,7 @@ FROM generate_series(3000, 5048) AS s(i)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
 # ---------------- Segment 4: 4096 rows == 2 * STANDARD_VECTOR_SIZE ------
@@ -116,7 +116,7 @@ FROM generate_series(10000, 14095) AS s(i)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
 # ---------------- Segment 5: 2047 (single chunk, max-tail-mask) ---------
@@ -129,11 +129,11 @@ FROM generate_series(20000, 22046) AS s(i)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
 # ---------------- Removals: force the mask-filter / id_map paths --------
-# Delete some rows from each of the existing segments so the consolidation
+# Delete some rows from each of the existing segments so the compaction
 # pass sees sources with `live_docs_count < docs_count`. This exercises
 # `ComputeDocIds`, `DocRemap{mask, id_map}`, and the masked branch of
 # `MergeNormColumnFromSources`.
@@ -162,10 +162,10 @@ DELETE FROM m WHERE pk IN (20000, 22046)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) m
+VACUUM (REFRESH_TABLE) m
 
 
-# Snapshot the pre-merge state. After compact_indexes runs everything
+# Snapshot the pre-merge state. After COMPACT_TABLE runs everything
 # below should still match exactly -- merging must not change query
 # results, only the segment shape.
 
@@ -243,10 +243,10 @@ count
 2642
 
 
-# Drive consolidation to a fixpoint. After this every source above
+# Drive compaction to a fixpoint. After this every source above
 # becomes one merged segment via MergeInto + MergeNormColumnFromSources.
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'm');
+VACUUM (COMPACT_TABLE) m;
 
 
 # Same queries must give identical answers post-merge.
@@ -307,7 +307,7 @@ count
 
 # Re-compact: idempotent (no-op merge).
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'm');
+VACUUM (COMPACT_TABLE) m;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_merge_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_merge_include.test
@@ -2,9 +2,9 @@ hash-threshold 100
 
 # Validity must round-trip through the cs segment merge for INCLUDE'd
 # composite types. We force the index into a multi-segment shape by
-# inserting in two batches separated by VACUUM (UPDATE_INDEXES) -- each
-# VACUUM commits a fresh segment -- then drive consolidation via
-# PRAGMA serenedb_vacuum('compact_indexes', ...) and re-run the same
+# inserting in two batches separated by VACUUM (REFRESH_TABLE) -- each
+# VACUUM commits a fresh segment -- then drive compaction via
+# VACUUM (COMPACT_TABLE) <table> and re-run the same
 # projection. The post-merge projection must match the pre-merge one,
 # including NULL rows and (for MAP) empty-vs-NULL distinction.
 
@@ -44,7 +44,7 @@ INSERT INTO arr_c VALUES (3, 'alpha three', [-1.0, 0.0, 1.0])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) arr_c
+VACUUM (REFRESH_TABLE) arr_c
 
 
 # Segment B: all non-null.
@@ -57,7 +57,7 @@ INSERT INTO arr_c VALUES (5, 'beta two', [7.0, 8.0, 9.0])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) arr_c
+VACUUM (REFRESH_TABLE) arr_c
 
 
 # Baseline projection across both pre-merge segments.
@@ -75,7 +75,7 @@ pk	vec
 
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'arr_c')
+VACUUM (COMPACT_TABLE) arr_c
 
 
 # After merge: the NULL row must survive.
@@ -118,7 +118,7 @@ pk	vec
 # Idempotency: a second compact pass on the already-merged segment must
 # keep the validity bitmap intact.
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'arr_c')
+VACUUM (COMPACT_TABLE) arr_c
 
 
 query
@@ -159,7 +159,7 @@ INSERT INTO struct_c VALUES (3, 'alpha three', ROW(NULL, 30))
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) struct_c
+VACUUM (REFRESH_TABLE) struct_c
 
 
 # Segment B: also exercises a NULL field on the second slot.
@@ -172,7 +172,7 @@ INSERT INTO struct_c VALUES (5, 'beta two', ROW('epsilon', 50))
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) struct_c
+VACUUM (REFRESH_TABLE) struct_c
 
 
 query
@@ -189,7 +189,7 @@ pk	payload
 
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'struct_c')
+VACUUM (COMPACT_TABLE) struct_c
 
 
 query
@@ -229,7 +229,7 @@ pk	payload
 
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'struct_c')
+VACUUM (COMPACT_TABLE) struct_c
 
 
 query
@@ -270,7 +270,7 @@ INSERT INTO map_c VALUES (3, 'alpha three', MAP {})
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) map_c
+VACUUM (REFRESH_TABLE) map_c
 
 
 # Segment B: also exercises a NULL value inside a non-null map.
@@ -283,7 +283,7 @@ INSERT INTO map_c VALUES (5, 'beta two', MAP {'e': NULL, 'f': 5})
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) map_c
+VACUUM (REFRESH_TABLE) map_c
 
 
 query
@@ -300,7 +300,7 @@ pk	attrs
 
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'map_c')
+VACUUM (COMPACT_TABLE) map_c
 
 
 query
@@ -341,7 +341,7 @@ pk	attrs
 
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'map_c')
+VACUUM (COMPACT_TABLE) map_c
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_nested_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_nested_include.test
@@ -52,7 +52,7 @@ INSERT INTO n1 VALUES (4, 'four',  [])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) n1
+VACUUM (REFRESH_TABLE) n1
 
 
 query
@@ -119,7 +119,7 @@ INSERT INTO n2 VALUES (3, 'three', [['x','y','z'],[]])
 
 skipif pg-wire-extended
 statement ok
-VACUUM (UPDATE_INDEXES) n2
+VACUUM (REFRESH_TABLE) n2
 
 
 skipif pg-wire-extended
@@ -195,7 +195,7 @@ INSERT INTO n3 VALUES (4, 'four',  ROW(NULL, NULL, [10.0, 20.0, 30.0]))
 
 skipif pg-wire-extended
 statement ok
-VACUUM (UPDATE_INDEXES) n3
+VACUUM (REFRESH_TABLE) n3
 
 
 skipif pg-wire-extended
@@ -273,7 +273,7 @@ INSERT INTO n4 VALUES (4, 'four',  MAP {'p': NULL})
 
 skipif pg-wire-extended
 statement ok
-VACUUM (UPDATE_INDEXES) n4
+VACUUM (REFRESH_TABLE) n4
 
 
 skipif pg-wire-extended
@@ -359,7 +359,7 @@ INSERT INTO n5 VALUES (5, 'five',  ROW(ROW('h5', NULL), [ROW(NULL, [7,8]), ROW('
 
 skipif pg-wire-extended
 statement ok
-VACUUM (UPDATE_INDEXES) n5
+VACUUM (REFRESH_TABLE) n5
 
 
 skipif pg-wire-extended
@@ -450,7 +450,7 @@ INSERT INTO n6 VALUES (4, 'four',  [
 
 skipif pg-wire-extended
 statement ok
-VACUUM (UPDATE_INDEXES) n6
+VACUUM (REFRESH_TABLE) n6
 
 
 skipif pg-wire-extended

--- a/tests/sqllogic/sdb/pg/index/inverted_index_null_writer.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_null_writer.test
@@ -47,7 +47,7 @@ FROM read_json('/tmp/${__DATABASE__}_null_writer.jsonl');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) rj_t;
+VACUUM (REFRESH_TABLE) rj_t;
 
 
 query
@@ -109,7 +109,7 @@ UPDATE upd_t SET body = NULL WHERE id % 2 = 0;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) upd_t;
+VACUUM (REFRESH_TABLE) upd_t;
 
 
 query
@@ -161,7 +161,7 @@ SELECT s::INT, NULL::VARCHAR FROM generate_series(1, 1024) AS s;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) const_t;
+VACUUM (REFRESH_TABLE) const_t;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_optimize_top_k.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_optimize_top_k.test
@@ -62,7 +62,7 @@ CREATE INDEX docs_wand_idx ON docs_wand USING inverted(id, body en_wand)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_wand;
+VACUUM (REFRESH_TABLE) docs_wand;
 
 
 # Top-K with WAND on. Tie-break on id for deterministic ordering across
@@ -111,7 +111,7 @@ CREATE INDEX docs_plain_idx ON docs_plain USING inverted(id, body en_wand);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_plain;
+VACUUM (REFRESH_TABLE) docs_plain;
 
 
 query I
@@ -212,7 +212,7 @@ CREATE INDEX docs_default_idx ON docs_default USING inverted(id, body en_wand);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_default;
+VACUUM (REFRESH_TABLE) docs_default;
 
 
 query I
@@ -310,11 +310,11 @@ INSERT INTO docs_plain VALUES (8, 'no match here');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_wand;
+VACUUM (REFRESH_TABLE) docs_wand;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_plain;
+VACUUM (REFRESH_TABLE) docs_plain;
 
 
 query I
@@ -483,7 +483,7 @@ CREATE INDEX docs_tfidf_idx ON docs_tfidf
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_tfidf;
+VACUUM (REFRESH_TABLE) docs_tfidf;
 
 
 query
@@ -532,7 +532,7 @@ CREATE INDEX docs_bm25_args_idx ON docs_bm25_args
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs_bm25_args;
+VACUUM (REFRESH_TABLE) docs_bm25_args;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/inverted_index_primitive_nulls.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_primitive_nulls.test
@@ -67,7 +67,7 @@ INSERT INTO prim_n VALUES (
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) prim_n
+VACUUM (REFRESH_TABLE) prim_n
 
 
 # Sanity: the INCLUDE'd columns are served by the cs (i), pk by rocksdb (l).

--- a/tests/sqllogic/sdb/pg/index/inverted_index_range_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_range_include.test
@@ -38,7 +38,7 @@ INSERT INTO vec_r VALUES (4, [10, 10, 10]::FLOAT[3], 'delta', 400, 'body-four')
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vec_r
+VACUUM (REFRESH_TABLE) vec_r
 
 
 # All-INCLUDE projection: plan should suppress the "Lookup" line --

--- a/tests/sqllogic/sdb/pg/index/inverted_index_raw_tf.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_raw_tf.test
@@ -42,7 +42,7 @@ CREATE INDEX docs_idx ON docs USING inverted(id, body en);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # raw_tf: per-doc score is just the term frequency. All matching docs have
@@ -97,7 +97,7 @@ INSERT INTO docs VALUES (7, 'fox runs fast fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # raw_tf across segments: doc 7 has two 'fox' occurrences.

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score.test
@@ -34,7 +34,7 @@ CREATE INDEX docs_idx ON docs USING inverted(id, body en);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # BM25 scores are non-negative; verify they are returned and > 0
@@ -91,7 +91,7 @@ INSERT INTO docs VALUES (5, 'a quick brown rabbit and a fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # Both segments contribute matching documents; all should have score > 0
@@ -245,7 +245,7 @@ INSERT INTO docs VALUES (41, 'smart fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # More than kScoreBlock (32) docs match 'fox'; all should exist in result
@@ -608,7 +608,7 @@ DELETE FROM docs WHERE id = 1;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 query
 SELECT id FROM docs_idx WHERE body @@ ts_phrase('fox') AND id = 1;
@@ -937,7 +937,7 @@ CREATE INDEX docs2_idx ON docs2 USING inverted(id, body en);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs2;
+VACUUM (REFRESH_TABLE) docs2;
 
 
 statement ok
@@ -1371,7 +1371,7 @@ INSERT INTO bigdocs SELECT i, 'fox' FROM generate_series(1, 1100) AS s(i);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) bigdocs;
+VACUUM (REFRESH_TABLE) bigdocs;
 
 
 # All 1100 docs match 'fox'; count exercises multi-batch materializer path
@@ -1443,7 +1443,7 @@ INSERT INTO boost_docs VALUES (2, 'beta');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) boost_docs;
+VACUUM (REFRESH_TABLE) boost_docs;
 
 
 query
@@ -1511,7 +1511,7 @@ INSERT INTO sql_boost_docs VALUES (3, 'gamma');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) sql_boost_docs;
+VACUUM (REFRESH_TABLE) sql_boost_docs;
 
 
 # Baseline (no SQL-surface boost): 3-way OR over the body terms; all
@@ -1630,7 +1630,7 @@ INSERT INTO prefix_docs VALUES (4, 'gamma-1');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) prefix_docs;
+VACUUM (REFRESH_TABLE) prefix_docs;
 
 
 # Bare `LIKE 'pre%'` -- DuckDB rewrites to prefix(sku, 'alpha-');

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score_layout.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score_layout.test
@@ -1,8 +1,8 @@
 # Reproducer for the flaky BM25-OR scoring bug from inverted_index_score.test:1480.
 # The original test was non-deterministic w.r.t. segment layout; here we pin
-# each layout explicitly via `VACUUM (UPDATE_INDEXES)` per INSERT or as a
-# single batch, plus `PRAGMA serenedb_vacuum('compact_indexes', tbl)` for
-# consolidation.
+# each layout explicitly via `VACUUM (REFRESH_TABLE)` per INSERT or as a
+# single batch, plus `VACUUM (COMPACT_TABLE) <table>` for
+# compaction.
 #
 # Data: 3 docs, each with one unique single-term body. The 3-way OR
 # `body @@ 'alpha' OR body @@ 'beta' OR body @@ 'gamma'` must return all
@@ -48,7 +48,7 @@ INSERT INTO one_seg_docs VALUES (3, 'gamma');
 
 # Single VACUUM => single batch flush => one segment.
 statement ok
-VACUUM (UPDATE_INDEXES) one_seg_docs;
+VACUUM (REFRESH_TABLE) one_seg_docs;
 
 
 # All three should be uniform.
@@ -79,19 +79,19 @@ statement count 1
 INSERT INTO three_segs_docs VALUES (1, 'alpha');
 
 statement ok
-VACUUM (UPDATE_INDEXES) three_segs_docs;
+VACUUM (REFRESH_TABLE) three_segs_docs;
 
 statement count 1
 INSERT INTO three_segs_docs VALUES (2, 'beta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) three_segs_docs;
+VACUUM (REFRESH_TABLE) three_segs_docs;
 
 statement count 1
 INSERT INTO three_segs_docs VALUES (3, 'gamma');
 
 statement ok
-VACUUM (UPDATE_INDEXES) three_segs_docs;
+VACUUM (REFRESH_TABLE) three_segs_docs;
 
 
 query
@@ -126,13 +126,13 @@ statement count 1
 INSERT INTO split_docs VALUES (3, 'gamma');
 
 statement ok
-VACUUM (UPDATE_INDEXES) split_docs;
+VACUUM (REFRESH_TABLE) split_docs;
 
 statement count 1
 INSERT INTO split_docs VALUES (2, 'beta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) split_docs;
+VACUUM (REFRESH_TABLE) split_docs;
 
 
 query
@@ -163,7 +163,7 @@ statement count 1
 INSERT INTO split2_docs VALUES (2, 'beta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) split2_docs;
+VACUUM (REFRESH_TABLE) split2_docs;
 
 statement count 1
 INSERT INTO split2_docs VALUES (1, 'alpha');
@@ -172,7 +172,7 @@ statement count 1
 INSERT INTO split2_docs VALUES (3, 'gamma');
 
 statement ok
-VACUUM (UPDATE_INDEXES) split2_docs;
+VACUUM (REFRESH_TABLE) split2_docs;
 
 
 query
@@ -187,42 +187,42 @@ id	d
 
 
 # =====================================================================
-# Layout E: 3 segments then consolidate via compact_indexes => should
+# Layout E: 3 segments then compact via COMPACT_TABLE => should
 # match Layout A (single merged segment).
 # =====================================================================
 
 statement ok
-CREATE TABLE consolidated_docs (id INTEGER PRIMARY KEY, body VARCHAR);
+CREATE TABLE compacted_docs (id INTEGER PRIMARY KEY, body VARCHAR);
 
 
 statement ok
-CREATE INDEX consolidated_idx ON consolidated_docs USING inverted(id, body one_seg_en);
+CREATE INDEX compacted_idx ON compacted_docs USING inverted(id, body one_seg_en);
 
 
 statement count 1
-INSERT INTO consolidated_docs VALUES (1, 'alpha');
+INSERT INTO compacted_docs VALUES (1, 'alpha');
 
 statement ok
-VACUUM (UPDATE_INDEXES) consolidated_docs;
+VACUUM (REFRESH_TABLE) compacted_docs;
 
 statement count 1
-INSERT INTO consolidated_docs VALUES (2, 'beta');
+INSERT INTO compacted_docs VALUES (2, 'beta');
 
 statement ok
-VACUUM (UPDATE_INDEXES) consolidated_docs;
+VACUUM (REFRESH_TABLE) compacted_docs;
 
 statement count 1
-INSERT INTO consolidated_docs VALUES (3, 'gamma');
+INSERT INTO compacted_docs VALUES (3, 'gamma');
 
 statement ok
-VACUUM (UPDATE_INDEXES) consolidated_docs;
+VACUUM (REFRESH_TABLE) compacted_docs;
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 'consolidated_docs');
+VACUUM (COMPACT_TABLE) compacted_docs;
 
 
 query
-SELECT id, BM25(consolidated_idx.tableoid) as d FROM consolidated_idx
+SELECT id, BM25(compacted_idx.tableoid) as d FROM compacted_idx
 WHERE body @@ 'alpha' OR body @@ 'beta' OR body @@ 'gamma'
 ORDER BY d DESC, id;
 ----
@@ -249,7 +249,7 @@ statement ok
 DROP TABLE split2_docs;
 
 statement ok
-DROP TABLE consolidated_docs;
+DROP TABLE compacted_docs;
 
 statement ok
 DROP TEXT SEARCH DICTIONARY one_seg_en;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_struct_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_struct_include.test
@@ -50,7 +50,7 @@ INSERT INTO struct_t VALUES (4, 'fourth', ROW('delta', NULL))
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) struct_t
+VACUUM (REFRESH_TABLE) struct_t
 
 
 # Sanity: the nested column is served by the iresearch columnstore (i),

--- a/tests/sqllogic/sdb/pg/index/inverted_index_topk.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_topk.test
@@ -42,7 +42,7 @@ CREATE INDEX docs_topk_idx ON docs USING inverted(id, body en_topk);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 query
@@ -389,7 +389,7 @@ INSERT INTO docs VALUES (19, 'purple fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 
 # Get expected results from full scan across two segments

--- a/tests/sqllogic/sdb/pg/index/inverted_index_topk.test_slow
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_topk.test_slow
@@ -64,7 +64,7 @@ CREATE INDEX wiki_topk_idx ON wiki_docs USING inverted(id, title, body en_topk_s
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wiki_docs;
+VACUUM (REFRESH_TABLE) wiki_docs;
 
 
 # Insert more to create a second segment
@@ -89,7 +89,7 @@ FROM generate_series(1, 3000) AS s;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wiki_docs;
+VACUUM (REFRESH_TABLE) wiki_docs;
 
 
 # ---- Search benchmark game-style queries ----

--- a/tests/sqllogic/sdb/pg/index/inverted_index_topk_include.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_topk_include.test
@@ -32,7 +32,7 @@ INSERT INTO docs VALUES
   (4, 'a clever fox',        44, 'four');
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 # Plan check: optimizer pulls TOP_N(score) into the SearchScan.
 query
@@ -92,19 +92,19 @@ statement ok
 INSERT INTO docs VALUES (5, 'fox alpha',          55, 'five');
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 statement ok
 INSERT INTO docs VALUES (6, 'fox beta gamma',     66, 'six');
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 statement ok
 INSERT INTO docs VALUES (7, 'fox delta epsilon zeta eta', 77, 'seven');
 
 statement ok
-VACUUM (UPDATE_INDEXES) docs;
+VACUUM (REFRESH_TABLE) docs;
 
 # Sanity: INCLUDE columns coming from later segments must still
 # resolve to the right rows for each score-ordered hit.

--- a/tests/sqllogic/sdb/pg/index/inverted_index_wand.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_wand.test
@@ -65,7 +65,7 @@ CREATE INDEX wand_small_idx ON wand_small USING inverted(id, body en_wand)
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_small;
+VACUUM (REFRESH_TABLE) wand_small;
 
 
 # Term-only filter + matching scorer + LIMIT -> WAND engages.
@@ -273,11 +273,11 @@ CREATE INDEX plain_big_idx ON plain_big USING inverted(id, body en_wand);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_big;
+VACUUM (REFRESH_TABLE) wand_big;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) plain_big;
+VACUUM (REFRESH_TABLE) plain_big;
 
 
 # Sanity: both indexes match the same population.

--- a/tests/sqllogic/sdb/pg/index/inverted_index_wand.test_slow
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_wand.test_slow
@@ -104,11 +104,11 @@ CREATE INDEX plain_huge_idx ON plain_huge USING inverted(id, body en_wand);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_huge;
+VACUUM (REFRESH_TABLE) wand_huge;
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) plain_huge;
+VACUUM (REFRESH_TABLE) plain_huge;
 
 
 # Sanity: both indexes saw the same vocabulary distribution.

--- a/tests/sqllogic/sdb/pg/index/inverted_index_wand_seek.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_wand_seek.test
@@ -30,7 +30,7 @@ CREATE INDEX wand_seek_idx ON wand_seek USING inverted(id, body en_wand_seek)
   WITH (optimize_top_k = 'bm25(1.2, 0.75)');
 
 statement ok
-VACUUM (UPDATE_INDEXES) wand_seek;
+VACUUM (REFRESH_TABLE) wand_seek;
 
 query I
 SELECT count(*) FROM wand_seek_idx

--- a/tests/sqllogic/sdb/pg/index/iresearch_snapshot_pinning.test
+++ b/tests/sqllogic/sdb/pg/index/iresearch_snapshot_pinning.test
@@ -11,7 +11,7 @@ CREATE INDEX t_hnsw ON t USING inverted(v hnsw (metric = 'l2'));
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 # Catalog snapshot pinning under REPEATABLE READ. The optimizer must use

--- a/tests/sqllogic/sdb/pg/index/levenshtein_match.test
+++ b/tests/sqllogic/sdb/pg/index/levenshtein_match.test
@@ -38,7 +38,7 @@ statement ok
 INSERT INTO test_levenshtein values (6, 'act');
 
 statement ok
-VACUUM (UPDATE_INDEXES) test_levenshtein;
+VACUUM (REFRESH_TABLE) test_levenshtein;
 
 # Exact match (distance 0)
 query
@@ -181,7 +181,7 @@ INSERT INTO test_levenshtein_prefix VALUES
     (5, 'banana');
 
 statement ok
-VACUUM (UPDATE_INDEXES) test_levenshtein_prefix;
+VACUUM (REFRESH_TABLE) test_levenshtein_prefix;
 
 
 # Prefix `app` + suffix `le` distance 0 -> only `apple` matches.

--- a/tests/sqllogic/sdb/pg/index/ngram_match.test
+++ b/tests/sqllogic/sdb/pg/index/ngram_match.test
@@ -36,7 +36,7 @@ statement ok
 INSERT INTO test_ngram values (5, 'hero');
 
 statement ok
-VACUUM (UPDATE_INDEXES) test_ngram;
+VACUUM (REFRESH_TABLE) test_ngram;
 
 # Default threshold (0.7) - should match strings with high ngram similarity to 'hello'
 query

--- a/tests/sqllogic/sdb/pg/index/offsets.test
+++ b/tests/sqllogic/sdb/pg/index/offsets.test
@@ -30,7 +30,7 @@ statement ok
 INSERT INTO offsets_test VALUES (4, 'good day', 'fox fox fox fox fox fox fox fox fox fox fox fox', 12);
 
 statement ok
-VACUUM (UPDATE_INDEXES) offsets_test;
+VACUUM (REFRESH_TABLE) offsets_test;
 
 statement ok
 CREATE TABLE offsets_test2 (id INTEGER PRIMARY KEY, body VARCHAR);
@@ -42,7 +42,7 @@ statement ok
 INSERT INTO offsets_test2 VALUES (1, 'fox'), (2, 'cat');
 
 statement ok
-VACUUM (UPDATE_INDEXES) offsets_test2;
+VACUUM (REFRESH_TABLE) offsets_test2;
 
 query
 SELECT id, ts_offsets(body) AS bo

--- a/tests/sqllogic/sdb/pg/index/opclass_name_resolution.test
+++ b/tests/sqllogic/sdb/pg/index/opclass_name_resolution.test
@@ -30,7 +30,7 @@ statement ok
 INSERT INTO shadow_hnsw_col VALUES (1, 'foo'), (2, 'bar'), (3, 'foo');
 
 statement ok
-VACUUM (UPDATE_INDEXES) shadow_hnsw_col;
+VACUUM (REFRESH_TABLE) shadow_hnsw_col;
 
 query
 SELECT id FROM shadow_hnsw_col_idx WHERE s = 'foo' ORDER BY id;
@@ -51,7 +51,7 @@ statement ok
 INSERT INTO shadow_inc_col VALUES (1, 'foo'), (2, 'bar'), (3, 'foo');
 
 statement ok
-VACUUM (UPDATE_INDEXES) shadow_inc_col;
+VACUUM (REFRESH_TABLE) shadow_inc_col;
 
 query
 SELECT id FROM shadow_inc_col_idx WHERE s = 'foo' ORDER BY id;
@@ -73,7 +73,7 @@ statement ok
 INSERT INTO shadow_hnsw_expr VALUES (1, 'foo', 'bar'), (2, 'baz', 'qux');
 
 statement ok
-VACUUM (UPDATE_INDEXES) shadow_hnsw_expr;
+VACUUM (REFRESH_TABLE) shadow_hnsw_expr;
 
 query
 SELECT id FROM shadow_hnsw_expr_idx WHERE a || b = 'foobar';
@@ -94,7 +94,7 @@ statement ok
 INSERT INTO shadow_inc_expr VALUES (1, 'foo', 'bar'), (2, 'baz', 'qux');
 
 statement ok
-VACUUM (UPDATE_INDEXES) shadow_inc_expr;
+VACUUM (REFRESH_TABLE) shadow_inc_expr;
 
 query
 SELECT id FROM shadow_inc_expr_idx WHERE a || b = 'foobar';
@@ -120,7 +120,7 @@ INSERT INTO parens_hnsw_col VALUES
     (3, [0, 0, 0]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) parens_hnsw_col;
+VACUUM (REFRESH_TABLE) parens_hnsw_col;
 
 query
 SELECT id FROM parens_hnsw_col_idx ORDER BY emb <-> [1, 2, 3]::FLOAT[3] LIMIT 1;
@@ -141,7 +141,7 @@ statement ok
 INSERT INTO parens_inc_col VALUES (1, 'foo'), (2, 'bar');
 
 statement ok
-VACUUM (UPDATE_INDEXES) parens_inc_col;
+VACUUM (REFRESH_TABLE) parens_inc_col;
 
 query
 SELECT id, s FROM parens_inc_col_idx WHERE id = 1;
@@ -162,7 +162,7 @@ statement ok
 INSERT INTO parens_hnsw_expr VALUES (1, 1, 2, 3), (2, 10, 10, 10);
 
 statement ok
-VACUUM (UPDATE_INDEXES) parens_hnsw_expr;
+VACUUM (REFRESH_TABLE) parens_hnsw_expr;
 
 query
 SELECT id FROM parens_hnsw_expr_idx
@@ -184,7 +184,7 @@ statement ok
 INSERT INTO parens_inc_expr VALUES (1, 10, 20), (2, 5, 5);
 
 statement ok
-VACUUM (UPDATE_INDEXES) parens_inc_expr;
+VACUUM (REFRESH_TABLE) parens_inc_expr;
 
 query
 SELECT id, a + b AS s FROM parens_inc_expr_idx ORDER BY id;

--- a/tests/sqllogic/sdb/pg/index/term_ops.test
+++ b/tests/sqllogic/sdb/pg/index/term_ops.test
@@ -32,7 +32,7 @@ statement ok
 INSERT INTO test_term_ops values (6, 'foo', 'F');
 
 statement ok
-VACUUM (UPDATE_INDEXES) test_term_ops;
+VACUUM (REFRESH_TABLE) test_term_ops;
 
 query
 SELECT a FROM test_term_ops_idx WHERE b @@ (ts_like('percent_not_contain')) ORDER BY a;
@@ -144,7 +144,7 @@ statement ok
 INSERT INTO test_wildcard_ops VALUES (7, 'percent_value');
 
 statement ok
-VACUUM (UPDATE_INDEXES) test_wildcard_ops;
+VACUUM (REFRESH_TABLE) test_wildcard_ops;
 
 # Match all values starting with 'hel' (hello, help; herald starts with 'her')
 query

--- a/tests/sqllogic/sdb/pg/index/ts_offsets_isolation.test
+++ b/tests/sqllogic/sdb/pg/index/ts_offsets_isolation.test
@@ -23,7 +23,7 @@ INSERT INTO t VALUES (1, 'the quick brown fox');
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 connection reader
 statement ok

--- a/tests/sqllogic/sdb/pg/index/tsquery_match.test
+++ b/tests/sqllogic/sdb/pg/index/tsquery_match.test
@@ -30,7 +30,7 @@ statement ok
 INSERT INTO tsq values (4, 'something else entirely', 'bar');
 
 statement ok
-VACUUM (UPDATE_INDEXES) tsq;
+VACUUM (REFRESH_TABLE) tsq;
 
 # ----------------------------------------------------------------------
 # Basic @@ with PHRASE
@@ -1500,7 +1500,7 @@ statement ok
 INSERT INTO re_idn VALUES (1, 'Foo'), (2, 'foobar'), (3, 'BARFOO'), (4, 'baz');
 
 statement ok
-VACUUM (UPDATE_INDEXES) re_idn;
+VACUUM (REFRESH_TABLE) re_idn;
 
 # `~` -- case-sensitive POSIX regex. The literal-prefix range bound
 # pushed by regex_range_filter is upper bound `foo<F4 BF BF C0>`,
@@ -2054,7 +2054,7 @@ statement ok
 INSERT INTO tsq_ngram values (1, 'hello'), (2, 'help'), (3, 'held');
 
 statement ok
-VACUUM (UPDATE_INDEXES) tsq_ngram;
+VACUUM (REFRESH_TABLE) tsq_ngram;
 
 query
 SELECT a FROM tsq_ngram_idx WHERE ngram_matches(b, 'hello', 0.3) ORDER BY a;
@@ -2492,7 +2492,7 @@ statement ok
 INSERT INTO tsq_kw VALUES (1, 'foo'), (2, 'foobar'), (3, 'bar'), (4, ''), (5, '50%'), (6, 'abc123');
 
 statement ok
-VACUUM (UPDATE_INDEXES) tsq_kw;
+VACUUM (REFRESH_TABLE) tsq_kw;
 
 # contains
 query

--- a/tests/sqllogic/sdb/pg/index/vacuum_options.test
+++ b/tests/sqllogic/sdb/pg/index/vacuum_options.test
@@ -1,0 +1,549 @@
+hash-threshold 100
+
+# `${__DATABASE__}` resolves to the per-test database the runner creates.
+control substitution on
+
+# Coverage test for VACUUM (REFRESH_*|COMPACT_*|SYNC_STATS_*|COMPACT_ROCKSDB).
+# Drives every scope variant on real data and locks down the error paths
+# (missing/extra arguments, over-qualified names, missing objects, mixed
+# extension + standard options, conflicting extension options).
+
+statement ok
+CREATE SCHEMA s1;
+
+
+statement ok
+CREATE SCHEMA s2;
+
+
+# Inverted opclasses resolve dictionaries from the target table's schema, so
+# each schema in this test gets its own copy of the `en` dictionary.
+statement ok
+CREATE TEXT SEARCH DICTIONARY public.en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false,
+    accent = false, frequency = true, position = true, norm = true);
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY s1.en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false,
+    accent = false, frequency = true, position = true, norm = true);
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY s2.en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false,
+    accent = false, frequency = true, position = true, norm = true);
+
+
+statement ok
+CREATE TABLE public.docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX docs_idx ON public.docs USING inverted(id, body en);
+
+
+statement ok
+CREATE TABLE s1.notes (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX notes_idx ON s1.notes USING inverted(id, body en);
+
+
+statement ok
+CREATE TABLE s2.memos (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX memos_idx ON s2.memos USING inverted(id, body en);
+
+
+# ---------------------------------------------------------------------------
+# REFRESH_* success paths -- each scope publishes its writes to readers.
+# ---------------------------------------------------------------------------
+
+# REFRESH_INDEX: only the named index becomes queryable.
+statement ok
+INSERT INTO public.docs VALUES (1, 'alpha refresh_index');
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('alpha');
+----
+count
+0
+
+
+statement ok
+VACUUM (REFRESH_INDEX) docs_idx;
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('alpha');
+----
+count
+1
+
+
+# REFRESH_TABLE: publishes every inverted index under the table.
+statement ok
+INSERT INTO s1.notes VALUES (1, 'beta refresh_table');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) s1.notes;
+
+
+query
+SELECT count(*) FROM s1.notes_idx WHERE body @@ ts_phrase('beta');
+----
+count
+1
+
+
+# REFRESH_SCHEMA: publishes every inverted index in the schema.
+statement ok
+INSERT INTO s2.memos VALUES (1, 'gamma refresh_schema');
+
+
+statement ok
+VACUUM (REFRESH_SCHEMA) s2;
+
+
+query
+SELECT count(*) FROM s2.memos_idx WHERE body @@ ts_phrase('gamma');
+----
+count
+1
+
+
+# REFRESH_SCHEMA with database-qualified name.
+statement ok
+INSERT INTO s2.memos VALUES (2, 'gamma refresh_schema qualified');
+
+
+statement ok
+VACUUM (REFRESH_SCHEMA) ${__DATABASE__}.s2;
+
+
+query
+SELECT count(*) FROM s2.memos_idx WHERE body @@ ts_phrase('qualified');
+----
+count
+1
+
+
+# REFRESH_DATABASE: publishes everything in the named database.
+statement ok
+INSERT INTO public.docs VALUES (2, 'delta refresh_database');
+
+
+statement ok
+INSERT INTO s1.notes VALUES (2, 'delta refresh_database notes');
+
+
+statement ok
+VACUUM (REFRESH_DATABASE) ${__DATABASE__};
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('delta');
+----
+count
+1
+
+
+query
+SELECT count(*) FROM s1.notes_idx WHERE body @@ ts_phrase('delta');
+----
+count
+1
+
+
+# Note: REFRESH_ALL / COMPACT_ALL / SYNC_STATS_ALL / COMPACT_ROCKSDB are
+# instance-wide and would touch other tests' per-test databases under the
+# shared sqllogic runner, so their success paths live in
+# tests/sqllogic/recovery/vacuum_global.test (one serened instance per test).
+# Their argument-validation errors are still covered below.
+
+# Fully-qualified INDEX scope still resolves.
+statement ok
+INSERT INTO public.docs VALUES (4, 'zeta qualified_index');
+
+
+statement ok
+VACUUM (REFRESH_INDEX) ${__DATABASE__}.public.docs_idx;
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('zeta');
+----
+count
+1
+
+
+# Fully-qualified TABLE scope still resolves.
+statement ok
+INSERT INTO s1.notes VALUES (3, 'eta qualified_table');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) ${__DATABASE__}.s1.notes;
+
+
+query
+SELECT count(*) FROM s1.notes_idx WHERE body @@ ts_phrase('eta');
+----
+count
+1
+
+
+# ---------------------------------------------------------------------------
+# COMPACT_* success paths -- compaction must not change query results.
+# We first inflate to several segments via interleaved REFRESH_TABLE.
+# ---------------------------------------------------------------------------
+
+statement ok
+INSERT INTO public.docs VALUES (10, 'theta compact A');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) public.docs;
+
+
+statement ok
+INSERT INTO public.docs VALUES (11, 'theta compact B');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) public.docs;
+
+
+statement ok
+INSERT INTO public.docs VALUES (12, 'theta compact C');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) public.docs;
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('theta');
+----
+count
+3
+
+
+# COMPACT_INDEX
+statement ok
+VACUUM (COMPACT_INDEX) docs_idx;
+
+
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('theta');
+----
+count
+3
+
+
+# COMPACT_TABLE -- no-op now (already compacted) but must still succeed.
+statement ok
+VACUUM (COMPACT_TABLE) public.docs;
+
+
+# COMPACT_SCHEMA
+statement ok
+VACUUM (COMPACT_SCHEMA) public;
+
+
+# COMPACT_SCHEMA with database-qualified name
+statement ok
+VACUUM (COMPACT_SCHEMA) ${__DATABASE__}.s2;
+
+
+# COMPACT_DATABASE
+statement ok
+VACUUM (COMPACT_DATABASE) ${__DATABASE__};
+
+
+# Query results survive compaction at every scope.
+query
+SELECT count(*) FROM public.docs_idx WHERE body @@ ts_phrase('theta');
+----
+count
+3
+
+
+query
+SELECT count(*) FROM s1.notes_idx WHERE body @@ ts_phrase('delta');
+----
+count
+1
+
+
+query
+SELECT count(*) FROM s2.memos_idx WHERE body @@ ts_phrase('gamma');
+----
+count
+2
+
+
+# ---------------------------------------------------------------------------
+# SYNC_STATS_* -- placeholder ops that must not error while rocksdb-backed
+# tables are still around. SYNC_STATS_ALL and COMPACT_ROCKSDB are instance-wide
+# and live in tests/sqllogic/recovery/vacuum_global.test.
+# ---------------------------------------------------------------------------
+
+statement ok
+VACUUM (SYNC_STATS_TABLE) public.docs;
+
+
+statement ok
+VACUUM (SYNC_STATS_SCHEMA) s1;
+
+
+statement ok
+VACUUM (SYNC_STATS_SCHEMA) ${__DATABASE__}.s2;
+
+
+statement ok
+VACUUM (SYNC_STATS_DATABASE) ${__DATABASE__};
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+# Missing required argument.
+statement error
+VACUUM (REFRESH_INDEX);
+----
+db error: ERROR: VACUUM (refresh_index) requires an object name
+
+
+statement error
+VACUUM (REFRESH_TABLE);
+----
+db error: ERROR: VACUUM (refresh_table) requires an object name
+
+
+statement error
+VACUUM (REFRESH_SCHEMA);
+----
+db error: ERROR: VACUUM (refresh_schema) requires an object name
+
+
+statement error
+VACUUM (REFRESH_DATABASE);
+----
+db error: ERROR: VACUUM (refresh_database) requires an object name
+
+
+statement error
+VACUUM (COMPACT_INDEX);
+----
+db error: ERROR: VACUUM (compact_index) requires an object name
+
+
+statement error
+VACUUM (COMPACT_TABLE);
+----
+db error: ERROR: VACUUM (compact_table) requires an object name
+
+
+statement error
+VACUUM (COMPACT_SCHEMA);
+----
+db error: ERROR: VACUUM (compact_schema) requires an object name
+
+
+statement error
+VACUUM (COMPACT_DATABASE);
+----
+db error: ERROR: VACUUM (compact_database) requires an object name
+
+
+statement error
+VACUUM (SYNC_STATS_TABLE);
+----
+db error: ERROR: VACUUM (sync_stats_table) requires an object name
+
+
+statement error
+VACUUM (SYNC_STATS_SCHEMA);
+----
+db error: ERROR: VACUUM (sync_stats_schema) requires an object name
+
+
+statement error
+VACUUM (SYNC_STATS_DATABASE);
+----
+db error: ERROR: VACUUM (sync_stats_database) requires an object name
+
+
+# Argument forbidden on _ALL scope.
+statement error
+VACUUM (REFRESH_ALL) docs;
+----
+db error: ERROR: VACUUM (refresh_all) does not take an argument
+
+
+statement error
+VACUUM (COMPACT_ALL) docs;
+----
+db error: ERROR: VACUUM (compact_all) does not take an argument
+
+
+statement error
+VACUUM (SYNC_STATS_ALL) docs;
+----
+db error: ERROR: VACUUM (sync_stats_all) does not take an argument
+
+
+statement error
+VACUUM (COMPACT_ROCKSDB) docs;
+----
+db error: ERROR: VACUUM (compact_rocksdb) does not take an argument
+
+
+# Over-qualified database / schema arguments.
+statement error
+VACUUM (REFRESH_DATABASE) ${__DATABASE__}.public;
+----
+db error: ERROR: VACUUM (REFRESH_DATABASE|COMPACT_DATABASE|SYNC_STATS_DATABASE) expects a single database name
+
+
+statement error
+VACUUM (COMPACT_DATABASE) ${__DATABASE__}.public;
+----
+db error: ERROR: VACUUM (REFRESH_DATABASE|COMPACT_DATABASE|SYNC_STATS_DATABASE) expects a single database name
+
+
+statement error
+VACUUM (SYNC_STATS_DATABASE) ${__DATABASE__}.public;
+----
+db error: ERROR: VACUUM (REFRESH_DATABASE|COMPACT_DATABASE|SYNC_STATS_DATABASE) expects a single database name
+
+
+statement error
+VACUUM (REFRESH_SCHEMA) ${__DATABASE__}.public.docs;
+----
+db error: ERROR: VACUUM (REFRESH_SCHEMA|COMPACT_SCHEMA|SYNC_STATS_SCHEMA) expects [<database>.]<schema>
+
+
+statement error
+VACUUM (COMPACT_SCHEMA) ${__DATABASE__}.public.docs;
+----
+db error: ERROR: VACUUM (REFRESH_SCHEMA|COMPACT_SCHEMA|SYNC_STATS_SCHEMA) expects [<database>.]<schema>
+
+
+statement error
+VACUUM (SYNC_STATS_SCHEMA) ${__DATABASE__}.public.docs;
+----
+db error: ERROR: VACUUM (REFRESH_SCHEMA|COMPACT_SCHEMA|SYNC_STATS_SCHEMA) expects [<database>.]<schema>
+
+
+# Catalog lookup failures, one per scope.
+statement error
+VACUUM (REFRESH_INDEX) nope_idx;
+----
+db error: ERROR: inverted index 'nope_idx' not found.
+
+
+statement error
+VACUUM (COMPACT_INDEX) nope_idx;
+----
+db error: ERROR: inverted index 'nope_idx' not found.
+
+
+statement error
+VACUUM (REFRESH_TABLE) nope_table;
+----
+db error: ERROR: relation 'nope_table' not found.
+
+
+statement error
+VACUUM (COMPACT_TABLE) nope_table;
+----
+db error: ERROR: relation 'nope_table' not found.
+
+
+statement error
+VACUUM (SYNC_STATS_TABLE) nope_table;
+----
+db error: ERROR: relation 'nope_table' not found.
+
+
+statement error
+VACUUM (REFRESH_SCHEMA) nope_schema;
+----
+db error: ERROR: schema 'nope_schema' does not exist.
+
+
+statement error
+VACUUM (COMPACT_SCHEMA) nope_schema;
+----
+db error: ERROR: schema 'nope_schema' does not exist.
+
+
+statement error
+VACUUM (SYNC_STATS_SCHEMA) nope_schema;
+----
+db error: ERROR: schema 'nope_schema' does not exist.
+
+
+statement error
+VACUUM (REFRESH_DATABASE) nope_db;
+----
+db error: ERROR: database 'nope_db' does not exist.
+
+
+statement error
+VACUUM (COMPACT_DATABASE) nope_db;
+----
+db error: ERROR: database 'nope_db' does not exist.
+
+
+statement error
+VACUUM (SYNC_STATS_DATABASE) nope_db;
+----
+db error: ERROR: database 'nope_db' does not exist.
+
+
+# Two extension options in one VACUUM -- parser-level rejection.
+statement error
+VACUUM (REFRESH_TABLE, COMPACT_TABLE) public.docs;
+----
+db error: ERROR: VACUUM accepts at most one SereneDB option (got both 'refresh_table' and 'compact_table')
+
+
+statement error
+VACUUM (COMPACT_SCHEMA, REFRESH_ALL) s1;
+----
+db error: ERROR: VACUUM accepts at most one SereneDB option (got both 'compact_schema' and 'refresh_all')
+
+
+# Extension option mixed with a standard VACUUM option.
+statement error
+VACUUM (REFRESH_TABLE, ANALYZE) public.docs;
+----
+db error: ERROR: VACUUM SereneDB option 'refresh_table' cannot be combined with standard VACUUM options
+
+
+# Cleanup
+statement ok
+DROP TABLE public.docs;
+
+
+statement ok
+DROP TEXT SEARCH DICTIONARY public.en;
+
+
+statement ok
+DROP SCHEMA s1 CASCADE;
+
+
+statement ok
+DROP SCHEMA s2 CASCADE;

--- a/tests/sqllogic/sdb/pg/index/vector_search.test
+++ b/tests/sqllogic/sdb/pg/index/vector_search.test
@@ -111,7 +111,7 @@ id
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t;
+VACUUM (REFRESH_TABLE) t;
 
 
 query
@@ -407,7 +407,7 @@ statement count 4
 INSERT INTO t_l2 VALUES (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3]), (3, [50, 25, 50]::FLOAT[3]), (4, [50, 50, 100]::FLOAT[3]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_l2;
+VACUUM (REFRESH_TABLE) t_l2;
 
 query
 SELECT id FROM l2_tuned ORDER BY emb <-> [0, 0, 0]::FLOAT[3] LIMIT 2;
@@ -430,7 +430,7 @@ INSERT INTO t_l1 VALUES (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3]),
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_l1;
+VACUUM (REFRESH_TABLE) t_l1;
 
 
 query
@@ -499,7 +499,7 @@ statement count 4
 INSERT INTO t_cos VALUES (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3]), (3, [50, 25, 50]::FLOAT[3]), (4, [50, 50, 100]::FLOAT[3]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_cos;
+VACUUM (REFRESH_TABLE) t_cos;
 
 query
 EXPLAIN SELECT id FROM cos_index ORDER BY emb <=> [1.0, 0.0, 0.0]::FLOAT[3] LIMIT 2;
@@ -620,7 +620,7 @@ statement count 4
 INSERT INTO t_ip VALUES (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3]), (3, [50, 25, 50]::FLOAT[3]), (4, [50, 50, 100]::FLOAT[3]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_ip;
+VACUUM (REFRESH_TABLE) t_ip;
 
 query
 EXPLAIN SELECT id FROM ip_index ORDER BY emb <#> [1.0, 0.0, 0.0]::FLOAT[3] LIMIT 2;
@@ -738,7 +738,7 @@ statement count 4
 INSERT INTO t_l1 VALUES (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3]), (3, [50, 25, 50]::FLOAT[3]), (4, [50, 50, 100]::FLOAT[3]);
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_l1;
+VACUUM (REFRESH_TABLE) t_l1;
 
 query
 SELECT id FROM l1_index ORDER BY l1_distance(emb, [0, 0, 0]::FLOAT[3]) LIMIT 2;
@@ -906,7 +906,7 @@ INSERT INTO t_proj VALUES (1, 1, 'a', [100, 0, 0]::FLOAT[3]), (2, 2, 'b', [50, 5
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_proj;
+VACUUM (REFRESH_TABLE) t_proj;
 
 
 query
@@ -1029,7 +1029,7 @@ INSERT INTO t_mixed VALUES (1, 'red fox', [100, 0, 0]::FLOAT[3]), (2, 'blue cat'
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_mixed;
+VACUUM (REFRESH_TABLE) t_mixed;
 
 
 query
@@ -1270,7 +1270,7 @@ INSERT INTO t_big SELECT i, [CAST(i AS FLOAT), CAST(i AS FLOAT), CAST(i AS FLOAT
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_big;
+VACUUM (REFRESH_TABLE) t_big;
 
 
 query
@@ -1353,7 +1353,7 @@ INSERT INTO t_merge VALUES (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_merge;
+VACUUM (REFRESH_TABLE) t_merge;
 
 
 statement count 2
@@ -1361,7 +1361,7 @@ INSERT INTO t_merge VALUES (3, [50, 25, 50]::FLOAT[3]), (4, [50, 50, 100]::FLOAT
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_merge;
+VACUUM (REFRESH_TABLE) t_merge;
 
 
 statement count 2
@@ -1369,7 +1369,7 @@ INSERT INTO t_merge VALUES (5, [10, 10, 10]::FLOAT[3]), (6, [20, 20, 20]::FLOAT[
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_merge;
+VACUUM (REFRESH_TABLE) t_merge;
 
 
 statement count 2
@@ -1377,11 +1377,11 @@ INSERT INTO t_merge VALUES (7, [5, 5, 5]::FLOAT[3]), (8, [30, 30, 30]::FLOAT[3])
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) t_merge;
+VACUUM (REFRESH_TABLE) t_merge;
 
 
 statement ok
-PRAGMA serenedb_vacuum('compact_indexes', 't_merge');
+VACUUM (COMPACT_TABLE) t_merge;
 
 
 query

--- a/tests/sqllogic/sdb/pg/index/vector_search.test_slow
+++ b/tests/sqllogic/sdb/pg/index/vector_search.test_slow
@@ -41,7 +41,7 @@ CREATE INDEX vecs_hnsw ON vecs USING inverted(emb hnsw (metric = 'l2', m = 64, e
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vecs;
+VACUUM (REFRESH_TABLE) vecs;
 
 
 query
@@ -123,7 +123,7 @@ CREATE INDEX vecs_hnsw_l1 ON vecs USING inverted(id, emb hnsw (metric = 'l1', m 
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vecs;
+VACUUM (REFRESH_TABLE) vecs;
 
 
 query
@@ -158,7 +158,7 @@ CREATE INDEX vecs_hnsw_cos ON vecs USING inverted(id, emb hnsw (metric = 'cosine
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vecs;
+VACUUM (REFRESH_TABLE) vecs;
 
 
 query
@@ -194,7 +194,7 @@ CREATE INDEX vecs_hnsw_ip ON vecs USING inverted(id, emb hnsw (metric = 'ip', m 
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vecs;
+VACUUM (REFRESH_TABLE) vecs;
 
 
 query
@@ -294,7 +294,7 @@ CREATE INDEX vecs_text_idx ON vecs_text USING inverted(id, body en, emb hnsw (me
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) vecs_text;
+VACUUM (REFRESH_TABLE) vecs_text;
 
 
 # Filtered ANN needs higher efSearch to maintain recall

--- a/tests/sqllogic/sdb/pg/index/vector_search_isolation.test
+++ b/tests/sqllogic/sdb/pg/index/vector_search_isolation.test
@@ -11,7 +11,7 @@ INSERT INTO v VALUES (1, [1.0, 0.0, 0.0]::FLOAT[3]);
 
 
 statement ok
-VACUUM (UPDATE_INDEXES) v;
+VACUUM (REFRESH_TABLE) v;
 
 
 connection reader
@@ -39,7 +39,7 @@ INSERT INTO v VALUES (2, [0.5, 0.5, 0.0]::FLOAT[3]);
 
 connection writer
 statement ok
-VACUUM (UPDATE_INDEXES) v;
+VACUUM (REFRESH_TABLE) v;
 
 
 connection reader
@@ -81,7 +81,7 @@ INSERT INTO v VALUES (3, [0.0, 1.0, 0.0]::FLOAT[3]);
 
 connection writer
 statement ok
-VACUUM (UPDATE_INDEXES) v;
+VACUUM (REFRESH_TABLE) v;
 
 
 connection reader_rc

--- a/tests/sqllogic/sdb/pg/settings/show_all.test
+++ b/tests/sqllogic/sdb/pg/settings/show_all.test
@@ -41,10 +41,9 @@ checkpoint_threshold	16.0 MiB	The WAL size threshold at which to automatically t
 cleanup_interval_step	1	Number of commit ticks between background unreferenced-file cleanup passes for newly created inverted indexes. Per-index WITH (cleanup_interval_step = ...) overrides. 0 disables cleanup. Default: 1.
 client_encoding	UTF8	Sets the client's character set encoding.
 client_min_messages	notice	Sets the message levels that are sent to the client.
-commit_interval	1000	Background commit interval (ms) for newly created inverted indexes. Per-index WITH (commit_interval = ...) overrides. 0 disables the commit task. Default: 1000.
+compaction_interval	1000	Background compaction interval (ms) for newly created inverted indexes. Per-index WITH (compaction_interval = ...) overrides. 0 disables the compaction task. Default: 1000.
 configure_metrics	[*]	Accepts a JSON enabling custom metrics
 configure_profiling	[*]	Accepts a JSON enabling custom metrics
-consolidation_interval	1000	Background consolidation interval (ms) for newly created inverted indexes. Per-index WITH (consolidation_interval = ...) overrides. 0 disables the consolidation task. Default: 1000.
 current_transaction_invalidation_policy	STANDARD_POLICY	Which types of exceptions invalidate the database for the current transaction
 custom_extension_repository	(empty)	Overrides the custom endpoint for remote extension installation
 custom_profiling_settings	[*]	Accepts a JSON enabling custom metrics
@@ -192,6 +191,7 @@ profiling_coverage	SELECT	The profiling coverage (SELECT or ALL)
 profiling_mode	NULL	The profiling mode (STANDARD or DETAILED)
 profiling_output	(empty)	The file to which profile output should be saved, or empty to print to the terminal
 progress_bar_time	2000	Sets the time (in milliseconds) how long a query needs to take before we start printing a progress bar
+refresh_interval	1000	Background refresh interval (ms) for newly created inverted indexes. Per-index WITH (refresh_interval = ...) overrides. 0 disables the refresh task. Default: 1000.
 role	postgres	Sets the current role.
 row_group_size	122880	Default column row-group size for INCLUDEd in newly created inverted indexes. Per-column (row_group_size = ...) and per-index WITH (row_group_size = ...) override. Reads from existing indexes are unaffected. Default: 122'880.
 s3_access_key_id	NULL	S3 Access Key ID
@@ -301,10 +301,9 @@ checkpoint_threshold	16.0 MiB	The WAL size threshold at which to automatically t
 cleanup_interval_step	1	Number of commit ticks between background unreferenced-file cleanup passes for newly created inverted indexes. Per-index WITH (cleanup_interval_step = ...) overrides. 0 disables cleanup. Default: 1.
 client_encoding	UTF8	Sets the client's character set encoding.
 client_min_messages	notice	Sets the message levels that are sent to the client.
-commit_interval	1000	Background commit interval (ms) for newly created inverted indexes. Per-index WITH (commit_interval = ...) overrides. 0 disables the commit task. Default: 1000.
+compaction_interval	1000	Background compaction interval (ms) for newly created inverted indexes. Per-index WITH (compaction_interval = ...) overrides. 0 disables the compaction task. Default: 1000.
 configure_metrics	[*]	Accepts a JSON enabling custom metrics
 configure_profiling	[*]	Accepts a JSON enabling custom metrics
-consolidation_interval	1000	Background consolidation interval (ms) for newly created inverted indexes. Per-index WITH (consolidation_interval = ...) overrides. 0 disables the consolidation task. Default: 1000.
 current_transaction_invalidation_policy	STANDARD_POLICY	Which types of exceptions invalidate the database for the current transaction
 custom_extension_repository	(empty)	Overrides the custom endpoint for remote extension installation
 custom_profiling_settings	[*]	Accepts a JSON enabling custom metrics
@@ -452,6 +451,7 @@ profiling_coverage	SELECT	The profiling coverage (SELECT or ALL)
 profiling_mode	NULL	The profiling mode (STANDARD or DETAILED)
 profiling_output	(empty)	The file to which profile output should be saved, or empty to print to the terminal
 progress_bar_time	2000	Sets the time (in milliseconds) how long a query needs to take before we start printing a progress bar
+refresh_interval	1000	Background refresh interval (ms) for newly created inverted indexes. Per-index WITH (refresh_interval = ...) overrides. 0 disables the refresh task. Default: 1000.
 role	postgres	Sets the current role.
 row_group_size	122880	Default column row-group size for INCLUDEd in newly created inverted indexes. Per-column (row_group_size = ...) and per-index WITH (row_group_size = ...) override. Reads from existing indexes are unaffected. Default: 122'880.
 s3_access_key_id	NULL	S3 Access Key ID

--- a/tests/sqllogic/sdb/pg/simple/truncate.test
+++ b/tests/sqllogic/sdb/pg/simple/truncate.test
@@ -257,7 +257,7 @@ SELECT
 FROM generate_series(1, 10000) AS t(x);
 
 statement ok
-VACUUM (UPDATE_INDEXES) vedernikoff;
+VACUUM (REFRESH_TABLE) vedernikoff;
 
 # Sanity-check both indexes before TRUNCATE.
 query
@@ -330,7 +330,7 @@ SELECT
 FROM generate_series(1, 500) AS t(x);
 
 statement ok
-VACUUM (UPDATE_INDEXES) vedernikoff;
+VACUUM (REFRESH_TABLE) vedernikoff;
 
 query
 SELECT count(*) FROM vedernikoff WHERE team = 'babsky';


### PR DESCRIPTION
## Summary

Replaces the two ad-hoc iresearch maintenance surfaces (`VACUUM (UPDATE_INDEXES)` and `PRAGMA serenedb_vacuum('compact_indexes', ...)`) with one verb family where the maintenance action and the scope are baked into the option name, and aligns the engine vocabulary with that surface. Closes #677.

### SQL surface

```sql
VACUUM (REFRESH_{INDEX,TABLE,SCHEMA,DATABASE,ALL})    [<object>]
VACUUM (COMPACT_{INDEX,TABLE,SCHEMA,DATABASE,ALL})    [<object>]
VACUUM (SYNC_STATS_{TABLE,SCHEMA,DATABASE,ALL})       [<object>]
VACUUM (COMPACT_ROCKSDB)
```

- The object is one bare or qualified name (`name`, `schema.name`, `db.schema.name`); the suffix tells the resolver how to interpret it, so the parser never has to disambiguate. `_ALL` takes no argument.
- `REFRESH` replaces `UPDATE_INDEXES` (makes recently-indexed docs visible); `COMPACT` replaces the `compact_indexes` PRAGMA (drives segment merging).
- `SYNC_STATS_*` and `COMPACT_ROCKSDB` are placeholders that go away with rocksdb-backed tables.
- The lowering rejects mixing a SereneDB option with standard VACUUM options or combining two SereneDB options.

### Engine renames (iresearch is internal-only; no public API contract)

- `Consolidate*`/`Consolidation*` -> `Compact*`/`Compaction*` across iresearch + server (functions, policy/result/candidate/context types, the segment-resource pool, metrics, prose).
- `IndexWriter::{Begin,Commit,Rollback}` -> `{RefreshBegin,RefreshCommit, RefreshAbort}`; `ThreadGroup::Commit` -> `Refresh`; `CommitTask` -> `RefreshTask`.
- Index options/settings `commit_interval` -> `refresh_interval`, `consolidation_interval` -> `compact_interval`.

### Tests

- `tests/sqllogic/sdb/pg/index/vacuum_options.test`: per-scope success paths (index/table/schema/database) plus all argument/qualification/not-found and option-combination error paths.
- `tests/sqllogic/recovery/vacuum_global.test`: the instance-wide scopes (`*_ALL`, `COMPACT_ROCKSDB`) on a dedicated serened instance, since they walk every database.
- Existing inverted-index + recovery tests migrated to the new syntax.

## Test plan

- [x] `ninja serened` + `iresearch-tests` build clean
- [x] `tests/sqllogic/sdb/pg/**` pass (both wire engines)
- [x] `vacuum_options.test` and `vacuum_global.test` pass
- [x] core iresearch suites (`CompactTierTest`, `MergeWriter*`, `IndexWriter*`, `index_death_test_formats_15`) pass

## Notes

- `third_party/duckdb` carries the vacuum grammar transformer changes plus the `VacuumOptions` field + serialization; if it lands as its own submodule PR it must go in first/together.

