### PR TITLE
fix: Add drop task  initial connect retry + fix CREATE / CHECKPOINT race

### DIFF
--- a/server/catalog/store/store.cpp
+++ b/server/catalog/store/store.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <duckdb/catalog/catalog.hpp>
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
+#include <duckdb/common/enums/database_modification_type.hpp>
 #include <duckdb/common/exception/binder_exception.hpp>
 #include <duckdb/common/serializer/memory_stream.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
@@ -44,12 +45,14 @@
 #include <duckdb/parser/parsed_data/alter_table_info.hpp>
 #include <duckdb/parser/parsed_data/create_table_info.hpp>
 #include <duckdb/parser/parsed_expression_iterator.hpp>
+#include <duckdb/transaction/meta_transaction.hpp>
 #include <exception>
 #include <filesystem>
 #include <initializer_list>
 #include <utility>
 
 #include "basics/assert.h"
+#include "basics/debugging.h"
 #include "basics/down_cast.h"
 #include "basics/duckdb_engine.h"
 #include "basics/exceptions.h"
@@ -1009,6 +1012,20 @@ Result CatalogStore::ExecuteCreateStoreTableImpl(const StoreTableDef& def,
     auto& context = *_conn->context;
     auto& catalog =
       duckdb::Catalog::GetCatalog(context, std::string{kStoreAlias});
+    // Acquire the store's (shared) checkpoint lock before creating the table.
+    // The direct catalog.CreateTable() call bypasses the statement-execution
+    // path that normally registers the modification and takes this lock (which
+    // serenedb's DROP/ALTER do go through, via _conn->Query). Without it, a
+    // store table can be created concurrently with a store checkpoint; the new
+    // table is then not in the checkpoint's snapshot, so MergeCheckpointDeltas
+    // never merges its index's added_data delta -> the entry is stranded -> a
+    // later delete fails "0 out of 1" -> "Failed to rollback transaction".
+    duckdb::MetaTransaction::Get(context).ModifyDatabase(
+      catalog.GetAttached(),
+      duckdb::DatabaseModificationType::CREATE_CATALOG_ENTRY);
+    SDB_IF_FAILURE("pause_store_create_table") {
+      sdb::WaitWhileFailurePointDebugging("pause_store_create_table");
+    }
     catalog.CreateTable(context, std::move(info));
     return {};
   });

--- a/tests/sqllogic/recovery/catalog_create_table_checkpoint_lock.test
+++ b/tests/sqllogic/recovery/catalog_create_table_checkpoint_lock.test
@@ -1,0 +1,76 @@
+## The 'pause_store_create_table' failpoint parks a CREATE right after it takes
+## the checkpoint lock. We then prove a concurrent non-force CHECKPOINT cannot
+## proceed (DuckDB refuses: "Cannot CHECKPOINT: there are other write
+## transactions active").
+##
+## If this test FAILS (a CHECKPOINT succeeds while a CREATE is parked) it means
+## one of two things:
+##   1. DuckDB changed its lock model so CREATE_CATALOG_ENTRY no longer
+##      conflicts with a checkpoint (their sync/lock no longer triggers), or
+##   2. our prevention regressed -- the ModifyDatabase(CREATE_CATALOG_ENTRY)
+##      call in ExecuteCreateStoreTableImpl no longer takes the lock.
+## Either way the invariant "store CREATE never overlaps a store checkpoint" is
+## no longer enforced and must be re-established before this test is removed.
+
+control substitution on
+control max-async-connections 4
+
+
+# Arm the failpoint, then start a CREATE that parks while holding the store's
+# checkpoint lock. It must run async so the runner can drive the checkpointer
+# connection while this CREATE is parked.
+connection writer
+statement ok
+SET sdb_faults = 'pause_store_create_table';
+
+
+connection writer
+statement async ok
+CREATE TABLE cctr_lock_probe(id INTEGER PRIMARY KEY, body TEXT);
+
+
+# Retry CHECKPOINT until it fails. The failure only appears once the writer has
+# reached the parked state and is holding the checkpoint lock, so this both
+# waits for the writer AND is the first half of the assertion. On a binary
+# without the fix the CHECKPOINT keeps succeeding, the retries are exhausted,
+# and this directive fails (see header).
+connection checkpointer
+statement error retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+CHECKPOINT;
+
+
+# The writer is still parked (lock held until the fault is cleared below), so a
+# CHECKPOINT now fails deterministically -- assert it is exactly the
+# checkpoint-lock conflict, not some unrelated error.
+connection checkpointer
+statement error (?i)cannot checkpoint.*other write transactions
+CHECKPOINT;
+
+
+# Release the writer from a SEPARATE connection. `writer` is blocked inside the
+# parked CREATE, and the runner waits for a connection's in-flight async
+# statement to finish before reusing that connection -- clearing the fault on
+# `writer` would deadlock (the clear would wait for the very CREATE it must
+# release). The failpoint set is global, so any connection can clear it.
+connection releaser
+statement ok
+SET sdb_faults = '-pause_store_create_table';
+
+
+# Retry the INSERT until the async CREATE has committed and the table is
+# visible -- same retry mechanism as the CHECKPOINT above, used for success
+# instead of error. This replaces an explicit `wait` for the writer.
+connection checkpointer
+statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+INSERT INTO cctr_lock_probe VALUES (1, 'ok');
+
+
+# Exercise the PK-index delete path -- the exact operation that fails "0 out of
+# 1" when a CREATE is stranded by an overlapping checkpoint. It succeeds here
+# because the overlap was prevented.
+statement ok
+DELETE FROM cctr_lock_probe WHERE id = 1;
+
+
+statement ok
+DROP TABLE cctr_lock_probe;


### PR DESCRIPTION
Bumps sqllogic submodule  to fix  recovery test run issue when test itself has passed but cleanup (e.g. db drop) gives connections error and fails entire test run.

And fix flaky error caused by CREATE TABLE  interleaved with background CHECKPOINT leading to corrupted PK index state usually surfaced as CI error like:
```
  tests-1  | Caused by:
  tests-1  |     query failed: db error: ERROR: Failed to rollback transaction. Cannot continue operation.
  tests-1  |     Original Error: FATAL Error: Invalid Input Error: Failed to delete all rows from index. Only deleted 0 out of 1 rows.
  tests-1  |     Chunk: Chunk - [3 Columns]
  tests-1  |     - FLAT INTEGER: 1 = [ 1]
  tests-1  |     - CONSTANT VARCHAR: 1 = [ NULL]
  tests-1  |     - CONSTANT INTEGER: 1 = [ NULL]
  tests-1  |     
  tests-1  |     Rollback Error: Invalid Input Error: Failed to delete all rows from index. Only deleted 0 out of 1 rows.
  tests-1  |     Chunk: Chunk - [3 Columns]
  tests-1  |     - DICTIONARY INTEGER: 1 = [ 1]
  tests-1  |     - DICTIONARY VARCHAR: 1 = [ alpha]
  tests-1  |     - DICTIONARY INTEGER: 1 = [ 11]
  tests-1  |     
  tests-1  |     [SQL] UPDATE ret_plain SET c = 11 WHERE a = 1 RETURNING a, c;
  tests-1  |     at sdb/pg/dml/returning.test:24
  tests-1  |     
```

Issue was that we make CreateTable as direct catalog API calls without proper locking that is done if one executes "CREATE TABLE" as a query. DROP is executed as a query so it works fine as is. 