### PR TITLE
fix: split log config into --log_storage + --log_path, default stdout

### DIFF
--- a/cmake/InstallMacros.cmake
+++ b/cmake/InstallMacros.cmake
@@ -39,7 +39,6 @@ macro(install_config name path)
     endif()
 
     set(CRLFSTYLE "UNIX")
-    set(COMMENT_LOGFILE "")
     set(PROGRAM_SUFFIX "")
 
     configure_file(

--- a/etc/serenedb/serened.conf.in
+++ b/etc/serenedb/serened.conf.in
@@ -22,6 +22,13 @@
 # Minimum log severity: trace | debug | info | warning | error | fatal.
 --log_level=info
 
-# Log destination: 'stdout', 'memory' (queryable via duckdb_logs()), or
-# 'file://<path>'.
-@COMMENT_LOGFILE@--log_storage=file://@LOCALSTATEDIR@/log/serenedb/serened.log
+# Log destination at process start:
+#   stdout  -- captured by systemd/journald (default)
+#   memory  -- queryable via SELECT * FROM duckdb_logs()
+#   file    -- written to --log_path below
+--log_storage=stdout
+
+# Filesystem destination, used only when --log_storage=file. A path ending in
+# '.csv' is written as a single log file; any other path is treated as a
+# directory that log CSVs are written into.
+# --log_path=@LOCALSTATEDIR@/log/serenedb

--- a/libs/app/app_server.cpp
+++ b/libs/app/app_server.cpp
@@ -48,6 +48,9 @@ void AppServer::parseOptions(int argc, char* argv[]) {
     static constexpr CategoryRule kRules[] = {
       {"server/rest_server/database_path_feature.cpp", "server"},
       {"server/storage_engine/search_engine.cpp", "server"},
+      {"server/network/server.cpp", "server"},
+      {"server/query/server_engine.cpp", "server"},
+      {"server/scheduler/background_scheduler.cpp", "server"},
       {"libs/basics/log_flags.cpp", "log"},
     };
     for (const auto& [suffix, category] : kRules) {

--- a/libs/basics/duckdb_engine.cpp
+++ b/libs/basics/duckdb_engine.cpp
@@ -24,13 +24,17 @@
 #include <absl/flags/flag.h>
 #include <absl/strings/ascii.h>
 
+#include <duckdb/common/case_insensitive_map.hpp>
+#include <duckdb/common/types/value.hpp>
 #include <duckdb/logging/log_manager.hpp>
 #include <duckdb/logging/logger.hpp>
+#include <duckdb/logging/logging.hpp>
 
 #include "basics/assert.h"
 #include "basics/log.h"
 
 ABSL_DECLARE_FLAG(std::string, log_storage);
+ABSL_DECLARE_FLAG(std::string, log_path);
 ABSL_DECLARE_FLAG(std::string, log_level);
 
 namespace sdb {
@@ -78,11 +82,19 @@ void DuckDBEngine::Initialize(DBConfigMutator mutator) {
   _db = std::make_unique<duckdb::DuckDB>(nullptr, &config);
 
   auto& manager = _db->instance->GetLogManager();
+
   duckdb::LogConfig cfg;
   cfg.enabled = true;
-  cfg.storage = absl::GetFlag(FLAGS_log_storage);
+  cfg.storage = absl::AsciiStrToLower(absl::GetFlag(FLAGS_log_storage));
   cfg.level = ParseLogLevel(absl::GetFlag(FLAGS_log_level));
   manager.SetConfig(*_db->instance, cfg);
+
+  if (cfg.storage == duckdb::LogConfig::FILE_STORAGE_NAME) {
+    duckdb::case_insensitive_map_t<duckdb::Value> storage_config;
+    storage_config["path"] = duckdb::Value(absl::GetFlag(FLAGS_log_path));
+    manager.UpdateLogStorageConfig(*_db->instance, storage_config);
+  }
+
   log::SetLogger(&manager.GlobalLogger());
 }
 

--- a/libs/basics/log_flags.cpp
+++ b/libs/basics/log_flags.cpp
@@ -23,10 +23,15 @@
 #include <string>
 
 ABSL_FLAG(std::string, log_storage, "stdout",
-          "Log destination at process start: 'stdout' (default; "
-          "container log drivers capture it), 'memory' (queryable via "
-          "SELECT * FROM duckdb_logs()), or 'file://<path>'. Override at "
-          "runtime with `SET logging_storage = '<value>'`.");
+          "Log destination at process start. Accepted values: 'stdout' "
+          "(default; systemd/container log drivers capture it), 'memory' "
+          "(queryable via SELECT * FROM duckdb_logs()), or 'file' (uses "
+          "--log_path). Override at runtime with "
+          "`CALL enable_logging(storage='<value>', storage_path='<path>')`.");
+ABSL_FLAG(std::string, log_path, "",
+          "Path used by --log_storage, when it takes one. Its meaning is "
+          "storage-dependent (for 'file', the log file or directory); ignored "
+          "by storages that take no path, such as 'stdout' and 'memory'.");
 ABSL_FLAG(std::string, log_level, "info",
           "Minimum log severity at process start: trace | debug | "
           "info | warning | error | fatal. Override at runtime with "

--- a/server/query/server_engine.cpp
+++ b/server/query/server_engine.cpp
@@ -214,7 +214,7 @@ extern "C" const duckdb::DefaultType* duckdb_external_types(
 }
 
 ABSL_FLAG(uint64_t, cpu_threads, 0,
-          "Executor pool size at process start. 0 = let DuckDB "
+          "Executor pool size at process start. 0 = let server "
           "auto-detect from cpu_count. The SQL-level `SET threads = N` "
           "continues to win at runtime.");
 

--- a/tests/drivers/python/fixtures/serened_cli_help.json
+++ b/tests/drivers/python/fixtures/serened_cli_help.json
@@ -70,11 +70,221 @@
       "label": "Server",
       "flags": [
         {
+          "name": "auth_api_key",
+          "flag": "--auth_api_key",
+          "type": "",
+          "defaultValue": "",
+          "description": "Static HTTP ApiKey credential as id:key (empty = ApiKey rejected).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "auth_bearer_token",
+          "flag": "--auth_bearer_token",
+          "type": "",
+          "defaultValue": "",
+          "description": "Static HTTP Bearer token (empty = Bearer rejected).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "auth_method",
+          "flag": "--auth_method",
+          "type": "",
+          "defaultValue": "scram",
+          "description": "Password auth method for --auth_password: scram (SCRAM-SHA-256, default), md5, or password (cleartext; requires TLS).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "auth_password",
+          "flag": "--auth_password",
+          "type": "",
+          "defaultValue": "",
+          "description": "Temporary single-user password (empty = trust). Placeholder until RBAC; SCRAM-SHA-256 by default. Cleartext password auth requires TLS.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "auth_timeout",
+          "flag": "--auth_timeout",
+          "type": "",
+          "defaultValue": "30s",
+          "description": "Max time from connect to authenticated, per connection (0 = off). pg: covers TLS+startup+auth; http: the request-header read deadline.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "auth_user",
+          "flag": "--auth_user",
+          "type": "",
+          "defaultValue": "postgres",
+          "description": "User the temporary --auth_password / token credentials apply to.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "background_threads",
+          "flag": "--background_threads",
+          "type": "",
+          "defaultValue": "0",
+          "description": "Number of background worker threads (drop / cleanup / maintenance tasks; later object-store prefetch). 0 = auto-detect.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "cpu_threads",
+          "flag": "--cpu_threads",
+          "type": "",
+          "defaultValue": "0",
+          "description": "Executor pool size at process start. 0 = let server auto-detect from cpu_count. The SQL-level `SET threads = N` continues to win at runtime.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "http_body_timeout",
+          "flag": "--http_body_timeout",
+          "type": "",
+          "defaultValue": "30s",
+          "description": "Max time to read one HTTP request body.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "http_cors_origins",
+          "flag": "--http_cors_origins",
+          "type": "",
+          "defaultValue": "",
+          "description": "CORS allow-origin list for the HTTP/ES API: comma-separated origins or '*' (empty disables CORS). Echoes an allowed Origin and answers preflight OPTIONS.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "idle_session_timeout",
+          "flag": "--idle_session_timeout",
+          "type": "",
+          "defaultValue": "1m15s",
+          "description": "Close a session idle (between requests) longer than this. Drives the HTTP keep-alive idle timeout.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "io_threads",
+          "flag": "--io_threads",
+          "type": "",
+          "defaultValue": "0",
+          "description": "IO threads for HTTP and pg-wire connections (0 = max(1, cpu_count / 4)).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "listen",
+          "flag": "--listen",
+          "type": "",
+          "defaultValue": "postgres://127.0.0.1:7890",
+          "description": "Listener URL(s), comma-separated or repeated (last-wins). Each is one listener: postgres://host:port[?sslmode=...], http(s)://host:port?api=es, postgres:///path/to.sock (unix).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "max_connections",
+          "flag": "--max_connections",
+          "type": "",
+          "defaultValue": "0",
+          "description": "Max concurrent client connections across all listeners (0 = unlimited). Over-cap connections get 53300 (pg) / 503 (http) then close. Per-listener override via ?max_connections=.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "pg_max_message_bytes",
+          "flag": "--pg_max_message_bytes",
+          "type": "",
+          "defaultValue": "67108864",
+          "description": "Maximum size of a single pg-wire message (statement text / bound parameter value). Bulk data should use COPY, which streams.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
           "name": "server_directory",
           "flag": "--server_directory",
           "type": "",
           "defaultValue": "serenedb-data",
           "description": "Path to the database directory. A positional argument, if given, takes precedence.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "tls_ca",
+          "flag": "--tls_ca",
+          "type": "",
+          "defaultValue": "",
+          "description": "Default PEM CA bundle to verify client certificates (sslmode=verify-ca/verify-full).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "tls_cert",
+          "flag": "--tls_cert",
+          "type": "",
+          "defaultValue": "",
+          "description": "Default PEM server certificate chain for TLS listeners (a listener may override with ?cert=).",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "tls_ciphers",
+          "flag": "--tls_ciphers",
+          "type": "",
+          "defaultValue": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305",
+          "description": "OpenSSL TLS 1.2 cipher list (forward-secret AEAD, Mozilla intermediate); TLS 1.3 suites are fixed by OpenSSL.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "tls_groups",
+          "flag": "--tls_groups",
+          "type": "",
+          "defaultValue": "X25519:P-256",
+          "description": "TLS key-exchange groups, colon-separated.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "tls_key",
+          "flag": "--tls_key",
+          "type": "",
+          "defaultValue": "",
+          "description": "Default PEM private key for --tls_cert.",
+          "source": "server",
+          "category": "server",
+          "categoryLabel": "Server"
+        },
+        {
+          "name": "tls_min_version",
+          "flag": "--tls_min_version",
+          "type": "",
+          "defaultValue": "1.2",
+          "description": "Minimum TLS version: 1.2 or 1.3 (legacy TLS is not supported).",
           "source": "server",
           "category": "server",
           "categoryLabel": "Server"
@@ -96,242 +306,24 @@
           "categoryLabel": "Logging"
         },
         {
+          "name": "log_path",
+          "flag": "--log_path",
+          "type": "",
+          "defaultValue": "",
+          "description": "Path used by --log_storage, when it takes one. Its meaning is storage-dependent (for 'file', the log file or directory); ignored by storages that take no path, such as 'stdout' and 'memory'.",
+          "source": "log",
+          "category": "log",
+          "categoryLabel": "Logging"
+        },
+        {
           "name": "log_storage",
           "flag": "--log_storage",
           "type": "",
           "defaultValue": "stdout",
-          "description": "Log destination at process start: 'stdout' (default; container log drivers capture it), 'memory' (queryable via SELECT * FROM duckdb_logs()), or 'file://<path>'. Override at runtime with `SET logging_storage = '<value>'`.",
+          "description": "Log destination at process start. Accepted values: 'stdout' (default; systemd/container log drivers capture it), 'memory' (queryable via SELECT * FROM duckdb_logs()), or 'file' (uses --log_path). Override at runtime with `CALL enable_logging(storage='<value>', storage_path='<path>')`.",
           "source": "log",
           "category": "log",
           "categoryLabel": "Logging"
-        }
-      ]
-    },
-    {
-      "id": "server/network/server.cpp",
-      "label": "server/network/server.cpp",
-      "flags": [
-        {
-          "name": "auth_api_key",
-          "flag": "--auth_api_key",
-          "type": "",
-          "defaultValue": "",
-          "description": "Static HTTP ApiKey credential as id:key (empty = ApiKey rejected).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "auth_bearer_token",
-          "flag": "--auth_bearer_token",
-          "type": "",
-          "defaultValue": "",
-          "description": "Static HTTP Bearer token (empty = Bearer rejected).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "auth_method",
-          "flag": "--auth_method",
-          "type": "",
-          "defaultValue": "scram",
-          "description": "Password auth method for --auth_password: scram (SCRAM-SHA-256, default), md5, or password (cleartext; requires TLS).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "auth_password",
-          "flag": "--auth_password",
-          "type": "",
-          "defaultValue": "",
-          "description": "Temporary single-user password (empty = trust). Placeholder until RBAC; SCRAM-SHA-256 by default. Cleartext password auth requires TLS.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "auth_timeout",
-          "flag": "--auth_timeout",
-          "type": "",
-          "defaultValue": "30s",
-          "description": "Max time from connect to authenticated, per connection (0 = off). pg: covers TLS+startup+auth; http: the request-header read deadline.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "auth_user",
-          "flag": "--auth_user",
-          "type": "",
-          "defaultValue": "postgres",
-          "description": "User the temporary --auth_password / token credentials apply to.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "http_body_timeout",
-          "flag": "--http_body_timeout",
-          "type": "",
-          "defaultValue": "30s",
-          "description": "Max time to read one HTTP request body.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "http_cors_origins",
-          "flag": "--http_cors_origins",
-          "type": "",
-          "defaultValue": "",
-          "description": "CORS allow-origin list for the HTTP/ES API: comma-separated origins or '*' (empty disables CORS). Echoes an allowed Origin and answers preflight OPTIONS.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "idle_session_timeout",
-          "flag": "--idle_session_timeout",
-          "type": "",
-          "defaultValue": "1m15s",
-          "description": "Close a session idle (between requests) longer than this. Drives the HTTP keep-alive idle timeout.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "io_threads",
-          "flag": "--io_threads",
-          "type": "",
-          "defaultValue": "0",
-          "description": "IO threads for HTTP and pg-wire connections (0 = max(1, cpu_count / 4)).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "listen",
-          "flag": "--listen",
-          "type": "",
-          "defaultValue": "postgres://127.0.0.1:7890",
-          "description": "Listener URL(s), comma-separated or repeated (last-wins). Each is one listener: postgres://host:port[?sslmode=...], http(s)://host:port?api=es, postgres:///path/to.sock (unix).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "max_connections",
-          "flag": "--max_connections",
-          "type": "",
-          "defaultValue": "0",
-          "description": "Max concurrent client connections across all listeners (0 = unlimited). Over-cap connections get 53300 (pg) / 503 (http) then close. Per-listener override via ?max_connections=.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "pg_max_message_bytes",
-          "flag": "--pg_max_message_bytes",
-          "type": "",
-          "defaultValue": "67108864",
-          "description": "Maximum size of a single pg-wire message (statement text / bound parameter value). Bulk data should use COPY, which streams.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "tls_ca",
-          "flag": "--tls_ca",
-          "type": "",
-          "defaultValue": "",
-          "description": "Default PEM CA bundle to verify client certificates (sslmode=verify-ca/verify-full).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "tls_cert",
-          "flag": "--tls_cert",
-          "type": "",
-          "defaultValue": "",
-          "description": "Default PEM server certificate chain for TLS listeners (a listener may override with ?cert=).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "tls_ciphers",
-          "flag": "--tls_ciphers",
-          "type": "",
-          "defaultValue": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305",
-          "description": "OpenSSL TLS 1.2 cipher list (forward-secret AEAD, Mozilla intermediate); TLS 1.3 suites are fixed by OpenSSL.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "tls_groups",
-          "flag": "--tls_groups",
-          "type": "",
-          "defaultValue": "X25519:P-256",
-          "description": "TLS key-exchange groups, colon-separated.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "tls_key",
-          "flag": "--tls_key",
-          "type": "",
-          "defaultValue": "",
-          "description": "Default PEM private key for --tls_cert.",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        },
-        {
-          "name": "tls_min_version",
-          "flag": "--tls_min_version",
-          "type": "",
-          "defaultValue": "1.2",
-          "description": "Minimum TLS version: 1.2 or 1.3 (legacy TLS is not supported).",
-          "source": "server/network/server.cpp",
-          "category": "server/network/server.cpp",
-          "categoryLabel": "server/network/server.cpp"
-        }
-      ]
-    },
-    {
-      "id": "server/query/server_engine.cpp",
-      "label": "server/query/server_engine.cpp",
-      "flags": [
-        {
-          "name": "cpu_threads",
-          "flag": "--cpu_threads",
-          "type": "",
-          "defaultValue": "0",
-          "description": "Executor pool size at process start. 0 = let DuckDB auto-detect from cpu_count. The SQL-level `SET threads = N` continues to win at runtime.",
-          "source": "server/query/server_engine.cpp",
-          "category": "server/query/server_engine.cpp",
-          "categoryLabel": "server/query/server_engine.cpp"
-        }
-      ]
-    },
-    {
-      "id": "server/scheduler/background_scheduler.cpp",
-      "label": "server/scheduler/background_scheduler.cpp",
-      "flags": [
-        {
-          "name": "background_threads",
-          "flag": "--background_threads",
-          "type": "",
-          "defaultValue": "0",
-          "description": "Number of background worker threads (drop / cleanup / maintenance tasks; later object-store prefetch). 0 = auto-detect.",
-          "source": "server/scheduler/background_scheduler.cpp",
-          "category": "server/scheduler/background_scheduler.cpp",
-          "categoryLabel": "server/scheduler/background_scheduler.cpp"
         }
       ]
     }


### PR DESCRIPTION
## Problem

`make release` failed the Deb/Docker RTA on `main`: the test client got `Connection refused` because `serened` never came up. From the service journal:

```
serened: libc++abi: terminating due to uncaught exception of type
  duckdb::InvalidInputException: Log storage
  'file:///var/log/serenedb/serened.log' is not yet registered
serenedb.service: Main process exited, code=killed, status=6/ABRT
```

The packaged `serened.conf` shipped `--log_storage=file://<path>`, but `LogManager` matches the value against storage *names* (`stdout` / `memory` / `file` / a registered name) — a `file://<path>` URI matches none, so `SetConfig` threw and the uncaught exception aborted the process before it bound its port. The `file://<path>` syntax was a serened-only convention that was never translated into API.

## Fix

Replace the URI with two flags (storage name + path config — the same shape as `enable_logging(storage, storage_path)`):

- `--log_storage`: `stdout` (default) | `memory` | `file`
- `--log_path`: filesystem destination, used when `--log_storage=file`

- `serened.conf` defaults to `--log_storage=stdout` (captured by systemd/journald), with a commented `--log_path` example. stdout is the idiomatic destination for a systemd service: `journalctl -u serenedb` works, and journald handles rotation/retention. File logging is opt-in.

## Testing

- The changed translation units compile.
- The generated `serened.conf` regenerates clean with no leftover template tokens.
