### PR TITLE
fix: Column readers stats  nulls flags not set properly

### DIFF
--- a/libs/iresearch/include/iresearch/formats/column/column_reader.cpp
+++ b/libs/iresearch/include/iresearch/formats/column/column_reader.cpp
@@ -235,12 +235,12 @@ bool ColumnReader::NullsInData() const noexcept {
 void ColumnReader::FinishStats(duckdb::BaseStatistics stats) {
   if (_validity) {
     stats.Merge(_validity->MergedStatistics());
-  } else if (_row_count > 0 && _type.id() != duckdb::LogicalTypeId::VALIDITY &&
-             (!_children.empty() || !NullsInData())) {
-    // No validity payload means the writer counted every row valid
-    // (ColumnWriter::SealValidity): the column has non-null values. A nested
-    // parent's row validity never hides in its data codec; a scalar's can
-    // (dict_fsst), and there the data block stats already carry the flags.
+  } else if (_row_count > 0 && !_children.empty()) {
+    // A nested parent rebuilds its stats from CreateEmpty (its own blocks are
+    // plumbing, e.g. list offsets), so the null flags only come from the
+    // validity child -- and its absence means the writer counted every row
+    // valid (ColumnWriter::SealValidity). Scalars need none of this: their
+    // data block stats already carry the flags.
     SDB_ASSERT(!stats.CanHaveNull(),
                "column without a validity payload carries null-bearing stats");
     stats.SetHasNoNull();

--- a/libs/iresearch/include/iresearch/formats/column/column_reader.cpp
+++ b/libs/iresearch/include/iresearch/formats/column/column_reader.cpp
@@ -235,6 +235,15 @@ bool ColumnReader::NullsInData() const noexcept {
 void ColumnReader::FinishStats(duckdb::BaseStatistics stats) {
   if (_validity) {
     stats.Merge(_validity->MergedStatistics());
+  } else if (_row_count > 0 && _type.id() != duckdb::LogicalTypeId::VALIDITY &&
+             (!_children.empty() || !NullsInData())) {
+    // No validity payload means the writer counted every row valid
+    // (ColumnWriter::SealValidity): the column has non-null values. A nested
+    // parent's row validity never hides in its data codec; a scalar's can
+    // (dict_fsst), and there the data block stats already carry the flags.
+    SDB_ASSERT(!stats.CanHaveNull(),
+               "column without a validity payload carries null-bearing stats");
+    stats.SetHasNoNull();
   }
   _stats = stats.ToUnique();
 }

--- a/tests/sqllogic/sdb/pg/index/inverted_index_list_nulls.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_list_nulls.test
@@ -154,15 +154,6 @@ pk
 4
 
 
-# The cases above put all rows into ONE index segment (single refresh), so the
-# segment always contains a row-level NULL and carries a validity payload. The
-# sections below pin the multi-segment layouts (VACUUM between insert groups
-# forces the segment split -- in production the background refresh loop can
-# split anywhere). A segment whose rows are all row-level valid writes NO
-# validity payload; its column statistics must still say "has non-null values",
-# otherwise IS [NOT] NULL wrongly kills the segment (runtime classification) or
-# the whole query (plan-time folding).
-
 # Layout 1: an all-valid segment (incl. NULL element and empty list -- both
 # row-level valid) next to a mixed segment. The per-segment IS [NOT] NULL
 # classification must not drop the all-valid segment.

--- a/tests/sqllogic/sdb/pg/index/inverted_index_list_nulls.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_list_nulls.test
@@ -152,3 +152,209 @@ pk
 1
 3
 4
+
+
+# The cases above put all rows into ONE index segment (single refresh), so the
+# segment always contains a row-level NULL and carries a validity payload. The
+# sections below pin the multi-segment layouts (VACUUM between insert groups
+# forces the segment split -- in production the background refresh loop can
+# split anywhere). A segment whose rows are all row-level valid writes NO
+# validity payload; its column statistics must still say "has non-null values",
+# otherwise IS [NOT] NULL wrongly kills the segment (runtime classification) or
+# the whole query (plan-time folding).
+
+# Layout 1: an all-valid segment (incl. NULL element and empty list -- both
+# row-level valid) next to a mixed segment. The per-segment IS [NOT] NULL
+# classification must not drop the all-valid segment.
+statement ok
+CREATE TABLE list_n2 (
+  pk INTEGER PRIMARY KEY,
+  text_for_search VARCHAR,
+  tags VARCHAR[]
+)
+
+
+statement ok
+CREATE INDEX list_n2_idx ON list_n2 USING inverted(pk, text_for_search en)
+  INCLUDE (tags)
+
+
+statement ok
+INSERT INTO list_n2 VALUES
+  (1, 'first',  ['alpha', 'beta']),
+  (2, 'second', ['gamma', NULL, 'delta']),
+  (3, 'third',  [])
+
+
+statement ok
+VACUUM (REFRESH_TABLE) list_n2
+
+
+statement ok
+INSERT INTO list_n2 VALUES
+  (4, 'fourth', NULL),
+  (5, 'fifth',  ['epsilon'])
+
+
+statement ok
+VACUUM (REFRESH_TABLE) list_n2
+
+
+query
+SELECT pk, tags FROM list_n2_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third')
+       OR text_for_search @@ ts_phrase('fourth')
+       OR text_for_search @@ ts_phrase('fifth'))
+ORDER BY pk;
+----
+pk	tags
+1	{alpha,beta}
+2	{gamma,NULL,delta}
+3	{}
+4	NULL
+5	{epsilon}
+
+
+query
+SELECT pk FROM list_n2_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third')
+       OR text_for_search @@ ts_phrase('fourth')
+       OR text_for_search @@ ts_phrase('fifth'))
+  AND tags IS NOT NULL
+ORDER BY pk;
+----
+pk
+1
+2
+3
+5
+
+
+query
+SELECT pk FROM list_n2_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third')
+       OR text_for_search @@ ts_phrase('fourth')
+       OR text_for_search @@ ts_phrase('fifth'))
+  AND tags IS NULL
+ORDER BY pk;
+----
+pk
+4
+
+
+# Layout 2: an all-valid segment next to an all-NULL segment (no mixed
+# segment). Here the index-wide merged statistics drive PLAN-TIME folding:
+# broken all-valid stats fold IS NOT NULL to an empty result and elide
+# IS NULL entirely (returning every row).
+statement ok
+CREATE TABLE list_n3 (
+  pk INTEGER PRIMARY KEY,
+  text_for_search VARCHAR,
+  tags VARCHAR[]
+)
+
+
+statement ok
+CREATE INDEX list_n3_idx ON list_n3 USING inverted(pk, text_for_search en)
+  INCLUDE (tags)
+
+
+statement ok
+INSERT INTO list_n3 VALUES
+  (1, 'first',  ['alpha']),
+  (2, 'second', [])
+
+
+statement ok
+VACUUM (REFRESH_TABLE) list_n3
+
+
+statement ok
+INSERT INTO list_n3 VALUES (3, 'third', NULL)
+
+
+statement ok
+VACUUM (REFRESH_TABLE) list_n3
+
+
+query
+SELECT pk FROM list_n3_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third'))
+  AND tags IS NOT NULL
+ORDER BY pk;
+----
+pk
+1
+2
+
+
+query
+SELECT pk FROM list_n3_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third'))
+  AND tags IS NULL
+ORDER BY pk;
+----
+pk
+3
+
+
+# Layout 3: an all-valid segment alone. Today this is right only by accident
+# (plan-time reads the empty flags as "no nulls" and elides the filter); with
+# correct stats it stays right for the right reason.
+statement ok
+CREATE TABLE list_n4 (
+  pk INTEGER PRIMARY KEY,
+  text_for_search VARCHAR,
+  tags VARCHAR[]
+)
+
+
+statement ok
+CREATE INDEX list_n4_idx ON list_n4 USING inverted(pk, text_for_search en)
+  INCLUDE (tags)
+
+
+statement ok
+INSERT INTO list_n4 VALUES
+  (1, 'first',  ['alpha']),
+  (2, 'second', ['gamma', NULL, 'delta']),
+  (3, 'third',  [])
+
+
+statement ok
+VACUUM (REFRESH_TABLE) list_n4
+
+
+query
+SELECT pk FROM list_n4_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third'))
+  AND tags IS NOT NULL
+ORDER BY pk;
+----
+pk
+1
+2
+3
+
+
+query
+SELECT pk FROM list_n4_idx
+WHERE (text_for_search @@ ts_phrase('first')
+       OR text_for_search @@ ts_phrase('second')
+       OR text_for_search @@ ts_phrase('third'))
+  AND tags IS NULL
+ORDER BY pk;
+----
+pk


### PR DESCRIPTION
Column reader wrongly sets nulls flags during read of "No nulls" segment. It has no validity mask so stats mask stays "empty" and that confuses planner/scanner
Fix forces "no nulls" flag to be set in this case with defensive assert.


Could be seen as flaky 
```
  tests-1  | failed to run `sdb/pg/index/inverted_index_list_nulls.test`
  tests-1  | 
  tests-1  | Caused by:
  tests-1  |     query result mismatch:
  tests-1  |     [SQL] SELECT pk FROM list_n_idx
  tests-1  |     WHERE (text_for_search @@ ts_phrase('first')
  tests-1  |            OR text_for_search @@ ts_phrase('second')
  tests-1  |            OR text_for_search @@ ts_phrase('third')
  tests-1  |            OR text_for_search @@ ts_phrase('fourth'))
  tests-1  |       AND tags IS NOT NULL
  tests-1  |     ORDER BY pk;
  tests-1  |     [Diff] (-expected|+actual)
  tests-1  |         pk
  tests-1  |     -   1
  tests-1  |     -   3
  tests-1  |     -   4
  tests-1  |     +   1
  tests-1  |     at sdb/pg/index/inverted_index_list_nulls.test:142
```
