### PR TITLE
feat: WAL group commit via a durable-horizon commit path

### DIFF
--- a/server/connector/duckdb_client_state.cpp
+++ b/server/connector/duckdb_client_state.cpp
@@ -185,10 +185,16 @@ void SereneDBClientState::TransactionPreCheckpoint(
   duckdb::AttachedDatabase& db, duckdb::ClientContext&,
   duckdb::idx_t wal_generation, duckdb::idx_t wal_end_offset) {
   // Commit the search-index leg synchronously with the store table changes:
-  // this fires after the store database's changes are durable but before the
-  // in-commit checkpoint, so the checkpoint's force-refresh never waits on an
-  // un-committed in-flight batch. Only the store database carries indexed
-  // tables, so settle on its commit.
+  // the engine fires this on the committing thread, while it still holds the
+  // WAL lock, right after the commit's WAL flush marker is written -- so ticks
+  // are handed out in WAL-append order across connections and recovery cursors
+  // stay monotonic with WAL offsets, even though the group fsyncs (and thus
+  // acknowledgements) complete out of order. Settling here is memory-only
+  // (segment flushes happen in the background refresh); the refresh gates its
+  // durable cursor on the WAL becoming durable, so the index never persists a
+  // batch whose store bytes a crash could still lose. It precedes any in-commit
+  // checkpoint, whose force-refresh therefore never waits on an un-committed
+  // in-flight batch. Only the store database carries indexed tables.
   if (db.GetName().GetIdentifierName() != catalog::kStoreDatabaseName) {
     return;
   }

--- a/server/network/server.cpp
+++ b/server/network/server.cpp
@@ -26,9 +26,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <duckdb/parallel/task_scheduler.hpp>
 #include <memory>
 #include <utility>
 
+#include "basics/duckdb_engine.h"
 #include "basics/log.h"
 #include "basics/number_of_cores.h"
 #include "catalog/catalog.h"
@@ -472,11 +474,24 @@ void Server::StartListeners() {
   }
 }
 
