### PR TITLE
feat: add multi-column search highlights

### DIFF
--- a/server/connector/functions/search.h
+++ b/server/connector/functions/search.h
@@ -106,6 +106,7 @@ inline constexpr std::string_view kHasAnyTokens = "has_any_tokens";
 
 // Highlighting + position projections.
 inline constexpr std::string_view kTsHighlight = "ts_highlight";
+inline constexpr std::string_view kTsHighlights = "ts_highlights";
 inline constexpr std::string_view kOffsets = "ts_offsets";
 
 // Term-dictionary access -- optimizer-claimed aggregate stubs.

--- a/server/connector/functions/ts_highlight.cpp
+++ b/server/connector/functions/ts_highlight.cpp
@@ -32,6 +32,7 @@
 #include <duckdb/common/constants.hpp>
 #include <duckdb/common/vector/flat_vector.hpp>
 #include <duckdb/common/vector/list_vector.hpp>
+#include <duckdb/common/vector/map_vector.hpp>
 #include <duckdb/common/vector/string_vector.hpp>
 #include <duckdb/execution/expression_executor.hpp>
 #include <duckdb/execution/expression_executor_state.hpp>
@@ -53,6 +54,16 @@
 #include "pg/sql_exception_macro.h"
 
 namespace sdb::connector {
+
+duckdb::unique_ptr<duckdb::FunctionData> TsHighlightsBindData::Copy() const {
+  return duckdb::make_uniq<TsHighlightsBindData>(*this);
+}
+
+bool TsHighlightsBindData::Equals(const duckdb::FunctionData& other) const {
+  const auto& rhs = other.Cast<TsHighlightsBindData>();
+  return options == rhs.options && field_names == rhs.field_names;
+}
+
 namespace {
 
 struct UTextDeleter {
@@ -551,6 +562,125 @@ void TsHighlightOffsets(duckdb::DataChunk& args, duckdb::ExpressionState& state,
   RenderChunk(local_state.state, args, bind.options, result);
 }
 
+duckdb::unique_ptr<duckdb::FunctionData> TsHighlightsBind(
+  duckdb::BindScalarFunctionInput& input) {
+  auto bind = duckdb::make_uniq<TsHighlightsBindData>();
+  const auto& args = input.GetArguments();
+  if (args.size() == 2) {
+    if (!args[1]->IsFoldable()) {
+      THROW_SQL_ERROR(
+        ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+        ERR_MSG("ts_highlights: options must be a constant expression"));
+    }
+    auto value = duckdb::ExpressionExecutor::EvaluateScalar(
+      input.GetClientContext(), *args[1]);
+    if (!value.IsNull()) {
+      bind->options =
+        highlight::ParseHighlightOptions(duckdb::StringValue::Get(value));
+    }
+  } else if (args.size() != 1) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+                    ERR_MSG("ts_highlights expects tableoid and optional "
+                            "highlight options"));
+  }
+  return bind;
+}
+
+void TsHighlights(duckdb::DataChunk& args, duckdb::ExpressionState& state,
+                  duckdb::Vector& result) {
+  const auto& bind = state.expr.Cast<duckdb::BoundFunctionExpression>()
+                       .BindInfo()
+                       ->Cast<TsHighlightsBindData>();
+  if (args.ColumnCount() != bind.field_names.size() * 2) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
+      ERR_MSG("ts_highlights() requires an inverted index scan in the same "
+              "sub-query"));
+  }
+
+  const auto count = args.size();
+  std::vector<duckdb::Vector> rendered;
+  std::vector<duckdb::UnifiedVectorFormat> offsets_formats(
+    bind.field_names.size());
+  std::vector<duckdb::UnifiedVectorFormat> rendered_formats(
+    bind.field_names.size());
+  rendered.reserve(bind.field_names.size());
+
+  HighlightState highlight_state;
+  highlight_state.sentence_iter = CreateSentenceIterator();
+  highlight_state.word_iter = CreateWordIterator();
+  const auto offsets_type =
+    duckdb::LogicalType::LIST(duckdb::LogicalType::INTEGER);
+  for (size_t field = 0; field < bind.field_names.size(); ++field) {
+    duckdb::DataChunk pair;
+    pair.InitializeEmpty({duckdb::LogicalType::VARCHAR, offsets_type});
+    pair.data[0].Reference(args.data[field * 2]);
+    pair.data[1].Reference(args.data[field * 2 + 1]);
+    pair.SetCardinality(count);
+    rendered.emplace_back(duckdb::LogicalType::VARCHAR, count);
+    RenderChunk(highlight_state, pair, bind.options, rendered.back());
+    args.data[field * 2 + 1].ToUnifiedFormat(count, offsets_formats[field]);
+    rendered.back().ToUnifiedFormat(count, rendered_formats[field]);
+  }
+
+  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
+  duckdb::ListVector::SetListSize(result, 0);
+  duckdb::idx_t entries_count = 0;
+  for (duckdb::idx_t row = 0; row < count; ++row) {
+    for (size_t field = 0; field < bind.field_names.size(); ++field) {
+      const auto& format = offsets_formats[field];
+      const auto idx = format.sel->get_index(row);
+      if (!format.validity.RowIsValid(idx)) {
+        continue;
+      }
+      const auto* entries =
+        duckdb::UnifiedVectorFormat::GetData<duckdb::list_entry_t>(format);
+      entries_count += entries[idx].length != 0;
+    }
+  }
+
+  duckdb::ListVector::Reserve(result, entries_count);
+  auto& keys = duckdb::MapVector::GetKeys(result);
+  auto& values = duckdb::MapVector::GetValues(result);
+  keys.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
+  values.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
+  auto* map_entries =
+    duckdb::FlatVector::GetDataMutable<duckdb::list_entry_t>(result);
+  auto* key_data = duckdb::FlatVector::GetDataMutable<duckdb::string_t>(keys);
+  auto* value_data =
+    duckdb::FlatVector::GetDataMutable<duckdb::string_t>(values);
+
+  duckdb::idx_t output_idx = 0;
+  for (duckdb::idx_t row = 0; row < count; ++row) {
+    const auto start = output_idx;
+    for (size_t field = 0; field < bind.field_names.size(); ++field) {
+      const auto& offsets = offsets_formats[field];
+      const auto offsets_idx = offsets.sel->get_index(row);
+      const auto* offsets_entries =
+        duckdb::UnifiedVectorFormat::GetData<duckdb::list_entry_t>(offsets);
+      if (!offsets.validity.RowIsValid(offsets_idx) ||
+          offsets_entries[offsets_idx].length == 0) {
+        continue;
+      }
+      const auto& text = rendered_formats[field];
+      const auto text_idx = text.sel->get_index(row);
+      if (!text.validity.RowIsValid(text_idx)) {
+        continue;
+      }
+      const auto* text_data =
+        duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(text);
+      key_data[output_idx] =
+        duckdb::StringVector::AddString(keys, bind.field_names[field]);
+      value_data[output_idx] =
+        duckdb::StringVector::AddString(values, text_data[text_idx]);
+      ++output_idx;
+    }
+    map_entries[row] = {start, output_idx - start};
+  }
+  SDB_ASSERT(output_idx == entries_count);
+  duckdb::ListVector::SetListSize(result, output_idx);
+}
+
 duckdb::unique_ptr<duckdb::FunctionData> TsHighlightBind(
   duckdb::BindScalarFunctionInput& input) {
   auto& context = input.GetClientContext();
@@ -729,6 +859,18 @@ void RegisterTsHighlight(duckdb::ExtensionLoader& loader) {
   set.AddFunction(
     MakeSugarFn({duckdb::LogicalType::ANY, duckdb::LogicalType::VARCHAR}));
   loader.RegisterFunction(std::move(set));
+
+  duckdb::ScalarFunction highlights{
+    duckdb::Identifier{kTsHighlights},
+    {duckdb::LogicalType::BIGINT},
+    duckdb::LogicalType::MAP(duckdb::LogicalType::VARCHAR,
+                             duckdb::LogicalType::VARCHAR),
+    TsHighlights,
+    TsHighlightsBind,
+  };
+  highlights.SetVarArgs(duckdb::LogicalType::ANY);
+  highlights.SetNullHandling(duckdb::FunctionNullHandling::SPECIAL_HANDLING);
+  loader.RegisterFunction(std::move(highlights));
 }
 
 }  // namespace sdb::connector

