### PR TITLE
fix: Support out-of-order block flushes in the inverted-index columnstore

### DIFF
--- a/libs/iresearch/include/iresearch/formats/column/col_reader.cpp
+++ b/libs/iresearch/include/iresearch/formats/column/col_reader.cpp
@@ -179,7 +179,19 @@ ColReader::ColReader(const Directory& dir, std::string_view segment_name,
         _norm_readers.push_back(std::move(nr));
       });
     });
+  deserializer.ReadOptionalList(
+    kFooterSlotBlockOffsets, "block_offsets",
+    [&](duckdb::Deserializer::List& list, duckdb::idx_t /*i*/) {
+      const auto offset = list.ReadElement<uint64_t>();
+      SDB_ENSURE(offset == kColBlockUnwritten ||
+                   (offset % 8 == 0 &&
+                    offset + _ctx.GetBlockAllocSize() <= footer_offset),
+                 ".col reader: overflow block offset ", offset,
+                 " out of range");
+      _block_offsets.push_back(offset);
+    });
   deserializer.End();
+  _ctx.SetBlockOffsets(_block_offsets);
 }
 
 ColReader::~ColReader() = default;

--- a/libs/iresearch/include/iresearch/formats/column/col_reader.hpp
+++ b/libs/iresearch/include/iresearch/formats/column/col_reader.hpp
@@ -53,6 +53,7 @@ inline constexpr std::string_view kFormatExt = "col";
 
 inline constexpr duckdb::field_id_t kFooterSlotColumns = 100;
 inline constexpr duckdb::field_id_t kFooterSlotNormColumns = 101;