-void Server::stop() {
+void Server::StopAccepting() noexcept {
   for (auto& acceptor : _acceptors) {
     acceptor->Stop();
   }
+}
+
+void Server::stop() {
+  // Join every DuckDB worker BEFORE freeing the io pool. A session's query
+  // pipeline runs on a DuckDB worker and, on completion, pushes result bytes up
+  // into this connection's io-side state (CpuResumer -> IoExecutor, the send
+  // gates). Freeing the io pool while such a worker is mid-push is a
+  // use-after-free. SetThreads cannot help: the regular pool clamps to one
+  // worker unless it is being destroyed, and the DatabaseInstance stays pinned
+  // alive by every session's Connection, so _db.reset() never joins the workers
+  // while sessions exist. Join() reaches zero workers on the live scheduler.
   if (_pool) {
+    duckdb::TaskScheduler::GetScheduler(DuckDBEngine::Instance().instance())
+      .Join();
     _pool->Stop();
     _pool.reset();
   }

--- a/server/network/server.h
+++ b/server/network/server.h
@@ -54,6 +54,14 @@ class Server final {
   // busy-spinning on an instant Delay() during startup.
   void StartIoPool();
   void StartListeners();
+  // Two-phase stop, mirroring start. StopAccepting() closes the listeners so no
+  // new connection is taken; it runs EARLY, before the rest of the engine comes
+  // down. stop() joins the DuckDB workers and then tears the io pool down; it
+  // must run LAST -- after every subsystem that submits DuckDB work (search,
+  // background, store, catalog) is down -- because a session query pipeline
+  // runs on a DuckDB worker and pushes results up into the io pool, so the pool
+  // can only be freed once no worker is left to touch it.
+  void StopAccepting() noexcept;
   void stop();
 
   // The io worker pool (sockets + reused for background timers); null until

--- a/server/query/transaction.cpp
+++ b/server/query/transaction.cpp
@@ -22,13 +22,17 @@
 
 #include <absl/cleanup/cleanup.h>
 
+#include <chrono>
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/main/database_manager.hpp>
 #include <duckdb/storage/block_manager.hpp>
 #include <duckdb/storage/storage_manager.hpp>
 #include <duckdb/transaction/meta_transaction.hpp>
+#include <random>
+#include <thread>
 
 #include "basics/assert.h"
+#include "basics/debugging.h"
 #include "basics/duckdb_engine.h"
 #include "basics/log.h"
 #include "catalog/catalog.h"
@@ -194,6 +198,14 @@ void Transaction::CommitSearch(
     max_queries =
       std::max<uint64_t>(max_queries, entry.transaction->GetQueries());
   }
+  SDB_IF_FAILURE("long_waited_advance") {
+    static std::atomic<uint32_t> gSeedCounter{0};
+    static thread_local std::mt19937 gRng{
+      gSeedCounter.fetch_add(1, std::memory_order_relaxed)};
+    std::this_thread::sleep_for(std::chrono::microseconds(
+      std::uniform_int_distribution<int>(0, 20000)(gRng)));
+  }
+
   const auto last_tick =
     search::TickDomain::Instance().Advance(max_queries + 1);
 

--- a/server/query/transaction.h
+++ b/server/query/transaction.h
@@ -61,13 +61,19 @@ class Transaction : public Config {
   void PreRollback() noexcept;
 
   // Commit the search-index leg synchronously with the store table changes:
-  // called inside the engine commit, after store durability but before the
-  // in-commit checkpoint, so the checkpoint's force-refresh never waits on an
-  // un-committed in-flight batch. Idempotent -- a no-op once the staged
-  // transactions have been committed (or when there were none). The cursor is
-  // this commit's exact store-WAL position (captured under the WAL lock by the
-  // engine); std::nullopt on the fallback path where the transaction did not
-  // commit the store database, in which case no recovery cursor is recorded.
+  // called by the engine from its TransactionPreCheckpoint hook, on the
+  // committing thread while it still holds the transaction lock and the WAL
+  // append ordering, right after this commit's WAL flush marker is written --
+  // so across connections ticks are handed out strictly in WAL-append order
+  // over complete batches and recovery cursors stay monotonic with WAL offsets,
+  // even though the group fsyncs (and thus the durable acknowledgements)
+  // complete afterwards and out of order. Everything here is memory-only; the
+  // background refresh gates its durable cursor on the WAL becoming durable, so
+  // a batch is never persisted before its store bytes are. The cursor is this
+  // commit's exact store-WAL position; std::nullopt on the fallback path where
+  // the transaction did not commit the store database, in which case no
+  // recovery cursor is recorded. Idempotent -- a no-op once the staged
+  // transactions have been committed (or when there were none).
   void CommitSearch(std::optional<search::WalCursor> cursor) noexcept;
 
   Result Commit();

--- a/server/rest_server/serened.cpp
+++ b/server/rest_server/serened.cpp
@@ -101,7 +101,9 @@ int RunServer(int argc, char** argv) {
         search.RequestStop();
       }
       if (up_network) {
-        stop("network", [&] { network.stop(); });
+        // Stop taking new connections early, but keep the io pool alive: the
+        // search/background loops below still drain their timers on it.
+        stop("accept", [&] { network.StopAccepting(); });
       }
       if (up_search) {
         stop("search", [&] { search.stop(); });
@@ -114,6 +116,13 @@ int RunServer(int argc, char** argv) {
       }
       if (up_catalog) {
         stop("catalog", [&] { catalog::ShutdownCatalog(); });
+      }
+      if (up_network) {
+        // Last: every DuckDB-work submitter above is now down, so join the
+        // DuckDB workers and tear the io pool down. A session query pipeline
+        // runs on a DuckDB worker and pushes results up into the io pool, so
+        // the pool can only be freed once no worker is left to touch it.
+        stop("network", [&] { network.stop(); });
       }
     };
 

--- a/tests/sqllogic/recovery/wal_index_recovery_concurrent_refresh.test
+++ b/tests/sqllogic/recovery/wal_index_recovery_concurrent_refresh.test
@@ -49,6 +49,9 @@ statement ok
 CREATE INDEX cc_idx ON cc_t USING inverted(id, body cc_dict)
   WITH (refresh_interval = 1);
 
+statement ok
+SET sdb_faults = 'long_waited_advance';
+
 ###############################################################################
 # Round 1: 8 concurrent writers x 250 rows, refresher loop in parallel
 ###############################################################################


### PR DESCRIPTION
Groups the WAL fsync across concurrently committing transactions, and pipelines it across lanes on filesystems that declare a safe sync parallelism, **without changing any observable commit behaviour** relative to upstream duckdb. Also fixes a search-index recovery-cursor ordering bug and a shutdown use-after-free.

## Engine (`third_party/duckdb`)

**Durable-horizon group commit.** A transaction applies its changes (`undo_buffer.Commit`, including index removal) and writes its `WAL_FLUSH` marker under the transaction lock, *exactly as upstream* — so a failure during apply (e.g. an index removal that throws) still truncates the not-yet-durable WAL and rolls the transaction back rather than going fatal. Only the fsync moves out of the lock: after recording the commit as pending, the committer drops the locks and runs a grouped `GroupSync`, so concurrent committers share or overlap a single fsync and a commit is acknowledged only once its own flush marker is durable.

- **Commit ordering is unchanged from upstream.** Apply → write flush marker → assign commit id → remove from the active set all happen under the transaction lock in the same order as vanilla duckdb; nothing about visibility or conflict handling moves. The only thing deferred is the physical fsync.
- **Durable-before-readable** is preserved by bounding new snapshots below the not-yet-durable suffix (`DurableSnapshotBound`, tracked by `last_pending_commit` / `last_durable_commit`): no transaction ever observes a commit that a crash could still lose, even though that commit is already applied in memory.
- **No extra locks, no timing heuristics.** `WaitForInFlightCommits` parks on the `last_durable_commit` atomic via C++20 atomic wait/notify (no mutex or condvar), and the commit path notifies only after it advances the horizon, so a commit is never slower than before. The WAL lane engine parks the same way on `sync_epoch`. Fsyncs pipeline across lanes only up to the file system's declared `FileSystem::SyncParallelism`; a committer whose bytes an in-flight fsync already covers parks instead of issuing a redundant one.

Three concurrency defects that surface once the fsync can run unlocked are fixed here, each TSAN-caught (upstream is clean because it never runs a commit's cleanup concurrently with a checkpoint):

- **Deferred undo cleanup vs. concurrent checkpoint** — concurrent updates keep the column that owns a referenced `UpdateSegment` alive until the committing transaction's undo is cleaned up (`PinUpdateColumn`), since group commit defers that cleanup past the unlocked fsync where a concurrent checkpoint could otherwise free it.
- **Stats→segment lock inversion** — `RowGroupCollection::FinalizeAppend` releases the collection stats lock before its debug-only `Verify()` (which walks the row-group segment tree), removing a stats→segment ordering that inverts with `Checkpoint`'s segment→stats order once a concurrent checkpoint can run.
- **Block-manager free-list race** — `SingleFileBlockManager::Read` takes `single_file_block_lock` around its debug free-list assertion (a `recursive_mutex` when assertions are enabled, to tolerate re-entry via a block load), since group commit lets a checkpoint's `Truncate` mutate the free list concurrently with a scan.

**`TransactionPreCheckpoint` hook.** The engine fires `ClientContextState::TransactionPreCheckpoint` on the committing thread while it still holds the WAL lock, right after this commit's flush marker is written and before the group fsync, passing the WAL generation and end offset so serenedb's out-of-band search-index leg commits in WAL-append order and gates its durability on the WAL becoming durable. `FileSystem::SyncParallelism` reports whether fsyncs may run in parallel.

## Server

**Search-index commit ordering.** `CommitSearch` runs from the engine's `TransactionPreCheckpoint` hook, which fires on the committing thread while it still holds the WAL append ordering, right after this commit's flush marker is written — so index commit ticks are handed out in WAL-append order across connections and recovery cursors stay monotonic with WAL offsets, even though the group fsyncs (and thus acknowledgements) complete out of order. The settle is memory-only; the background refresh gates its durable cursor on the WAL becoming durable, so the index never persists a batch whose store bytes a crash could still lose. Previously acknowledgement order could invert the ticks and corrupt the recovery cursor, re-streaming or skipping index documents after a crash; the `long_waited_advance` fault (armed in `wal_index_recovery_concurrent_refresh.test`) reproduces it.

**Shutdown ordering (use-after-free).** Two-phase shutdown mirroring startup: `StopAccepting()` closes the listeners early (no new connections), and `stop()` runs last — after every DuckDB-work submitter (search, background, store, catalog) is down — joining all DuckDB workers via the new `TaskScheduler::Join()` before tearing down the io pool. A session's query pipeline runs on a DuckDB worker and pushes result bytes up into the io pool, so the pool can only be freed once no worker is left to touch it (`SetThreads`/`_db.reset()` cannot reach zero workers while sessions pin the instance).

## Validation
- Full CI matrix on the standalone-duckdb reference of this engine (relassert = RelWithDebInfo + ASan/UBSan + asserts; release; ThreadSan): green — the fork port's group-commit code is identical to that reference apart from the abseil/C++20 adaptation (`absl::CondVar`/`absl::Mutex` where the reference uses `std::condition_variable`, C++20 atomic-wait for the `last_durable_commit` and WAL `sync_epoch` parking) and the fork's checkpoint-failure logging.
- `serened` (C++20 / abseil / ThreadSan) builds and links clean.
- Recovery-cursor bug covered by the `long_waited_advance` fault loop in `wal_index_recovery_concurrent_refresh.test`.
