### PR TITLE
Fix GEOMETRY WKT writer dropping a digit from integer coordinates

### DIFF
--- a/tests/sqllogic/sdb/pg/simple/geometry_wkt.test
+++ b/tests/sqllogic/sdb/pg/simple/geometry_wkt.test
@@ -1,0 +1,44 @@
+# Regression: integer GEOMETRY coordinates must round-trip through WKT.
+#
+# SereneDB compiles DuckDB against std::format, whose "{}" renders doubles in
+# shortest form ("30", not "30.0"). The DuckDB geometry WKT writer used to strip
+# a trailing zero assuming the "30.0" form, corrupting "30" -> "3" (so
+# POINT(30 10) came back as POINT (3 1)). See serenedb/duckdb#30.
+
+query
+SELECT 'POINT(30 10)'::GEOMETRY::TEXT AS wkt;
+----
+wkt
+POINT (30 10)
+
+query
+SELECT 'POINT(100 5)'::GEOMETRY::TEXT AS wkt;
+----
+wkt
+POINT (100 5)
+
+query
+SELECT 'POINT(4500 200)'::GEOMETRY::TEXT AS wkt;
+----
+wkt
+POINT (4500 200)
+
+query
+SELECT 'LINESTRING(30 10, 10 30, 40 40)'::GEOMETRY::TEXT AS wkt;
+----
+wkt
+LINESTRING (30 10, 10 30, 40 40)
+
+# Fractional coordinates must be preserved exactly (no over-stripping).
+query
+SELECT 'POINT(30.5 10.25)'::GEOMETRY::TEXT AS wkt;
+----
+wkt
+POINT (30.5 10.25)
+
+# ST_AsText goes through the same WKT writer.
+query
+SELECT ST_AsText('POINT(30 10)'::GEOMETRY) AS wkt;
+----
+wkt
+POINT (30 10)


### PR DESCRIPTION
## Problem

Casting a `GEOMETRY` back to text (`::TEXT`, `ST_AsText`) corrupted integer coordinates: `POINT(30 10)` round-tripped to `POINT (3 1)`, `POINT(100 5)` to `POINT (10 5)`, etc. Any coordinate ending in a trailing zero lost a digit.

## Root cause

DuckDB's geometry WKT writer (`TextWriter::Write(double)`) stripped a trailing `0`/`.0` from each formatted coordinate, assuming `"{}"` produced `"30.0"` (the form `{fmt}` 6.1.2 emits). SereneDB compiles DuckDB against **`std::format`** (via `third_party/fake/fmt`), whose `"{}"` produces the **shortest** form `"30"` — so the strip deleted a real digit. Vanilla DuckDB v1.5 (built with `{fmt}` 6.1.2) is unaffected, which is why this only surfaced in the SereneDB build.

## Changes

- **Submodule bump** `third_party/duckdb` → the fix (serenedb/duckdb#30), which drops the trailing-zero strip so the shortest-form output is emitted as-is. The bump fast-forwards along `v2026.05.19` and also picks up the two already-merged commits #28 and #29.
- **Regression test** `tests/sqllogic/sdb/pg/simple/geometry_wkt.test` — asserts integer and fractional coordinates round-trip through `GEOMETRY::TEXT` and `ST_AsText`. It fails without the fix under the `serened` (`std::format`) build and passes with it.

Depends on serenedb/duckdb#30; update the submodule pointer to that PR's merge commit once it lands.