### PR TITLE
Pipelined WAL group-commit fsyncs from declared sync semantics

### DIFF
--- a/server/connector/duckdb_client_state.cpp
+++ b/server/connector/duckdb_client_state.cpp
@@ -181,8 +181,9 @@ void SereneDBClientState::TransactionPreCommit(
   tls_committing_ctx = _connection_ctx.get();
 }
 
-void SereneDBClientState::TransactionPreCheckpoint(duckdb::AttachedDatabase& db,
-                                                   duckdb::ClientContext&) {
+void SereneDBClientState::TransactionPreCheckpoint(
+  duckdb::AttachedDatabase& db, duckdb::ClientContext&,
+  duckdb::idx_t wal_generation, duckdb::idx_t wal_end_offset) {
   // Commit the search-index leg synchronously with the store table changes:
   // this fires after the store database's changes are durable but before the
   // in-commit checkpoint, so the checkpoint's force-refresh never waits on an
@@ -191,7 +192,16 @@ void SereneDBClientState::TransactionPreCheckpoint(duckdb::AttachedDatabase& db,
   if (db.GetName().GetIdentifierName() != catalog::kStoreDatabaseName) {
     return;
   }
-  _connection_ctx->CommitSearch();
+  // This commit's exact WAL position, captured under the WAL lock by the
+  // engine: with overlapping commits, reading the WAL size here would include
+  // later transactions' bytes and over-claim the recovery cursor (skipping
+  // their re-stream after a crash). A commit whose changes are carried by its
+  // in-commit checkpoint (wal_end_offset == 0) recovers from the start of the
+  // post-checkpoint WAL generation.
+  const auto cursor = wal_end_offset > 0
+                        ? search::WalCursor{wal_generation, wal_end_offset}
+                        : search::WalCursor{wal_generation + 1, 0};
+  _connection_ctx->CommitSearch(cursor);
 }
 
 void SereneDBClientState::TransactionPreRollback(

--- a/server/connector/duckdb_client_state.h
+++ b/server/connector/duckdb_client_state.h
@@ -99,7 +99,9 @@ class SereneDBClientState final : public duckdb::ClientContextState {
                             duckdb::ClientContext& context) final;
 
   void TransactionPreCheckpoint(duckdb::AttachedDatabase& db,
-                                duckdb::ClientContext& context) final;
+                                duckdb::ClientContext& context,
+                                duckdb::idx_t wal_generation,
+                                duckdb::idx_t wal_end_offset) final;
 
   void TransactionPreRollback(
     duckdb::MetaTransaction& transaction, duckdb::ClientContext& context,

--- a/server/query/transaction.cpp
+++ b/server/query/transaction.cpp
@@ -168,7 +168,8 @@ void Transaction::PreCommit() noexcept {
 
 void Transaction::PreRollback() noexcept { RollbackVariables(); }
 
-void Transaction::CommitSearch() noexcept {
+void Transaction::CommitSearch(
+  std::optional<search::WalCursor> cursor) noexcept {
   if (_search_transactions.empty()) {
     return;
   }
@@ -198,31 +199,18 @@ void Transaction::CommitSearch() noexcept {
 
   std::move(rollback).Cancel();
 
-  // This commit's exact store-WAL end offset, with the checkpoint iteration as
-  // the generation. We run after the store WAL is durable (inside the engine
-  // commit, before the in-commit checkpoint), so GetWALSize() is this
-  // transaction's WAL end offset and is constant throughout CommitSearch; read
-  // it once. Commits serialize, so ticks and offsets arrive in the same order.
-  search::WalCursor cursor;
-  bool has_cursor = false;
-  if (auto store =
-        duckdb::DatabaseManager::Get(DuckDBEngine::Instance().instance())
-          .GetDatabase(duckdb::Identifier{catalog::kStoreDatabaseName})) {
-    auto& sm = store->GetStorageManager();
-    cursor = search::WalCursor{sm.GetBlockManager().GetCheckpointIteration(),
-                               sm.GetWALSize()};
-    has_cursor = true;
-  }
-
   for (auto& [index_id, entry] : _search_transactions) {
     // Record this commit's WAL cursor into the index's own table BEFORE its
     // segment becomes flushable (Commit below emplaces it into the flush
     // context). A concurrent refresh can only flush this batch after Commit, by
     // which point the offset is already in the table, so the refresh's
     // CursorAtOrBelow(flushed_tick) can never under-claim and re-stream an
-    // already-durable insert after a crash.
-    if (entry.storage && has_cursor) {
-      entry.storage->RecordFlushCursor(last_tick, cursor);
+    // already-durable insert after a crash. The cursor is this commit's exact
+    // WAL position, captured under the WAL lock by the engine: commits overlap,
+    // so reading the WAL size here would include later transactions' bytes and
+    // over-claim (skipping their re-stream after a crash).
+    if (entry.storage && cursor) {
+      entry.storage->RecordFlushCursor(last_tick, *cursor);
     }
     if (entry.transaction->Commit(last_tick)) {
       continue;
@@ -252,8 +240,8 @@ Result Transaction::Commit() {
 
   // Inverted-index trxs: normally already settled inside the engine commit
   // (TransactionPreCheckpoint); this is the fallback for transactions that did
-  // not commit the store database.
-  CommitSearch();
+  // not commit the store database, so there is no store-WAL cursor to record.
+  CommitSearch(std::nullopt);
 
   // Search-table (TableEngine::Search) commit point (WAL_DESIGN.md §9): the §9
   // crash boundaries + the single multi-shard WAL fsync that is the atomic

--- a/server/query/transaction.h
+++ b/server/query/transaction.h
@@ -64,8 +64,11 @@ class Transaction : public Config {
   // called inside the engine commit, after store durability but before the
   // in-commit checkpoint, so the checkpoint's force-refresh never waits on an
   // un-committed in-flight batch. Idempotent -- a no-op once the staged
-  // transactions have been committed (or when there were none).
-  void CommitSearch() noexcept;
+  // transactions have been committed (or when there were none). The cursor is
+  // this commit's exact store-WAL position (captured under the WAL lock by the
+  // engine); std::nullopt on the fallback path where the transaction did not
+  // commit the store database, in which case no recovery cursor is recorded.
+  void CommitSearch(std::optional<search::WalCursor> cursor) noexcept;
 
   Result Commit();
 


### PR DESCRIPTION
Bumps `third_party/duckdb` to `df184672c5`, reworking the group-commit fsync coordination:

- A committer fsyncs itself, overlapping in-flight fsyncs up to the file system's declared sync parallelism (new `FileSystem::SyncParallelism`: network file systems declare PARALLEL, local journaled file systems SERIAL, where a single fsync stream with late-snapped targets batches naturally). Replaces the single-leader futex state machine; no settings, no timing.
- New snapshots are bounded at the durable horizon: no transaction can observe a commit a crash could lose, and snapshot acquisition never waits.
- fsync failure is terminal (poison + fatal): a retried fsync can falsely succeed after the OS drops failed dirty pages.
- Fixes a truncate/fsync race that could raise the durable offset past the truncation point.

The durable horizon has to be respected by everything that destroys MVCC versions; a second round (upstream CI + local suite sweeps) hardens those paths:

- Checkpoints read a fresh snapshot: a bounded one silently dropped pending commits from the checkpoint image right before WAL truncation.
- Snapshot bounds are floored above the bootstrap catalog (its entries commit at timestamp 1), and version cleanup thresholds are clamped at the horizon so no future bounded snapshot can read a vacuumed chain.
- Strict timestamp comparisons became at-or-after in the four places where a bounded snapshot can equal a commit id (catalog write-write conflict, row update conflict, update-chain version selection, commit-drop verification); for fresh snapshots the equality is unreachable, so upstream behavior is unchanged.
- Checkpoints first let in-flight fsyncs land and run the cleanups the horizon held back: parked committed transactions keep their shared checkpoint locks (starving the exclusive acquisition) and their undo references segments the checkpoint frees.
- Only WAL-skipping bulk commits, which stay non-durable for their whole carrying checkpoint, gate transaction starts (the FORCE CHECKPOINT mechanism, with same-thread reentrancy for checkpoint-internal index binds). Ordinary checkpoints run gate-free and downgrade to concurrent when a snapshot raced into the commit's fsync window.
- `SingleFileBlockManager::iteration_count` is atomic: committers read it lock-free for the search recovery cursor while checkpoints bump it under the block lock (TSAN-reported race, fork-only reader).

Benchmarked with duckdb/duckdb#23631's own group-commit benchmark: equal or faster in every thread-count x fsync-latency cell against both main and that PR. Upstreamed as duckdb/duckdb#23655.

Validation on the duckdb side: full unittest suite green (4586 cases), relassert suite green on the merge with upstream main (the single failure is upstream's own `partial_aggregate_precomputation` in-group timeout, reproduced on pure main), TSAN interquery tests green. serenedb sqllogic was green on both wire protocols for the previous iteration; rerun pending the build-system rework.
