### PR TITLE
fix: package config as absl flagfile so serened starts from systemd

### DIFF
--- a/etc/relative/serened.conf
+++ b/etc/relative/serened.conf
@@ -1,5 +1,0 @@
-[server]
-endpoint = pgsql+tcp://0.0.0.0:7890
-
-[log]
-level = info

--- a/etc/serenedb/serened.conf.in
+++ b/etc/serenedb/serened.conf.in
@@ -1,33 +1,27 @@
 # SereneDB configuration file
 #
+# This file is an absl flagfile: one '--flag=value' per line, '#' starts a
+# comment line, blank lines are ignored. serened reads it via
+# '--flagfile=/etc/serenedb/serened.conf' (see the systemd unit). Run
+# 'serened --helpfull' to list every available flag.
 
-[database]
-directory = @LOCALSTATEDIR@/lib/serenedb
+# Path to the database directory.
+--server_directory=@LOCALSTATEDIR@/lib/serenedb
 
-[server]
-# Specify the endpoint for HTTP requests by clients.
-#  tcp://ipv4-address:port
-#  tcp://[ipv6-address]:port
-#  ssl://ipv4-address:port
-#  ssl://[ipv6-address]:port
-#  unix:///path/to/socket
+# Endpoint(s) the server listens on. Repeat the flag for multiple endpoints.
+#  pgsql+tcp://ipv4-address:port
+#  pgsql+tcp://[ipv6-address]:port
+#  pgsql+ssl://ipv4-address:port
+#  pgsql+unix:///path/to/socket
 #
 # Examples:
-#   endpoint = tcp://0.0.0.0:7890
-#   endpoint = tcp://127.0.0.1:7890
-#   endpoint = tcp://localhost:7890
-#   endpoint = tcp://myserver.somedomain.com:7890
-#   endpoint = tcp://[::]:7890
-#   endpoint = tcp://[fe80::21a:5df1:aede:98cf]:7890
-#
-endpoint = pgsql+tcp://127.0.0.1:7890
+#   --server_endpoints=pgsql+tcp://0.0.0.0:7890
+#   --server_endpoints=pgsql+tcp://[::]:7890
+--server_endpoints=pgsql+tcp://127.0.0.1:7890
 
-# reuse a port on restart or wait until it is freed by the operating system
-# reuse-address = false
-# number of maximal server threads. use 0 to make serened determine the
-# number of threads automatically, based on available CPUs
-# maximal-threads = 0
+# Minimum log severity: trace | debug | info | warning | error | fatal.
+--log_level=info
 
-[log]
-level = info
-@COMMENT_LOGFILE@file = @LOCALSTATEDIR@/log/serenedb/serened.log
+# Log destination: 'stdout', 'memory' (queryable via duckdb_logs()), or
+# 'file://<path>'.
+@COMMENT_LOGFILE@--log_storage=file://@LOCALSTATEDIR@/log/serenedb/serened.log

--- a/packages/debian/source/common/serenedb.service
+++ b/packages/debian/source/common/serenedb.service
@@ -15,7 +15,7 @@ TasksMax=131072
 # '+' prefix runs these as root (needed for chown/install -o)
 ExecStartPre=+/usr/bin/env chown -R serenedb:serenedb /var/lib/serenedb /var/log/serenedb
 
-ExecStart=/usr/bin/serened
+ExecStart=/usr/bin/serened --flagfile=/etc/serenedb/serened.conf
 
 TimeoutSec=3600
 Restart=on-failure

--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -26,8 +26,8 @@ RUN \
   # TODO: add /docker-entrypoint-initdb.d for PostgreSQL-style init scripts (.sh/.sql)
   # Bind to all interfaces and log to stdout (for docker networking and journald)
   if [ -f /etc/serenedb/serened.conf ]; then \
-    sed -i -e 's~^endpoint.*7890$~endpoint = pgsql+tcp://0.0.0.0:7890~' /etc/serenedb/serened.conf; \
-    sed -i -e 's!^\(file\s*=\s*\).*!\1 -!' /etc/serenedb/serened.conf; \
+    sed -i -e 's~^--server_endpoints=.*~--server_endpoints=pgsql+tcp://0.0.0.0:7890~' /etc/serenedb/serened.conf; \
+    sed -i -e 's~^--log_storage=.*~--log_storage=stdout~' /etc/serenedb/serened.conf; \
   fi && \
   # Explicitly set UTC timezone (ubuntu:24.04 defaults to UTC, but be safe)
   echo "UTC" > /etc/timezone && \

