### PR TITLE
fix: index-scan bugs — multiref CTE inlining (#962, #753), vector score-filter (#964), out-of-order scan units

### DIFF
--- a/scripts/check_no_throw_duckdb.py
+++ b/scripts/check_no_throw_duckdb.py
@@ -7,9 +7,15 @@ flattened through DuckExceptionToErrcode's lossy per-type mapping (e.g. every
 InvalidInputException becomes 22023). Server code must throw THROW_SQL_ERROR
 with the PG-correct ERRCODE_* instead.
 
-The one sanctioned exception is duckdb::TransactionException: the commit /
-rollback seam speaks to DuckDB's own transaction machinery and the wire layer
-special-cases ExceptionType::TRANSACTION, so those throws must stay duckdb-typed.
+Two throws are sanctioned:
+
+- duckdb::TransactionException: the commit / rollback seam speaks to DuckDB's
+  own transaction machinery and the wire layer special-cases
+  ExceptionType::TRANSACTION, so those throws must stay duckdb-typed.
+- duckdb::NotImplementedException: the plan serialize / deserialize callbacks
+  on DuckDB TableFunctions that serenedb never invokes (single-process, no plan
+  serialization) are unreachable placeholders, and NotImplementedException is
+  the idiomatic DuckDB marker there -- no wire mapping is ever exercised.
 """
 import os
 import re
@@ -17,7 +23,9 @@ import sys
 
 ROOT = "server"
 EXTENSIONS = (".cpp", ".cc", ".c", ".hpp", ".hh", ".h", ".ipp", ".tpp")
-THROW_RE = re.compile(r"throw duckdb::(?!TransactionException)")
+THROW_RE = re.compile(
+    r"throw duckdb::(?!(?:TransactionException|NotImplementedException)\b)"
+)
 
 
 def is_target(path: str) -> bool:
@@ -55,7 +63,8 @@ def main() -> int:
             "\nRaw duckdb exception thrown in server code. Use "
             "THROW_SQL_ERROR(ERR_CODE(ERRCODE_...), ERR_MSG(...)) so the "
             "PG sqlstate survives to the client (pg/sql_exception_macro.h); "
-            "only duckdb::TransactionException is allowed.",
+            "only duckdb::TransactionException and "
+            "duckdb::NotImplementedException are allowed.",
             file=sys.stderr,
         )
     return 1 if failed else 0

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -2027,6 +2027,17 @@ void ColScanLocalState::StartUnit(
     bulk_doc_in_seg = unit.begin;
     bulk_seg_doc_count = unit.begin + unit.count;
     streaming_doc.reset();
+    // A scan order can hand out a segment's bulk units out of row order, so a
+    // unit may start behind the reused per-segment scanner, whose column
+    // cursors only move forward (GatherFilter/Skip never rewind). Only then
+    // drop the scanner so OpenScanner rebuilds it fresh at `unit.begin`;
+    // ascending units keep reusing it.
+    if (current_seg_idx < full_scanners.size()) {
+      auto& scanner = full_scanners[current_seg_idx];
+      if (scanner && bulk_doc_in_seg < scanner->ScannedEnd()) {
+        scanner.reset();
+      }
+    }
     return;
   }
   bulk_doc_in_seg = 0;

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -28,7 +28,9 @@
 #include <duckdb/common/projection_index.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
 #include <duckdb/common/vector/list_vector.hpp>
+#include <duckdb/common/vector_operations/unary_executor.hpp>
 #include <duckdb/function/scalar/generic_common.hpp>
+#include <duckdb/function/scalar_function.hpp>
 #include <duckdb/planner/expression/bound_cast_expression.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
@@ -36,6 +38,7 @@
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
+#include <duckdb/planner/expression_iterator.hpp>
 #include <duckdb/planner/filter/expression_filter.hpp>
 #include <duckdb/planner/table_filter_set.hpp>
 #include <duckdb/storage/table/column_segment.hpp>
@@ -560,6 +563,62 @@ irs::NullCheckKind DetectNullCheck(const duckdb::Expression& expr) {
            : irs::NullCheckKind::IsNotNull;
 }
 
+namespace {
+
+// Vectorized score-emit op for the pushed score filter -- maps a FLOAT column
+// of raw "larger = nearer" scores to the user-facing value for `E`.
+template<ScoreEmit E>
+void EmitScoreFilterExec(duckdb::DataChunk& args, duckdb::ExpressionState&,
+                         duckdb::Vector& result) {
+  duckdb::UnaryExecutor::Execute<float, float>(
+    args.data[0], result, args.size(),
+    [](float score) { return ApplyScoreEmit(E, score); });
+}
+
+// Wraps a raw score reference in the emit op, so a predicate written in the
+// user-facing score evaluates correctly against the raw score vector.
+duckdb::unique_ptr<duckdb::Expression> WrapScoreEmit(
+  duckdb::unique_ptr<duckdb::Expression> score_ref, ScoreEmit emit) {
+  duckdb::scalar_function_t exec;
+  switch (emit) {
+    case ScoreEmit::SqrtNeg:
+      exec = EmitScoreFilterExec<ScoreEmit::SqrtNeg>;
+      break;
+    case ScoreEmit::OneMinus:
+      exec = EmitScoreFilterExec<ScoreEmit::OneMinus>;
+      break;
+    case ScoreEmit::Negate:
+      exec = EmitScoreFilterExec<ScoreEmit::Negate>;
+      break;
+    case ScoreEmit::Identity:
+      return score_ref;
+  }
+  duckdb::ScalarFunction fn(duckdb::Identifier{"sdb_score_emit"},
+                            {duckdb::LogicalType::FLOAT},
+                            duckdb::LogicalType::FLOAT, std::move(exec));
+  duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
+  children.push_back(std::move(score_ref));
+  return duckdb::make_uniq<duckdb::BoundFunctionExpression>(
+    duckdb::BoundScalarFunction(fn), std::move(children), nullptr);
+}
+
+// A pushed score-column filter references the (single) score column via
+// BoundReferenceExpression; wrap each such reference so `emit` is baked into
+// the predicate.
+void WrapScoreRefsWithEmit(duckdb::unique_ptr<duckdb::Expression>& expr,
+                           ScoreEmit emit) {
+  if (expr->GetExpressionClass() == duckdb::ExpressionClass::BOUND_REF) {
+    expr = WrapScoreEmit(std::move(expr), emit);
+    return;
+  }
+  duckdb::ExpressionIterator::EnumerateChildren(
+    *expr, [&](duckdb::unique_ptr<duckdb::Expression>& child) {
+      WrapScoreRefsWithEmit(child, emit);
+    });
+}
+
+}  // namespace
+
 // Classifies the pushed filters: score-column filters and covered `.col`
 // filters are applied in-scan (`col_filters`); a filter on a lookup
 // (source-only) column sets `has_lookup_filter` -- it is forwarded to the
@@ -575,12 +634,30 @@ void BuildTableFilter(IResearchScanGlobalState& state,
   // were stripped; the floor was recorded on the bind data there). The
   // dynamic TOP_N boundary's shared runtime bound is captured for WAND
   // seeding -- it may sit alone or AND-combined with other score predicates.
+  const auto score_emit = bind_data.vector_scorer
+                            ? bind_data.vector_scorer->score_emit
+                            : ScoreEmit::Identity;
   const auto push_score_filter = [&](const duckdb::TableFilter& filter) {
+    // The scan holds raw "larger = nearer" scores, but a score predicate is
+    // written in the user-facing score. For a non-identity emit, bake the emit
+    // into a copy of the predicate so FilterScores evaluates it in the right
+    // space -- the raw scores stay intact for the collector's ranking.
+    const duckdb::TableFilter* pushed = &filter;
+    if (score_emit != ScoreEmit::Identity) {
+      auto adjusted = duckdb::ExpressionFilter::GetExpressionFilter(
+                        filter, "BuildTableFilter")
+                        .expr->Copy();
+      WrapScoreRefsWithEmit(adjusted, score_emit);
+      auto owned =
+        duckdb::make_uniq<duckdb::ExpressionFilter>(std::move(adjusted));
+      pushed = owned.get();
+      state.emit_score_filters.push_back(std::move(owned));
+    }
     state.col_filters.push_back(
-      {.field = 0, .filter = &filter, .is_score = true});
-    const auto& expr =
-      *duckdb::ExpressionFilter::GetExpressionFilter(filter, "BuildTableFilter")
-         .expr;
+      {.field = 0, .filter = pushed, .is_score = true});
+    const auto& expr = *duckdb::ExpressionFilter::GetExpressionFilter(
+                          *pushed, "BuildTableFilter")
+                          .expr;
     if (auto dyn =
           duckdb::ExpressionFilter::GetOptionalDynamicFilterData(expr)) {
       state.score_dynamic_filter = std::move(dyn);
@@ -785,32 +862,17 @@ void IResearchScanGetMetrics(duckdb::TableFunctionGetMetricsInput& input) {
 
 void ApplyScoreEmit(const IResearchScanGlobalState& gstate, float* scores,
                     duckdb::idx_t n) {
-  if (!gstate.vector_scorer) {
-    // Text scores are already the user-facing value (Identity).
+  // Map in place at the emit boundary so the output vector sees the user-facing
+  // value. Text scores are already user-facing (no vector scorer).
+  if (gstate.vector_scorer == nullptr) {
     return;
   }
-  // The raw score is "larger = nearer" (ResolveScoringDistance negates distance
-  // kernels); map it in place to the user value at the emit boundary, so the
-  // score-column filter, the output vector (and any WAND threshold) all see the
-  // one user-facing value.
-  switch (gstate.vector_scorer->score_emit) {
-    case ScoreEmit::Identity:
-      break;
-    case ScoreEmit::SqrtNeg:
-      for (duckdb::idx_t i = 0; i < n; ++i) {
-        scores[i] = std::sqrt(-scores[i]);
-      }
-      break;
-    case ScoreEmit::OneMinus:
-      for (duckdb::idx_t i = 0; i < n; ++i) {
-        scores[i] = 1.0f - scores[i];
-      }
-      break;
-    case ScoreEmit::Negate:
-      for (duckdb::idx_t i = 0; i < n; ++i) {
-        scores[i] = -scores[i];
-      }
-      break;
+  const auto emit = gstate.vector_scorer->score_emit;
+  if (emit == ScoreEmit::Identity) {
+    return;
+  }
+  for (duckdb::idx_t i = 0; i < n; ++i) {
+    scores[i] = ApplyScoreEmit(emit, scores[i]);
   }
 }
 

--- a/server/connector/duckdb_search_full_scan.hpp
+++ b/server/connector/duckdb_search_full_scan.hpp
@@ -159,6 +159,10 @@ struct IResearchScanGlobalState : public duckdb::GlobalTableFunctionState {
     duckdb::unique_ptr<duckdb::TableFilter> not_null;
   };
   std::vector<ColFilter> col_filters;
+  // Owns the emit-adjusted copies of pushed score filters (the predicate with
+  // the score-emit baked into the score reference, so it evaluates in the
+  // user-facing space it was written in). A `col_filters` entry points into it.
+  std::vector<duckdb::unique_ptr<duckdb::TableFilter>> emit_score_filters;
   // Score-filter machinery. `score_dynamic_filter` is the shared runtime bound
   // TOP_N updates (captured from the pushed dynamic score filter; null when
   // none). `score_static_floor` is the lower bound implied by pushed static

--- a/server/connector/duckdb_system_table_entry.cpp
+++ b/server/connector/duckdb_system_table_entry.cpp
@@ -115,6 +115,19 @@ void SystemTableScan(duckdb::ClientContext& context,
   state.offset += count;
 }
 
+void SystemTableScanSerialize(duckdb::Serializer&,
+                              const duckdb::optional_ptr<duckdb::FunctionData>,
+                              const duckdb::TableFunction&) {
+  throw duckdb::NotImplementedException(
+    "system_table_scan serialization not implemented");
+}
+
+duckdb::unique_ptr<duckdb::FunctionData> SystemTableScanDeserialize(
+  duckdb::Deserializer&, duckdb::TableFunction&) {
+  throw duckdb::NotImplementedException(
+    "system_table_scan deserialization not implemented");
+}
+
 }  // namespace
 
 SystemTableEntry::SystemTableEntry(duckdb::Catalog& catalog,
@@ -159,6 +172,8 @@ duckdb::TableFunction SystemTableEntry::GetScanFunction(
                              nullptr /* bind */, SystemTableInit);
   func.projection_pushdown = true;
   func.get_bind_info = SystemTableGetBindInfo;
+  func.serialize = SystemTableScanSerialize;
+  func.deserialize = SystemTableScanDeserialize;
   return func;
 }
 

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -27,6 +27,7 @@
 #include <duckdb/common/types/data_chunk.hpp>
 #include <duckdb/common/types/variant.hpp>
 #include <duckdb/function/table_function.hpp>
+#include <duckdb/main/extension/extension_loader.hpp>
 #include <duckdb/optimizer/column_lifetime_analyzer.hpp>
 #include <duckdb/planner/expression/bound_columnref_expression.hpp>
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
@@ -1157,6 +1158,19 @@ duckdb::unique_ptr<duckdb::BaseStatistics> IResearchScanStatistics(
   return nullptr;
 }
 
+void IResearchScanSerialize(duckdb::Serializer&,
+                            const duckdb::optional_ptr<duckdb::FunctionData>,
+                            const duckdb::TableFunction&) {
+  throw duckdb::NotImplementedException(
+    "iresearch_scan serialization not implemented");
+}
+
+duckdb::unique_ptr<duckdb::FunctionData> IResearchScanDeserialize(
+  duckdb::Deserializer&, duckdb::TableFunction&) {
+  throw duckdb::NotImplementedException(
+    "iresearch_scan deserialization not implemented");
+}
+
 }  // namespace
 
 duckdb::TableFunction CreateIResearchScanFunction() {
@@ -1187,6 +1201,8 @@ duckdb::TableFunction CreateIResearchScanFunction() {
   func.supports_pushdown_extract = &IResearchSupportsPushdownExtract;
   func.supports_pushdown_filter = &IResearchSupportsPushdownFilter;
   func.statistics_extended = &IResearchScanStatistics;
+  func.serialize = IResearchScanSerialize;
+  func.deserialize = IResearchScanDeserialize;
   func.verify_serialization = false;
   func.projection_pushdown = true;
   func.filter_pushdown = true;
@@ -1198,6 +1214,11 @@ duckdb::TableFunction CreateIResearchScanFunction() {
   // could be made to preserve index order if we implement set_scan_order
   func.order_preservation_type = duckdb::OrderPreservationType::NO_ORDER;
   return func;
+}
+
+void RegisterIResearchScanFunction(duckdb::DatabaseInstance& db) {
+  duckdb::ExtensionLoader loader(db, "serenedb");
+  loader.RegisterFunction(CreateIResearchScanFunction());
 }
 
 }  // namespace sdb::connector

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -66,6 +66,24 @@ enum class ScoreEmit : uint8_t {
   Negate,    // -score       (l1, l2_sqr, negative_ip, l1_norm)
 };
 
+// Maps one raw "larger = nearer" score to its user-facing value. Single source
+// of truth: applied to the output scores at the emit boundary, and baked into
+// the pushed score-column filter so the predicate is evaluated in the same
+// (user-facing) space it was written in.
+inline float ApplyScoreEmit(ScoreEmit emit, float score) {
+  switch (emit) {
+    case ScoreEmit::Identity:
+      return score;
+    case ScoreEmit::SqrtNeg:
+      return std::sqrt(-score);
+    case ScoreEmit::OneMinus:
+      return 1.0F - score;
+    case ScoreEmit::Negate:
+      return -score;
+  }
+  SDB_UNREACHABLE();
+}
+
 struct VectorScorerOptions {
   irs::field_id field_id;
   std::vector<float> query_vector;

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -314,4 +314,6 @@ uint32_t ReadBoundedIntSetting(duckdb::ClientContext& context,
 
 duckdb::TableFunction CreateIResearchScanFunction();
 
+void RegisterIResearchScanFunction(duckdb::DatabaseInstance& db);
+
 }  // namespace sdb::connector

--- a/server/connector/full_scanner.cpp
+++ b/server/connector/full_scanner.cpp
@@ -83,6 +83,7 @@ duckdb::idx_t FullScanner::Scan(uint64_t start_row, duckdb::idx_t count,
   if (count == 0) {
     return 0;
   }
+  _scanned_end = std::max<uint64_t>(_scanned_end, start_row + count);
   SDB_IF_FAILURE("SearchIncludeFetchFault") {
     THROW_SQL_ERROR(ERR_MSG("intentional debug error"));
   }

--- a/server/connector/full_scanner.h
+++ b/server/connector/full_scanner.h
@@ -48,6 +48,13 @@ class FullScanner {
 
   bool HasAny() const noexcept { return !_bound.empty() || !_filters.Empty(); }
 
+  // The exclusive end row this scanner has advanced to (max start_row + count
+  // over Scan calls). The column cursors only move forward, so a Scan below
+  // this row is invalid -- the caller rebuilds the scanner instead (see
+  // ColScanLocalState::StartUnit, where a scan order can hand out units of one
+  // segment out of row order).
+  uint64_t ScannedEnd() const noexcept { return _scanned_end; }
+
   // Zonemap skip for the bulk loop: no row before the returned end can pass
   // the pushed filters (0 = no skip), so the caller jumps the scan cursor.
   uint64_t DeadUntil(uint64_t row) {
@@ -77,6 +84,7 @@ class FullScanner {
   ColFilterChain _filters;
   duckdb::buffer_ptr<duckdb::SelectionData> _sel_data;
   duckdb::SelectionVector _sel;
+  uint64_t _scanned_end = 0;
 };
 
 }  // namespace sdb::connector

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -894,12 +894,30 @@ void RewriteIResearchExpressions(
   }
 }
 
-std::optional<duckdb::ColumnBinding> CastFreeColumnRefBinding(
-  const duckdb::Expression* e) {
-  while (e && e->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
-    e = &e->Cast<duckdb::BoundCastExpression>().Child();
+// Resolves the column reference on one side of a comparison, under an optional
+// cast and an optional unary negation (`-(col)`). `negated` reports whether the
+// negation was present -- the caller folds it into the comparison.
+std::optional<duckdb::ColumnBinding> ScoreSideBinding(
+  const duckdb::Expression* e, bool& negated) {
+  negated = false;
+  const auto strip_casts = [](const duckdb::Expression* x) {
+    while (x &&
+           x->GetExpressionClass() == duckdb::ExpressionClass::BOUND_CAST) {
+      x = &x->Cast<duckdb::BoundCastExpression>().Child();
+    }
+    return x;
+  };
+  e = strip_casts(e);
+  if (e != nullptr &&
+      e->GetExpressionClass() == duckdb::ExpressionClass::BOUND_FUNCTION) {
+    const auto& fn = e->Cast<duckdb::BoundFunctionExpression>();
+    if (fn.Function().GetName().GetIdentifierName() == "-" &&
+        fn.GetChildren().size() == 1) {
+      negated = true;
+      e = strip_casts(fn.GetChildren()[0].get());
+    }
   }
-  if (!e ||
+  if (e == nullptr ||
       e->GetExpressionClass() != duckdb::ExpressionClass::BOUND_COLUMN_REF) {
     return std::nullopt;
   }
@@ -923,48 +941,72 @@ bool TryClaimAnnRange(
       continue;
     }
     auto& cmp = expr.Cast<duckdb::BoundFunctionExpression>();
+    auto op = cmp.GetExpressionType();
+    if (op != duckdb::ExpressionType::COMPARE_LESSTHAN &&
+        op != duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO &&
+        op != duckdb::ExpressionType::COMPARE_GREATERTHAN &&
+        op != duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+      continue;
+    }
     auto& cmp_left = duckdb::BoundComparisonExpression::LeftMutable(cmp);
     auto& cmp_right = duckdb::BoundComparisonExpression::RightMutable(cmp);
-    const auto [score_side, const_side] =
-      [&] -> std::pair<duckdb::Expression*, duckdb::Expression*> {
-      switch (cmp.GetExpressionType()) {
-        case duckdb::ExpressionType::COMPARE_LESSTHAN:
-        case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
-          return {cmp_left.get(), cmp_right.get()};
-        case duckdb::ExpressionType::COMPARE_GREATERTHAN:
-        case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-          return {cmp_right.get(), cmp_left.get()};
-        default:
-          return {nullptr, nullptr};
+
+    // Find the side that resolves to the score column (bare or `-(score)`); the
+    // other side is the bound.
+    const auto is_score = [&](const std::optional<duckdb::ColumnBinding>& b) {
+      return b && ResolveColumnId(*b, bind_data, get) ==
+                    catalog::Column::kInvertedIndexScoreId;
+    };
+    bool negated = false;
+    bool score_on_left = true;
+    duckdb::Expression* const_side = cmp_right.get();
+    auto binding = ScoreSideBinding(cmp_left.get(), negated);
+    if (!is_score(binding)) {
+      score_on_left = false;
+      const_side = cmp_left.get();
+      binding = ScoreSideBinding(cmp_right.get(), negated);
+      if (!is_score(binding)) {
+        continue;
       }
-    }();
-    const auto score_binding = CastFreeColumnRefBinding(score_side);
-    if (!score_binding || ResolveColumnId(*score_binding, bind_data, get) !=
-                            catalog::Column::kInvertedIndexScoreId) {
+    }
+
+    duckdb::Value bound_value;
+    if (!TryFoldExpression(context, *const_side, bound_value)) {
       continue;
     }
-    duckdb::Value radius_value;
-    if (!TryFoldExpression(context, *const_side, radius_value)) {
-      continue;
-    }
-    const auto radius = [&] -> std::optional<float> {
-      switch (radius_value.type().id()) {
+    const auto bound = [&] -> std::optional<float> {
+      switch (bound_value.type().id()) {
         case duckdb::LogicalTypeId::FLOAT:
-          return radius_value.GetValue<float>();
+          return bound_value.GetValue<float>();
         case duckdb::LogicalTypeId::DOUBLE:
-          return static_cast<float>(radius_value.GetValue<double>());
+          return static_cast<float>(bound_value.GetValue<double>());
         default:
           return std::nullopt;
       }
     }();
-    if (!radius) {
+    if (!bound) {
       continue;
     }
-    const auto cmp_type = cmp.GetExpressionType();
-    scan.vector_scorer->radius = *radius;
-    scan.vector_scorer->radius_inclusive =
-      cmp_type == duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO ||
-      cmp_type == duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+
+    // Normalize to `score <op> radius` (score = the raw vector distance): put
+    // the score on the left, then fold away a `-(score)` wrapper. A radius is
+    // an upper bound on the distance; a lower bound stays a residual filter
+    // (the scan evaluates it in user-facing space).
+    float radius = *bound;
+    if (!score_on_left) {
+      op = duckdb::FlipComparisonExpression(op);
+    }
+    if (negated) {
+      op = duckdb::FlipComparisonExpression(op);
+      radius = -radius;
+    }
+    const bool inclusive =
+      op == duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO;
+    if (op != duckdb::ExpressionType::COMPARE_LESSTHAN && !inclusive) {
+      continue;
+    }
+    scan.vector_scorer->radius = radius;
+    scan.vector_scorer->radius_inclusive = inclusive;
     filters.erase(filters.begin() + i);
     return true;
   }

--- a/server/query/server_engine.cpp
+++ b/server/query/server_engine.cpp
@@ -36,6 +36,7 @@
 #include "connector/duckdb_physical_create_index.h"
 #include "connector/duckdb_rbac_function.h"
 #include "connector/duckdb_storage_extension.h"
+#include "connector/duckdb_table_function.h"
 #include "connector/duckdb_tokenizer_function.h"
 #include "connector/duckdb_vacuum_function.h"
 #include "connector/functions/array.h"
@@ -274,6 +275,8 @@ void RegisterServerExtensions(duckdb::DatabaseInstance& db) {
   connector::RegisterPgTextCopyFunction(db);
 
   connector::RegisterSearchFunctions(db);
+
+  connector::RegisterIResearchScanFunction(db);
 
   connector::RegisterVectorFunctions(db);
 

--- a/tests/sqllogic/recovery/inverted_index_scan_order_multiunit.test
+++ b/tests/sqllogic/recovery/inverted_index_scan_order_multiunit.test
@@ -1,0 +1,96 @@
+# Regression: a segment larger than one row group (122880 rows) splits into
+# multiple bulk scan units; under a scan order (ORDER BY a covered column LIMIT)
+# those units are reordered best-first, so a single worker can scan a lower-row
+# unit after a higher-row one. The per-segment columnstore scanner's cursor only
+# moves forward (GatherFilter/Skip never rewind), so the out-of-order unit
+# tripped `GatherFilter requires ascending rows` (and, on the no-filter path,
+# `cursor <= start_row`). Fixed by rebuilding the scanner when a unit starts
+# behind its ScannedEnd. `threads = 1` forces the one-worker interleaving that
+# makes the backward scan deterministic; hosted under recovery/ (not sdb/)
+# because each recovery test runs against its own instance, so the global
+# thread-count mutation is isolated from parallel test sessions.
+
+onlyif serenedb
+statement ok
+SET threads = 1
+
+
+onlyif serenedb
+statement ok
+CREATE TEXT SEARCH DICTIONARY en
+  (template = 'delimiter', delimiter = ' ', frequency = true, position = true)
+
+
+onlyif serenedb
+statement ok
+CREATE TABLE big (rk INT, cat INT, body TEXT)
+
+
+onlyif serenedb
+statement ok
+CREATE INDEX big_idx ON big USING inverted (body en) INCLUDE (rk, cat)
+
+
+# One INSERT -> one segment; 200000 > 122880 -> two bulk units.
+onlyif serenedb
+statement ok
+INSERT INTO big SELECT i, i % 100, 'x' FROM generate_series(1, 200000) s(i)
+
+
+onlyif serenedb
+statement ok
+VACUUM (REFRESH_TABLE) big
+
+
+# Covered `.col` filter + scan order: the best-first reorder scans the second
+# unit behind the first. cat <= 50 keeps 51 of every 100 rows = 102000.
+onlyif serenedb
+query
+SELECT count(*) FROM (
+  SELECT rk FROM big_idx WHERE cat <= 50 ORDER BY rk DESC LIMIT 150000) t;
+----
+count
+102000
+
+
+onlyif serenedb
+query
+SELECT rk FROM big_idx WHERE cat <= 50 ORDER BY rk DESC LIMIT 5;
+----
+rk
+200000
+199950
+199949
+199948
+199947
+
+
+onlyif serenedb
+query
+SELECT rk FROM big_idx WHERE cat <= 50 ORDER BY rk ASC LIMIT 5;
+----
+rk
+1
+2
+3
+4
+5
+
+
+# Same reordering on the no-filter ColScan path (`cursor <= start_row`).
+onlyif serenedb
+query
+SELECT count(*) FROM (SELECT rk FROM big_idx ORDER BY rk DESC LIMIT 150000) t;
+----
+count
+150000
+
+
+onlyif serenedb
+query
+SELECT rk FROM big_idx ORDER BY rk DESC LIMIT 3;
+----
+rk
+200000
+199999
+199998

--- a/tests/sqllogic/sdb/pg/index/inverted_index_cte_multiref.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_cte_multiref.test
@@ -1,0 +1,159 @@
+hash-threshold 100000
+
+# Regression: a CTE that scans an index, referenced more than once and inlined
+# by the CTE_INLINING optimizer, was failing with "Table Function with name
+# iresearch_scan does not exist!". Inlining deep-copies the CTE body by round-
+# tripping the plan through serialize/deserialize; the IRESEARCH_SCAN table
+# function is attached to the LogicalGet on the fly and was never registered in
+# the catalog, so the copy failed the by-name lookup. Inlining only kicks in
+# when the CTE is referenced multiple times AND the query side has a LIMIT/TOP_N
+# (otherwise the CTE stays materialized), so every query below carries an outer
+# LIMIT. Fixed by registering the scan in the catalog and giving it a serialize
+# hook that reports NotImplemented, so inlining falls back to materialization.
+# Issues #962 and #753.
+
+statement ok
+CREATE TABLE t (id INT, body TEXT)
+
+
+statement ok
+INSERT INTO t VALUES
+  (1, 'mouse rodent vole'), (2, 'mouse'), (3, 'bat mouse mouse'),
+  (4, 'elephant'), (5, 'mouse mouse'), (6, 'computer mouse usb')
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY d
+  (template = 'delimiter', delimiter = ' ', frequency = true, position = true, norm = true)
+
+
+statement ok
+CREATE INDEX t_idx ON t USING inverted (id, body d)
+
+
+# #962: CTE with an inner ORDER BY ... LIMIT, referenced twice (main scan plus a
+# scalar subquery over the same CTE), ids ordered by BM25 norm (tie broken by id).
+query
+WITH lex AS (
+    SELECT id, s FROM (
+        SELECT id, BM25(t_idx.tableoid) AS s
+        FROM t_idx WHERE body @@ 'mouse' ORDER BY s DESC LIMIT 5) l)
+SELECT id FROM lex ORDER BY (s / NULLIF((SELECT max(s) FROM lex), 0)) DESC, id LIMIT 5;
+----
+id
+5
+2
+3
+1
+6
+
+
+# #753: two references combined by UNION ALL.
+query
+WITH c AS (SELECT id FROM t_idx WHERE body @@ 'mouse')
+SELECT id FROM (SELECT id FROM c UNION ALL SELECT id FROM c) u ORDER BY id LIMIT 4;
+----
+id
+1
+1
+2
+2
+
+
+# #753: self-join of the CTE.
+query
+WITH c AS (SELECT id FROM t_idx WHERE body @@ 'mouse')
+SELECT a.id FROM c a JOIN c b ON a.id <> b.id ORDER BY a.id LIMIT 4;
+----
+id
+1
+1
+1
+1
+
+
+# #753: comma-join of the CTE.
+query
+WITH c AS (SELECT id FROM t_idx WHERE body @@ 'mouse')
+SELECT a.id FROM c a, c b WHERE a.id < b.id ORDER BY a.id, b.id LIMIT 4;
+----
+id
+1
+1
+1
+1
+
+
+# #753: AS MATERIALIZED was the documented workaround; it stays materialized (no
+# inlining) and must keep working.
+query
+WITH c AS MATERIALIZED (SELECT id FROM t_idx WHERE body @@ 'mouse')
+SELECT id FROM (SELECT id FROM c UNION ALL SELECT id FROM c) u ORDER BY id LIMIT 4;
+----
+id
+1
+1
+2
+2
+
+
+# Vector (ANN) scans go through the same table function; #753 hit this too.
+statement ok
+CREATE TABLE v (id INT, emb FLOAT[3])
+
+
+statement ok
+CREATE INDEX v_idx ON v USING inverted (id, emb ivf (metric = 'l2'))
+
+
+statement ok
+INSERT INTO v VALUES
+  (1, [100, 0, 0]::FLOAT[3]), (2, [50, 50, 50]::FLOAT[3]),
+  (3, [50, 25, 50]::FLOAT[3]), (4, [50, 50, 100]::FLOAT[3])
+
+
+statement ok
+VACUUM (REFRESH_TABLE) v
+
+
+# ANN CTE referenced twice via self-join.
+query
+WITH cand AS (SELECT id FROM v_idx ORDER BY emb <-> [0.0, 0.0, 0.0]::FLOAT[3] LIMIT 3)
+SELECT a.id FROM cand a JOIN cand b ON a.id <> b.id ORDER BY a.id LIMIT 4;
+----
+id
+1
+1
+2
+2
+
+
+# ANN CTE referenced twice via a scalar subquery.
+query
+WITH cand AS (SELECT id FROM v_idx ORDER BY emb <-> [0.0, 0.0, 0.0]::FLOAT[3] LIMIT 3)
+SELECT id, (SELECT count(*) FROM cand) AS n FROM cand ORDER BY id LIMIT 3;
+----
+id	n
+1	3
+2	3
+3	3
+
+
+# The system-catalog scan (system_table_scan) had the identical defect: a system
+# table in a multiply-referenced, inlined CTE failed the same by-name lookup.
+query
+WITH c AS (SELECT relname FROM pg_class WHERE relname = 't_idx' LIMIT 5)
+SELECT relname FROM (SELECT relname FROM c UNION ALL SELECT relname FROM c) u ORDER BY relname LIMIT 2;
+----
+relname
+t_idx
+t_idx
+
+
+query
+WITH c AS (SELECT relname FROM pg_class WHERE relname IN ('t', 'v') LIMIT 10)
+SELECT a.relname FROM c a JOIN c b ON a.relname <> b.relname ORDER BY a.relname LIMIT 2;
+----
+relname
+t
+v

--- a/tests/sqllogic/sdb/pg/index/vector_search_score_filter.test
+++ b/tests/sqllogic/sdb/pg/index/vector_search_score_filter.test
@@ -1,0 +1,113 @@
+hash-threshold 100000
+
+# Regression: a score-threshold predicate in a vector scan's WHERE was evaluated
+# against the raw "larger = nearer" score, not the user-facing (emit-mapped)
+# score, so any non-identity emit (`<#>` -> Negate, l2_distance -> SqrtNeg, ...)
+# silently returned the wrong rows. Fixed by baking the score emit into the
+# pushed score-column filter, so it is evaluated in the space the predicate was
+# written in. Issue #964.
+
+# --- inner product: `<#>` returns -IP, mapped to the user value via Negate ---
+statement ok
+CREATE TABLE t (id VARCHAR PRIMARY KEY, v FLOAT[4])
+
+
+statement ok
+CREATE INDEX t_idx ON t USING inverted (id, v ivf (metric = 'ip', quant = 'sq8'))
+
+
+statement ok
+INSERT INTO t VALUES
+  ('r0', '{1,0,0,0}'), ('r1', '{0.9,0.1,0,0}'),
+  ('r2', '{0,1,0,0}'), ('r3', '{0,0,1,0}')
+
+
+statement ok
+VACUUM (REFRESH_TABLE) t
+
+
+# #964: similarity = -(v <#> q) >= 0 keeps every non-negative-IP row; the top-2
+# by distance are r0, r1. Returned [] before the fix.
+query
+SELECT id FROM t_idx
+WHERE -(v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4]) >= 0.0
+ORDER BY v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4] LIMIT 2;
+----
+id
+r0
+r1
+
+
+# A threshold keeping only the low-IP rows: IP < 0.5 selects r2, r3 (IP 0), which
+# the ORDER BY then returns. Returned r0, r1 (raw-space) before the fix.
+query
+SELECT id FROM t_idx
+WHERE (v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4]) > -0.5
+ORDER BY v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4] LIMIT 2;
+----
+id
+r2
+r3
+
+
+# Higher similarity floor keeps r0, r1 (IP 1, 0.9 >= 0.5).
+query
+SELECT id FROM t_idx
+WHERE -(v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4]) >= 0.5
+ORDER BY v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4] LIMIT 4;
+----
+id
+r0
+r1
+
+
+# A bare distance bound (claimed as a vector radius, a separate path) still works.
+query
+SELECT id FROM t_idx
+WHERE (v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4]) <= -0.95
+ORDER BY v <#> ARRAY[1.0, 0, 0, 0]::FLOAT[4] LIMIT 4;
+----
+id
+r0
+
+
+# --- l2 distance: emitted via SqrtNeg ---
+statement ok
+CREATE TABLE l2t (id INT, emb FLOAT[3])
+
+
+statement ok
+CREATE INDEX l2t_idx ON l2t USING inverted (id, emb ivf (metric = 'l2'))
+
+
+statement ok
+INSERT INTO l2t VALUES
+  (1, [0, 0, 0]::FLOAT[3]), (2, [3, 0, 0]::FLOAT[3]),
+  (3, [10, 0, 0]::FLOAT[3]), (4, [100, 0, 0]::FLOAT[3])
+
+
+statement ok
+VACUUM (REFRESH_TABLE) l2t
+
+
+# A lower bound on distance (a residual score filter, not a radius): keep the
+# rows farther than 5 -> ids 3, 4. Wrong (raw-space) before the fix.
+query
+SELECT id FROM l2t_idx
+WHERE l2_distance(emb, [0.0, 0, 0]::FLOAT[3]) > 5.0
+ORDER BY emb <-> [0.0, 0, 0]::FLOAT[3] LIMIT 5;
+----
+id
+3
+4
+
+
+# Bare distance radius still works.
+query
+SELECT id FROM l2t_idx
+WHERE l2_distance(emb, [0.0, 0, 0]::FLOAT[3]) <= 5.0
+ORDER BY emb <-> [0.0, 0, 0]::FLOAT[3] LIMIT 5;
+----
+id
+1
+2


### PR DESCRIPTION
Three related index-scan fixes surfaced by the linked issues.

## 1. Index-backed CTE referenced more than once (#962, #753)

A CTE that scans an index (`iresearch_scan`) or a system table (`system_table_scan`), referenced more than once and inlined by the `CTE_INLINING` optimizer, failed with `Table Function with name iresearch_scan does not exist!`. Inlining deep-copies the CTE body by round-tripping the plan through serialize/deserialize; these scan functions are attached to the `LogicalGet` on the fly and were never registered in the catalog, so the copy failed the by-name lookup.

Register `iresearch_scan` in the catalog and give both scans a serialize/deserialize hook that reports `NotImplemented`, so CTE inlining catches it and falls back to keeping the CTE materialized — matching how `iceberg_scan` already behaves. (#753 was closed earlier, but the root cause was never fixed; it reproduces whenever the query side has a `LIMIT`/`TOP_N`, i.e. #962.)

Test: `tests/sqllogic/sdb/pg/index/inverted_index_cte_multiref.test` — BM25, ANN, and system-table CTEs (UNION ALL / self-join / comma-join / scalar subquery), plus the `AS MATERIALIZED` control.

## 2. Vector score-threshold filter evaluated in the wrong space (#964)

A score-threshold predicate in a vector scan's `WHERE` (e.g. `-(v <#> q) >= 0`) was evaluated against the raw "larger = nearer" score, but the predicate is written in terms of the user-facing (emit-mapped) score. For a non-identity emit (`<#>` → negate, l2 → sqrt-neg, cosine-distance → one-minus) this silently returned the wrong rows.

Bake the score emit into the pushed score-column filter: the score reference is wrapped with the emit op, so the predicate is evaluated inline against the raw score vector while the collector keeps the raw scores for ranking. Also route wrapped comparisons like `-(score) >= c` through the vector-radius path, so a similarity threshold prunes at the index instead of leaving a per-row residual filter.

Test: `tests/sqllogic/sdb/pg/index/vector_search_score_filter.test`.

## 3. Out-of-order scan units crash the columnstore scanner (found while testing #2)

A segment larger than one row group splits into multiple bulk scan units; under a scan order (`ORDER BY` a covered column `LIMIT`), `OrderSegmentScanUnits` reorders them best-first, so a single worker can scan a lower-row unit after a higher-row one. The per-segment `FullScanner` is reused across a segment's units and its column cursors only move forward, so the out-of-order unit tripped `GatherFilter requires ascending rows` (and, on the no-filter path, `cursor <= start_row`). It surfaced flakily under parallel scans.

Track the scanner's furthest scanned row (`ScannedEnd`) and rebuild it only when a unit starts behind that — ascending units keep reusing the scanner.

Test: `tests/sqllogic/recovery/inverted_index_scan_order_multiunit.test` — `SET threads = 1` forces the deterministic single-worker interleaving; hosted under `recovery/` because that global thread-count mutation is isolated to its own instance there.

## Validation

Every test passes on both pg-wire engines (simple + extended); the full `--fast` index suite is green (378 OK, exit 0).