--- a/server/connector/functions/ts_highlight.h
+++ b/server/connector/functions/ts_highlight.h
@@ -20,9 +20,20 @@
 
 #pragma once
 
+#include <duckdb/function/function.hpp>
 #include <duckdb/main/extension/extension_loader.hpp>
 
+#include "connector/highlight/highlight_options.h"
+
 namespace sdb::connector {
+
+struct TsHighlightsBindData final : public duckdb::FunctionData {
+  highlight::HighlightOptions options;
+  std::vector<std::string> field_names;
+
+  duckdb::unique_ptr<duckdb::FunctionData> Copy() const final;
+  bool Equals(const duckdb::FunctionData& other) const final;
+};
 
 void RegisterTsHighlight(duckdb::ExtensionLoader& loader);
 

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -75,6 +75,7 @@
 #include "connector/duckdb_client_state.h"
 #include "connector/duckdb_table_function.h"
 #include "connector/functions/search.h"
+#include "connector/functions/ts_highlight.h"
 #include "connector/functions/ts_offsets.h"
 #include "connector/functions/vector.h"
 #include "connector/index_expression.hpp"
@@ -329,6 +330,27 @@ duckdb::idx_t AppendVirtualGetColumn(connector::SereneDBScanBindData& bind_data,
     get.projection_ids.push_back(proj_idx);
   }
   get.types.push_back(col_type);
+  return get_col_idx;
+}
+
+duckdb::idx_t EnsureGetColumn(connector::SereneDBScanBindData& bind_data,
+                              duckdb::LogicalGet& get,
+                              catalog::Column::Id column_id) {
+  for (duckdb::idx_t i = 0; i < get.GetColumnIds().size(); ++i) {
+    if (ResolveColumnId({get.table_index, duckdb::ProjectionIndex{i}},
+                        bind_data, get) == column_id) {
+      return i;
+    }
+  }
+  const auto found = absl::c_find(bind_data.column_ids, column_id);
+  SDB_ASSERT(found != bind_data.column_ids.end());
+  const auto bind_idx = found - bind_data.column_ids.begin();
+  const auto get_col_idx = get.GetColumnIds().size();
+  const auto proj_idx = get.AddColumnId(bind_idx);
+  if (!get.projection_ids.empty()) {
+    get.projection_ids.push_back(proj_idx);
+  }
+  get.types.push_back(bind_data.column_types[bind_idx]);
   return get_col_idx;
 }
 
