### PR TITLE
fix(CI): emulate a real host in Deb RTA so removal runs maintainer scripts

### DIFF
--- a/scripts/ci/deb-rta-setup.sh
+++ b/scripts/ci/deb-rta-setup.sh
@@ -4,12 +4,16 @@ set -eo pipefail
 # Wait for systemd to boot
 systemctl is-system-running --wait || true
 
-# Install the .deb
+# Drop the base-image policy-rc.d stub (exit 101) so the package maintainer
+# scripts manage the service through systemd like on a real host
+rm -f /usr/sbin/policy-rc.d
+
+# Install the .deb (postinst auto-starts serenedb on the default endpoint)
 apt-get update -qq
 apt-get install -y /workspace/"$DEB_PACKAGE"
 
 # Configure for testing: listen on all interfaces so the tests container can reach us
 sed -i 's|^--server_endpoints=.*|--server_endpoints=pgsql+tcp://0.0.0.0:7890|' /etc/serenedb/serened.conf
 
-# Start the service
-systemctl start serenedb
+# Apply the new endpoint (postinst already started the service)
+systemctl restart serenedb

--- a/scripts/ci/steps/08-ci-deb-rta.bash
+++ b/scripts/ci/steps/08-ci-deb-rta.bash
@@ -96,7 +96,6 @@ sleep 10
 check "service recovered after crash" $EXEC systemctl is-active --quiet serenedb
 
 echo "=== apt remove ==="
-$EXEC systemctl stop serenedb
 $EXEC apt-get remove -y serenedb
 check "binary removed" $EXEC test ! -f /usr/bin/serened
 check "data dir preserved after remove" $EXEC test -d /var/lib/serenedb


### PR DESCRIPTION
## Why

Follow-up to #810. That PR made the purge pass by stopping the service by hand before `apt remove`, which sidesteps the package's own removal flow — we never exercise the prerm. The lifecycle stage should test the real `apt remove`/`autoremove`, including the package stopping its own service.

Root cause (investigated on the actual image): the RTA `serenedb` container boots systemd (`command: /lib/systemd/systemd`, privileged) to run the package like a real host, but it inherits the **Ubuntu base image's `/usr/sbin/policy-rc.d` (`#!/bin/sh` / `exit 101`)** — not dpkg-owned, injected by the base image to stop daemons starting during `apt` in containers. That stub makes `deb-systemd-invoke` a no-op, so the package's postinst *start* and prerm *stop* never run. setup.sh already worked around the start side with an explicit `systemctl start`; the stop side stayed broken, so `serened` ran straight through `apt remove` and the purge's `rm -rf` raced a live RocksDB writer:

```
rm: cannot remove '/var/lib/serenedb/engine_rocksdb': Directory not empty
```

## What

Drop the `policy-rc.d` stub once at the top of `setup.sh` so the whole lifecycle behaves like a host:

- postinst's `deb-systemd-invoke start` runs for real on install,
- `systemctl start` → `restart` after the endpoint rewrite (postinst already started it on the default endpoint),
- prerm's `deb-systemd-invoke stop` runs for real on removal, so the process is down before postrm clears the data dir,
- drop the manual `systemctl stop` from the removal stage (added in #810) now that prerm handles it.

Only `serenedb` is ever installed in that container, so unblocking auto-start has no collateral. This tests both the real install and the real removal paths.