### PR TITLE
fix: Avoid livelock for shutdown during fanout

### DIFF
--- a/server/scheduler/background_scheduler.cpp
+++ b/server/scheduler/background_scheduler.cpp
@@ -92,9 +92,7 @@ yaclib::Future<> BackgroundScheduler::Delay(clock::duration d) {
         absl::MutexLock lock{&_delays_mutex};
         _delays.erase(timer);
       }
-      // Runs on an io thread: trivial promise-set only, no background work
-      // here.
-      std::move(p).Set();
+      Run([p = std::move(p)]() mutable { std::move(p).Set(); }).Detach();
     });
   _delays.insert(std::move(timer));
   return std::move(f);

--- a/server/scheduler/background_scheduler.cpp
+++ b/server/scheduler/background_scheduler.cpp
@@ -92,7 +92,9 @@ yaclib::Future<> BackgroundScheduler::Delay(clock::duration d) {
         absl::MutexLock lock{&_delays_mutex};
         _delays.erase(timer);
       }
-      Run([p = std::move(p)]() mutable { std::move(p).Set(); }).Detach();
+      // Runs on an io thread: trivial promise-set only, no background work
+      // here.
+      std::move(p).Set();
     });
   _delays.insert(std::move(timer));
   return std::move(f);

--- a/server/search/task.cpp
+++ b/server/search/task.cpp
@@ -203,7 +203,7 @@ std::vector<yaclib::FutureOn<bool>> LaunchCompactionFanout(
   BackgroundScheduler& s, SearchEngine& engine,
   const std::weak_ptr<Storage>& weak) noexcept {
   std::vector<yaclib::FutureOn<bool>> runs;
-  while (engine.TryAcquireCompaction()) {
+  while (!ShouldStop() && engine.TryAcquireCompaction()) {
     const bool small = engine.FreeCompactionSlots() == 0;
     runs.push_back(s.Run([&, weak, small] {
       absl::Cleanup release = [&] { engine.ReleaseCompaction(); };

--- a/server/search/task.cpp
+++ b/server/search/task.cpp
@@ -367,6 +367,7 @@ yaclib::Future<> CompactionCoordinator(std::weak_ptr<Storage> weak) {
       }
       cascade = false;
 
+      co_await yaclib::On(s.executor());
       auto runs = LaunchCompactionFanout(s, engine, weak);
       if (runs.empty()) {
         // Gate full: every slot is busy elsewhere; wait for one to free up.


### PR DESCRIPTION
If fanout runs exactly as shutdown is called - slot acquisition loop may run forever as "runs" see stop flag and release slots almost instantly and fanout continues to run indefinitely long  as slots are never exhausted.

Also for fanout we make hob back to executor thread to free io thread from cpu bound task 