### PR TITLE
fix(ci): seed POSTGRES_PASSWORD for RTA (fixes release password-auth failure)

### DIFF
--- a/scripts/ci/docker-compose.docker-rta.yml
+++ b/scripts/ci/docker-compose.docker-rta.yml
@@ -15,6 +15,8 @@ services:
       test-tmp-init:
         condition: service_completed_successfully
     command: serened --auth_timeout=600s
+    environment:
+      - POSTGRES_PASSWORD=postgres
     volumes:
       - "sdb-test-tmp:/test-tmp"
     networks:

--- a/scripts/ci/docker-compose.tarball-rta.yml
+++ b/scripts/ci/docker-compose.tarball-rta.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - HOME=/tmp
       - TARBALL_NAME
+      - POSTGRES_PASSWORD=postgres
     networks:
       - rta-network
     command: >


### PR DESCRIPTION
## Problem

The `make release` workflow fails its RTA smoke tests (Tarball RTA on both arches + Docker RTA) with:

```
FATAL: password authentication failed for user "postgres"
```

serened starts fine and accepts connections — the failure is the sqllogictest client being rejected at auth.

## Root cause

#908 ("Improve RBAC flags") deliberately closed the passwordless-superuser-on-the-network hole:
- default HBA narrowed `trust` for `postgres` to loopback only (`server/network/pg/hba.cpp`);
- the per-session `is_default → trust` fallback was removed (`server/network/pg/pg_wire_session.cpp`).

The RTA test client connects to serened **from a separate container** (non-loopback) as `postgres`. It now misses the loopback `trust` rules and falls through to `host all all 0.0.0.0/0 scram-sha-256` — against an **empty** verifier, because a fresh datadir only seeds a password when `POSTGRES_PASSWORD` is set (`server/catalog/catalog.cpp`). Result: auth fails.

This is correct, intended server behavior — so the fix is in the RTA harness, not a revert.

## Fix

Set `POSTGRES_PASSWORD=postgres` on the `serenedb` service in both RTA compose files so the bootstrap superuser gets a SCRAM verifier. The vendored sqllogictest runner already defaults `user=postgres` / `password=postgres` (`SLT_USER`/`SLT_PASSWORD`, `third_party/sqllogictest-rs/.../main.rs`), so **no client-side change is needed** — the default client password now matches.

Note: `PGPASSWORD` was **not** usable — the runner builds its tokio-postgres config manually and never reads libpq env vars.

## Validation

Launched serened locally with `POSTGRES_PASSWORD=postgres` on `0.0.0.0`: bootstrap logs `initial password set for role 'postgres' from POSTGRES_PASSWORD`, and a `postgres`/`postgres` connection authenticates. The cross-container non-loopback rejection is the exact path the CI log shows failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)