+inline constexpr duckdb::field_id_t kFooterSlotBlockOffsets = 102;
 
 inline std::string FileName(std::string_view segment_name) {
   return absl::StrCat(segment_name, ".", kFormatExt);
@@ -76,6 +77,9 @@ class ColReader final {
   bool HasNormColumn(field_id id) const noexcept;
   const NormColumnReader* NormColumn(field_id id) const noexcept;
   ReadContext& Ctx() noexcept { return _ctx; }
+  std::span<const uint64_t> BlockOffsets() const noexcept {
+    return _block_offsets;
+  }
 
   IndexInput::ptr ReopenIn() const {
     return _ctx.HasIn() ? _ctx.In().Reopen() : nullptr;
@@ -85,6 +89,7 @@ class ColReader final {
  private:
   duckdb::DatabaseInstance* _db;
   ReadContext _ctx;
+  std::vector<uint64_t> _block_offsets;
   std::vector<std::unique_ptr<ColumnReader>> _columns;
   sdb::containers::FlatHashMap<field_id, ColumnReader*> _by_id;
   std::vector<std::unique_ptr<NormColumnReader>> _norm_readers;

--- a/libs/iresearch/include/iresearch/formats/column/col_writer.cpp
+++ b/libs/iresearch/include/iresearch/formats/column/col_writer.cpp
@@ -232,6 +232,15 @@ void ColWriter::Commit(uint64_t target_row) {
                            SerializeNormColumn(obj, *norm_columns[i]);
                          });
                        });
+  if (const auto block_offsets =
+        _write_ctx ? _write_ctx->BlockOffsets() : std::span<const uint64_t>{};
+      !block_offsets.empty()) {
+    serializer.WriteList(kFooterSlotBlockOffsets, "block_offsets",
+                         block_offsets.size(),
+                         [&](duckdb::Serializer::List& list, duckdb::idx_t i) {
+                           list.WriteElement(block_offsets[i]);
+                         });
+  }
   serializer.End();
   _out->WriteU64(footer_offset);
   format_utils::WriteFooter(*_out);

--- a/libs/iresearch/include/iresearch/formats/column/internal/block_manager.hpp
+++ b/libs/iresearch/include/iresearch/formats/column/internal/block_manager.hpp
@@ -20,12 +20,14 @@
 
 #pragma once
 
+#include <cstdint>
 #include <duckdb/storage/block.hpp>
 #include <duckdb/storage/block_allocator.hpp>
 #include <duckdb/storage/block_manager.hpp>
 #include <duckdb/storage/buffer_manager.hpp>
 #include <duckdb/storage/metadata/metadata_manager.hpp>
 #include <duckdb/storage/storage_info.hpp>
+#include <limits>
 
 namespace duckdb {
 
@@ -33,6 +35,14 @@ class DatabaseInstance;
 
 }  // namespace duckdb
 namespace irs {
+
+// Overflow-block ids are logical handles resolved through a footer id->offset
+// table (compressors flush blocks out of allocation order); the bias keeps
+// them disjoint from ReadContext's dense RegisterColBlock ids.
+inline constexpr duckdb::block_id_t kColBlockIdBias = duckdb::block_id_t{1}
+                                                      << 40;
+inline constexpr uint64_t kColBlockUnwritten =
+  std::numeric_limits<uint64_t>::max();
 
 class BlockManager : public duckdb::BlockManager {
  public:

--- a/libs/iresearch/include/iresearch/formats/column/internal/write_context.cpp
+++ b/libs/iresearch/include/iresearch/formats/column/internal/write_context.cpp
@@ -33,18 +33,15 @@ WriteContext::WriteContext(duckdb::DatabaseInstance& db, IndexOutput& out)
 WriteContext::~WriteContext() = default;
 
 duckdb::block_id_t WriteContext::GetFreeBlockId() {
-  const auto cursor = static_cast<duckdb::block_id_t>(_out->Position());
-  if (_next_id < cursor) {
-    _next_id = cursor;
-  }
-  const auto id = _next_id;
-  _next_id += static_cast<duckdb::block_id_t>(GetBlockAllocSize());
+  const auto id =
+    kColBlockIdBias + static_cast<duckdb::block_id_t>(_block_offsets.size());
+  _block_offsets.push_back(kColBlockUnwritten);
   return id;
 }
 
 duckdb::block_id_t WriteContext::PeekFreeBlockId() {
-  const auto cursor = static_cast<duckdb::block_id_t>(_out->Position());
-  return _next_id < cursor ? cursor : _next_id;
+  return kColBlockIdBias +
+         static_cast<duckdb::block_id_t>(_block_offsets.size());
 }
 
 void WriteContext::Write(duckdb::FileBuffer& block,
@@ -55,10 +52,18 @@ void WriteContext::Write(duckdb::FileBuffer& block,
 void WriteContext::Write(duckdb::QueryContext /*context*/,
                          duckdb::FileBuffer& block,
                          duckdb::block_id_t block_id) {
-  const auto cursor = static_cast<duckdb::block_id_t>(_out->Position());
-  SDB_ENSURE(cursor == block_id,
-             "WriteContext::Write out-of-order: cursor=", cursor,
-             " expected=", block_id);
+  SDB_ENSURE(block_id >= kColBlockIdBias,
+             "WriteContext::Write: foreign block id ", block_id);
+  const auto idx = static_cast<uint64_t>(block_id - kColBlockIdBias);
+  SDB_ENSURE(idx < _block_offsets.size(),
+             "WriteContext::Write: unallocated block id ", block_id);
+  SDB_ENSURE(_block_offsets[idx] == kColBlockUnwritten,
+             "WriteContext::Write: block ", block_id, " written twice");
+  if (const uint64_t misalign = _out->Position() % 8; misalign != 0) {
+    static constexpr byte_type kPad[8]{};
+    _out->WriteData(kPad, 8 - misalign);
+  }
+  _block_offsets[idx] = _out->Position();
   _out->WriteData(reinterpret_cast<const byte_type*>(block.InternalBuffer()),
                   block.AllocSize());
 }
@@ -89,7 +94,7 @@ void WriteContext::WriteHeader(duckdb::QueryContext /*context*/,
 }
 
 duckdb::idx_t WriteContext::TotalBlocks() {
-  return static_cast<duckdb::idx_t>(_next_id / GetBlockAllocSize());
+  return static_cast<duckdb::idx_t>(_block_offsets.size());
 }
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/formats/column/internal/write_context.hpp
+++ b/libs/iresearch/include/iresearch/formats/column/internal/write_context.hpp
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <span>
+#include <vector>
+
 #include "iresearch/formats/column/internal/block_manager.hpp"
 #include "iresearch/store/data_output.hpp"
 #include "iresearch/types.hpp"
@@ -43,6 +47,10 @@ class WriteContext final : public BlockManager {
 
   IndexOutput& Out() noexcept { return *_out; }
 
+  std::span<const uint64_t> BlockOffsets() const noexcept {
+    return _block_offsets;
+  }
+
   duckdb::block_id_t GetFreeBlockId() final;
   duckdb::block_id_t PeekFreeBlockId() final;
   void Write(duckdb::FileBuffer& block, duckdb::block_id_t block_id) final;
@@ -62,7 +70,7 @@ class WriteContext final : public BlockManager {
 
  private:
   IndexOutput* _out;
-  duckdb::block_id_t _next_id = 0;
+  std::vector<uint64_t> _block_offsets;
 };
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/formats/column/read_context.cpp
+++ b/libs/iresearch/include/iresearch/formats/column/read_context.cpp
@@ -63,11 +63,12 @@ void AdviseWillNeed(const duckdb::MemoryMappedFile& mapping, uint64_t offset,
 }  // namespace
 
 ReadContext::ReadContext(duckdb::DatabaseInstance& db) noexcept
-  : BlockManager{db, /*block_header_size=*/0} {}
+  : BlockManager{db, duckdb::Storage::DEFAULT_BLOCK_HEADER_SIZE} {}
 
 ReadContext::ReadContext(const ColReader& reader)
   : ReadContext{reader.Database()} {
   _in = reader.ReopenIn();
+  _block_offsets = reader.BlockOffsets();
   ResetMapping();
 }
 
@@ -87,6 +88,7 @@ void ReadContext::Reset(const ColReader& reader) {
              "ReadContext::Reset: Database mismatch");
   SDB_ASSERT(_live_handles == 0, "ReadContext::Reset with live block handles");
   _in = reader.ReopenIn();
+  _block_offsets = reader.BlockOffsets();
   ResetMapping();
 }
 
@@ -113,8 +115,10 @@ duckdb::shared_ptr<duckdb::BlockHandle> ReadContext::RegisterColBlock(
 }
 
 void ReadContext::UnregisterBlock(duckdb::block_id_t id) {
-  SDB_ASSERT(_live_handles != 0);
-  --_live_handles;
+  if (id < kColBlockIdBias) {
+    SDB_ASSERT(_live_handles != 0);
+    --_live_handles;
+  }
   duckdb::BlockManager::UnregisterBlock(id);
 }
 
@@ -131,6 +135,23 @@ duckdb::unique_ptr<duckdb::Block> ReadContext::CreateBlock(
 }
 
 void ReadContext::Read(duckdb::QueryContext context, duckdb::Block& block) {
+  if (block.id >= kColBlockIdBias) {
+    const auto idx = static_cast<size_t>(block.id - kColBlockIdBias);
+    SDB_ENSURE(idx < _block_offsets.size() && _in,
+               "ReadContext::Read: unregistered overflow block ", block.id);
+    const auto offset = _block_offsets[idx];
+    SDB_ENSURE(offset != kColBlockUnwritten,
+               "ReadContext::Read: overflow block ", block.id,
+               " was never written");
+    const auto size = block.AllocSize();
+    if (_mapping && offset + size <= _mapping->Size()) {
+      block.Read(context, *_mapping, offset);
+      AdviseWillNeed(*_mapping, offset, size);
+      return;
+    }
+    _in->ReadData(offset, block.InternalBuffer(), size);
+    return;
+  }
   const auto id = static_cast<size_t>(block.id);
   SDB_ENSURE(id < _ranges.size() && _in,
              "ReadContext::Read: unregistered block ", block.id);

--- a/libs/iresearch/include/iresearch/formats/column/read_context.hpp
+++ b/libs/iresearch/include/iresearch/formats/column/read_context.hpp
@@ -20,7 +20,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <duckdb/common/memory_mapped_file.hpp>
+#include <span>
 #include <vector>
 
 #include "iresearch/formats/column/internal/block_manager.hpp"
@@ -53,6 +55,10 @@ class ReadContext final : public BlockManager {
   const IndexInput& In() const noexcept { return *_in; }
   bool HasIn() const noexcept { return _in != nullptr; }
 
+  void SetBlockOffsets(std::span<const uint64_t> offsets) noexcept {
+    _block_offsets = offsets;
+  }
+
   duckdb::shared_ptr<duckdb::BlockHandle> RegisterColBlock(uint64_t offset,
                                                            uint64_t size);
 
@@ -82,6 +88,7 @@ class ReadContext final : public BlockManager {
   IndexInput::ptr _in;
   duckdb::unique_ptr<duckdb::MemoryMappedFile> _mapping;
   std::vector<std::pair<uint64_t, uint64_t>> _ranges;
+  std::span<const uint64_t> _block_offsets;
   size_t _live_handles = 0;
 };
 

--- a/tests/libs/iresearch/formats/column/column_reader_test.cpp
+++ b/tests/libs/iresearch/formats/column/column_reader_test.cpp
@@ -2454,4 +2454,75 @@ TEST_F(ColumnReaderTest, VectorColumnForcedUncompressed) {
   }
 }
 
+// zstd streams a row group across many 256KiB overflow pages and flushes them
+// out of allocation order (a page holding a vector's string-length metadata is
+// held back until the vector completes while later data pages flush first).
+// Regression for github issue #970: the writer asserted on the out-of-order
+// flush and CREATE INDEX ... INCLUDE crashed on code-sized VARCHAR corpora.
+TEST_F(ColumnReaderTest, ZstdMultiPageOverflowBlocks) {
+  constexpr uint64_t kRows = 6000;
+  constexpr uint32_t kRgSize = 8192;
+  constexpr irs::field_id kS = 3;
+
+  auto s_val = [](uint64_t g) {
+    std::string out;
+    out.reserve(2100);
+    uint64_t x = g * 6364136223846793005ULL + 1442695040888963407ULL;
+    while (out.size() < 2048) {
+      x ^= x >> 33;
+      x *= 0xff51afd7ed558ccdULL;
+      x ^= x >> 33;
+      out += std::to_string(x);
+      out += ' ';
+    }
+    return out;
+  };
+
+  irs::MemoryDirectory dir{};
+  {
+    irs::ColWriter w{dir, "seg", Db()};
+    auto& cwS = w.OpenColumn(kS, duckdb::LogicalType::VARCHAR,
+                             /*skip_validity=*/false, kRgSize,
+                             duckdb::CompressionType::COMPRESSION_ZSTD);
+    uint64_t pos = 0;
+    while (pos < kRows) {
+      const auto take =
+        std::min<duckdb::idx_t>(kRows - pos, STANDARD_VECTOR_SIZE);
+      duckdb::Vector v{duckdb::LogicalType::VARCHAR, STANDARD_VECTOR_SIZE};
+      auto* d = duckdb::FlatVector::GetDataMutable<duckdb::string_t>(v);
+      for (duckdb::idx_t k = 0; k < take; ++k) {
+        d[k] = duckdb::StringVector::AddString(v, s_val(pos + k));
+      }
+      duckdb::FlatVector::SetSize(v, take);
+      cwS.Append(v, take);
+      pos += take;
+    }
+    w.Commit(0);
+  }
+
+  irs::ColReader r{dir, "seg", Db()};
+  ASSERT_FALSE(r.BlockOffsets().empty());
+  const auto* cs = r.Column(kS);
+  ASSERT_NE(cs, nullptr);
+  ASSERT_EQ(cs->RowCount(), kRows);
+
+  auto state = cs->InitScan(r.Ctx());
+  uint64_t pos = 0;
+  while (pos < kRows) {
+    const auto take =
+      std::min<duckdb::idx_t>(kRows - pos, STANDARD_VECTOR_SIZE);
+    duckdb::Vector result{duckdb::LogicalType::VARCHAR, STANDARD_VECTOR_SIZE};
+    cs->Scan(state, result, take);
+    result.Flatten(take);
+    const auto* rd = duckdb::FlatVector::GetData<duckdb::string_t>(result);
+    const auto& rv = duckdb::FlatVector::Validity(result);
+    for (duckdb::idx_t k = 0; k < take; ++k) {
+      const auto g = pos + k;
+      ASSERT_TRUE(rv.RowIsValid(k)) << "row " << g;
+      EXPECT_EQ(rd[k].GetString(), s_val(g)) << "row " << g;
+    }
+    pos += take;
+  }
+}
+
 }  // namespace

--- a/tests/sqllogic/sdb/pg/index/inverted_index_include_zstd_multipage.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_include_zstd_multipage.test
@@ -1,0 +1,59 @@
+# Regression for github issue #970: CREATE INDEX ... INCLUDE crashed the
+# server on code-sized VARCHAR corpora when the included column compressed
+# with zstd.
+#
+# zstd streams a row group across many 256KiB overflow pages through the
+# BlockManager and flushes them out of allocation order: a page holding a
+# vector's string-length metadata is held back until the vector completes
+# while later data pages flush first. The columnstore WriteContext asserted
+# on the out-of-order flush ("WriteContext::Write out-of-order") -- an
+# InternalError on release builds and an abort on debug builds. Overflow
+# block ids are now logical handles resolved through a footer id->offset
+# table, so flush order no longer matters.
+#
+# The bodies must be large (multi-KB) and poorly compressible so one zstd
+# vector (2048 rows) spans several 256KiB pages: md5 hex garbage, ~2KB per
+# row, >2048 rows so at least one vector's string-length metadata lands on
+# an overflow page rather than the segment page.
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY zstd_mp_dict(
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true
+);
+
+statement ok
+CREATE TABLE zstd_mp_src AS
+SELECT 'src/file_' || i || '.c' AS path,
+       (SELECT string_agg(md5((i * 100 + j)::VARCHAR), ' ')
+        FROM generate_series(1, 60) g(j)) AS content
+FROM generate_series(1, 3000) t(i);
+
+statement ok
+CREATE INDEX zstd_mp_idx ON zstd_mp_src USING inverted(content zstd_mp_dict)
+  INCLUDE (path, content included (compression = 'zstd'));
+
+# Whole corpus is indexed.
+query
+SELECT count(*) AS n FROM zstd_mp_idx;
+----
+n
+3000
+
+# The included content materialises byte-for-byte from the index columnstore.
+query
+SELECT count(*) AS mismatches
+FROM zstd_mp_idx i
+JOIN zstd_mp_src s ON i.path = s.path
+WHERE i.content IS DISTINCT FROM s.content;
+----
+mismatches
+0
+
+# Full-text search still resolves and returns the covering columns.
+query
+SELECT path, length(content) AS len FROM zstd_mp_idx
+WHERE content @@ md5('101');
+----
+path	len
+src/file_1.c	1979


### PR DESCRIPTION
## Problem

Fixes #970.

`CREATE INDEX ... USING inverted (...) INCLUDE (path, content)` on code-sized VARCHAR corpora (multi-KB..MB bodies, e.g. a Linux source tree) failed or crashed the server:

- release builds: `InternalError: WriteContext::Write out-of-order: cursor=... expected=...`
- debug builds: hard abort (customer-observed "server closed the connection unexpectedly")

Reproduced locally with ~6000 rows of ~2KB incompressible text and `INCLUDE (content included (compression = 'zstd'))` — deterministic abort in `WriteContext::Write` via `ZSTDCompressionState::GetExtraPageBuffer → FlushPage`.

## Root cause

DuckDB's zstd compression streams a row group across many 256KiB overflow pages through the `BlockManager` and legitimately flushes them **out of allocation order**: the page holding a vector's string-length metadata is held back (`CanFlush() == false`) until the vector completes, while later-allocated data pages flush first. That is fine on DuckDB's random-access block manager, but the columnstore `WriteContext` is an append-only stream over an `IndexOutput` that treated block ids as file offsets and asserted `cursor == block_id` on every write.

Small corpora never hit this: everything fits on the segment page and no overflow pages exist, which is why the smoke-scale `INCLUDE` worked.

The read side was also unprepared for these blocks: `ReadContext::Read` threw "unregistered block" for any id outside its dense range table, and its block-header size (0) disagreed with the writer's (8), which would have shifted every multi-page read by 8 bytes even if writes had succeeded.

## Fix

- Block ids handed to compressors are now **logical handles** (biased by `1<<40` so they can never collide with `ReadContext`'s dense `RegisterColBlock` ids). `WriteContext::Write` appends each block wherever the output cursor is (8-aligned) and records an id→offset table.
- `ColWriter::Commit` persists that table in a new **optional footer slot** (`kFooterSlotBlockOffsets = 102`, written only when non-empty). `ColReader` loads it via `ReadOptionalList`; old `.col` files lack the slot and contain no overflow blocks, so they read unchanged.
- `ReadContext` resolves biased ids through the table (mmap fast path included) and now uses the same block-header size as `WriteContext`, so write- and read-side `GetBlockSize()` agree.

## Validation

- New gtest `ColumnReaderTest.ZstdMultiPageOverflowBlocks` (write + full read-back of a multi-page forced-zstd VARCHAR column) — aborted before the fix, passes now.
- New sqllogic test `inverted_index_include_zstd_multipage.test` (end-to-end `CREATE INDEX ... INCLUDE (content zstd)` on a ~6MB corpus, byte-for-byte materialisation + `@@` search).
- `ColumnReaderTest.*` (40), `IndexColumn*` (26), formats suites, `*Merge*` (74) — all pass.
- sqllogic `index/*.test` suite: 390/390 on both Debug and Release builds; recovery suite 161/161.
- Manual: issue-970 repro (forced zstd and auto codec) on Debug + Release, including server restart durability, ~1.4MB max file bodies, and post-index DML + `VACUUM (REFRESH_TABLE)` — index content matches the base table byte-for-byte in every case.