@@ -654,6 +676,78 @@ duckdb::unique_ptr<duckdb::Expression> PushdownOffsetsCall(
     duckdb::Identifier{offsets_col_name}, col_type, binding);
   out->SetAlias(func.GetAlias());
   return out;
+}
+
+void PushdownHighlightsCall(duckdb::BoundFunctionExpression& func,
+                            duckdb::LogicalOperator& root,
+                            duckdb::ClientContext& context) {
+  auto& bind = func.BindInfoMutable()->Cast<connector::TsHighlightsBindData>();
+  if (!bind.field_names.empty()) {
+    return;
+  }
+  if ((func.GetChildren().size() != 1 && func.GetChildren().size() != 2) ||
+      func.GetChildren()[0]->GetExpressionClass() !=
+        duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG("ts_highlights() first argument must be an index tableoid"));
+  }
+  const auto& anchor =
+    func.GetChildren()[0]->Cast<duckdb::BoundColumnRefExpression>();
+  auto found = FindIResearchScan(root, anchor.Binding().table_index);
+  if (!found) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
+      ERR_MSG("ts_highlights() requires an inverted index scan in the same "
+              "sub-query"));
+  }
+  if (!found->bind_data->inverted_index) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    ERR_MSG("ts_highlights() requires an inverted index"));
+  }
+
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  for (const auto column_id : found->bind_data->inverted_index->GetColumns()) {
+    const auto* info =
+      found->bind_data->inverted_index->FindColumnInfo(column_id);
+    if (!info || !info->HasTextDictionary()) {
+      continue;
+    }
+    const auto bind_col = absl::c_find(found->bind_data->column_ids, column_id);
+    if (bind_col == found->bind_data->column_ids.end()) {
+      continue;
+    }
+    const auto bind_idx = bind_col - found->bind_data->column_ids.begin();
+    const auto name = found->bind_data->ColumnNameById(column_id);
+    const auto& type = found->bind_data->column_types[bind_idx];
+    const auto get_col_idx =
+      EnsureGetColumn(*found->bind_data, *found->get, column_id);
+    const auto binding = ExposeGetColumnAt(
+      root, anchor.Binding().table_index, *found->get, get_col_idx, name, type);
+    auto body = duckdb::make_uniq<duckdb::BoundColumnRefExpression>(
+      duckdb::Identifier{name}, type, binding);
+
+    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> offsets_args;
+    offsets_args.emplace_back(body->Copy());
+    if (bind.options.max_offsets != 0) {
+      offsets_args.emplace_back(
+        duckdb::make_uniq<duckdb::BoundConstantExpression>(
+          duckdb::Value::INTEGER(
+            static_cast<int32_t>(bind.options.max_offsets))));
+    }
+    duckdb::FunctionBinder binder{context};
+    duckdb::ErrorData error;
+    auto offsets = binder.BindScalarFunction(
+      duckdb::Identifier{DEFAULT_SCHEMA},
+      duckdb::Identifier{connector::kOffsets}, std::move(offsets_args), error);
+    if (!offsets) {
+      error.Throw();
+    }
+    bind.field_names.emplace_back(name);
+    children.emplace_back(std::move(body));
+    children.emplace_back(std::move(offsets));
+  }
+  func.GetChildrenMutable() = std::move(children);
 }
 
 enum class TsDictColKind { Term, TermRaw, Count, Freq, Score };
