### PR TITLE
fix(CI): stop serenedb before apt remove in Deb RTA

### DIFF
--- a/scripts/ci/steps/08-ci-deb-rta.bash
+++ b/scripts/ci/steps/08-ci-deb-rta.bash
@@ -96,6 +96,7 @@ sleep 10
 check "service recovered after crash" $EXEC systemctl is-active --quiet serenedb
 
 echo "=== apt remove ==="
+$EXEC systemctl stop serenedb
 $EXEC apt-get remove -y serenedb
 check "binary removed" $EXEC test ! -f /usr/bin/serened
 check "data dir preserved after remove" $EXEC test -d /var/lib/serenedb


### PR DESCRIPTION
## Why

Follow-up to the flagfile fix. With the server now actually starting in Deb RTA, the sqllogic tests pass — but the lifecycle stage fails at `apt purge` ([run 27566530259](https://github.com/serenedb/serenedb/actions/runs/27566530259/job/81491881567), amd64):

```
Purging configuration files for serenedb (26.06.1) ...
rm: cannot remove '/var/lib/serenedb/engine_rocksdb': Directory not empty
dpkg: error processing package serenedb (--purge):
 installed serenedb package post-removal script subprocess returned error exit status 1
```

The data dir now holds a live RocksDB instance. The container's `policy-rc.d` returns 101, so the package's prerm `deb-systemd-invoke stop` is a no-op (`/usr/sbin/policy-rc.d returned 101, not running 'stop serenedb.service'`) and `serened` keeps running through `apt remove`. The postrm's `rm -rf /var/lib/serenedb` then races the live process recreating SST/WAL files → "Directory not empty".

This is a container artifact, not a packaging bug: on a real host (no `policy-rc.d`) prerm stops the service and purge succeeds.

## What

Stop the service directly before `apt-get remove`. Direct `systemctl stop` isn't blocked by `policy-rc.d` (the "Service stop" lifecycle test already relies on this), so the process is down before postrm clears the data dir. This matches the harness's existing pattern of working around `policy-rc.d` with direct `systemctl` calls (setup.sh starts the service the same way).