--- a/packages/docker/entrypoint.sh
+++ b/packages/docker/entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "serened" ]; then
 	RUNTIME_CONFIG="/tmp/serened.conf"
 	if [ -f "$CONFIG_FILE" ]; then
 		cp "$CONFIG_FILE" "$RUNTIME_CONFIG"
-		set -- "$@" --config "$RUNTIME_CONFIG"
+		set -- "$@" "--flagfile=$RUNTIME_CONFIG"
 		echo "Config: $RUNTIME_CONFIG"
 	fi
 

--- a/scripts/ci/deb-rta-setup.sh
+++ b/scripts/ci/deb-rta-setup.sh
@@ -8,9 +8,8 @@ systemctl is-system-running --wait || true
 apt-get update -qq
 apt-get install -y /workspace/"$DEB_PACKAGE"
 
-# Configure for testing
-sed -i 's|^endpoint.*|endpoint = pgsql+tcp://0.0.0.0:7890|' /etc/serenedb/serened.conf
-echo -e '\n[server]\nauthentication = false' >>/etc/serenedb/serened.conf
+# Configure for testing: listen on all interfaces so the tests container can reach us
+sed -i 's|^--server_endpoints=.*|--server_endpoints=pgsql+tcp://0.0.0.0:7890|' /etc/serenedb/serened.conf
 
 # Start the service
 systemctl start serenedb

--- a/scripts/ci/docker-compose.tarball-drivers-rta.yml
+++ b/scripts/ci/docker-compose.tarball-drivers-rta.yml
@@ -18,7 +18,7 @@ services:
         mkdir -p /tmp/serenedb &&
         tar -xzf /workspace/$TARBALL_NAME -C /tmp/serenedb --strip-components=1 &&
         exec /tmp/serenedb/usr/bin/serened \
-          --config /tmp/serenedb/etc/serenedb/serened.conf \
+          --flagfile=/tmp/serenedb/etc/serenedb/serened.conf \
           --server_endpoints pgsql+tcp://0.0.0.0:7890 \
       '
 

--- a/scripts/ci/docker-compose.tarball-rta.yml
+++ b/scripts/ci/docker-compose.tarball-rta.yml
@@ -18,7 +18,7 @@ services:
         mkdir -p /tmp/serenedb &&
         tar -xzf /workspace/$TARBALL_NAME -C /tmp/serenedb --strip-components=1 &&
         exec /tmp/serenedb/usr/bin/serened \
-          --config /tmp/serenedb/etc/serenedb/serened.conf \
+          --flagfile=/tmp/serenedb/etc/serenedb/serened.conf \
           --server_endpoints pgsql+tcp://0.0.0.0:7890 \
       '
 


### PR DESCRIPTION
## Why

The `make release` Deb RTA failed on both arches ([run 27562245603](https://github.com/serenedb/serenedb/actions/runs/27562245603)). The build itself was green; the RTA's test client got `Connection refused` because `serened` never came up. From the service journal:

```
serened: INFO  "no database path has been supplied, using default 'serenedb-data'"
serened: FATAL Unable to create database directory '/serenedb-data': Permission denied
serenedb.service: Main process exited, code=exited, status=1/FAILURE
```

Root cause: the shipped `serened.conf` is an INI file (`[database] directory`, `[server] endpoint`), but `serened` parses options purely via absl flags and never reads that file. The systemd unit's `ExecStart=/usr/bin/serened` passed neither a data dir nor a flagfile, so the server fell back to the relative default `serenedb-data` → `/serenedb-data` and couldn't create it as the unprivileged `serenedb` user. The Docker entrypoint and tarball RTA compose files also passed a `--config` flag that doesn't exist.

## What

Convert the config to absl flagfile format and launch `serened` with `--flagfile`:

- `etc/serenedb/serened.conf.in`: INI → flagfile (`--server_directory`, `--server_endpoints`, `--log_level`, `--log_storage`)
- systemd unit: `ExecStart` now passes `--flagfile=/etc/serenedb/serened.conf`
- Docker entrypoint + both tarball RTA compose files: `--config` → `--flagfile`
- Dockerfile and `deb-rta-setup.sh` sed edits retarget the new flag lines
- drop the bogus `authentication = false` append (no such flag; it would make the flagfile fail to parse)
- delete the unused `etc/relative/serened.conf` (referenced by nothing)

## Verification

Ran the real `serened` binary against a configured flagfile: it parsed the flagfile, created the `--server_directory` data dir, and listened on the configured endpoint. Lifecycle logs still go to stdout (the `--log_storage` flag only governs DuckDB's internal log store), so the deb RTA's `journalctl` check stays satisfied.