@@ -1770,6 +1864,8 @@ void RewriteCallInExpr(duckdb::unique_ptr<duckdb::Expression>& expr,
                       ERR_MSG(name,
                               "() requires an inverted index scan in the same "
                               "sub-query"));
+    } else if (name == connector::kTsHighlights) {
+      PushdownHighlightsCall(func, root, context);
     } else if (name == connector::kOffsets) {
       if (auto repl = PushdownOffsetsCall(func, root)) {
         expr = std::move(repl);

--- a/tests/sqllogic/sdb/pg/index/headline.test
+++ b/tests/sqllogic/sdb/pg/index/headline.test
@@ -1406,4 +1406,61 @@ The <b>quick</b> brown fox jumps over the lazy dog
 
 
 statement ok
+CREATE TABLE hl_multi (
+    id INTEGER PRIMARY KEY,
+    title VARCHAR,
+    body VARCHAR
+)
+
+statement ok
+CREATE INDEX hl_multi_idx ON hl_multi
+USING inverted(id, title hl_simple, body hl_simple)
+
+statement ok
+INSERT INTO hl_multi VALUES
+    (1, 'quick tractor', 'quiet engine'),
+    (2, 'quiet tractor', 'quick engine'),
+    (3, 'quick tractor', 'quick engine')
+
+statement ok
+VACUUM (REFRESH_TABLE) hl_multi
+
+query
+SELECT id,
+       map_keys(ts_highlights(hl_multi_idx.tableoid)) AS fields,
+       coalesce(map_extract_value(ts_highlights(hl_multi_idx.tableoid), 'title'), '-') AS title,
+       coalesce(map_extract_value(ts_highlights(hl_multi_idx.tableoid), 'body'), '-') AS body
+FROM hl_multi_idx
+WHERE (title @@ ts_phrase('quick'))::boost(2.0)
+   OR (body @@ ts_phrase('quick'))::boost(3.0)
+ORDER BY id
+----
+id\tfields\ttitle\tbody
+1\t{title}\t<b>quick</b> tractor\t-
+2\t{body}\t-\t<b>quick</b> engine
+3\t{title,body}\t<b>quick</b> tractor\t<b>quick</b> engine
+
+query
+SELECT map_extract_value(
+    ts_highlights(hl_multi_idx.tableoid, 'StartSel=[, StopSel=]'),
+    'title') AS title
+FROM hl_multi_idx
+WHERE title @@ ts_phrase('quick') AND id = 1
+----
+title
+[quick] tractor
+
+query
+SELECT cardinality(ts_highlights(hl_multi_idx.tableoid)) AS fields
+FROM hl_multi_idx
+WHERE id = 1
+----
+fields
+0
+
+statement ok
+DROP TABLE hl_multi
+
+
+statement ok
 DROP TEXT SEARCH DICTIONARY hl_inplace_dict


### PR DESCRIPTION
Fixes #918

## Summary
- add `ts_highlights(tableoid[, options])` to return highlighted snippets keyed by each matched indexed text column
- rewrite the function against the inverted-index scan so each field uses its own offsets
- cover OR queries, per-clause boosts, custom tags, and empty maps when no positional offsets are available

## Validation
- `uvx --from pre-commit pre-commit run clang-format --files server/connector/functions/search.h server/connector/functions/ts_highlight.cpp server/connector/functions/ts_highlight.h server/connector/optimizer/iresearch_plan.cpp`
- `git diff --check`
- Full `ninja -C build serened` was attempted, but the local execution window was spent building the project toolchain dependencies and did not reach the changed target. Full compile and sqllogic coverage are therefore deferred to CI.
