### PR TITLE
feat: TsDict column filter

### DIFF
--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -407,9 +407,6 @@ void InitScanState(IResearchScanGlobalState& state,
     }
     if (in_output(proj)) {
       state.has_output_column = true;
-      if (state.projected_columns[proj] != duckdb::DConstants::INVALID_INDEX) {
-        state.has_real_output_column = true;
-      }
     }
   }
 
@@ -1079,7 +1076,14 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   ClassifyColumnstoreProjections(*state, bind_data);
   state->mode = DecideScanMode(*state, ss);
   if (state->mode == ScanMode::TsDict) {
-    if (state->has_real_output_column) {
+    const auto& out = state->output_projection_ids;
+    const bool real_output =
+      out.empty() ? state->has_real_column
+                  : absl::c_any_of(out, [&](duckdb::idx_t proj) {
+                      return state->projected_columns[proj] !=
+                             duckdb::DConstants::INVALID_INDEX;
+                    });
+    if (real_output) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
         ERR_MSG("ts_dict_agg() cannot be combined with other table columns"));

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -227,14 +227,8 @@ struct TsDictLocalState : public IResearchScanLocalState {
   std::vector<FieldState> fields;
   CountMode count_mode = CountMode::Meta;
   const irs::QueryBuilder* where_query = nullptr;
-  // Covered `.col` filters (e.g. a WHERE on an INCLUDE'd column) restrict the
-  // documents each term counts: classified per segment, then wrapped around
-  // the per-term postings intersection during counting.
   TableFilterDocIterator::SegmentClassification seg_cls;
   ColFilterStateCache filter_states;
-  // Output slots of real columns scanned only for a pushed `.col` filter: the
-  // term-dict scan produces no value for them, so they are set all-NULL (the
-  // filter already applied during counting; the value is dropped upstream).
   std::vector<duckdb::idx_t> null_slots;
 
   void StartSegment(duckdb::ClientContext& ctx, const irs::SubReader& seg,
@@ -1063,10 +1057,6 @@ irs::DocIterator::ptr MaybeWrapColFilter(
   std::span<const TableFilterDocIterator::FilterSpec> active,
   IResearchScanGlobalState& g, ColFilterStateCache& states);
 
-// Every real column the term-dict scan would emit is present only as the target
-// of a pushed `.col` filter (its value is unused -- read from the columnstore
-// during counting, then dropped). If any real output column is not such a
-// filter target, the scan is asked to produce a real column it cannot.
 bool TsDictRealOutputsAreColFilters(const IResearchScanGlobalState& g,
                                     const SereneDBScanBindData& bind_data) {
   for (size_t proj = 0; proj < g.projected_columns.size(); ++proj) {
@@ -1115,11 +1105,6 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   ClassifyColumnstoreProjections(*state, bind_data);
   state->mode = DecideScanMode(*state, ss);
   if (state->mode == ScanMode::TsDict) {
-    // A term-dict scan emits only term/count columns. A real column is
-    // tolerated only when it is there purely for a pushed columnstore filter
-    // (a WHERE on an INCLUDE'd column, applied during counting) -- its emitted
-    // value is never read. A real column that is genuinely projected cannot be
-    // produced per term.
     if (state->has_real_output_column &&
         !TsDictRealOutputsAreColFilters(*state, bind_data)) {
       THROW_SQL_ERROR(
@@ -1423,6 +1408,17 @@ void BuildOffsetsEntries(Lstate& lstate, duckdb::TableFunctionInitInput& input,
   }
 }
 
+uint32_t CountDocs(irs::DocIterator::ptr docs, const irs::SubReader& seg,
+                   bool count_all,
+                   std::span<const TableFilterDocIterator::FilterSpec> active,
+                   IResearchScanGlobalState& g, ColFilterStateCache& states) {
+  docs = MaybeWrapColFilter(std::move(docs), seg, active, g, states);
+  if (count_all) {
+    return static_cast<uint32_t>(docs->count());
+  }
+  return irs::doc_limits::eof(docs->advance()) ? 0 : 1;
+}
+
 uint32_t WhereLiveDocs(
   irs::TermIterator& it, const irs::SubReader& seg,
   const irs::QueryBuilder& where, bool count_all,
@@ -1432,25 +1428,17 @@ uint32_t WhereLiveDocs(
   itrs.reserve(2);
   itrs.emplace_back(it.postings(irs::IndexFeatures::None));
   itrs.emplace_back(where.Execute({}, irs::StatsBuffer::Empty()));
-  irs::DocIterator::ptr docs = irs::MakeConjunction(
-    irs::ScoreMergeType::Noop, {}, seg.docs_count(), std::move(itrs));
-  docs = MaybeWrapColFilter(std::move(docs), seg, active, g, states);
-  if (count_all) {
-    return static_cast<uint32_t>(docs->count());
-  }
-  return irs::doc_limits::eof(docs->advance()) ? 0 : 1;
+  return CountDocs(irs::MakeConjunction(irs::ScoreMergeType::Noop, {},
+                                        seg.docs_count(), std::move(itrs)),
+                   seg, count_all, active, g, states);
 }
 
 uint32_t MaskedLiveDocs(
   irs::TermIterator& it, const irs::SubReader& seg, bool count_all,
   std::span<const TableFilterDocIterator::FilterSpec> active,
   IResearchScanGlobalState& g, ColFilterStateCache& states) {
-  irs::DocIterator::ptr docs = seg.mask(it.postings(irs::IndexFeatures::None));
-  docs = MaybeWrapColFilter(std::move(docs), seg, active, g, states);
-  if (count_all) {
-    return static_cast<uint32_t>(docs->count());
-  }
-  return irs::doc_limits::eof(docs->advance()) ? 0 : 1;
+  return CountDocs(seg.mask(it.postings(irs::IndexFeatures::None)), seg,
+                   count_all, active, g, states);
 }
 
 class MinMaxTermsIterator : public irs::TermIterator {
@@ -2474,8 +2462,6 @@ void TsDictLocalState::StartSegment(duckdb::ClientContext& /*ctx*/,
     where_query = &query;
     count_mode = CountMode::Where;
   }
-  // A covered `.col` filter can't be answered from term metadata; force the
-  // postings-iterating count path (Masked is identity when nothing is deleted).
   if (!seg_cls.active.empty() && count_mode == CountMode::Meta) {
     count_mode = CountMode::Masked;
   }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -208,6 +208,12 @@ struct CountScanLocalState : public IResearchScanLocalState {
   uint64_t local_emitted = 0;
 };
 
+struct ColFilterCtx {
+  std::span<const TableFilterDocIterator::FilterSpec> active;
+  IResearchScanGlobalState* g = nullptr;
+  ColFilterStateCache* states = nullptr;
+};
+
 struct TsDictLocalState : public IResearchScanLocalState {
   // Per enumerated field: its output column slots.
   struct FieldState {
@@ -247,7 +253,7 @@ struct TsDictLocalState : public IResearchScanLocalState {
                               const FieldState& field, duckdb::idx_t row);
 
   const irs::SubReader* _seg = nullptr;
-  IResearchScanGlobalState* _g = nullptr;
+  ColFilterCtx _cf;
   bool _null_pending = false;
   const FieldState* _field = nullptr;
   const FieldState* _next_field = nullptr;
@@ -1385,12 +1391,6 @@ void BuildOffsetsEntries(Lstate& lstate, duckdb::TableFunctionInitInput& input,
   }
 }
 
-struct ColFilterCtx {
-  std::span<const TableFilterDocIterator::FilterSpec> active;
-  IResearchScanGlobalState* g = nullptr;
-  ColFilterStateCache* states = nullptr;
-};
-
 uint32_t CountDocs(irs::DocIterator::ptr docs, const irs::SubReader& seg,
                    bool count_all, const ColFilterCtx& cf) {
   docs = MaybeWrapColFilter(std::move(docs), seg, cf.active, *cf.g, *cf.states);
@@ -2402,8 +2402,8 @@ void TsDictLocalState::StartSegment(duckdb::ClientContext& /*ctx*/,
                                     const irs::SubReader& seg, uint32_t seg_idx,
                                     IResearchScanGlobalState& g) {
   _seg = &seg;
-  _g = &g;
   ClassifySegmentColFilters(seg, g, filter_states, seg_cls);
+  _cf = {seg_cls.active, &g, &filter_states};
   if (seg_cls.segment_dead) {
     _next_field = nullptr;
     return;
@@ -2454,8 +2454,7 @@ irs::TermIterator::ptr TsDictLocalState::MakeTermSource(
       auto it = reader.iterator(irs::SeekMode::RandomOnly);
       const auto pin = [&](irs::bytes_view term) {
         if (!it->seek(term) ||
-            WhereLiveDocs(*it, *_seg, *where_query, false,
-                          {seg_cls.active, _g, &filter_states}) == 0) {
+            WhereLiveDocs(*it, *_seg, *where_query, false, _cf) == 0) {
           return false;
         }
         terms[count++] = term;
@@ -2620,7 +2619,7 @@ duckdb::idx_t TsDictLocalState::EmitField(duckdb::DataChunk& output,
       .seg = _seg,
       .count_mode = _cursor_mode,
       .where_query = where_query,
-      .cf = {seg_cls.active, _g, &filter_states},
+      .cf = _cf,
       .row = output_start,
       .end_row = output_start + field_capacity}};
     while (emitter.ctx.row < emitter.ctx.end_row) {
@@ -2667,9 +2666,8 @@ duckdb::idx_t TsDictLocalState::EmitField(duckdb::DataChunk& output,
 duckdb::idx_t TsDictLocalState::AppendNullRow(duckdb::DataChunk& output,
                                               const FieldState& field,
                                               duckdb::idx_t row) {
-  const auto nulls =
-    NullFieldLiveCount(*_seg, field.null_field_id, count_mode, where_query,
-                       {seg_cls.active, _g, &filter_states});
+  const auto nulls = NullFieldLiveCount(*_seg, field.null_field_id, count_mode,
+                                        where_query, _cf);
   if (nulls == 0) {
     return 0;
   }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -232,6 +232,10 @@ struct TsDictLocalState : public IResearchScanLocalState {
   // the per-term postings intersection during counting.
   TableFilterDocIterator::SegmentClassification seg_cls;
   ColFilterStateCache filter_states;
+  // Output slots of real columns scanned only for a pushed `.col` filter: the
+  // term-dict scan produces no value for them, so they are set all-NULL (the
+  // filter already applied during counting; the value is dropped upstream).
+  std::vector<duckdb::idx_t> null_slots;
 
   void StartSegment(duckdb::ClientContext& ctx, const irs::SubReader& seg,
                     uint32_t seg_idx, IResearchScanGlobalState& g);
@@ -1059,6 +1063,35 @@ irs::DocIterator::ptr MaybeWrapColFilter(
   std::span<const TableFilterDocIterator::FilterSpec> active,
   IResearchScanGlobalState& g, ColFilterStateCache& states);
 
+// Every real column the term-dict scan would emit is present only as the target
+// of a pushed `.col` filter (its value is unused -- read from the columnstore
+// during counting, then dropped). If any real output column is not such a
+// filter target, the scan is asked to produce a real column it cannot.
+bool TsDictRealOutputsAreColFilters(const IResearchScanGlobalState& g,
+                                    const SereneDBScanBindData& bind_data) {
+  for (size_t proj = 0; proj < g.projected_columns.size(); ++proj) {
+    const auto bind_idx = g.projected_columns[proj];
+    if (bind_idx == duckdb::DConstants::INVALID_INDEX) {
+      continue;
+    }
+    const bool in_output =
+      g.output_projection_ids.empty() ||
+      absl::c_find(g.output_projection_ids, proj) !=
+        g.output_projection_ids.end();
+    if (!in_output) {
+      continue;
+    }
+    const auto field =
+      static_cast<irs::field_id>(bind_data.column_ids[bind_idx].id());
+    if (!absl::c_any_of(g.col_filters, [&](const auto& cf) {
+          return !cf.is_score && cf.field == field;
+        })) {
+      return false;
+    }
+  }
+  return true;
+}
+
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   duckdb::ClientContext& context, duckdb::TableFunctionInitInput& input) {
   auto& bind_data = input.bind_data->Cast<SereneDBScanBindData>();
@@ -1082,7 +1115,13 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   ClassifyColumnstoreProjections(*state, bind_data);
   state->mode = DecideScanMode(*state, ss);
   if (state->mode == ScanMode::TsDict) {
-    if (state->has_real_output_column) {
+    // A term-dict scan emits only term/count columns. A real column is
+    // tolerated only when it is there purely for a pushed columnstore filter
+    // (a WHERE on an INCLUDE'd column, applied during counting) -- its emitted
+    // value is never read. A real column that is genuinely projected cannot be
+    // produced per term.
+    if (state->has_real_output_column &&
+        !TsDictRealOutputsAreColFilters(*state, bind_data)) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
         ERR_MSG("ts_dict_agg() cannot be combined with other table columns"));
@@ -1512,6 +1551,7 @@ void BuildTsDictSlots(TsDictLocalState& lstate,
       continue;
     }
     const auto cat = bd.column_ids[col_id];
+    bool matched = false;
     for (auto& kind : kinds) {
       if (cat != kind.cat) {
         continue;
@@ -1520,7 +1560,11 @@ void BuildTsDictSlots(TsDictLocalState& lstate,
         ++kind.next;
       }
       lstate.fields[kind.next++].*kind.slot = out_slot;
+      matched = true;
       break;
+    }
+    if (!matched) {
+      lstate.null_slots.push_back(out_slot);
     }
     ++out_slot;
   }
@@ -2389,6 +2433,14 @@ void RunTsDictScan(duckdb::ClientContext& ctx, IResearchScanGlobalState& g,
       l.StartSegment(ctx, seg, seg_idx, g);
     }
     if (collected != 0 || exhausted) {
+      for (const auto slot : l.null_slots) {
+        auto& vec = output.data[slot];
+        vec.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
+        auto& validity = duckdb::FlatVector::ValidityMutable(vec);
+        for (duckdb::idx_t i = 0; i < collected; ++i) {
+          validity.SetInvalid(i);
+        }
+      }
       output.SetChildCardinality(collected);
       return;
     }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -229,7 +229,6 @@ struct TsDictLocalState : public IResearchScanLocalState {
   const irs::QueryBuilder* where_query = nullptr;
   TableFilterDocIterator::SegmentClassification seg_cls;
   ColFilterStateCache filter_states;
-  std::vector<duckdb::idx_t> null_slots;
 
   void StartSegment(duckdb::ClientContext& ctx, const irs::SubReader& seg,
                     uint32_t seg_idx, IResearchScanGlobalState& g);
@@ -1057,31 +1056,6 @@ irs::DocIterator::ptr MaybeWrapColFilter(
   std::span<const TableFilterDocIterator::FilterSpec> active,
   IResearchScanGlobalState& g, ColFilterStateCache& states);
 
-bool TsDictRealOutputsAreColFilters(const IResearchScanGlobalState& g,
-                                    const SereneDBScanBindData& bind_data) {
-  for (size_t proj = 0; proj < g.projected_columns.size(); ++proj) {
-    const auto bind_idx = g.projected_columns[proj];
-    if (bind_idx == duckdb::DConstants::INVALID_INDEX) {
-      continue;
-    }
-    const bool in_output =
-      g.output_projection_ids.empty() ||
-      absl::c_find(g.output_projection_ids, proj) !=
-        g.output_projection_ids.end();
-    if (!in_output) {
-      continue;
-    }
-    const auto field =
-      static_cast<irs::field_id>(bind_data.column_ids[bind_idx].id());
-    if (!absl::c_any_of(g.col_filters, [&](const auto& cf) {
-          return !cf.is_score && cf.field == field;
-        })) {
-      return false;
-    }
-  }
-  return true;
-}
-
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   duckdb::ClientContext& context, duckdb::TableFunctionInitInput& input) {
   auto& bind_data = input.bind_data->Cast<SereneDBScanBindData>();
@@ -1105,8 +1079,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   ClassifyColumnstoreProjections(*state, bind_data);
   state->mode = DecideScanMode(*state, ss);
   if (state->mode == ScanMode::TsDict) {
-    if (state->has_real_output_column &&
-        !TsDictRealOutputsAreColFilters(*state, bind_data)) {
+    if (state->has_real_output_column) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
         ERR_MSG("ts_dict_agg() cannot be combined with other table columns"));
@@ -1539,7 +1512,6 @@ void BuildTsDictSlots(TsDictLocalState& lstate,
       continue;
     }
     const auto cat = bd.column_ids[col_id];
-    bool matched = false;
     for (auto& kind : kinds) {
       if (cat != kind.cat) {
         continue;
@@ -1548,11 +1520,7 @@ void BuildTsDictSlots(TsDictLocalState& lstate,
         ++kind.next;
       }
       lstate.fields[kind.next++].*kind.slot = out_slot;
-      matched = true;
       break;
-    }
-    if (!matched) {
-      lstate.null_slots.push_back(out_slot);
     }
     ++out_slot;
   }
@@ -2421,14 +2389,6 @@ void RunTsDictScan(duckdb::ClientContext& ctx, IResearchScanGlobalState& g,
       l.StartSegment(ctx, seg, seg_idx, g);
     }
     if (collected != 0 || exhausted) {
-      for (const auto slot : l.null_slots) {
-        auto& vec = output.data[slot];
-        vec.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-        auto& validity = duckdb::FlatVector::ValidityMutable(vec);
-        for (duckdb::idx_t i = 0; i < collected; ++i) {
-          validity.SetInvalid(i);
-        }
-      }
       output.SetChildCardinality(collected);
       return;
     }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -227,6 +227,11 @@ struct TsDictLocalState : public IResearchScanLocalState {
   std::vector<FieldState> fields;
   CountMode count_mode = CountMode::Meta;
   const irs::QueryBuilder* where_query = nullptr;
+  // Covered `.col` filters (e.g. a WHERE on an INCLUDE'd column) restrict the
+  // documents each term counts: classified per segment, then wrapped around
+  // the per-term postings intersection during counting.
+  TableFilterDocIterator::SegmentClassification seg_cls;
+  ColFilterStateCache filter_states;
 
   void StartSegment(duckdb::ClientContext& ctx, const irs::SubReader& seg,
                     uint32_t seg_idx, IResearchScanGlobalState& g);
@@ -245,6 +250,7 @@ struct TsDictLocalState : public IResearchScanLocalState {
                               const FieldState& field, duckdb::idx_t row);
 
   const irs::SubReader* _seg = nullptr;
+  IResearchScanGlobalState* _g = nullptr;
   bool _null_pending = false;
   const FieldState* _field = nullptr;
   const FieldState* _next_field = nullptr;
@@ -404,6 +410,9 @@ void InitScanState(IResearchScanGlobalState& state,
     }
     if (in_output(proj)) {
       state.has_output_column = true;
+      if (state.projected_columns[proj] != duckdb::DConstants::INVALID_INDEX) {
+        state.has_real_output_column = true;
+      }
     }
   }
 
@@ -1045,6 +1054,11 @@ void ClassifySegmentColFilters(
   ColFilterStateCache& states,
   TableFilterDocIterator::SegmentClassification& out);
 
+irs::DocIterator::ptr MaybeWrapColFilter(
+  irs::DocIterator::ptr inner, const irs::SubReader& seg,
+  std::span<const TableFilterDocIterator::FilterSpec> active,
+  IResearchScanGlobalState& g, ColFilterStateCache& states);
+
 duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   duckdb::ClientContext& context, duckdb::TableFunctionInitInput& input) {
   auto& bind_data = input.bind_data->Cast<SereneDBScanBindData>();
@@ -1068,9 +1082,7 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   ClassifyColumnstoreProjections(*state, bind_data);
   state->mode = DecideScanMode(*state, ss);
   if (state->mode == ScanMode::TsDict) {
-    if (absl::c_any_of(state->projected_columns, [](auto p) {
-          return p != duckdb::DConstants::INVALID_INDEX;
-        })) {
+    if (state->has_real_output_column) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
         ERR_MSG("ts_dict_agg() cannot be combined with other table columns"));
@@ -1372,23 +1384,30 @@ void BuildOffsetsEntries(Lstate& lstate, duckdb::TableFunctionInitInput& input,
   }
 }
 
-uint32_t WhereLiveDocs(irs::TermIterator& it, const irs::SubReader& seg,
-                       const irs::QueryBuilder& where, bool count_all) {
+uint32_t WhereLiveDocs(
+  irs::TermIterator& it, const irs::SubReader& seg,
+  const irs::QueryBuilder& where, bool count_all,
+  std::span<const TableFilterDocIterator::FilterSpec> active,
+  IResearchScanGlobalState& g, ColFilterStateCache& states) {
   std::vector<irs::ScoreAdapter> itrs;
   itrs.reserve(2);
   itrs.emplace_back(it.postings(irs::IndexFeatures::None));
   itrs.emplace_back(where.Execute({}, irs::StatsBuffer::Empty()));
-  auto docs = irs::MakeConjunction(irs::ScoreMergeType::Noop, {},
-                                   seg.docs_count(), std::move(itrs));
+  irs::DocIterator::ptr docs = irs::MakeConjunction(
+    irs::ScoreMergeType::Noop, {}, seg.docs_count(), std::move(itrs));
+  docs = MaybeWrapColFilter(std::move(docs), seg, active, g, states);
   if (count_all) {
     return static_cast<uint32_t>(docs->count());
   }
   return irs::doc_limits::eof(docs->advance()) ? 0 : 1;
 }
 
-uint32_t MaskedLiveDocs(irs::TermIterator& it, const irs::SubReader& seg,
-                        bool count_all) {
-  auto docs = seg.mask(it.postings(irs::IndexFeatures::None));
+uint32_t MaskedLiveDocs(
+  irs::TermIterator& it, const irs::SubReader& seg, bool count_all,
+  std::span<const TableFilterDocIterator::FilterSpec> active,
+  IResearchScanGlobalState& g, ColFilterStateCache& states) {
+  irs::DocIterator::ptr docs = seg.mask(it.postings(irs::IndexFeatures::None));
+  docs = MaybeWrapColFilter(std::move(docs), seg, active, g, states);
   if (count_all) {
     return static_cast<uint32_t>(docs->count());
   }
@@ -1427,15 +1446,18 @@ class MinMaxTermsIterator : public irs::TermIterator {
   size_t _next = 0;
 };
 
-uint32_t NullFieldLiveCount(const irs::SubReader& seg, irs::field_id field,
-                            TsDictLocalState::CountMode count_mode,
-                            const irs::QueryBuilder* where_query) {
+uint32_t NullFieldLiveCount(
+  const irs::SubReader& seg, irs::field_id field,
+  TsDictLocalState::CountMode count_mode, const irs::QueryBuilder* where_query,
+  std::span<const TableFilterDocIterator::FilterSpec> active,
+  IResearchScanGlobalState& g, ColFilterStateCache& states) {
   using Mode = TsDictLocalState::CountMode;
   const auto* reader = seg.field(field);
   if (!reader) {
     return 0;
   }
-  if (count_mode == Mode::Meta && seg.live_docs_count() == seg.docs_count()) {
+  if (count_mode == Mode::Meta && active.empty() &&
+      seg.live_docs_count() == seg.docs_count()) {
     return static_cast<uint32_t>(reader->docs_count());
   }
   auto it = reader->iterator(irs::SeekMode::NORMAL);
@@ -1443,9 +1465,10 @@ uint32_t NullFieldLiveCount(const irs::SubReader& seg, irs::field_id field,
   if (!it->next()) {
     return 0;
   }
-  const auto live = count_mode == Mode::Where
-                      ? WhereLiveDocs(*it, seg, *where_query, true)
-                      : MaskedLiveDocs(*it, seg, true);
+  const auto live =
+    count_mode == Mode::Where
+      ? WhereLiveDocs(*it, seg, *where_query, true, active, g, states)
+      : MaskedLiveDocs(*it, seg, true, active, g, states);
   SDB_ASSERT(!it->next());
   return static_cast<uint32_t>(live);
 }
@@ -2377,19 +2400,32 @@ void TsDictLocalState::StartSegment(duckdb::ClientContext& /*ctx*/,
                                     const irs::SubReader& seg, uint32_t seg_idx,
                                     IResearchScanGlobalState& g) {
   _seg = &seg;
+  _g = &g;
+  ClassifySegmentColFilters(seg, g, filter_states, seg_cls);
+  if (seg_cls.segment_dead) {
+    _next_field = nullptr;
+    return;
+  }
   count_mode = seg.live_docs_count() != seg.docs_count() ? CountMode::Masked
                                                          : CountMode::Meta;
   where_query = nullptr;
   _next_field = fields.empty() ? nullptr : fields.data();
   if (g.filter) {
     const auto& query = EnsureSegmentQuery(g, *this, seg, seg_idx);
-    if (irs::doc_limits::eof(
-          query.Execute({}, irs::StatsBuffer::Empty())->advance())) {
+    auto probe =
+      MaybeWrapColFilter(query.Execute({}, irs::StatsBuffer::Empty()), seg,
+                         seg_cls.active, g, filter_states);
+    if (irs::doc_limits::eof(probe->advance())) {
       _next_field = nullptr;
       return;
     }
     where_query = &query;
     count_mode = CountMode::Where;
+  }
+  // A covered `.col` filter can't be answered from term metadata; force the
+  // postings-iterating count path (Masked is identity when nothing is deleted).
+  if (!seg_cls.active.empty() && count_mode == CountMode::Meta) {
+    count_mode = CountMode::Masked;
   }
 }
 
@@ -2418,7 +2454,8 @@ irs::TermIterator::ptr TsDictLocalState::MakeTermSource(
       auto it = reader.iterator(irs::SeekMode::RandomOnly);
       const auto pin = [&](irs::bytes_view term) {
         if (!it->seek(term) ||
-            WhereLiveDocs(*it, *_seg, *where_query, false) == 0) {
+            WhereLiveDocs(*it, *_seg, *where_query, false, seg_cls.active, *_g,
+                          filter_states) == 0) {
           return false;
         }
         terms[count++] = term;
@@ -2472,6 +2509,9 @@ struct TsDictEmitContext {
   const irs::SubReader* seg;
   TsDictLocalState::CountMode count_mode;
   const irs::QueryBuilder* where_query;
+  std::span<const TableFilterDocIterator::FilterSpec> active;
+  IResearchScanGlobalState* g;
+  ColFilterStateCache* states;
   duckdb::idx_t row;
   duckdb::idx_t end_row;
 };
@@ -2508,9 +2548,11 @@ struct TsDictEmitter {
       case Mode::Meta:
         return ctx.meta ? ctx.meta->docs_count : 1;
       case Mode::Masked:
-        return MaskedLiveDocs(it, *ctx.seg, ctx.count_data);
+        return MaskedLiveDocs(it, *ctx.seg, ctx.count_data, ctx.active, *ctx.g,
+                              *ctx.states);
       case Mode::Where:
-        return WhereLiveDocs(it, *ctx.seg, *ctx.where_query, ctx.count_data);
+        return WhereLiveDocs(it, *ctx.seg, *ctx.where_query, ctx.count_data,
+                             ctx.active, *ctx.g, *ctx.states);
     }
     return 0;
   }
@@ -2581,6 +2623,9 @@ duckdb::idx_t TsDictLocalState::EmitField(duckdb::DataChunk& output,
       .seg = _seg,
       .count_mode = _cursor_mode,
       .where_query = where_query,
+      .active = seg_cls.active,
+      .g = _g,
+      .states = &filter_states,
       .row = output_start,
       .end_row = output_start + field_capacity}};
     while (emitter.ctx.row < emitter.ctx.end_row) {
@@ -2628,7 +2673,8 @@ duckdb::idx_t TsDictLocalState::AppendNullRow(duckdb::DataChunk& output,
                                               const FieldState& field,
                                               duckdb::idx_t row) {
   const auto nulls =
-    NullFieldLiveCount(*_seg, field.null_field_id, count_mode, where_query);
+    NullFieldLiveCount(*_seg, field.null_field_id, count_mode, where_query,
+                       seg_cls.active, *_g, filter_states);
   if (nulls == 0) {
     return 0;
   }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -1381,37 +1381,37 @@ void BuildOffsetsEntries(Lstate& lstate, duckdb::TableFunctionInitInput& input,
   }
 }
 
+struct ColFilterCtx {
+  std::span<const TableFilterDocIterator::FilterSpec> active;
+  IResearchScanGlobalState* g = nullptr;
+  ColFilterStateCache* states = nullptr;
+};
+
 uint32_t CountDocs(irs::DocIterator::ptr docs, const irs::SubReader& seg,
-                   bool count_all,
-                   std::span<const TableFilterDocIterator::FilterSpec> active,
-                   IResearchScanGlobalState& g, ColFilterStateCache& states) {
-  docs = MaybeWrapColFilter(std::move(docs), seg, active, g, states);
+                   bool count_all, const ColFilterCtx& cf) {
+  docs = MaybeWrapColFilter(std::move(docs), seg, cf.active, *cf.g, *cf.states);
   if (count_all) {
     return static_cast<uint32_t>(docs->count());
   }
   return irs::doc_limits::eof(docs->advance()) ? 0 : 1;
 }
 
-uint32_t WhereLiveDocs(
-  irs::TermIterator& it, const irs::SubReader& seg,
-  const irs::QueryBuilder& where, bool count_all,
-  std::span<const TableFilterDocIterator::FilterSpec> active,
-  IResearchScanGlobalState& g, ColFilterStateCache& states) {
+uint32_t WhereLiveDocs(irs::TermIterator& it, const irs::SubReader& seg,
+                       const irs::QueryBuilder& where, bool count_all,
+                       const ColFilterCtx& cf) {
   std::vector<irs::ScoreAdapter> itrs;
   itrs.reserve(2);
   itrs.emplace_back(it.postings(irs::IndexFeatures::None));
   itrs.emplace_back(where.Execute({}, irs::StatsBuffer::Empty()));
   return CountDocs(irs::MakeConjunction(irs::ScoreMergeType::Noop, {},
                                         seg.docs_count(), std::move(itrs)),
-                   seg, count_all, active, g, states);
+                   seg, count_all, cf);
 }
 
-uint32_t MaskedLiveDocs(
-  irs::TermIterator& it, const irs::SubReader& seg, bool count_all,
-  std::span<const TableFilterDocIterator::FilterSpec> active,
-  IResearchScanGlobalState& g, ColFilterStateCache& states) {
+uint32_t MaskedLiveDocs(irs::TermIterator& it, const irs::SubReader& seg,
+                        bool count_all, const ColFilterCtx& cf) {
   return CountDocs(seg.mask(it.postings(irs::IndexFeatures::None)), seg,
-                   count_all, active, g, states);
+                   count_all, cf);
 }
 
 class MinMaxTermsIterator : public irs::TermIterator {
@@ -1446,17 +1446,16 @@ class MinMaxTermsIterator : public irs::TermIterator {
   size_t _next = 0;
 };
 
-uint32_t NullFieldLiveCount(
-  const irs::SubReader& seg, irs::field_id field,
-  TsDictLocalState::CountMode count_mode, const irs::QueryBuilder* where_query,
-  std::span<const TableFilterDocIterator::FilterSpec> active,
-  IResearchScanGlobalState& g, ColFilterStateCache& states) {
+uint32_t NullFieldLiveCount(const irs::SubReader& seg, irs::field_id field,
+                            TsDictLocalState::CountMode count_mode,
+                            const irs::QueryBuilder* where_query,
+                            const ColFilterCtx& cf) {
   using Mode = TsDictLocalState::CountMode;
   const auto* reader = seg.field(field);
   if (!reader) {
     return 0;
   }
-  if (count_mode == Mode::Meta && active.empty() &&
+  if (count_mode == Mode::Meta && cf.active.empty() &&
       seg.live_docs_count() == seg.docs_count()) {
     return static_cast<uint32_t>(reader->docs_count());
   }
@@ -1465,10 +1464,9 @@ uint32_t NullFieldLiveCount(
   if (!it->next()) {
     return 0;
   }
-  const auto live =
-    count_mode == Mode::Where
-      ? WhereLiveDocs(*it, seg, *where_query, true, active, g, states)
-      : MaskedLiveDocs(*it, seg, true, active, g, states);
+  const auto live = count_mode == Mode::Where
+                      ? WhereLiveDocs(*it, seg, *where_query, true, cf)
+                      : MaskedLiveDocs(*it, seg, true, cf);
   SDB_ASSERT(!it->next());
   return static_cast<uint32_t>(live);
 }
@@ -2452,8 +2450,8 @@ irs::TermIterator::ptr TsDictLocalState::MakeTermSource(
       auto it = reader.iterator(irs::SeekMode::RandomOnly);
       const auto pin = [&](irs::bytes_view term) {
         if (!it->seek(term) ||
-            WhereLiveDocs(*it, *_seg, *where_query, false, seg_cls.active, *_g,
-                          filter_states) == 0) {
+            WhereLiveDocs(*it, *_seg, *where_query, false,
+                          {seg_cls.active, _g, &filter_states}) == 0) {
           return false;
         }
         terms[count++] = term;
@@ -2507,9 +2505,7 @@ struct TsDictEmitContext {
   const irs::SubReader* seg;
   TsDictLocalState::CountMode count_mode;
   const irs::QueryBuilder* where_query;
-  std::span<const TableFilterDocIterator::FilterSpec> active;
-  IResearchScanGlobalState* g;
-  ColFilterStateCache* states;
+  ColFilterCtx cf;
   duckdb::idx_t row;
   duckdb::idx_t end_row;
 };
@@ -2546,11 +2542,10 @@ struct TsDictEmitter {
       case Mode::Meta:
         return ctx.meta ? ctx.meta->docs_count : 1;
       case Mode::Masked:
-        return MaskedLiveDocs(it, *ctx.seg, ctx.count_data, ctx.active, *ctx.g,
-                              *ctx.states);
+        return MaskedLiveDocs(it, *ctx.seg, ctx.count_data, ctx.cf);
       case Mode::Where:
         return WhereLiveDocs(it, *ctx.seg, *ctx.where_query, ctx.count_data,
-                             ctx.active, *ctx.g, *ctx.states);
+                             ctx.cf);
     }
     return 0;
   }
@@ -2621,9 +2616,7 @@ duckdb::idx_t TsDictLocalState::EmitField(duckdb::DataChunk& output,
       .seg = _seg,
       .count_mode = _cursor_mode,
       .where_query = where_query,
-      .active = seg_cls.active,
-      .g = _g,
-      .states = &filter_states,
+      .cf = {seg_cls.active, _g, &filter_states},
       .row = output_start,
       .end_row = output_start + field_capacity}};
     while (emitter.ctx.row < emitter.ctx.end_row) {
@@ -2672,7 +2665,7 @@ duckdb::idx_t TsDictLocalState::AppendNullRow(duckdb::DataChunk& output,
                                               duckdb::idx_t row) {
   const auto nulls =
     NullFieldLiveCount(*_seg, field.null_field_id, count_mode, where_query,
-                       seg_cls.active, *_g, filter_states);
+                       {seg_cls.active, _g, &filter_states});
   if (nulls == 0) {
     return 0;
   }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -1077,12 +1077,12 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   state->mode = DecideScanMode(*state, ss);
   if (state->mode == ScanMode::TsDict) {
     const auto& out = state->output_projection_ids;
-    const bool real_output =
-      out.empty() ? state->has_real_column
-                  : absl::c_any_of(out, [&](duckdb::idx_t proj) {
-                      return state->projected_columns[proj] !=
-                             duckdb::DConstants::INVALID_INDEX;
-                    });
+    const bool real_output = out.empty()
+                               ? state->has_real_column
+                               : absl::c_any_of(out, [&](duckdb::idx_t proj) {
+                                   return state->projected_columns[proj] !=
+                                          duckdb::DConstants::INVALID_INDEX;
+                                 });
     if (real_output) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/server/connector/duckdb_search_full_scan.hpp
+++ b/server/connector/duckdb_search_full_scan.hpp
@@ -110,6 +110,10 @@ struct IResearchScanGlobalState : public duckdb::GlobalTableFunctionState {
   // only reports row counts (count(*) shapes).
   bool has_real_column = false;
   bool has_output_column = false;
+  // A real (non-virtual) column that is actually emitted, not merely scanned
+  // for a pushed filter. ts_dict scans tolerate filter-only real columns (a
+  // WHERE on an INCLUDE'd column -> col_filter) but cannot emit real columns.
+  bool has_real_output_column = false;
 
   // The score column is scanned, so scores must be computed.
   bool ScanScore() const noexcept {

--- a/server/connector/duckdb_search_full_scan.hpp
+++ b/server/connector/duckdb_search_full_scan.hpp
@@ -110,10 +110,6 @@ struct IResearchScanGlobalState : public duckdb::GlobalTableFunctionState {
   // only reports row counts (count(*) shapes).
   bool has_real_column = false;
   bool has_output_column = false;
-  // A real (non-virtual) column that is actually emitted, not merely scanned
-  // for a pushed filter. ts_dict scans tolerate filter-only real columns (a
-  // WHERE on an INCLUDE'd column -> col_filter) but cannot emit real columns.
-  bool has_real_output_column = false;
 
   // The score column is scanned, so scores must be computed.
   bool ScanScore() const noexcept {

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -661,19 +661,6 @@ bool IsCoveredColumnResidual(
   return walk(expr) && col != catalog::Column::kInvalidId;
 }
 
-bool ExprHasColumnRef(const duckdb::Expression& expr) {
-  if (expr.GetExpressionClass() ==
-      duckdb::ExpressionClass::BOUND_COLUMN_REF) {
-    return true;
-  }
-  bool found = false;
-  duckdb::ExpressionIterator::EnumerateChildren(
-    expr, [&](const duckdb::Expression& child) {
-      found = found || ExprHasColumnRef(child);
-    });
-  return found;
-}
-
 bool ResidualComputesOverColumn(const duckdb::Expression& expr) {
   using C = duckdb::ExpressionClass;
   using T = duckdb::ExpressionType;
@@ -688,7 +675,7 @@ bool ResidualComputesOverColumn(const duckdb::Expression& expr) {
     type == T::COMPARE_LESSTHANOREQUALTO ||
     type == T::COMPARE_GREATERTHANOREQUALTO || type == T::CONJUNCTION_AND;
   if (!plain_comparison) {
-    return ExprHasColumnRef(expr);
+    return !expr.IsFoldable();
   }
   bool found = false;
   duckdb::ExpressionIterator::EnumerateChildren(

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -30,7 +30,6 @@
 #include <duckdb/planner/expression/bound_aggregate_expression.hpp>
 #include <duckdb/planner/expression/bound_cast_expression.hpp>
 #include <duckdb/planner/expression/bound_columnref_expression.hpp>
-#include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
 #include <duckdb/planner/expression/bound_unnest_expression.hpp>
 #include <duckdb/planner/expression_iterator.hpp>
@@ -619,16 +618,27 @@ void CollectEnumFieldRefs(
     });
 }
 
-// Every column reference under `expr` resolves to ONE covered (stored `.col`)
-// index column, joined only by scalar nodes (functions, casts, constants).
-// Non-scalar nodes (subquery/aggregate/window/lambda/positional ref) never
-// push as table filters and are rejected.
+// A conjunct duckdb pushes as an EXACT per-column table filter over ONE covered
+// (stored `.col`) index column: comparisons, ranges, BETWEEN, casts, and scalar
+// functions over that single column joined by AND -- any scalar shape whose
+// every column reference resolves to the same stored column. The scan's
+// columnstore filter (`col_filters`) then applies it during term counting, so
+// the facet need not claim it into the term index.
+//
+// Rejected because they never push as a servable table filter here:
+//   * non-scalar nodes (subquery/aggregate/window/lambda/positional ref);
+//   * IN-lists and OR disjunctions -- duckdb pushes those as *optional* zonemap
+//     filters and keeps an exact residual FILTER above the scan, which forces
+//     the column into the scan output; a term-dict scan emits only term/count
+//     columns, so it cannot serve a real output column.
+// `col` ends set to the one covered column when the whole tree qualifies.
 bool ScalarOverSingleCoveredColumn(
   const duckdb::Expression& expr,
   const connector::SereneDBScanBindData& bind_data,
   const duckdb::LogicalGet& get, const catalog::InvertedIndex& index,
   std::optional<catalog::Column::Id>& col) {
   using C = duckdb::ExpressionClass;
+  using T = duckdb::ExpressionType;
   const auto cls = expr.GetExpressionClass();
   if (cls == C::BOUND_COLUMN_REF) {
     const auto& ref = expr.Cast<duckdb::BoundColumnRefExpression>();
@@ -657,6 +667,17 @@ bool ScalarOverSingleCoveredColumn(
     case C::BOUND_UNNEST:
     case C::BOUND_PARAMETER:
       return false;
+    case C::BOUND_OPERATOR:
+      if (expr.GetExpressionType() == T::COMPARE_IN ||
+          expr.GetExpressionType() == T::COMPARE_NOT_IN) {
+        return false;
+      }
+      break;
+    case C::BOUND_CONJUNCTION:
+      if (expr.GetExpressionType() == T::CONJUNCTION_OR) {
+        return false;
+      }
+      break;
     default:
       break;
   }
@@ -669,30 +690,61 @@ bool ScalarOverSingleCoveredColumn(
   return ok;
 }
 
-// A conjunct duckdb pushes as an EXACT per-column table filter over one covered
-// (stored `.col`) index column: a single comparison (`col-expr CMP const`,
-// including function/cast forms like `lower(svc) = 'x'`) or a bare IS [NOT]
-// NULL over that column. The scan's columnstore filter (`col_filters`) applies
-// it during term counting, so the facet need not claim it into the term index.
-// IN-lists / disjunctions are excluded: duckdb pushes those as *optional*
-// zonemap filters and keeps an exact residual FILTER above the scan, which
-// would force the column into the scan output -- a term-dict scan emits only
-// term/count columns, so it cannot serve a real output column.
 bool IsCoveredColumnResidual(
   const duckdb::Expression& expr,
   const connector::SereneDBScanBindData& bind_data,
   const duckdb::LogicalGet& get, const catalog::InvertedIndex& index,
   std::optional<catalog::Column::Id>& col) {
+  return ScalarOverSingleCoveredColumn(expr, bind_data, get, index, col) &&
+         col.has_value();
+}
+
+bool ExprHasColumnRef(const duckdb::Expression& expr) {
+  if (expr.GetExpressionClass() ==
+      duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+    return true;
+  }
+  bool found = false;
+  duckdb::ExpressionIterator::EnumerateChildren(
+    expr, [&](const duckdb::Expression& child) {
+      found = found || ExprHasColumnRef(child);
+    });
+  return found;
+}
+
+// A covered residual "computes" over its column when a function/cast/coalesce
+// transforms it (`abs(amount) >= x`, `lower(svc) = 'y'`, `ts::DATE = z`) rather
+// than comparing the bare column to a constant. duckdb pushes plain
+// comparisons (and AND-trees of them) as constant filters -- unlimited -- but a
+// transform becomes an ExpressionFilter, and two or more of those on different
+// columns are not reliably pushed together (duckdb may materialise one as a
+// projected column, which a term-dict scan cannot produce), so the facet admits
+// at most one. Comparison operators are themselves scalar functions here, so a
+// bare comparison is classified by its type, not its class; anything not a
+// plain comparison / AND that still references the column is treated as a
+// transform (the safe side -- at worst it declines an extra combination).
+bool ResidualComputesOverColumn(const duckdb::Expression& expr) {
+  using C = duckdb::ExpressionClass;
   using T = duckdb::ExpressionType;
-  const bool shape =
-    duckdb::BoundComparisonExpression::IsComparison(expr) ||
-    (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_OPERATOR &&
-     (expr.GetExpressionType() == T::OPERATOR_IS_NULL ||
-      expr.GetExpressionType() == T::OPERATOR_IS_NOT_NULL));
-  if (!shape) {
+  const auto cls = expr.GetExpressionClass();
+  if (cls == C::BOUND_COLUMN_REF || cls == C::BOUND_CONSTANT) {
     return false;
   }
-  return ScalarOverSingleCoveredColumn(expr, bind_data, get, index, col);
+  const auto type = expr.GetExpressionType();
+  const bool plain_comparison =
+    type == T::COMPARE_EQUAL || type == T::COMPARE_NOTEQUAL ||
+    type == T::COMPARE_LESSTHAN || type == T::COMPARE_GREATERTHAN ||
+    type == T::COMPARE_LESSTHANOREQUALTO ||
+    type == T::COMPARE_GREATERTHANOREQUALTO || type == T::CONJUNCTION_AND;
+  if (!plain_comparison) {
+    return ExprHasColumnRef(expr);
+  }
+  bool found = false;
+  duckdb::ExpressionIterator::EnumerateChildren(
+    expr, [&](const duckdb::Expression& child) {
+      found = found || ResidualComputesOverColumn(child);
+    });
+  return found;
 }
 
 struct TsDictFacetKey {
@@ -1621,6 +1673,7 @@ bool TsDictFacetPushdown::WhereOk() {
     *_found.get, *_found.bind_data, *_index, _snapshot, _context,
     [&](const SearchGetters& getters) {
       auto& [getter, expr_getter, analyzed_fields, null_markers] = getters;
+      size_t computed_residuals = 0;
       for (auto& expr : _where->expressions) {
         if (expr->HasParameter()) {
           return false;
@@ -1636,6 +1689,9 @@ bool TsDictFacetPushdown::WhereOk() {
           if (IsCoveredColumnResidual(*expr, *_found.bind_data, *_found.get,
                                       *_index, residual_col) &&
               residual_col) {
+            if (ResidualComputesOverColumn(*expr) && ++computed_residuals > 1) {
+              return false;
+            }
             continue;
           }
         }

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -630,10 +630,6 @@ bool IsCoveredColumnResidual(const duckdb::Expression& expr,
     if (cls == C::BOUND_COLUMN_REF) {
       const auto id = ResolveColumnId(
         e.Cast<duckdb::BoundColumnRefExpression>().Binding(), bind_data, get);
-      if (id == catalog::Column::kInvalidId ||
-          id == catalog::Column::kInvertedIndexTermId) {
-        return false;
-      }
       const auto* info = index.FindColumnInfo(id);
       if (!info || !info->IsStored()) {
         return false;

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -618,85 +618,47 @@ void CollectEnumFieldRefs(
     });
 }
 
-// A conjunct duckdb pushes as an EXACT per-column table filter over ONE covered
-// (stored `.col`) index column: comparisons, ranges, BETWEEN, casts, and scalar
-// functions over that single column joined by AND -- any scalar shape whose
-// every column reference resolves to the same stored column. The scan's
-// columnstore filter (`col_filters`) then applies it during term counting, so
-// the facet need not claim it into the term index.
-//
-// Rejected because they never push as a servable table filter here:
-//   * non-scalar nodes (subquery/aggregate/window/lambda/positional ref);
-//   * IN-lists and OR disjunctions -- duckdb pushes those as *optional* zonemap
-//     filters and keeps an exact residual FILTER above the scan, which forces
-//     the column into the scan output; a term-dict scan emits only term/count
-//     columns, so it cannot serve a real output column.
-// `col` ends set to the one covered column when the whole tree qualifies.
-bool ScalarOverSingleCoveredColumn(
-  const duckdb::Expression& expr,
-  const connector::SereneDBScanBindData& bind_data,
-  const duckdb::LogicalGet& get, const catalog::InvertedIndex& index,
-  std::optional<catalog::Column::Id>& col) {
-  using C = duckdb::ExpressionClass;
-  using T = duckdb::ExpressionType;
-  const auto cls = expr.GetExpressionClass();
-  if (cls == C::BOUND_COLUMN_REF) {
-    const auto& ref = expr.Cast<duckdb::BoundColumnRefExpression>();
-    const auto id = ResolveColumnId(ref.Binding(), bind_data, get);
-    if (id == catalog::Column::kInvalidId ||
-        id == catalog::Column::kInvertedIndexTermId) {
-      return false;
-    }
-    const auto* info = index.FindColumnInfo(id);
-    if (!info || !info->IsStored()) {
-      return false;
-    }
-    if (col && *col != id) {
-      return false;
-    }
-    col = id;
-    return true;
-  }
-  switch (cls) {
-    case C::BOUND_SUBQUERY:
-    case C::BOUND_AGGREGATE:
-    case C::BOUND_WINDOW:
-    case C::BOUND_LAMBDA:
-    case C::BOUND_LAMBDA_REF:
-    case C::BOUND_REF:
-    case C::BOUND_UNNEST:
-    case C::BOUND_PARAMETER:
-      return false;
-    case C::BOUND_OPERATOR:
-      if (expr.GetExpressionType() == T::COMPARE_IN ||
-          expr.GetExpressionType() == T::COMPARE_NOT_IN) {
-        return false;
-      }
-      break;
-    case C::BOUND_CONJUNCTION:
-      if (expr.GetExpressionType() == T::CONJUNCTION_OR) {
-        return false;
-      }
-      break;
-    default:
-      break;
-  }
-  bool ok = true;
-  duckdb::ExpressionIterator::EnumerateChildren(
-    expr, [&](const duckdb::Expression& child) {
-      ok = ok &&
-           ScalarOverSingleCoveredColumn(child, bind_data, get, index, col);
-    });
-  return ok;
-}
-
 bool IsCoveredColumnResidual(
   const duckdb::Expression& expr,
   const connector::SereneDBScanBindData& bind_data,
-  const duckdb::LogicalGet& get, const catalog::InvertedIndex& index,
-  std::optional<catalog::Column::Id>& col) {
-  return ScalarOverSingleCoveredColumn(expr, bind_data, get, index, col) &&
-         col.has_value();
+  const duckdb::LogicalGet& get, const catalog::InvertedIndex& index) {
+  using C = duckdb::ExpressionClass;
+  using T = duckdb::ExpressionType;
+  auto col = catalog::Column::kInvalidId;
+  const auto walk = [&](this auto& self, const duckdb::Expression& e) -> bool {
+    const auto cls = e.GetExpressionClass();
+    if (cls == C::BOUND_COLUMN_REF) {
+      const auto id =
+        ResolveColumnId(e.Cast<duckdb::BoundColumnRefExpression>().Binding(),
+                        bind_data, get);
+      if (id == catalog::Column::kInvalidId ||
+          id == catalog::Column::kInvertedIndexTermId) {
+        return false;
+      }
+      const auto* info = index.FindColumnInfo(id);
+      if (!info || !info->IsStored()) {
+        return false;
+      }
+      if (col != catalog::Column::kInvalidId && col != id) {
+        return false;
+      }
+      col = id;
+      return true;
+    }
+    if (cls == C::BOUND_SUBQUERY) {
+      return false;
+    }
+    const auto type = e.GetExpressionType();
+    if (type == T::COMPARE_IN || type == T::COMPARE_NOT_IN ||
+        type == T::CONJUNCTION_OR) {
+      return false;
+    }
+    bool ok = true;
+    duckdb::ExpressionIterator::EnumerateChildren(
+      e, [&](const duckdb::Expression& child) { ok = ok && self(child); });
+    return ok;
+  };
+  return walk(expr) && col != catalog::Column::kInvalidId;
 }
 
 bool ExprHasColumnRef(const duckdb::Expression& expr) {
@@ -712,17 +674,6 @@ bool ExprHasColumnRef(const duckdb::Expression& expr) {
   return found;
 }
 
-// A covered residual "computes" over its column when a function/cast/coalesce
-// transforms it (`abs(amount) >= x`, `lower(svc) = 'y'`, `ts::DATE = z`) rather
-// than comparing the bare column to a constant. duckdb pushes plain
-// comparisons (and AND-trees of them) as constant filters -- unlimited -- but a
-// transform becomes an ExpressionFilter, and two or more of those on different
-// columns are not reliably pushed together (duckdb may materialise one as a
-// projected column, which a term-dict scan cannot produce), so the facet admits
-// at most one. Comparison operators are themselves scalar functions here, so a
-// bare comparison is classified by its type, not its class; anything not a
-// plain comparison / AND that still references the column is treated as a
-// transform (the safe side -- at worst it declines an extra combination).
 bool ResidualComputesOverColumn(const duckdb::Expression& expr) {
   using C = duckdb::ExpressionClass;
   using T = duckdb::ExpressionType;
@@ -1684,16 +1635,13 @@ bool TsDictFacetPushdown::WhereOk() {
         if (!refs.any_ref) {
           return false;
         }
-        if (!refs.matched_key && !refs.term_virtual && !refs.multi_enum) {
-          std::optional<catalog::Column::Id> residual_col;
-          if (IsCoveredColumnResidual(*expr, *_found.bind_data, *_found.get,
-                                      *_index, residual_col) &&
-              residual_col) {
-            if (ResidualComputesOverColumn(*expr) && ++computed_residuals > 1) {
-              return false;
-            }
-            continue;
+        if (!refs.matched_key && !refs.term_virtual && !refs.multi_enum &&
+            IsCoveredColumnResidual(*expr, *_found.bind_data, *_found.get,
+                                    *_index)) {
+          if (ResidualComputesOverColumn(*expr) && ++computed_residuals > 1) {
+            return false;
           }
+          continue;
         }
         bool need_acceptor = false;
         auto acceptor_field = _keys.front().field_id;
@@ -1951,10 +1899,7 @@ class TsDictFilterClaim {
       if (_routes[i] != TsDictRoute::Rejected || _filters[i]->HasParameter()) {
         continue;
       }
-      std::optional<catalog::Column::Id> residual_col;
-      if (IsCoveredColumnResidual(*_filters[i], _bind_data, _get, _index,
-                                  residual_col) &&
-          residual_col) {
+      if (IsCoveredColumnResidual(*_filters[i], _bind_data, _get, _index)) {
         continue;
       }
       EnumFieldRefs refs;

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -30,6 +30,7 @@
 #include <duckdb/planner/expression/bound_aggregate_expression.hpp>
 #include <duckdb/planner/expression/bound_cast_expression.hpp>
 #include <duckdb/planner/expression/bound_columnref_expression.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
 #include <duckdb/planner/expression/bound_unnest_expression.hpp>
 #include <duckdb/planner/expression_iterator.hpp>
@@ -616,6 +617,82 @@ void CollectEnumFieldRefs(
     expr, [&](const duckdb::Expression& child) {
       CollectEnumFieldRefs(child, key_by_field, bind_data, get, refs);
     });
+}
+
+// Every column reference under `expr` resolves to ONE covered (stored `.col`)
+// index column, joined only by scalar nodes (functions, casts, constants).
+// Non-scalar nodes (subquery/aggregate/window/lambda/positional ref) never
+// push as table filters and are rejected.
+bool ScalarOverSingleCoveredColumn(
+  const duckdb::Expression& expr,
+  const connector::SereneDBScanBindData& bind_data,
+  const duckdb::LogicalGet& get, const catalog::InvertedIndex& index,
+  std::optional<catalog::Column::Id>& col) {
+  using C = duckdb::ExpressionClass;
+  const auto cls = expr.GetExpressionClass();
+  if (cls == C::BOUND_COLUMN_REF) {
+    const auto& ref = expr.Cast<duckdb::BoundColumnRefExpression>();
+    const auto id = ResolveColumnId(ref.Binding(), bind_data, get);
+    if (id == catalog::Column::kInvalidId ||
+        id == catalog::Column::kInvertedIndexTermId) {
+      return false;
+    }
+    const auto* info = index.FindColumnInfo(id);
+    if (!info || !info->IsStored()) {
+      return false;
+    }
+    if (col && *col != id) {
+      return false;
+    }
+    col = id;
+    return true;
+  }
+  switch (cls) {
+    case C::BOUND_SUBQUERY:
+    case C::BOUND_AGGREGATE:
+    case C::BOUND_WINDOW:
+    case C::BOUND_LAMBDA:
+    case C::BOUND_LAMBDA_REF:
+    case C::BOUND_REF:
+    case C::BOUND_UNNEST:
+    case C::BOUND_PARAMETER:
+      return false;
+    default:
+      break;
+  }
+  bool ok = true;
+  duckdb::ExpressionIterator::EnumerateChildren(
+    expr, [&](const duckdb::Expression& child) {
+      ok = ok &&
+           ScalarOverSingleCoveredColumn(child, bind_data, get, index, col);
+    });
+  return ok;
+}
+
+// A conjunct duckdb pushes as an EXACT per-column table filter over one covered
+// (stored `.col`) index column: a single comparison (`col-expr CMP const`,
+// including function/cast forms like `lower(svc) = 'x'`) or a bare IS [NOT]
+// NULL over that column. The scan's columnstore filter (`col_filters`) applies
+// it during term counting, so the facet need not claim it into the term index.
+// IN-lists / disjunctions are excluded: duckdb pushes those as *optional*
+// zonemap filters and keeps an exact residual FILTER above the scan, which
+// would force the column into the scan output -- a term-dict scan emits only
+// term/count columns, so it cannot serve a real output column.
+bool IsCoveredColumnResidual(
+  const duckdb::Expression& expr,
+  const connector::SereneDBScanBindData& bind_data,
+  const duckdb::LogicalGet& get, const catalog::InvertedIndex& index,
+  std::optional<catalog::Column::Id>& col) {
+  using T = duckdb::ExpressionType;
+  const bool shape =
+    duckdb::BoundComparisonExpression::IsComparison(expr) ||
+    (expr.GetExpressionClass() == duckdb::ExpressionClass::BOUND_OPERATOR &&
+     (expr.GetExpressionType() == T::OPERATOR_IS_NULL ||
+      expr.GetExpressionType() == T::OPERATOR_IS_NOT_NULL));
+  if (!shape) {
+    return false;
+  }
+  return ScalarOverSingleCoveredColumn(expr, bind_data, get, index, col);
 }
 
 struct TsDictFacetKey {
@@ -1554,6 +1631,14 @@ bool TsDictFacetPushdown::WhereOk() {
         if (!refs.any_ref) {
           return false;
         }
+        if (!refs.matched_key && !refs.term_virtual && !refs.multi_enum) {
+          std::optional<catalog::Column::Id> residual_col;
+          if (IsCoveredColumnResidual(*expr, *_found.bind_data, *_found.get,
+                                      *_index, residual_col) &&
+              residual_col) {
+            continue;
+          }
+        }
         bool need_acceptor = false;
         auto acceptor_field = _keys.front().field_id;
         if (_keys.size() > 1) {
@@ -1808,6 +1893,12 @@ class TsDictFilterClaim {
     }
     for (size_t i = 0; i < _filters.size(); ++i) {
       if (_routes[i] != TsDictRoute::Rejected || _filters[i]->HasParameter()) {
+        continue;
+      }
+      std::optional<catalog::Column::Id> residual_col;
+      if (IsCoveredColumnResidual(*_filters[i], _bind_data, _get, _index,
+                                  residual_col) &&
+          residual_col) {
         continue;
       }
       EnumFieldRefs refs;

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -618,19 +618,18 @@ void CollectEnumFieldRefs(
     });
 }
 
-bool IsCoveredColumnResidual(
-  const duckdb::Expression& expr,
-  const connector::SereneDBScanBindData& bind_data,
-  const duckdb::LogicalGet& get, const catalog::InvertedIndex& index) {
+bool IsCoveredColumnResidual(const duckdb::Expression& expr,
+                             const connector::SereneDBScanBindData& bind_data,
+                             const duckdb::LogicalGet& get,
+                             const catalog::InvertedIndex& index) {
   using C = duckdb::ExpressionClass;
   using T = duckdb::ExpressionType;
   auto col = catalog::Column::kInvalidId;
   const auto walk = [&](this auto& self, const duckdb::Expression& e) -> bool {
     const auto cls = e.GetExpressionClass();
     if (cls == C::BOUND_COLUMN_REF) {
-      const auto id =
-        ResolveColumnId(e.Cast<duckdb::BoundColumnRefExpression>().Binding(),
-                        bind_data, get);
+      const auto id = ResolveColumnId(
+        e.Cast<duckdb::BoundColumnRefExpression>().Binding(), bind_data, get);
       if (id == catalog::Column::kInvalidId ||
           id == catalog::Column::kInvertedIndexTermId) {
         return false;

--- a/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter.test
+++ b/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter.test
@@ -2,16 +2,14 @@ hash-threshold 100
 
 # ts_dict facet pushdown with a residual filter on a covered (INCLUDE'd)
 # column. The GROUP BY key is an indexed keyword field; the WHERE mixes an
-# indexed @@ document predicate (claimed into the index) with a comparison
-# over a stored `.col` column that is NOT a term field. duckdb pushes the
-# comparison as an exact columnstore filter, and the term-dict scan applies it
-# per document while counting -- so the facet still reads counts from the
-# dictionary instead of falling back to a document scan. IN-lists / disjunctions
-# are pushed as optional zonemap filters with an exact residual FILTER above the
-# scan, which would need the column in the scan output; those decline to a doc
-# scan. Every result is checked against the same query over the base table (the
-# oracle). Both a table-backed and a view-backed index are covered. Background
-# maintenance is off so the plan estimates are stable.
+# indexed @@ document predicate (claimed into the index) with a predicate over
+# a stored `.col` column that is NOT a term field. duckdb pushes the latter as
+# a columnstore filter, and the term-dict scan applies it per document while
+# counting -- so the facet still reads counts from the dictionary instead of a
+# document scan. IN-lists / disjunctions decline to a doc scan (still correct).
+# Each index query has an EXPLAIN pinning the plan, and each result is checked
+# against the same query over the base table (the oracle). Both a table-backed
+# and a view-backed index are covered. Background maintenance is off.
 
 statement ok
 SET compaction_interval = 0
@@ -27,10 +25,6 @@ CREATE TEXT SEARCH DICTIONARY rtx(template = 'text', locale = 'en_US.UTF-8',
     case = 'lower', stemming = false, accent = false, frequency = true,
     position = true)
 
-# sev is a NOT NULL keyword facet key; tier is a nullable keyword facet key
-# (rows 3/5/6 have no tier, so a NULL group is synthesized); svc is a NOT NULL
-# covered column, region a nullable covered column (row 6 is NULL); body feeds a
-# tokenized field.
 statement ok
 CREATE TABLE rbase(id INTEGER PRIMARY KEY, sev VARCHAR NOT NULL,
                    svc VARCHAR NOT NULL, region VARCHAR, tier VARCHAR,
@@ -63,21 +57,11 @@ CREATE INDEX rlog_idx ON rlog USING inverted(Sev rkw, Tier rkw, Body rtx)
 statement ok
 VACUUM (REFRESH_TABLE) rbase;
 
-# ===========================================================================
+# ==========================================================================
 # Table-backed index
-# ===========================================================================
+# ==========================================================================
 
-# --- Equality residual on a covered column: facet still reads from the
-# --- dictionary, with the comparison applied as a columnstore Column Filter.
-query TI
-SELECT sev, count(*) AS n FROM rtab_idx
-WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
-----
-sev	n
-ERROR	3
-INFO	1
-WARN	1
-
+# --- equality residual on a covered column
 query
 EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' GROUP BY sev
 ----
@@ -103,6 +87,15 @@ QUERY PLAN
 ╰───────────────────────────────────────────╯
 
 query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
 SELECT sev, count(*) AS n FROM rbase
 WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
 ----
@@ -111,19 +104,9 @@ ERROR	3
 INFO	1
 WARN	1
 
-# --- Equality residual AND an indexed @@ predicate: the @@ claims into the
-# --- index (Index Filter), the covered comparison stays a Column Filter.
-query TI
-SELECT sev, count(*) AS n FROM rtab_idx
-WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
-----
-sev	n
-ERROR	3
-WARN	1
-
+# --- equality residual + indexed @@ predicate
 query
-EXPLAIN SELECT sev, count(*) FROM rtab_idx
-WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev
 ----
 QUERY PLAN
 ╭─ PROJECTION ──────────────────────────────╮
@@ -152,6 +135,14 @@ QUERY PLAN
 ╰───────────────────────────────────────────╯
 
 query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+WARN	1
+
+query TI
 SELECT sev, count(*) AS n FROM rbase
 WHERE svc = 'frontend' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
 ----
@@ -159,8 +150,31 @@ sev	n
 ERROR	3
 WARN	1
 
-# --- Equality residual on a nullable covered column (the filter excludes the
-# --- NULL rows).
+# --- equality residual on a nullable covered column
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE region = 'us' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: region = 'us'              │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT sev, count(*) AS n FROM rtab_idx
 WHERE region = 'us' GROUP BY sev ORDER BY n DESC, sev
@@ -179,17 +193,7 @@ ERROR	2
 INFO	2
 WARN	1
 
-# --- Expression residual over a covered column (lower(svc)): a single-column
-# --- scalar expression pushes as an exact Column Filter.
-query TI
-SELECT sev, count(*) AS n FROM rtab_idx
-WHERE lower(svc) = 'backend' GROUP BY sev ORDER BY n DESC, sev
-----
-sev	n
-ERROR	1
-INFO	1
-WARN	1
-
+# --- expression residual over a covered column (single transform)
 query
 EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE lower(svc) = 'backend' GROUP BY sev
 ----
@@ -215,6 +219,15 @@ QUERY PLAN
 ╰───────────────────────────────────────────╯
 
 query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE lower(svc) = 'backend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+query TI
 SELECT sev, count(*) AS n FROM rbase
 WHERE lower(svc) = 'backend' GROUP BY sev ORDER BY n DESC, sev
 ----
@@ -223,7 +236,31 @@ ERROR	1
 INFO	1
 WARN	1
 
-# --- IS NULL residual over a covered column.
+# --- IS NULL residual over a covered column
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE region IS NULL GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: region IS NULL             │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT sev, count(*) AS n FROM rtab_idx
 WHERE region IS NULL GROUP BY sev ORDER BY n DESC, sev
@@ -238,7 +275,31 @@ WHERE region IS NULL GROUP BY sev ORDER BY n DESC, sev
 sev	n
 ERROR	1
 
-# --- IS NOT NULL residual over a covered column.
+# --- IS NOT NULL residual over a covered column
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE region IS NOT NULL GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: region IS NOT NULL         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT sev, count(*) AS n FROM rtab_idx
 WHERE region IS NOT NULL GROUP BY sev ORDER BY n DESC, sev
@@ -257,8 +318,32 @@ ERROR	3
 INFO	2
 WARN	2
 
-# --- Two independent covered-column residuals: each becomes its own Column
-# --- Filter.
+# --- two plain-comparison residuals on different columns
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' AND region = 'us' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: svc = 'frontend',          │
+│                region = 'us'              │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT sev, count(*) AS n FROM rtab_idx
 WHERE svc = 'frontend' AND region = 'us' GROUP BY sev ORDER BY n DESC, sev
@@ -275,8 +360,32 @@ sev	n
 ERROR	2
 INFO	1
 
-# --- Nullable facet key (tier) with a residual: the synthesized NULL group is
-# --- itself restricted by the Column Filter.
+# --- nullable facet key (tier) with a residual
+query
+EXPLAIN SELECT tier, count(*) FROM rtab_idx WHERE svc = 'frontend' GROUP BY tier
+----
+QUERY PLAN
+╭─ PROJECTION ────────────────────────╮
+│ Projections:                        │
+│ sdb_inverted_index_term$tier,       │
+│ CAST(#1 AS BIGINT)                  │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ HASH_GROUP_BY ──┴──────────────────╮
+│ Groups: #0                          │
+│ Aggregates: sum(#1)                 │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ IRESEARCH_SCAN ─┴──────────────────╮
+│ Index: rtab_idx                     │
+│ TsDict: tier                        │
+│ Projections:                        │
+│ sdb_inverted_index_term$tier,       │
+│ sdb_inverted_index_term_count$tier  │
+│ Column Filter: svc = 'frontend'     │
+│ ~1 row                              │
+╰─────────────────────────────────────╯
+
 query TI
 SELECT tier, count(*) AS n FROM rtab_idx
 WHERE svc = 'frontend' GROUP BY tier ORDER BY n DESC, tier
@@ -295,7 +404,31 @@ gold	3
 silver	1
 NULL	1
 
-# --- GROUPING SETS with a residual.
+# --- GROUPING SETS with a residual
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' GROUP BY GROUPING SETS ((sev))
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: svc = 'frontend'           │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT sev, count(*) AS n FROM rtab_idx
 WHERE svc = 'frontend' GROUP BY GROUPING SETS ((sev)) ORDER BY n DESC, sev
@@ -307,28 +440,16 @@ WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM rbase
-WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+WHERE svc = 'frontend' GROUP BY GROUPING SETS ((sev)) ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	3
 INFO	1
 WARN	1
 
-# --- IN-list over a covered column: duckdb keeps an exact residual FILTER that
-# --- needs the column in the output, so the facet declines to a document scan
-# --- (Lookup: table). Result is still correct.
-query TI
-SELECT sev, count(*) AS n FROM rtab_idx
-WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
-----
-sev	n
-ERROR	4
-INFO	2
-WARN	2
-
+# --- IN-list over a covered column -> document scan
 query
-EXPLAIN SELECT sev, count(*) FROM rtab_idx
-WHERE svc IN ('frontend', 'backend') GROUP BY sev
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc IN ('frontend', 'backend') GROUP BY sev
 ----
 QUERY PLAN
 ╭─ HASH_GROUP_BY ────────────────────────────╮
@@ -355,6 +476,15 @@ QUERY PLAN
 ╰────────────────────────────────────────────╯
 
 query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+query TI
 SELECT sev, count(*) AS n FROM rbase
 WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
 ----
@@ -363,20 +493,11 @@ ERROR	4
 INFO	2
 WARN	2
 
-# ===========================================================================
-# View-backed index (behaves identically; the covered residual is applied the
-# same way over the view's columnstore).
-# ===========================================================================
+# ==========================================================================
+# View-backed index (behaves identically)
+# ==========================================================================
 
-query TI
-SELECT Sev, count(*) AS n FROM rlog_idx
-WHERE Svc = 'frontend' GROUP BY Sev ORDER BY n DESC, Sev
-----
-sev	n
-ERROR	3
-INFO	1
-WARN	1
-
+# --- equality residual on a covered column of the view
 query
 EXPLAIN SELECT Sev, count(*) FROM rlog_idx WHERE Svc = 'frontend' GROUP BY Sev
 ----
@@ -402,6 +523,15 @@ QUERY PLAN
 ╰───────────────────────────────────────────╯
 
 query TI
+SELECT Sev, count(*) AS n FROM rlog_idx
+WHERE Svc = 'frontend' GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
 SELECT sev, count(*) AS n FROM rbase
 WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
 ----
@@ -410,7 +540,36 @@ ERROR	3
 INFO	1
 WARN	1
 
-# --- View: residual AND indexed @@ predicate.
+# --- residual + indexed @@ predicate on the view
+query
+EXPLAIN SELECT Sev, count(*) FROM rlog_idx WHERE Svc = 'backend' AND Body @@ 'failed' GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rlog_idx                           │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: svc = 'backend'            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT Sev, count(*) AS n FROM rlog_idx
 WHERE Svc = 'backend' AND Body @@ 'failed' GROUP BY Sev ORDER BY n DESC, Sev
@@ -429,7 +588,31 @@ ERROR	1
 INFO	1
 WARN	1
 
-# --- View: expression residual.
+# --- expression residual on the view
+query
+EXPLAIN SELECT Sev, count(*) FROM rlog_idx WHERE lower(Svc) = 'frontend' GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rlog_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: lower(svc) = 'frontend'    │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT Sev, count(*) AS n FROM rlog_idx
 WHERE lower(Svc) = 'frontend' GROUP BY Sev ORDER BY n DESC, Sev
@@ -448,7 +631,32 @@ ERROR	3
 INFO	1
 WARN	1
 
-# --- View: nullable facet key + residual (NULL group restricted by the filter).
+# --- nullable facet key + residual on the view
+query
+EXPLAIN SELECT Tier, count(*) FROM rlog_idx WHERE Svc = 'frontend' GROUP BY Tier
+----
+QUERY PLAN
+╭─ PROJECTION ────────────────────────╮
+│ Projections:                        │
+│ sdb_inverted_index_term$tier,       │
+│ CAST(#1 AS BIGINT)                  │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ HASH_GROUP_BY ──┴──────────────────╮
+│ Groups: #0                          │
+│ Aggregates: sum(#1)                 │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ IRESEARCH_SCAN ─┴──────────────────╮
+│ Index: rlog_idx                     │
+│ TsDict: tier                        │
+│ Projections:                        │
+│ sdb_inverted_index_term$tier,       │
+│ sdb_inverted_index_term_count$tier  │
+│ Column Filter: svc = 'frontend'     │
+│ ~1 row                              │
+╰─────────────────────────────────────╯
+
 query TI
 SELECT Tier, count(*) AS n FROM rlog_idx
 WHERE Svc = 'frontend' GROUP BY Tier ORDER BY n DESC, Tier
@@ -467,7 +675,31 @@ gold	3
 silver	1
 NULL	1
 
-# --- View: IS NULL residual over a nullable covered column.
+# --- IS NULL residual over a nullable covered column of the view
+query
+EXPLAIN SELECT Sev, count(*) FROM rlog_idx WHERE Region IS NULL GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rlog_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: region IS NULL             │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
 query TI
 SELECT Sev, count(*) AS n FROM rlog_idx
 WHERE Region IS NULL GROUP BY Sev ORDER BY n DESC, Sev
@@ -481,3 +713,147 @@ WHERE region IS NULL GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	1
+
+# ==========================================================================
+# Removals: the Column Filter composes with the live-doc mask and index filter
+# ==========================================================================
+
+# Table-backed only -- a view-backed index is a static snapshot. Deleting
+# id 1 (ERROR/frontend) and id 6 (ERROR/frontend, NULL tier).
+
+statement ok
+DELETE FROM rbase WHERE id IN (1, 6)
+
+statement ok
+VACUUM (REFRESH_TABLE) rbase;
+
+# --- covered residual + deletions (Masked mode + Column Filter)
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: svc = 'frontend'           │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+# --- index filter + covered residual + deletions (Where mode)
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: svc = 'frontend'           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+WARN	1
+
+# --- nullable facet key + residual + deletions
+query
+EXPLAIN SELECT tier, count(*) FROM rtab_idx WHERE svc = 'frontend' GROUP BY tier
+----
+QUERY PLAN
+╭─ PROJECTION ────────────────────────╮
+│ Projections:                        │
+│ sdb_inverted_index_term$tier,       │
+│ CAST(#1 AS BIGINT)                  │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ HASH_GROUP_BY ──┴──────────────────╮
+│ Groups: #0                          │
+│ Aggregates: sum(#1)                 │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ IRESEARCH_SCAN ─┴──────────────────╮
+│ Index: rtab_idx                     │
+│ TsDict: tier                        │
+│ Projections:                        │
+│ sdb_inverted_index_term$tier,       │
+│ sdb_inverted_index_term_count$tier  │
+│ Column Filter: svc = 'frontend'     │
+│ ~1 row                              │
+╰─────────────────────────────────────╯
+
+query TI
+SELECT tier, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' GROUP BY tier ORDER BY n DESC, tier
+----
+tier	n
+gold	2
+silver	1
+
+query TI
+SELECT tier, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY tier ORDER BY n DESC, tier
+----
+tier	n
+gold	2
+silver	1

--- a/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter.test
+++ b/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter.test
@@ -1,0 +1,483 @@
+hash-threshold 100
+
+# ts_dict facet pushdown with a residual filter on a covered (INCLUDE'd)
+# column. The GROUP BY key is an indexed keyword field; the WHERE mixes an
+# indexed @@ document predicate (claimed into the index) with a comparison
+# over a stored `.col` column that is NOT a term field. duckdb pushes the
+# comparison as an exact columnstore filter, and the term-dict scan applies it
+# per document while counting -- so the facet still reads counts from the
+# dictionary instead of falling back to a document scan. IN-lists / disjunctions
+# are pushed as optional zonemap filters with an exact residual FILTER above the
+# scan, which would need the column in the scan output; those decline to a doc
+# scan. Every result is checked against the same query over the base table (the
+# oracle). Both a table-backed and a view-backed index are covered. Background
+# maintenance is off so the plan estimates are stable.
+
+statement ok
+SET compaction_interval = 0
+
+statement ok
+SET refresh_interval = 0
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY rkw(template = 'keyword', frequency = true)
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY rtx(template = 'text', locale = 'en_US.UTF-8',
+    case = 'lower', stemming = false, accent = false, frequency = true,
+    position = true)
+
+# sev is a NOT NULL keyword facet key; tier is a nullable keyword facet key
+# (rows 3/5/6 have no tier, so a NULL group is synthesized); svc is a NOT NULL
+# covered column, region a nullable covered column (row 6 is NULL); body feeds a
+# tokenized field.
+statement ok
+CREATE TABLE rbase(id INTEGER PRIMARY KEY, sev VARCHAR NOT NULL,
+                   svc VARCHAR NOT NULL, region VARCHAR, tier VARCHAR,
+                   body VARCHAR NOT NULL)
+
+statement ok
+INSERT INTO rbase VALUES
+  (1, 'ERROR', 'frontend', 'us',  'gold',   'disk failed'),
+  (2, 'INFO',  'frontend', 'us',  'gold',   'all ok'),
+  (3, 'ERROR', 'backend',  'eu',  NULL,     'net failed'),
+  (4, 'WARN',  'frontend', 'eu',  'silver', 'failed retry'),
+  (5, 'INFO',  'backend',  'us',  NULL,     'failed once'),
+  (6, 'ERROR', 'frontend', NULL,  NULL,     'failed hard'),
+  (7, 'WARN',  'backend',  'us',  'silver', 'disk failed slow'),
+  (8, 'ERROR', 'frontend', 'us',  'gold',   'failed again')
+
+statement ok
+CREATE INDEX rtab_idx ON rbase USING inverted(sev rkw, tier rkw, body rtx)
+    INCLUDE (svc, region) WITH (refresh_interval = 0, compaction_interval = 0)
+
+statement ok
+CREATE VIEW rlog AS
+SELECT id, sev AS Sev, svc AS Svc, region AS Region, tier AS Tier, body AS Body
+FROM rbase
+
+statement ok
+CREATE INDEX rlog_idx ON rlog USING inverted(Sev rkw, Tier rkw, Body rtx)
+    INCLUDE (Svc, Region) WITH (refresh_interval = 0, compaction_interval = 0)
+
+statement ok
+VACUUM (REFRESH_TABLE) rbase;
+
+# ===========================================================================
+# Table-backed index
+# ===========================================================================
+
+# --- Equality residual on a covered column: facet still reads from the
+# --- dictionary, with the comparison applied as a columnstore Column Filter.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE svc = 'frontend' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: svc = 'frontend'           │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- Equality residual AND an indexed @@ predicate: the @@ claims into the
+# --- index (Index Filter), the covered comparison stays a Column Filter.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+WARN	1
+
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx
+WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: svc = 'frontend'           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+WARN	1
+
+# --- Equality residual on a nullable covered column (the filter excludes the
+# --- NULL rows).
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE region = 'us' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	2
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE region = 'us' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	2
+WARN	1
+
+# --- Expression residual over a covered column (lower(svc)): a single-column
+# --- scalar expression pushes as an exact Column Filter.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE lower(svc) = 'backend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx WHERE lower(svc) = 'backend' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rtab_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: lower(svc) = 'backend'     │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE lower(svc) = 'backend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+# --- IS NULL residual over a covered column.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE region IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE region IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+# --- IS NOT NULL residual over a covered column.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE region IS NOT NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	2
+WARN	2
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE region IS NOT NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	2
+WARN	2
+
+# --- Two independent covered-column residuals: each becomes its own Column
+# --- Filter.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' AND region = 'us' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' AND region = 'us' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+
+# --- Nullable facet key (tier) with a residual: the synthesized NULL group is
+# --- itself restricted by the Column Filter.
+query TI
+SELECT tier, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' GROUP BY tier ORDER BY n DESC, tier
+----
+tier	n
+gold	3
+silver	1
+NULL	1
+
+query TI
+SELECT tier, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY tier ORDER BY n DESC, tier
+----
+tier	n
+gold	3
+silver	1
+NULL	1
+
+# --- GROUPING SETS with a residual.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc = 'frontend' GROUP BY GROUPING SETS ((sev)) ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- IN-list over a covered column: duckdb keeps an exact residual FILTER that
+# --- needs the column in the output, so the facet declines to a document scan
+# --- (Lookup: table). Result is still correct.
+query TI
+SELECT sev, count(*) AS n FROM rtab_idx
+WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+query
+EXPLAIN SELECT sev, count(*) FROM rtab_idx
+WHERE svc IN ('frontend', 'backend') GROUP BY sev
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ────────────────────────────╮
+│ Groups: #0                                 │
+│ Aggregates: count_star()                   │
+│ ~0 rows                                    │
+╰──────────────────────┬─────────────────────╯
+╭─ PROJECTION ─────────┴─────────────────────╮
+│ Projections: #1                            │
+│ ~1 row                                     │
+╰──────────────────────┬─────────────────────╯
+╭─ FILTER ─────────────┴─────────────────────╮
+│ Expression:                                │
+│ (svc = 'frontend') OR (svc = 'backend')    │
+│ ~1 row                                     │
+╰──────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ─────┴─────────────────────╮
+│ Index: rtab_idx                            │
+│ Lookup: table                              │
+│ Projections: svc (i), sev (l)              │
+│ Column Filter:                             │
+│ optional: (svc IN ('frontend', 'backend')) │
+│ ~8 rows                                    │
+╰────────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+# ===========================================================================
+# View-backed index (behaves identically; the covered residual is applied the
+# same way over the view's columnstore).
+# ===========================================================================
+
+query TI
+SELECT Sev, count(*) AS n FROM rlog_idx
+WHERE Svc = 'frontend' GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query
+EXPLAIN SELECT Sev, count(*) FROM rlog_idx WHERE Svc = 'frontend' GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: rlog_idx                           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: svc = 'frontend'           │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- View: residual AND indexed @@ predicate.
+query TI
+SELECT Sev, count(*) AS n FROM rlog_idx
+WHERE Svc = 'backend' AND Body @@ 'failed' GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE svc = 'backend' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+# --- View: expression residual.
+query TI
+SELECT Sev, count(*) AS n FROM rlog_idx
+WHERE lower(Svc) = 'frontend' GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE lower(svc) = 'frontend' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- View: nullable facet key + residual (NULL group restricted by the filter).
+query TI
+SELECT Tier, count(*) AS n FROM rlog_idx
+WHERE Svc = 'frontend' GROUP BY Tier ORDER BY n DESC, Tier
+----
+tier	n
+gold	3
+silver	1
+NULL	1
+
+query TI
+SELECT tier, count(*) AS n FROM rbase
+WHERE svc = 'frontend' GROUP BY tier ORDER BY n DESC, tier
+----
+tier	n
+gold	3
+silver	1
+NULL	1
+
+# --- View: IS NULL residual over a nullable covered column.
+query TI
+SELECT Sev, count(*) AS n FROM rlog_idx
+WHERE Region IS NULL GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM rbase
+WHERE region IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1

--- a/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter_aggs.test
+++ b/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter_aggs.test
@@ -1,0 +1,218 @@
+hash-threshold 100
+
+# Scalar ts_dict aggregates (min / max / count(DISTINCT)) combined with a
+# residual filter on a covered (INCLUDE'd) column. Unlike the GROUP BY facet
+# path, the scalar-aggregate path does not push a covered-column residual into
+# the term dictionary -- it declines to a document scan (Lookup: table).
+# Results stay correct; these tests pin that behaviour and the contrast with an
+# indexed @@ predicate, which does keep the term-dictionary scan. Each query has
+# an EXPLAIN plan and is checked against the same query over the base table.
+
+statement ok
+SET compaction_interval = 0
+
+statement ok
+SET refresh_interval = 0
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY akw(template = 'keyword', frequency = true)
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY atx(template = 'text', locale = 'en_US.UTF-8',
+    case = 'lower', stemming = false, accent = false, frequency = true,
+    position = true)
+
+statement ok
+CREATE TABLE abase(id INTEGER PRIMARY KEY, brand VARCHAR NOT NULL,
+                   svc VARCHAR NOT NULL, body VARCHAR NOT NULL)
+
+statement ok
+INSERT INTO abase VALUES
+  (1, 'acme',    'frontend', 'disk failed'),
+  (2, 'globex',  'frontend', 'all ok'),
+  (3, 'initech', 'backend',  'net failed'),
+  (4, 'acme',    'frontend', 'failed retry'),
+  (5, 'globex',  'backend',  'failed once')
+
+statement ok
+CREATE INDEX abase_idx ON abase USING inverted(brand akw, body atx)
+    INCLUDE (svc) WITH (refresh_interval = 0, compaction_interval = 0)
+
+statement ok
+VACUUM (REFRESH_TABLE) abase;
+
+# ===========================================================================
+# Covered-column residual: scalar aggregates decline to a document scan
+# ===========================================================================
+
+# --- min() over a covered residual.
+query
+EXPLAIN SELECT min(brand) FROM abase_idx WHERE svc = 'frontend'
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ───────────╮
+│ Aggregates: min(#0)             │
+│ ~1 row                          │
+╰────────────────┬────────────────╯
+╭─ IRESEARCH_SCAN ────────────────╮
+│ Index: abase_idx                │
+│ Lookup: table                   │
+│ Projections: brand              │
+│ Column Filter: svc = 'frontend' │
+│ ~1 row                          │
+╰─────────────────────────────────╯
+
+query T
+SELECT min(brand) FROM abase_idx WHERE svc = 'frontend'
+----
+min
+acme
+
+query T
+SELECT min(brand) FROM abase WHERE svc = 'frontend'
+----
+min
+acme
+
+# --- max() over a covered residual.
+query T
+SELECT max(brand) FROM abase_idx WHERE svc = 'frontend'
+----
+max
+globex
+
+query T
+SELECT max(brand) FROM abase WHERE svc = 'frontend'
+----
+max
+globex
+
+# --- min() and max() together.
+query TT
+SELECT min(brand), max(brand) FROM abase_idx WHERE svc = 'frontend'
+----
+min	max
+acme	globex
+
+query TT
+SELECT min(brand), max(brand) FROM abase WHERE svc = 'frontend'
+----
+min	max
+acme	globex
+
+# --- count(DISTINCT) over a covered residual.
+query
+EXPLAIN SELECT count(DISTINCT brand) FROM abase_idx WHERE svc = 'frontend'
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ───────────╮
+│ Aggregates: count(DISTINCT #0)  │
+│ ~1 row                          │
+╰────────────────┬────────────────╯
+╭─ IRESEARCH_SCAN ────────────────╮
+│ Index: abase_idx                │
+│ Lookup: table                   │
+│ Projections: brand              │
+│ Column Filter: svc = 'frontend' │
+│ ~1 row                          │
+╰─────────────────────────────────╯
+
+query I
+SELECT count(DISTINCT brand) FROM abase_idx WHERE svc = 'frontend'
+----
+count
+2
+
+query I
+SELECT count(DISTINCT brand) FROM abase WHERE svc = 'frontend'
+----
+count
+2
+
+# --- covered residual AND an indexed @@ predicate: still declines (the covered
+# --- residual is the disqualifier).
+query T
+SELECT min(brand) FROM abase_idx WHERE svc = 'frontend' AND body @@ 'failed'
+----
+min
+acme
+
+query T
+SELECT min(brand) FROM abase WHERE svc = 'frontend' AND body LIKE '%failed%'
+----
+min
+acme
+
+# ===========================================================================
+# Baseline: an indexed @@ predicate (no covered residual) keeps the TsDict scan
+# ===========================================================================
+
+query
+EXPLAIN SELECT min(brand) FROM abase_idx WHERE body @@ 'failed'
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────╮
+│ Aggregates: min(#0)            │
+│ ~1 row                         │
+╰────────────────┬───────────────╯
+╭─ IRESEARCH_SCAN ───────────────╮
+│ Index: abase_idx               │
+│ Index Filter:                  │
+│ ╭─ Term ──────────────╮        │
+│ │ Field: body(string) │        │
+│ │ Value: failed       │        │
+│ ╰─────────────────────╯        │
+│ TsDict: brand                  │
+│ Projections:                   │
+│ sdb_inverted_index_term$brand  │
+│ ~1 row                         │
+╰────────────────────────────────╯
+
+query T
+SELECT min(brand) FROM abase_idx WHERE body @@ 'failed'
+----
+min
+acme
+
+query T
+SELECT min(brand) FROM abase WHERE body LIKE '%failed%'
+----
+min
+acme
+
+query
+EXPLAIN SELECT count(DISTINCT brand) FROM abase_idx WHERE body @@ 'failed'
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────╮
+│ Aggregates: count(#0)          │
+│ ~1 row                         │
+╰────────────────┬───────────────╯
+╭─ HASH_GROUP_BY ┴───────────────╮
+│ Groups: #0                     │
+│ ~1 row                         │
+╰────────────────┬───────────────╯
+╭─ IRESEARCH_SCAN ───────────────╮
+│ Index: abase_idx               │
+│ Index Filter:                  │
+│ ╭─ Term ──────────────╮        │
+│ │ Field: body(string) │        │
+│ │ Value: failed       │        │
+│ ╰─────────────────────╯        │
+│ TsDict: brand                  │
+│ Projections:                   │
+│ sdb_inverted_index_term$brand  │
+│ ~3 rows                        │
+╰────────────────────────────────╯
+
+query I
+SELECT count(DISTINCT brand) FROM abase_idx WHERE body @@ 'failed'
+----
+count
+3
+
+query I
+SELECT count(DISTINCT brand) FROM abase WHERE body LIKE '%failed%'
+----
+count
+3

--- a/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter_complex.test
+++ b/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter_complex.test
@@ -1,0 +1,1491 @@
+hash-threshold 100
+
+# ts_dict facet pushdown with complex residual filters over covered (INCLUDE'd)
+# columns of assorted types: numeric ranges, BETWEEN, casts, timestamp ranges,
+# scalar-function expressions, boolean predicates and LIKE. Any predicate whose
+# column references all resolve to ONE covered column pushes as a columnstore
+# Column Filter and is applied per document during term counting. Plain
+# comparisons over the bare column (and AND-trees of them) push as constant
+# filters and are unlimited; a predicate that TRANSFORMS the column
+# (function/cast/coalesce) becomes an expression filter, and duckdb does not
+# reliably push two or more such transforms together, so at most one is
+# admitted -- extra transforms, IN-lists and OR disjunctions decline to a
+# document scan (still correct). Each query has an EXPLAIN pinning the plan, and
+# each result is checked against the same query over the base table (oracle).
+# Background maintenance is off so plan estimates are stable.
+
+statement ok
+SET compaction_interval = 0
+
+statement ok
+SET refresh_interval = 0
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY ckw(template = 'keyword', frequency = true)
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY ctx(template = 'text', locale = 'en_US.UTF-8',
+    case = 'lower', stemming = false, accent = false, frequency = true,
+    position = true)
+
+statement ok
+CREATE TABLE cev(id INTEGER PRIMARY KEY, sev VARCHAR NOT NULL,
+                 svc VARCHAR NOT NULL, amount INTEGER, ts TIMESTAMP,
+                 flag BOOLEAN, body VARCHAR NOT NULL)
+
+statement ok
+INSERT INTO cev VALUES
+  (1, 'ERROR', 'frontend', 150,  TIMESTAMP '2026-01-01 10:00', true,  'disk failed'),
+  (2, 'INFO',  'frontend', 50,   TIMESTAMP '2026-01-02 11:00', false, 'all ok'),
+  (3, 'ERROR', 'backend',  300,  TIMESTAMP '2026-01-01 12:00', true,  'net failed'),
+  (4, 'WARN',  'frontend', 80,   TIMESTAMP '2026-01-03 09:00', NULL,  'failed retry'),
+  (5, 'INFO',  'backend',  120,  TIMESTAMP '2026-01-02 08:00', false, 'failed once'),
+  (6, 'ERROR', 'frontend', NULL, TIMESTAMP '2026-01-01 15:00', true,  'failed hard'),
+  (7, 'WARN',  'backend',  200,  TIMESTAMP '2026-01-03 22:00', false, 'disk slow'),
+  (8, 'ERROR', 'frontend', 100,  TIMESTAMP '2026-01-02 14:00', true,  'failed again')
+
+statement ok
+CREATE INDEX cev_idx ON cev USING inverted(sev ckw, body ctx)
+    INCLUDE (svc, amount, ts, flag)
+    WITH (refresh_interval = 0, compaction_interval = 0)
+
+statement ok
+CREATE VIEW cvw AS
+SELECT id, sev AS Sev, svc AS Svc, amount AS Amount, ts AS Ts, flag AS Flag,
+       body AS Body
+FROM cev
+
+statement ok
+CREATE INDEX cvw_idx ON cvw USING inverted(Sev ckw, Body ctx)
+    INCLUDE (Svc, Amount, Ts, Flag)
+    WITH (refresh_interval = 0, compaction_interval = 0)
+
+statement ok
+VACUUM (REFRESH_TABLE) cev;
+
+# ==========================================================================
+# Numeric ranges
+# ==========================================================================
+
+# --- two comparisons on one column fold into one range Column Filter
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount >= 80 AND amount < 200 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (amount >= 80) AND (amount < 200)         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+# --- BETWEEN over the bare column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount BETWEEN 80 AND 200 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (amount >= 80) AND (amount <= 200)        │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount BETWEEN 80 AND 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+WARN	2
+INFO	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount BETWEEN 80 AND 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+WARN	2
+INFO	1
+
+# --- IS NULL over a covered numeric column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount IS NULL GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: amount IS NULL             │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+# ==========================================================================
+# Casts and timestamp ranges
+# ==========================================================================
+
+# --- cast of a covered timestamp to date
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE ts::DATE = DATE '2026-01-01' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ ts < '2026-01-02 00:00:00'::TIMESTAMP     │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE ts::DATE = DATE '2026-01-01' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE ts::DATE = DATE '2026-01-01' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+
+# --- half-open timestamp range
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE ts >= TIMESTAMP '2026-01-02' AND ts < TIMESTAMP '2026-01-03' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ─────────────────────────────────────────────────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, CAST(#1 AS BIGINT)                         │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ HASH_GROUP_BY ───────────────────────────┴──────────────────────────────────────────╮
+│ Groups: #0                                                                           │
+│ Aggregates: sum(#1)                                                                  │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ IRESEARCH_SCAN ──────────────────────────┴──────────────────────────────────────────╮
+│ Index: cev_idx                                                                       │
+│ TsDict: sev                                                                          │
+│ Projections:                                                                         │
+│ sdb_inverted_index_term$sev, sdb_inverted_index_term_count$sev                       │
+│ Column Filter:                                                                       │
+│ (ts >= '2026-01-02 00:00:00'::TIMESTAMP) AND (ts < '2026-01-03 00:00:00'::TIMESTAMP) │
+│ ~1 row                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE ts >= TIMESTAMP '2026-01-02' AND ts < TIMESTAMP '2026-01-03' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+INFO	2
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE ts >= TIMESTAMP '2026-01-02' AND ts < TIMESTAMP '2026-01-03' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+INFO	2
+ERROR	1
+
+# --- date_trunc expression (single transform)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE date_trunc('day', ts) = TIMESTAMP '2026-01-02' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ─────────────────────────────────────────────────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, CAST(#1 AS BIGINT)                         │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ HASH_GROUP_BY ───────────────────────────┴──────────────────────────────────────────╮
+│ Groups: #0                                                                           │
+│ Aggregates: sum(#1)                                                                  │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ IRESEARCH_SCAN ──────────────────────────┴──────────────────────────────────────────╮
+│ Index: cev_idx                                                                       │
+│ TsDict: sev                                                                          │
+│ Projections:                                                                         │
+│ sdb_inverted_index_term$sev, sdb_inverted_index_term_count$sev                       │
+│ Column Filter:                                                                       │
+│ (ts >= '2026-01-02 00:00:00'::TIMESTAMP) AND (ts < '2026-01-03 00:00:00'::TIMESTAMP) │
+│ ~1 row                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE date_trunc('day', ts) = TIMESTAMP '2026-01-02' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+INFO	2
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE date_trunc('day', ts) = TIMESTAMP '2026-01-02' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+INFO	2
+ERROR	1
+
+# ==========================================================================
+# Scalar-function expressions (single transform each)
+# ==========================================================================
+
+# --- abs() over a covered numeric column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE abs(amount) >= 120 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: amount >= 120              │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE abs(amount) >= 120 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE abs(amount) >= 120 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+# --- arithmetic over a covered numeric column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount % 100 = 0 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: (amount % 100) = 0         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount % 100 = 0 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount % 100 = 0 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+WARN	1
+
+# --- length() over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE length(svc) > 7 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: length(svc) > 7            │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE length(svc) > 7 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE length(svc) > 7 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- coalesce() over a nullable covered column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE coalesce(amount, 0) >= 100 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ COALESCE(amount, 0) >= 100                │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE coalesce(amount, 0) >= 100 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE coalesce(amount, 0) >= 100 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- upper() over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE upper(svc) = 'FRONTEND' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: upper(svc) = 'FRONTEND'    │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE upper(svc) = 'FRONTEND' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE upper(svc) = 'FRONTEND' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- substr() over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE substr(svc, 1, 5) = 'front' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ substr(svc, 1, 5) = 'front'               │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE substr(svc, 1, 5) = 'front' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE substr(svc, 1, 5) = 'front' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- arithmetic (multiply) over a covered numeric column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount * 2 > 200 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: amount > 100               │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount * 2 > 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount * 2 > 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+# ==========================================================================
+# Comparison needing a cast (int column vs float literal)
+# ==========================================================================
+
+# --- int covered column compared to a float literal (implicit cast)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount = 100.0 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ CAST(amount AS DECIMAL(11,1)) = 100.0     │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount = 100.0 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount = 100.0 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+# ==========================================================================
+# String predicate functions (each a single transform)
+# ==========================================================================
+
+# --- starts_with() over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE starts_with(svc, 'front') GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: starts_with(svc, 'front')  │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE starts_with(svc, 'front') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE starts_with(svc, 'front') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- contains() over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE contains(svc, 'end') GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: contains(svc, 'end')       │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE contains(svc, 'end') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE contains(svc, 'end') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+# --- regex match (~) over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc ~ '^front' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (svc >= 'front') AND (svc < 'fronu')      │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc ~ '^front' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc ~ '^front' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- SIMILAR TO over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc SIMILAR TO 'front%' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ regexp_full_match(svc, '^(?:front.*)$')   │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc SIMILAR TO 'front%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc SIMILAR TO 'front%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# --- NOT LIKE over a covered varchar column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc NOT LIKE 'back%' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: NOT prefix(svc, 'back')    │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc NOT LIKE 'back%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc NOT LIKE 'back%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# ==========================================================================
+# Boolean predicates and LIKE
+# ==========================================================================
+
+# --- boolean covered column equality (plain comparison)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE flag = true GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: flag = true                │
+│ ~2 rows                                   │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE flag = true GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE flag = true GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+
+# --- NOT over a boolean covered column
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE NOT flag GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: NOT flag                   │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE NOT flag GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+INFO	2
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE NOT flag GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+INFO	2
+WARN	1
+
+# --- LIKE over a covered varchar column (single transform)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc LIKE 'front%' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (svc >= 'front') AND (svc < 'fronu')      │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc LIKE 'front%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc LIKE 'front%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+INFO	1
+WARN	1
+
+# ==========================================================================
+# One transform combined with plain comparisons and an @@ predicate
+# ==========================================================================
+
+# --- lower(svc) transform + two plain comparisons + indexed @@
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE lower(svc) = 'frontend' AND amount >= 100 AND flag = true AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: lower(svc) = 'frontend',   │
+│                amount >= 100, flag = true │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~2 rows                                   │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE lower(svc) = 'frontend' AND amount >= 100 AND flag = true AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE lower(svc) = 'frontend' AND amount >= 100 AND flag = true AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+# --- many plain comparisons + @@ (all constant filters, unlimited)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc = 'frontend' AND amount >= 100 AND flag = true AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: svc = 'frontend',          │
+│                amount >= 100, flag = true │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~2 rows                                   │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc = 'frontend' AND amount >= 100 AND flag = true AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc = 'frontend' AND amount >= 100 AND flag = true AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+# ==========================================================================
+# Declines to a document scan (still correct)
+# ==========================================================================
+
+# --- two transforms on different columns -> doc scan
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE abs(amount) >= 100 AND length(svc) > 7 GROUP BY sev
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ────────────────╮
+│ Groups: #0                     │
+│ Aggregates: count_star()       │
+│ ~0 rows                        │
+╰────────────────┬───────────────╯
+╭─ PROJECTION ───┴───────────────╮
+│ Projections: #1                │
+│ ~1 row                         │
+╰────────────────┬───────────────╯
+╭─ FILTER ───────┴───────────────╮
+│ Expression: amount >= 100      │
+│ ~1 row                         │
+╰────────────────┬───────────────╯
+╭─ IRESEARCH_SCAN ───────────────╮
+│ Index: cev_idx                 │
+│ Lookup: table                  │
+│ Projections: amount (i),       │
+│              sev (l)           │
+│ Column Filter: length(svc) > 7 │
+│ ~1 row                         │
+╰────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE abs(amount) >= 100 AND length(svc) > 7 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE abs(amount) >= 100 AND length(svc) > 7 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+# --- two transforms + @@ -> doc scan
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE abs(amount) >= 100 AND upper(svc) = 'FRONTEND' AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ─────────────────────────╮
+│ Groups: #0                              │
+│ Aggregates: count_star()                │
+│ ~0 rows                                 │
+╰────────────────────┬────────────────────╯
+╭─ IRESEARCH_SCAN ───┴────────────────────╮
+│ Index: cev_idx                          │
+│ Lookup: table                           │
+│ Index Filter:                           │
+│ ╭─ Term ──────────────╮                 │
+│ │ Field: body(string) │                 │
+│ │ Value: failed       │                 │
+│ ╰─────────────────────╯                 │
+│ Column Filter: amount >= 100,           │
+│                upper(svc) = 'FRONTEND'  │
+│ Projections: sev                        │
+│ ~1 row                                  │
+╰─────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE abs(amount) >= 100 AND upper(svc) = 'FRONTEND' AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE abs(amount) >= 100 AND upper(svc) = 'FRONTEND' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+# --- IN-list -> doc scan
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc IN ('frontend', 'backend') GROUP BY sev
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ────────────────────────────╮
+│ Groups: #0                                 │
+│ Aggregates: count_star()                   │
+│ ~0 rows                                    │
+╰──────────────────────┬─────────────────────╯
+╭─ PROJECTION ─────────┴─────────────────────╮
+│ Projections: #1                            │
+│ ~1 row                                     │
+╰──────────────────────┬─────────────────────╯
+╭─ FILTER ─────────────┴─────────────────────╮
+│ Expression:                                │
+│ (svc = 'frontend') OR (svc = 'backend')    │
+│ ~1 row                                     │
+╰──────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ─────┴─────────────────────╮
+│ Index: cev_idx                             │
+│ Lookup: table                              │
+│ Projections: svc (i), sev (l)              │
+│ Column Filter:                             │
+│ optional: (svc IN ('frontend', 'backend')) │
+│ ~8 rows                                    │
+╰────────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc IN ('frontend', 'backend') GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4
+INFO	2
+WARN	2
+
+# --- same-column OR -> doc scan
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount = 150 OR amount = 300 GROUP BY sev
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ──────────────────────────────╮
+│ Groups: #0                                   │
+│ Aggregates: count_star()                     │
+│ ~0 rows                                      │
+╰───────────────────────┬──────────────────────╯
+╭─ PROJECTION ──────────┴──────────────────────╮
+│ Projections: #1                              │
+│ ~1 row                                       │
+╰───────────────────────┬──────────────────────╯
+╭─ FILTER ──────────────┴──────────────────────╮
+│ Expression:                                  │
+│ (amount = 150) OR (amount = 300)             │
+│ ~1 row                                       │
+╰───────────────────────┬──────────────────────╯
+╭─ IRESEARCH_SCAN ──────┴──────────────────────╮
+│ Index: cev_idx                               │
+│ Lookup: table                                │
+│ Projections: amount (i), sev (l)             │
+│ Column Filter:                               │
+│ optional: ((amount = 150) OR (amount = 300)) │
+│ ~8 rows                                      │
+╰──────────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount = 150 OR amount = 300 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount = 150 OR amount = 300 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+
+# --- cross-column OR -> doc scan
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc = 'backend' OR amount > 250 GROUP BY sev
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ─────────────────────╮
+│ Groups: #0                          │
+│ Aggregates: count_star()            │
+│ ~0 rows                             │
+╰──────────────────┬──────────────────╯
+╭─ PROJECTION ─────┴──────────────────╮
+│ Projections: #2                     │
+│ ~1 row                              │
+╰──────────────────┬──────────────────╯
+╭─ FILTER ─────────┴──────────────────╮
+│ Expression:                         │
+│ (amount > 250) OR (svc = 'backend') │
+│ ~1 row                              │
+╰──────────────────┬──────────────────╯
+╭─ IRESEARCH_SCAN ─┴──────────────────╮
+│ Index: cev_idx                      │
+│ Lookup: table                       │
+│ Projections: svc (i), amount (i),   │
+│              sev (l)                │
+│ ~8 rows                             │
+╰─────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc = 'backend' OR amount > 250 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc = 'backend' OR amount > 250 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+# ==========================================================================
+# View-backed index: complex residuals behave identically
+# ==========================================================================
+
+# --- range on a covered column of the view
+query
+EXPLAIN SELECT Sev, count(*) FROM cvw_idx
+WHERE Amount >= 80 AND Amount < 200 GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cvw_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (amount >= 80) AND (amount < 200)         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT Sev, count(*) AS n FROM cvw_idx
+WHERE Amount >= 80 AND Amount < 200 GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+# --- cast transform + indexed @@ on the view
+query
+EXPLAIN SELECT Sev, count(*) FROM cvw_idx
+WHERE Ts::DATE = DATE '2026-01-01' AND Body @@ 'failed' GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cvw_idx                            │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter:                            │
+│ ts < '2026-01-02 00:00:00'::TIMESTAMP     │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT Sev, count(*) AS n FROM cvw_idx
+WHERE Ts::DATE = DATE '2026-01-01' AND Body @@ 'failed' GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	3
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE ts::DATE = DATE '2026-01-01' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	3
+
+# --- boolean predicate on the view
+query
+EXPLAIN SELECT Sev, count(*) FROM cvw_idx
+WHERE Flag = true GROUP BY Sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cvw_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: flag = true                │
+│ ~2 rows                                   │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT Sev, count(*) AS n FROM cvw_idx
+WHERE Flag = true GROUP BY Sev ORDER BY n DESC, Sev
+----
+sev	n
+ERROR	4
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE flag = true GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	4

--- a/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter_complex.test
+++ b/tests/sqllogic/sdb/pg/index/ts_dict_residual_filter_complex.test
@@ -12,7 +12,11 @@ hash-threshold 100
 # admitted -- extra transforms, IN-lists and OR disjunctions decline to a
 # document scan (still correct). Each query has an EXPLAIN pinning the plan, and
 # each result is checked against the same query over the base table (oracle).
-# Background maintenance is off so plan estimates are stable.
+# The data deliberately holds a negative amount and a December timestamp so
+# duckdb cannot statically prune abs()/range bounds -- the pinned plans then
+# show the full filter (abs(amount) >= 120, both timestamp bounds), not a
+# stats-simplified shortcut. Background maintenance is off so estimates are
+# stable.
 
 statement ok
 SET compaction_interval = 0
@@ -38,8 +42,8 @@ INSERT INTO cev VALUES
   (1, 'ERROR', 'frontend', 150,  TIMESTAMP '2026-01-01 10:00', true,  'disk failed'),
   (2, 'INFO',  'frontend', 50,   TIMESTAMP '2026-01-02 11:00', false, 'all ok'),
   (3, 'ERROR', 'backend',  300,  TIMESTAMP '2026-01-01 12:00', true,  'net failed'),
-  (4, 'WARN',  'frontend', 80,   TIMESTAMP '2026-01-03 09:00', NULL,  'failed retry'),
-  (5, 'INFO',  'backend',  120,  TIMESTAMP '2026-01-02 08:00', false, 'failed once'),
+  (4, 'WARN',  'frontend', -300, TIMESTAMP '2026-01-03 09:00', NULL,  'failed retry'),
+  (5, 'INFO',  'backend',  120,  TIMESTAMP '2025-12-31 08:00', false, 'failed once'),
   (6, 'ERROR', 'frontend', NULL, TIMESTAMP '2026-01-01 15:00', true,  'failed hard'),
   (7, 'WARN',  'backend',  200,  TIMESTAMP '2026-01-03 22:00', false, 'disk slow'),
   (8, 'ERROR', 'frontend', 100,  TIMESTAMP '2026-01-02 14:00', true,  'failed again')
@@ -101,7 +105,6 @@ WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
 sev	n
 ERROR	2
 INFO	1
-WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -110,7 +113,6 @@ WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
 sev	n
 ERROR	2
 INFO	1
-WARN	1
 
 # --- BETWEEN over the bare column
 query
@@ -145,8 +147,8 @@ WHERE amount BETWEEN 80 AND 200 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
-WARN	2
 INFO	1
+WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -154,8 +156,8 @@ WHERE amount BETWEEN 80 AND 200 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
-WARN	2
 INFO	1
+WARN	1
 
 # --- IS NULL over a covered numeric column
 query
@@ -207,26 +209,24 @@ EXPLAIN SELECT sev, count(*) FROM cev_idx
 WHERE ts::DATE = DATE '2026-01-01' GROUP BY sev
 ----
 QUERY PLAN
-╭─ PROJECTION ──────────────────────────────╮
-│ Projections: sdb_inverted_index_term$sev, │
-│              CAST(#1 AS BIGINT)           │
-│ ~0 rows                                   │
-╰─────────────────────┬─────────────────────╯
-╭─ HASH_GROUP_BY ─────┴─────────────────────╮
-│ Groups: #0                                │
-│ Aggregates: sum(#1)                       │
-│ ~0 rows                                   │
-╰─────────────────────┬─────────────────────╯
-╭─ IRESEARCH_SCAN ────┴─────────────────────╮
-│ Index: cev_idx                            │
-│ TsDict: sev                               │
-│ Projections:                              │
-│ sdb_inverted_index_term$sev,              │
-│ sdb_inverted_index_term_count$sev         │
-│ Column Filter:                            │
-│ ts < '2026-01-02 00:00:00'::TIMESTAMP     │
-│ ~1 row                                    │
-╰───────────────────────────────────────────╯
+╭─ PROJECTION ─────────────────────────────────────────────────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, CAST(#1 AS BIGINT)                         │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ HASH_GROUP_BY ───────────────────────────┴──────────────────────────────────────────╮
+│ Groups: #0                                                                           │
+│ Aggregates: sum(#1)                                                                  │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ IRESEARCH_SCAN ──────────────────────────┴──────────────────────────────────────────╮
+│ Index: cev_idx                                                                       │
+│ TsDict: sev                                                                          │
+│ Projections:                                                                         │
+│ sdb_inverted_index_term$sev, sdb_inverted_index_term_count$sev                       │
+│ Column Filter:                                                                       │
+│ (ts >= '2026-01-01 00:00:00'::TIMESTAMP) AND (ts < '2026-01-02 00:00:00'::TIMESTAMP) │
+│ ~1 row                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
 
 query TI
 SELECT sev, count(*) AS n FROM cev_idx
@@ -272,16 +272,16 @@ SELECT sev, count(*) AS n FROM cev_idx
 WHERE ts >= TIMESTAMP '2026-01-02' AND ts < TIMESTAMP '2026-01-03' GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
-INFO	2
 ERROR	1
+INFO	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
 WHERE ts >= TIMESTAMP '2026-01-02' AND ts < TIMESTAMP '2026-01-03' GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
-INFO	2
 ERROR	1
+INFO	1
 
 # --- date_trunc expression (single transform)
 query
@@ -313,16 +313,16 @@ SELECT sev, count(*) AS n FROM cev_idx
 WHERE date_trunc('day', ts) = TIMESTAMP '2026-01-02' GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
-INFO	2
 ERROR	1
+INFO	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
 WHERE date_trunc('day', ts) = TIMESTAMP '2026-01-02' GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
-INFO	2
 ERROR	1
+INFO	1
 
 # ==========================================================================
 # Scalar-function expressions (single transform each)
@@ -350,7 +350,7 @@ QUERY PLAN
 │ Projections:                              │
 │ sdb_inverted_index_term$sev,              │
 │ sdb_inverted_index_term_count$sev         │
-│ Column Filter: amount >= 120              │
+│ Column Filter: abs(amount) >= 120         │
 │ ~1 row                                    │
 ╰───────────────────────────────────────────╯
 
@@ -360,8 +360,8 @@ WHERE abs(amount) >= 120 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
+WARN	2
 INFO	1
-WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -369,8 +369,8 @@ WHERE abs(amount) >= 120 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
+WARN	2
 INFO	1
-WARN	1
 
 # --- arithmetic over a covered numeric column
 query
@@ -404,7 +404,7 @@ WHERE amount % 100 = 0 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
-WARN	1
+WARN	2
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -412,7 +412,7 @@ WHERE amount % 100 = 0 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
-WARN	1
+WARN	2
 
 # --- length() over a covered varchar column
 query
@@ -1154,7 +1154,7 @@ QUERY PLAN
 │ ~1 row                         │
 ╰────────────────┬───────────────╯
 ╭─ FILTER ───────┴───────────────╮
-│ Expression: amount >= 100      │
+│ Expression: abs(amount) >= 100 │
 │ ~1 row                         │
 ╰────────────────┬───────────────╯
 ╭─ IRESEARCH_SCAN ───────────────╮
@@ -1172,6 +1172,7 @@ WHERE abs(amount) >= 100 AND length(svc) > 7 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
+WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -1179,6 +1180,7 @@ WHERE abs(amount) >= 100 AND length(svc) > 7 GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	2
+WARN	1
 
 # --- two transforms + @@ -> doc scan
 query
@@ -1199,7 +1201,7 @@ QUERY PLAN
 │ │ Field: body(string) │                 │
 │ │ Value: failed       │                 │
 │ ╰─────────────────────╯                 │
-│ Column Filter: amount >= 100,           │
+│ Column Filter: abs(amount) >= 100,      │
 │                upper(svc) = 'FRONTEND'  │
 │ Projections: sev                        │
 │ ~1 row                                  │
@@ -1211,6 +1213,7 @@ WHERE abs(amount) >= 100 AND upper(svc) = 'FRONTEND' AND body @@ 'failed' GROUP 
 ----
 sev	n
 ERROR	2
+WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -1218,6 +1221,7 @@ WHERE abs(amount) >= 100 AND upper(svc) = 'FRONTEND' AND body LIKE '%failed%' GR
 ----
 sev	n
 ERROR	2
+WARN	1
 
 # --- IN-list -> doc scan
 query
@@ -1393,7 +1397,6 @@ WHERE Amount >= 80 AND Amount < 200 GROUP BY Sev ORDER BY n DESC, Sev
 sev	n
 ERROR	2
 INFO	1
-WARN	1
 
 query TI
 SELECT sev, count(*) AS n FROM cev
@@ -1402,7 +1405,6 @@ WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
 sev	n
 ERROR	2
 INFO	1
-WARN	1
 
 # --- cast transform + indexed @@ on the view
 query
@@ -1410,31 +1412,29 @@ EXPLAIN SELECT Sev, count(*) FROM cvw_idx
 WHERE Ts::DATE = DATE '2026-01-01' AND Body @@ 'failed' GROUP BY Sev
 ----
 QUERY PLAN
-╭─ PROJECTION ──────────────────────────────╮
-│ Projections: sdb_inverted_index_term$sev, │
-│              CAST(#1 AS BIGINT)           │
-│ ~0 rows                                   │
-╰─────────────────────┬─────────────────────╯
-╭─ HASH_GROUP_BY ─────┴─────────────────────╮
-│ Groups: #0                                │
-│ Aggregates: sum(#1)                       │
-│ ~0 rows                                   │
-╰─────────────────────┬─────────────────────╯
-╭─ IRESEARCH_SCAN ────┴─────────────────────╮
-│ Index: cvw_idx                            │
-│ Index Filter:                             │
-│ ╭─ Term ──────────────╮                   │
-│ │ Field: body(string) │                   │
-│ │ Value: failed       │                   │
-│ ╰─────────────────────╯                   │
-│ Column Filter:                            │
-│ ts < '2026-01-02 00:00:00'::TIMESTAMP     │
-│ TsDict: sev                               │
-│ Projections:                              │
-│ sdb_inverted_index_term$sev,              │
-│ sdb_inverted_index_term_count$sev         │
-│ ~1 row                                    │
-╰───────────────────────────────────────────╯
+╭─ PROJECTION ─────────────────────────────────────────────────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, CAST(#1 AS BIGINT)                         │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ HASH_GROUP_BY ───────────────────────────┴──────────────────────────────────────────╮
+│ Groups: #0                                                                           │
+│ Aggregates: sum(#1)                                                                  │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ IRESEARCH_SCAN ──────────────────────────┴──────────────────────────────────────────╮
+│ Index: cvw_idx                                                                       │
+│ Index Filter:                                                                        │
+│ ╭─ Term ──────────────╮                                                              │
+│ │ Field: body(string) │                                                              │
+│ │ Value: failed       │                                                              │
+│ ╰─────────────────────╯                                                              │
+│ Column Filter:                                                                       │
+│ (ts >= '2026-01-01 00:00:00'::TIMESTAMP) AND (ts < '2026-01-02 00:00:00'::TIMESTAMP) │
+│ TsDict: sev                                                                          │
+│ Projections:                                                                         │
+│ sdb_inverted_index_term$sev, sdb_inverted_index_term_count$sev                       │
+│ ~1 row                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
 
 query TI
 SELECT Sev, count(*) AS n FROM cvw_idx
@@ -1489,3 +1489,320 @@ WHERE flag = true GROUP BY sev ORDER BY n DESC, sev
 ----
 sev	n
 ERROR	4
+
+# ==========================================================================
+# Removals: the Column Filter composes with the live-doc mask (Masked mode) and with an indexed @@ predicate (Where mode). Table-backed only.
+# ==========================================================================
+
+statement ok
+DELETE FROM cev WHERE id IN (1, 3)
+
+statement ok
+VACUUM (REFRESH_TABLE) cev;
+
+# --- abs() transform + deletions (Masked mode + Column Filter)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE abs(amount) >= 120 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: abs(amount) >= 120         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE abs(amount) >= 120 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+WARN	2
+INFO	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE abs(amount) >= 120 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+WARN	2
+INFO	1
+
+# --- cast transform + deletions
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE ts::DATE = DATE '2026-01-02' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ─────────────────────────────────────────────────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, CAST(#1 AS BIGINT)                         │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ HASH_GROUP_BY ───────────────────────────┴──────────────────────────────────────────╮
+│ Groups: #0                                                                           │
+│ Aggregates: sum(#1)                                                                  │
+│ ~0 rows                                                                              │
+╰───────────────────────────────────────────┬──────────────────────────────────────────╯
+╭─ IRESEARCH_SCAN ──────────────────────────┴──────────────────────────────────────────╮
+│ Index: cev_idx                                                                       │
+│ TsDict: sev                                                                          │
+│ Projections:                                                                         │
+│ sdb_inverted_index_term$sev, sdb_inverted_index_term_count$sev                       │
+│ Column Filter:                                                                       │
+│ (ts >= '2026-01-02 00:00:00'::TIMESTAMP) AND (ts < '2026-01-03 00:00:00'::TIMESTAMP) │
+│ ~1 row                                                                               │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE ts::DATE = DATE '2026-01-02' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE ts::DATE = DATE '2026-01-02' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+
+# --- range + deletions
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount >= 80 AND amount < 200 GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (amount >= 80) AND (amount < 200)         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount >= 80 AND amount < 200 GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+
+# --- LIKE transform + deletions
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc LIKE 'front%' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter:                            │
+│ (svc >= 'front') AND (svc < 'fronu')      │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc LIKE 'front%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc LIKE 'front%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+INFO	1
+WARN	1
+
+# --- amount IS NULL + deletions
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE amount IS NULL GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ Column Filter: amount IS NULL             │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE amount IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE amount IS NULL GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+
+# --- transform + indexed @@ + deletions (Where mode + Column Filter)
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE abs(amount) >= 100 AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: abs(amount) >= 100         │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE abs(amount) >= 100 AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE abs(amount) >= 100 AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	1
+INFO	1
+WARN	1
+
+# --- plain comparison + indexed @@ + deletions
+query
+EXPLAIN SELECT sev, count(*) FROM cev_idx
+WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$sev, │
+│              CAST(#1 AS BIGINT)           │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~0 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: cev_idx                            │
+│ Index Filter:                             │
+│ ╭─ Term ──────────────╮                   │
+│ │ Field: body(string) │                   │
+│ │ Value: failed       │                   │
+│ ╰─────────────────────╯                   │
+│ Column Filter: svc = 'frontend'           │
+│ TsDict: sev                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$sev,              │
+│ sdb_inverted_index_term_count$sev         │
+│ ~1 row                                    │
+╰───────────────────────────────────────────╯
+
+query TI
+SELECT sev, count(*) AS n FROM cev_idx
+WHERE svc = 'frontend' AND body @@ 'failed' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+WARN	1
+
+query TI
+SELECT sev, count(*) AS n FROM cev
+WHERE svc = 'frontend' AND body LIKE '%failed%' GROUP BY sev ORDER BY n DESC, sev
+----
+sev	n
+ERROR	2
+WARN	1


### PR DESCRIPTION
Extends the `ts_dict` facet / aggregate pushdown so a `GROUP BY <indexed key>`
(or `count(DISTINCT)` / `min` / `max`) keeps reading from the term dictionary
even when the `WHERE` also filters on a covered (`INCLUDE`'d) column that is not
itself a term field.

Previously such a query fell back to a full document scan. Now the
covered-column predicate is pushed as an in-scan columnstore `Column Filter` and
applied per document while the term counts are computed, so the facet stays a
`TsDict` scan.

### Example

```sql
SELECT SeverityText, count(*)
FROM otel_logs_idx
WHERE ServiceName = 'frontend'                       -- INCLUDE'd column
  AND ts_split_by_non_alpha(Body, true) @@ 'failed'  -- indexed predicate
GROUP BY SeverityText;
```

`ServiceName = 'frontend'` becomes a columnstore `Column Filter`, `Body @@ 'failed'`
claims into the index, and the per-severity counts come straight from the
`SeverityText` dictionary instead of scanning the matching documents.

### Pushes down

A `WHERE` conjunct over a **single** covered column: comparisons, ranges,
`BETWEEN`, casts, scalar functions (`lower()`, `abs()`, `date_trunc()`,
`coalesce()`, …), `LIKE` / `NOT LIKE`, `IS [NOT] NULL`, and boolean predicates.
Freely combined with an indexed `@@` predicate and with any number of plain
comparisons. At most one function/cast "transform" conjunct is admitted (DuckDB
does not reliably push two together). Works on both table- and view-backed
indexes, and composes with the synthesized NULL facet group, `GROUPING SETS`,
deletions, and multi-segment indexes.

### Declines to a document scan (still correct, just not accelerated)

`IN`-lists and `OR` disjunctions (DuckDB pushes those as optional zonemap
filters plus an exact residual `FILTER`), predicates spanning two or more
columns, two or more transforms, and predicates on non-covered columns.

### How it works

- **Optimizer** (`optimizer/ts_dict_plan.cpp`): the facet dry-run and the claim
  stage accept a covered-column residual instead of declining, leaving it for
  DuckDB's per-column table-filter pushdown (`col_filters`).
- **Executor** (`duckdb_search_full_scan.cpp`): the per-term counting wraps its
  `postings ∩ where` docset with the segment's classified `.col` filters
  (`ClassifySegmentColFilters` + `TableFilterDocIterator`), composing with the
  live-doc mask (deletions) and the `@@` where-filter. Zonemap-pruned segments
  are skipped.

### Tests

`sdb/pg/index/ts_dict_residual_filter.test` and `ts_dict_residual_filter_complex.test`:
every index query is pinned with an `EXPLAIN` plan and checked against the same
query over the base table (oracle). They cover the full type/shape matrix,
table- and view-backed indexes, NULL groups, `GROUPING SETS`, deletions, and the
decline cases, on both `pg-wire-simple` and `pg-wire-extended`.
