### PR TITLE
fix: wildcard tokenizer store for LIST/ARRAY values

### DIFF
--- a/libs/iresearch/include/iresearch/analysis/wildcard_analyzer.cpp
+++ b/libs/iresearch/include/iresearch/analysis/wildcard_analyzer.cpp
@@ -62,12 +62,19 @@ Attribute* WildcardAnalyzer::GetMutable(TypeInfo::type_id type) noexcept {
   return _ngram->GetMutable(type);
 }
 
+void WildcardAnalyzer::ClearStore() noexcept {
+  _terms.clear();
+  _terms_begin = begin();
+  _terms_end = _terms_begin;
+  _store.value = {};
+}
+
 bool WildcardAnalyzer::reset(std::string_view data) {
   _ngram->reset({});
   if (!_analyzer->reset(data)) {
     return false;
   }
-  _terms.clear();
+  const auto begin_offset = _terms.size();
   while (_analyzer->next()) {
     auto size = _term->value.size();
     if (size > std::numeric_limits<int32_t>::max()) {
@@ -82,8 +89,8 @@ bool WildcardAnalyzer::reset(std::string_view data) {
     auto* data = begin() + idx;
     WriteVarint<uint32_t>(static_cast<uint32_t>(size), data);
   }
-  _terms_begin = begin();
-  _terms_end = _terms_begin + _terms.size();
+  _terms_begin = begin() + begin_offset;
+  _terms_end = begin() + _terms.size();
   _store.value = ViewCast<byte_type>(std::string_view{_terms});
   return _terms_begin != _terms_end;
 }

--- a/libs/iresearch/include/iresearch/analysis/wildcard_analyzer.hpp
+++ b/libs/iresearch/include/iresearch/analysis/wildcard_analyzer.hpp
@@ -55,6 +55,8 @@ class WildcardAnalyzer final : public TypedAnalyzer<WildcardAnalyzer>,
 
   bool reset(std::string_view data) final;
 
+  void ClearStore() noexcept;
+
   bool next() final;
 
   auto& ngram() const noexcept {

--- a/libs/iresearch/include/iresearch/search/filter.cpp
+++ b/libs/iresearch/include/iresearch/search/filter.cpp
@@ -24,6 +24,8 @@
 
 #include "basics/singleton.hpp"
 #include "iresearch/index/index_reader.hpp"
+#include "pg/errcodes.h"
+#include "pg/sql_exception_macro.h"
 
 namespace irs {
 namespace {
@@ -71,6 +73,16 @@ TermIterator::ptr Filter::CompileTermIterator(const TermReader& reader) const {
 QueryBuilder::ptr Empty::PrepareSegment(const SubReader&,
                                         const PrepareContext&) const {
   return QueryBuilder::Empty();
+}
+
+void ThrowMissingTokenizerStore(irs::field_id store_field_id) {
+  THROW_SQL_ERROR(
+    ERR_CODE(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+    ERR_MSG("inverted index segment has indexed terms for a tokenizer that "
+            "requires a stored-token column, but column id ",
+            store_field_id, " is missing from the segment"),
+    ERR_HINT("The index was written without the tokenizer store. Rebuild it "
+             "with REINDEX."));
 }
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/filter.hpp
+++ b/libs/iresearch/include/iresearch/search/filter.hpp
@@ -204,4 +204,6 @@ struct FilterVisitor;
 using field_visitor =
   absl::AnyInvocable<void(const SubReader&, const TermReader&, FilterVisitor&)>;
 
+[[noreturn]] void ThrowMissingTokenizerStore(irs::field_id store_field_id);
+
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/geo_filter.cpp
+++ b/libs/iresearch/include/iresearch/search/geo_filter.cpp
@@ -533,7 +533,7 @@ GeoState PrepareState(const SubReader& segment, const PrepareContext& ctx,
   }
   const auto* stored_field = segment.Column(store_field_id);
   if (!stored_field) {
-    return state;
+    ThrowMissingTokenizerStore(store_field_id);
   }
   auto terms = reader->iterator(SeekMode::NORMAL);
   if (!terms) [[unlikely]] {

--- a/libs/iresearch/include/iresearch/search/wildcard_ngram_filter.cpp
+++ b/libs/iresearch/include/iresearch/search/wildcard_ngram_filter.cpp
@@ -41,6 +41,8 @@
 #include "iresearch/search/prefix_filter.hpp"
 #include "iresearch/search/term_filter.hpp"
 #include "iresearch/utils/bytes_utils.hpp"
+#include "pg/errcodes.h"
+#include "pg/sql_exception_macro.h"
 
 namespace irs {
 namespace {
@@ -174,12 +176,10 @@ class WildcardQuery : public QueryBuilder {
     }
     SDB_ASSERT(irs::field_limits::valid(_store_field_id));
     const auto* col_reader = _segment.GetColReader();
-    if (!col_reader) {
-      return DocIterator::empty();
-    }
-    const auto* column = col_reader->Column(_store_field_id);
+    const auto* column =
+      col_reader ? col_reader->Column(_store_field_id) : nullptr;
     if (!column) {
-      return DocIterator::empty();
+      ThrowMissingTokenizerStore(_store_field_id);
     }
     return memory::make_managed<WildcardIterator>(_matcher, std::move(approx),
                                                   *column, *col_reader);

--- a/server/connector/search_sink_writer.cpp
+++ b/server/connector/search_sink_writer.cpp
@@ -26,6 +26,7 @@
 #include <duckdb/common/vector/struct_vector.hpp>
 #include <iresearch/analysis/geo_analyzer.hpp>
 #include <iresearch/analysis/tokenizers.hpp>
+#include <iresearch/analysis/wildcard_analyzer.hpp>
 
 #include "basics/assert.h"
 #include "basics/down_cast.h"
@@ -41,6 +42,15 @@ namespace {
 constexpr size_t kDefaultPoolSize = 8;  // arbitrary value
 
 using StreamPool = irs::UnboundedObjectPool<search::AnalyzerImpl::Builder>;
+
+irs::analysis::WildcardAnalyzer* AsAccumulatingStore(
+  const catalog::Tokenizer::TokenizerWrapper& analyzer) {
+  if (!analyzer ||
+      analyzer->type() != irs::Type<irs::analysis::WildcardAnalyzer>::id()) {
+    return nullptr;
+  }
+  return &basics::downCast<irs::analysis::WildcardAnalyzer>(*analyzer);
+}
 
 }  // namespace
 
@@ -148,9 +158,13 @@ void SearchSinkInsertBaseImpl::WriteScalarBatch(
   auto* store_writer = irs::field_limits::valid(tokenizer_column)
                          ? EnsurePerRowBlobWriter(tokenizer_column)
                          : nullptr;
+  auto* accumulating_store = AsAccumulatingStore(_field.string_analyzer);
   _document->NextFieldBatch();
 
   for (duckdb::idx_t i = 0; i < count; ++i) {
+    if (accumulating_store) {
+      accumulating_store->ClearStore();
+    }
     if constexpr (Kind == duckdb::LogicalTypeId::SQLNULL) {
       _null_field.SetNullValue();
       EmitField(&_null_field);
@@ -174,13 +188,22 @@ void SearchSinkInsertBaseImpl::WriteScalarBatch(
 
 template<duckdb::LogicalTypeId ChildKind>
 void SearchSinkInsertBaseImpl::WriteListBatch(duckdb::idx_t count,
-                                              duckdb::idx_t array_size) {
+                                              duckdb::idx_t array_size,
+                                              irs::field_id tokenizer_column) {
   SDB_ASSERT(_document);
+  auto* store_writer = irs::field_limits::valid(tokenizer_column)
+                         ? EnsurePerRowBlobWriter(tokenizer_column)
+                         : nullptr;
+  const auto* store_attr = store_writer ? _field.store_attr : nullptr;
+  auto* accumulating_store = AsAccumulatingStore(_field.string_analyzer);
   _document->NextFieldBatch();
 
   const auto& parent_fmt = _vec_fmt.unified;
   const auto& child_fmt = _vec_fmt.children[0].unified;
   for (duckdb::idx_t i = 0; i < count; ++i) {
+    if (accumulating_store) {
+      accumulating_store->ClearStore();
+    }
     const auto parent_idx = parent_fmt.sel->get_index(i);
     if (!parent_fmt.validity.RowIsValid(parent_idx)) {
       InsertNullValue();
@@ -213,6 +236,10 @@ void SearchSinkInsertBaseImpl::WriteListBatch(duckdb::idx_t count,
       }
     }
 
+    if (store_attr && !irs::IsNull(store_attr->value) &&
+        !store_attr->value.empty()) {
+      AppendBlobTo(*store_writer, store_attr->value);
+    }
     _document->NextDocument();
   }
 }
@@ -301,74 +328,74 @@ bool SearchSinkInsertBaseImpl::DispatchScalarBatch(
 
 bool SearchSinkInsertBaseImpl::DispatchListBatch(
   duckdb::LogicalTypeId child_kind, duckdb::idx_t count,
-  duckdb::idx_t array_size) {
+  duckdb::idx_t array_size, irs::field_id tokenizer_column) {
   using enum duckdb::LogicalTypeId;
   switch (child_kind) {
     case VARCHAR:
-      WriteListBatch<VARCHAR>(count, array_size);
+      WriteListBatch<VARCHAR>(count, array_size, tokenizer_column);
       return true;
     case BLOB:
-      WriteListBatch<BLOB>(count, array_size);
+      WriteListBatch<BLOB>(count, array_size, tokenizer_column);
       return true;
     case BOOLEAN:
-      WriteListBatch<BOOLEAN>(count, array_size);
+      WriteListBatch<BOOLEAN>(count, array_size, tokenizer_column);
       return true;
     case TINYINT:
-      WriteListBatch<TINYINT>(count, array_size);
+      WriteListBatch<TINYINT>(count, array_size, tokenizer_column);
       return true;
     case SMALLINT:
-      WriteListBatch<SMALLINT>(count, array_size);
+      WriteListBatch<SMALLINT>(count, array_size, tokenizer_column);
       return true;
     case INTEGER:
-      WriteListBatch<INTEGER>(count, array_size);
+      WriteListBatch<INTEGER>(count, array_size, tokenizer_column);
       return true;
     case DATE:
-      WriteListBatch<DATE>(count, array_size);
+      WriteListBatch<DATE>(count, array_size, tokenizer_column);
       return true;
     case BIGINT:
-      WriteListBatch<BIGINT>(count, array_size);
+      WriteListBatch<BIGINT>(count, array_size, tokenizer_column);
       return true;
     case UTINYINT:
-      WriteListBatch<UTINYINT>(count, array_size);
+      WriteListBatch<UTINYINT>(count, array_size, tokenizer_column);
       return true;
     case USMALLINT:
-      WriteListBatch<USMALLINT>(count, array_size);
+      WriteListBatch<USMALLINT>(count, array_size, tokenizer_column);
       return true;
     case UINTEGER:
-      WriteListBatch<UINTEGER>(count, array_size);
+      WriteListBatch<UINTEGER>(count, array_size, tokenizer_column);
       return true;
     case TIME:
-      WriteListBatch<TIME>(count, array_size);
+      WriteListBatch<TIME>(count, array_size, tokenizer_column);
       return true;
     case TIME_TZ:
-      WriteListBatch<TIME_TZ>(count, array_size);
+      WriteListBatch<TIME_TZ>(count, array_size, tokenizer_column);
       return true;
     case TIME_NS:
-      WriteListBatch<TIME_NS>(count, array_size);
+      WriteListBatch<TIME_NS>(count, array_size, tokenizer_column);
       return true;
     case TIMESTAMP:
-      WriteListBatch<TIMESTAMP>(count, array_size);
+      WriteListBatch<TIMESTAMP>(count, array_size, tokenizer_column);
       return true;
     case TIMESTAMP_TZ:
-      WriteListBatch<TIMESTAMP_TZ>(count, array_size);
+      WriteListBatch<TIMESTAMP_TZ>(count, array_size, tokenizer_column);
       return true;
     case TIMESTAMP_SEC:
-      WriteListBatch<TIMESTAMP_SEC>(count, array_size);
+      WriteListBatch<TIMESTAMP_SEC>(count, array_size, tokenizer_column);
       return true;
     case TIMESTAMP_MS:
-      WriteListBatch<TIMESTAMP_MS>(count, array_size);
+      WriteListBatch<TIMESTAMP_MS>(count, array_size, tokenizer_column);
       return true;
     case TIMESTAMP_NS:
-      WriteListBatch<TIMESTAMP_NS>(count, array_size);
+      WriteListBatch<TIMESTAMP_NS>(count, array_size, tokenizer_column);
       return true;
     case TIMESTAMP_TZ_NS:
-      WriteListBatch<TIMESTAMP_TZ_NS>(count, array_size);
+      WriteListBatch<TIMESTAMP_TZ_NS>(count, array_size, tokenizer_column);
       return true;
     case FLOAT:
-      WriteListBatch<FLOAT>(count, array_size);
+      WriteListBatch<FLOAT>(count, array_size, tokenizer_column);
       return true;
     case DOUBLE:
-      WriteListBatch<DOUBLE>(count, array_size);
+      WriteListBatch<DOUBLE>(count, array_size, tokenizer_column);
       return true;
     default:
       return false;
@@ -387,8 +414,13 @@ void SearchSinkInsertBaseImpl::WriteJsonBatch(const duckdb::Vector& vec,
   const bool has_store = irs::field_limits::valid(jpf.tokenizer_column);
   auto* store_writer =
     has_store ? EnsurePerRowBlobWriter(jpf.tokenizer_column) : nullptr;
+  auto* accumulating_store =
+    AsAccumulatingStore(jpf.string_field.string_analyzer);
 
   for (duckdb::idx_t i = 0; i < count; ++i) {
+    if (accumulating_store) {
+      accumulating_store->ClearStore();
+    }
     const auto sel_idx = fmt.sel->get_index(i);
     const bool is_null = !fmt.validity.RowIsValid(sel_idx);
     bool wrote_string_blob = false;
@@ -527,9 +559,15 @@ void SearchSinkInsertBaseImpl::SwitchFieldImpl(irs::field_id field_id,
     const duckdb::idx_t array_size =
       (kind == duckdb::LogicalTypeId::ARRAY ? duckdb::ArrayType::GetSize(type)
                                             : 0);
+    irs::field_id list_tokenizer_column = irs::field_limits::invalid();
     if (child_kind == duckdb::LogicalTypeId::VARCHAR ||
         child_kind == duckdb::LogicalTypeId::BLOB) {
-      _field.PrepareForStringValue(resolve_tokenizer());
+      auto tokenizer = resolve_tokenizer();
+      list_tokenizer_column = tokenizer.tokenizer_column;
+      _field.PrepareForStringValue(std::move(tokenizer));
+      if (!_field.store_attr) {
+        list_tokenizer_column = irs::field_limits::invalid();
+      }
     } else if (child_kind == duckdb::LogicalTypeId::BOOLEAN) {
       _field.PrepareForBooleanValue();
     } else if (catalog::term_dict::IsNumeric(
@@ -542,7 +580,7 @@ void SearchSinkInsertBaseImpl::SwitchFieldImpl(irs::field_id field_id,
     if (is_stored) {
       AppendToColumn(field_id, type, vec, count);
     }
-    DispatchListBatch(child_kind, count, array_size);
+    DispatchListBatch(child_kind, count, array_size, list_tokenizer_column);
     return;
   }
 

--- a/server/connector/search_sink_writer.hpp
+++ b/server/connector/search_sink_writer.hpp
@@ -208,13 +208,15 @@ class SearchSinkInsertBaseImpl {
   void WriteScalarBatch(duckdb::idx_t count, irs::field_id tokenizer_column);
 
   template<duckdb::LogicalTypeId ChildKind>
-  void WriteListBatch(duckdb::idx_t count, duckdb::idx_t array_size);
+  void WriteListBatch(duckdb::idx_t count, duckdb::idx_t array_size,
+                      irs::field_id tokenizer_column);
 
   bool DispatchScalarBatch(duckdb::LogicalTypeId kind, duckdb::idx_t count,
                            irs::field_id tokenizer_column);
 
   bool DispatchListBatch(duckdb::LogicalTypeId child_kind, duckdb::idx_t count,
-                         duckdb::idx_t array_size);
+                         duckdb::idx_t array_size,
+                         irs::field_id tokenizer_column);
 
   void WriteJsonBatch(const duckdb::Vector& vec, duckdb::idx_t count);
 

--- a/tests/sqllogic/sdb/pg/index/inverted_index_matrix_tokenizer_list_g17.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_matrix_tokenizer_list_g17.test
@@ -8,7 +8,11 @@ CREATE TEXT SEARCH DICTIONARY ng_dict(template = 'ngram', mingram = 2,
     maxgram = 3, preserveoriginal = false, frequency = true, position = true);
 
 statement ok
-CREATE TEXT SEARCH DICTIONARY any_text_dict(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true);
+CREATE TEXT SEARCH DICTIONARY any_text_dict(template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true)
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY wc_dict(template = 'wildcard', ngramsize = 3,
+    tokenizer_template = 'delimiter', tokenizer_delimiter = ' ');
 
 
 # ============================================================================
@@ -31,10 +35,24 @@ CREATE TEXT SEARCH DICTIONARY any_text_dict(template = 'text', locale = 'en_US.U
 #      implicit. g17 builds that entire matrix, plus implicit-path
 #      expression-source LIST<JSON>.
 #
-# Reuses existing dicts (kw_dict, ng_dict, any_text_dict) -- no new dict
-# declarations. All cells in g17 are validator-positive; the negative cells
-# (LIST<JSON> + tokenizer, LIST<GEOMETRY>) are already pinned by m_jl_*,
-# g1_reject_*, m_gl_*, g7_gl, and g7_ga.
+#  (3) wc_dict (template = 'wildcard') was missing from the grid entirely --
+#      the one tokenizer whose analyzer exposes a StoreAttr, so the one where
+#      the LIST/ARRAY write path has extra work to do (a per-row stored-token
+#      blob accumulated across the row's elements). It was absent precisely
+#      where it mattered most, and the store column went unwritten for list
+#      values until that was fixed.
+#
+#      wc_dict cells assert ts_like results rather than only count(*): a bare
+#      count over the index passes even when the store column is empty, since
+#      the n-gram postings are written either way and only the RE2 re-check
+#      against the store consumes it. Cell-level row counts are what let (1)
+#      and (2) miss this class of bug; do not add a wc_dict cell that only
+#      counts rows.
+#
+# Reuses kw_dict / ng_dict / any_text_dict and adds wc_dict. All cells in g17
+# are validator-positive; the negative cells (LIST<JSON> + tokenizer,
+# LIST<GEOMETRY>) are already pinned by m_jl_*, g1_reject_*, m_gl_*, g7_gl,
+# and g7_ga.
 # ============================================================================
 
 statement ok
@@ -194,6 +212,18 @@ statement ok
 CREATE INDEX g17_vla_va_expr_imp  ON g17_vla USING inverted(pk, (va));
 
 statement ok
+CREATE INDEX g17_vla_vs_col_wc    ON g17_vla USING inverted(pk, vs wc_dict);
+
+statement ok
+CREATE INDEX g17_vla_va_col_wc    ON g17_vla USING inverted(pk, va wc_dict);
+
+statement ok
+CREATE INDEX g17_vla_vs_expr_wc   ON g17_vla USING inverted(pk, (vs) wc_dict);
+
+statement ok
+CREATE INDEX g17_vla_va_expr_wc   ON g17_vla USING inverted(pk, (va) wc_dict);
+
+statement ok
 INSERT INTO g17_vla VALUES
     (1, ['alpha', 'beta'], ['alpha', 'beta', 'gamma']),
     (2, ['delta'],         ['delta', 'epsilon', 'zeta']);
@@ -255,6 +285,69 @@ SELECT count(*) FROM g17_vla_va_expr_imp;
 count
 2
 
+# wc_dict cells. Data is
+#   pk 1: vs = [alpha, beta],  va = [alpha, beta, gamma]
+#   pk 2: vs = [delta],        va = [delta, epsilon, zeta]
+# so '%lph%' hits element 0, '%psilo%' element 1 and '%amma' element 2 -- a
+# store blob that only carried the row's first element would miss the last two.
+
+query I
+SELECT pk FROM g17_vla_vs_col_wc WHERE vs @@ ts_like('%lph%') ORDER BY pk;
+----
+pk
+1
+
+query I
+SELECT pk FROM g17_vla_vs_col_wc WHERE vs @@ ts_like('%elt%') ORDER BY pk;
+----
+pk
+2
+
+query I
+SELECT pk FROM g17_vla_va_col_wc WHERE va @@ ts_like('%amma') ORDER BY pk;
+----
+pk
+1
+
+query I
+SELECT pk FROM g17_vla_va_col_wc WHERE va @@ ts_like('%psilo%') ORDER BY pk;
+----
+pk
+2
+
+# '%psilo%' is present in va but not in vs, so the two columns must disagree.
+query I
+SELECT pk FROM g17_vla_vs_col_wc WHERE vs @@ ts_like('%psilo%') ORDER BY pk;
+----
+pk
+
+query I
+SELECT pk FROM g17_vla_vs_expr_wc
+WHERE vs @@ ts_like('%lph%') ORDER BY pk;
+----
+pk
+1
+
+query I
+SELECT pk FROM g17_vla_va_expr_wc
+WHERE va @@ ts_like('%amma') ORDER BY pk;
+----
+pk
+1
+
+query I
+SELECT pk FROM g17_vla_va_expr_wc
+WHERE va @@ ts_like('%psilo%') ORDER BY pk;
+----
+pk
+2
+
+query I
+SELECT pk FROM g17_vla_va_expr_wc
+WHERE va @@ ts_like('%zzz%') ORDER BY pk;
+----
+pk
+
 
 # --- (b) ng_dict on LIST<BLOB>      column ---------------------------------
 # --- (c) ng_dict on ARRAY<BLOB, 3>  column ---------------------------------
@@ -292,6 +385,15 @@ CREATE INDEX g17_bla_ba_expr_at   ON g17_bla USING inverted(pk, (ba) any_text_di
 
 statement ok
 CREATE INDEX g17_bla_bs_expr_imp  ON g17_bla USING inverted(pk, (bs));
+
+statement ok
+CREATE INDEX g17_bla_bs_col_wc    ON g17_bla USING inverted(pk, bs wc_dict);
+
+statement ok
+CREATE INDEX g17_bla_ba_col_wc    ON g17_bla USING inverted(pk, ba wc_dict);
+
+statement ok
+CREATE INDEX g17_bla_bs_expr_wc   ON g17_bla USING inverted(pk, (bs) wc_dict);
 
 statement ok
 INSERT INTO g17_bla VALUES
@@ -355,6 +457,38 @@ SELECT count(*) FROM g17_bla_bs_expr_imp;
 count
 2
 
+# wc_dict on BLOB lists. bs pk 1 = [hello, world] so '%orl%' is element 1;
+# ba pk 2 = [ddd, eee, fff] so '%fff%' is element 2.
+
+query I
+SELECT pk FROM g17_bla_bs_col_wc WHERE bs @@ ts_like('%orl%') ORDER BY pk;
+----
+pk
+1
+
+query I
+SELECT pk FROM g17_bla_bs_col_wc WHERE bs @@ ts_like('%adbee%') ORDER BY pk;
+----
+pk
+2
+
+query I
+SELECT pk FROM g17_bla_ba_col_wc WHERE ba @@ ts_like('%fff%') ORDER BY pk;
+----
+pk
+2
+
+query I
+SELECT pk FROM g17_bla_bs_expr_wc WHERE bs @@ ts_like('%orl%') ORDER BY pk;
+----
+pk
+1
+
+query I
+SELECT pk FROM g17_bla_bs_expr_wc WHERE bs @@ ts_like('%zzz%') ORDER BY pk;
+----
+pk
+
 
 # --- (z) implicit (no opclass) LIST<JSON> expression source -----------------
 # Mirrors g7_jl_imp on the column side; this is the expression-source twin.
@@ -405,3 +539,6 @@ DROP TEXT SEARCH DICTIONARY ng_dict;
 
 statement ok
 DROP TEXT SEARCH DICTIONARY any_text_dict;
+
+statement ok
+DROP TEXT SEARCH DICTIONARY wc_dict;

--- a/tests/sqllogic/sdb/pg/index/inverted_index_wildcard_list.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_wildcard_list.test
@@ -1,0 +1,183 @@
+hash-threshold 100
+control substitution on
+
+# ts_like on a LIST/ARRAY-typed indexed column or indexed expression backed by
+# a `template = 'wildcard'` dictionary.
+#
+# ByWildcardNgram is an approximate n-gram match plus an exact RE2 re-check
+# against the tokenizer store column (the analyzer's StoreAttr, one blob per
+# row holding every base token of that row). SwitchFieldImpl used to compute
+# that store column only on the scalar path: the LIST/ARRAY branch called
+# DispatchListBatch without a tokenizer column, so nothing was ever written.
+# WildcardQuery::Execute then found no store column and returned an empty
+# iterator, so every ts_like against a list-typed wildcard field answered
+# zero rows -- silently, since a missing store reads the same as a non-match.
+# The n-gram postings themselves were always correct, which is why ts_any on
+# a raw n-gram still matched.
+#
+# A row now accumulates the per-element store blobs into one per-row blob.
+# The encoding is self-delimiting ([varint len][marker][bytes][marker] per
+# token), so concatenating a row's elements is exactly what
+# WildcardIterator::Check decodes.
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY wc_list_dict(
+    template = 'wildcard',
+    ngramsize = 3,
+    tokenizer_template = 'delimiter',
+    tokenizer_delimiter = ' '
+)
+
+# --- LIST column -----------------------------------------------------------
+
+statement ok
+CREATE TABLE wc_list_t (id BIGINT PRIMARY KEY, tags VARCHAR[])
+
+statement ok
+INSERT INTO wc_list_t VALUES
+    (1, ['search', 'alpha']),
+    (2, ['research']),
+    (3, ['seabird']),
+    (4, ['plain']),
+    (5, NULL)
+
+statement ok
+CREATE INDEX wc_list_idx ON wc_list_t
+    USING inverted(id, tags wc_list_dict)
+    INCLUDE (id, tags)
+
+# Infix hits both elements of a multi-element row and a single-element row.
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('%ear%') ORDER BY id
+----
+id
+1
+2
+
+# A later element of a multi-element row is reachable: 'alpha' is element 1
+# of row 1, so the per-row store blob must carry more than the first token.
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('%pha') ORDER BY id
+----
+id
+1
+
+# Prefix patterns lower to ByPrefix and never touch the store column, so they
+# were already correct -- pinned here so the two paths stay in agreement.
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('sea%') ORDER BY id
+----
+id
+1
+3
+
+# An n-gram that exists but whose full token fails the RE2 re-check must not
+# leak through: 'sea' matches row 3's trigrams, 'seab%rd' does not match
+# 'search'.
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('seab%rd') ORDER BY id
+----
+id
+3
+
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('%zzz%') ORDER BY id
+----
+id
+
+# NULL rows carry no store blob and match nothing, including '%'.
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('%ai%') ORDER BY id
+----
+id
+4
+
+# --- ARRAY column ----------------------------------------------------------
+
+statement ok
+CREATE TABLE wc_arr_t (id BIGINT PRIMARY KEY, tags VARCHAR[2])
+
+statement ok
+INSERT INTO wc_arr_t VALUES
+    (1, ['search', 'alpha']),
+    (2, ['research', 'beta']),
+    (3, ['plain', 'gamma'])
+
+statement ok
+CREATE INDEX wc_arr_idx ON wc_arr_t
+    USING inverted(id, tags wc_list_dict)
+    INCLUDE (id, tags)
+
+query I
+SELECT id FROM wc_arr_idx WHERE tags @@ ts_like('%ear%') ORDER BY id
+----
+id
+1
+2
+
+query I
+SELECT id FROM wc_arr_idx WHERE tags @@ ts_like('%mma') ORDER BY id
+----
+id
+3
+
+# --- indexed expression returning VARCHAR[] --------------------------------
+
+statement ok
+CREATE TABLE wc_expr_t (id BIGINT PRIMARY KEY, body VARCHAR)
+
+statement ok
+INSERT INTO wc_expr_t VALUES
+    (1, 'search Alpha'),
+    (2, 'research'),
+    (3, 'seabird'),
+    (4, 'plain')
+
+statement ok
+CREATE INDEX wc_expr_idx ON wc_expr_t
+    USING inverted(id, (ts_split_by_non_alpha(body, true)) wc_list_dict)
+    INCLUDE (id, body)
+
+query I
+SELECT id FROM wc_expr_idx
+WHERE ts_split_by_non_alpha(body, true) @@ ts_like('%ear%') ORDER BY id
+----
+id
+1
+2
+
+# ts_split_by_non_alpha(..., true) lowercases, so the stored token is 'alpha'.
+query I
+SELECT id FROM wc_expr_idx
+WHERE ts_split_by_non_alpha(body, true) @@ ts_like('%pha') ORDER BY id
+----
+id
+1
+
+# Survives a flush into iresearch segments, i.e. the store column round-trips
+# through the columnstore and not just the in-memory staging vector.
+statement ok
+VACUUM (REFRESH_TABLE) wc_list_t
+
+statement ok
+VACUUM (REFRESH_TABLE) wc_expr_t
+
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('%ear%') ORDER BY id
+----
+id
+1
+2
+
+query I
+SELECT id FROM wc_list_idx WHERE tags @@ ts_like('%pha') ORDER BY id
+----
+id
+1
+
+query I
+SELECT id FROM wc_expr_idx
+WHERE ts_split_by_non_alpha(body, true) @@ ts_like('%pha') ORDER BY id
+----
+id
+1


### PR DESCRIPTION
`ts_like` on a LIST/ARRAY-typed column, or on an indexed expression returning one,
backed by a `template = 'wildcard'` dictionary returned zero rows. Minimal repro:

```sql
CREATE TEXT SEARCH DICTIONARY wc (template = 'wildcard', ngramsize = 3,
    tokenizer_template = 'delimiter', tokenizer_delimiter = ' ');
CREATE TABLE t (id INTEGER, tags VARCHAR[]);
INSERT INTO t VALUES (1, ['search', 'alpha']), (2, ['research']), (3, ['plain']);
CREATE INDEX t_idx ON t USING inverted(id, tags wc) INCLUDE (id, tags);

SELECT count(*) FROM t_idx WHERE tags @@ ts_like('%ear%');  -- 0, expected 2
SELECT count(*) FROM t_idx WHERE tags @@ ts_any(['ear']);   -- 2, postings are fine
```

The same shape on a scalar VARCHAR column has always worked, which is what made this
look analyzer-specific rather than value-shape-specific.

## Cause

`ByWildcardNgram` is an approximate n-gram match plus an exact RE2 re-check against the
tokenizer store column (the analyzer's `StoreAttr`, one blob per row holding every base
token of that row). `SwitchFieldImpl` resolved that column only on the scalar path:
`DispatchListBatch` / `WriteListBatch` never took a `tokenizer_column`, so no store blob
was written for list values and every candidate doc failed the re-check.

The n-gram postings were always written correctly, hence `ts_any` on a raw trigram
matching while `ts_like` returned nothing.

It failed silently because a declared-but-unwritten store column is indistinguishable
from "no documents matched": `WildcardQuery::Execute` returned `DocIterator::empty()` when
the column was absent, and `WildcardIterator::Check` returns false on an empty span. No
error, no log. The one guard that existed, `SDB_ASSERT(field_limits::valid(...))` in
`ts_like.cpp`, asserts that the catalog allocated an id, which it had. Only the bytes were
missing, so it could not fire.

## Change

`WildcardAnalyzer::reset` appends to `_terms` instead of clearing it, so a row spanning
several `reset` calls (one per list element) accumulates into a single blob, and
`_store.value` is the whole accumulation. `ClearStore` resets it once per row. The sink
hands the analyzer's span straight to the column writer, so there is no intermediate
buffer and no extra copy of the row's token bytes.

This is safe because the write path is the only caller of `WildcardAnalyzer::reset`; the
query side (`ByWildcardNgramOptions`) drives `analyzer.ngram()` directly and never touches
`_terms` or `_store`. `_terms_begin` and `_store.value` are recomputed off `begin()` after
the append, so a reallocating append is handled, and `reset` clears `_ngram` before
appending so the ngram tokenizer cannot be left holding a stale view into `_terms`.

The per-row clear is deliberately not gated on a store writer being present. Gating it
would tie "does anyone read the store" to "is the store bounded", and a path that reset a
wildcard analyzer without a store writer would grow `_terms` for the whole batch. Not
reachable today (all three `TokenizerProvider` constructions go through
`InvertedIndex::GetTokenizer`), but not something to depend on.

A missing store column now throws `ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE` with a
REINDEX hint instead of returning an empty iterator, via a shared
`irs::ThrowMissingTokenizerStore`. Applied in `wildcard_ngram_filter` and in `geo_filter`,
which had the same silent-empty branch. Both sites only reach the store lookup once the
field has matching terms in that segment, so "field absent from this segment" stays
legitimate and only "terms present, store missing" throws.

Indexes built before this change keep returning zero rows for list-valued wildcard fields
until rebuilt; they now say so instead of answering 0.

## Tests

`tests/sqllogic/sdb/pg/index/inverted_index_wildcard_list.test` covers LIST, ARRAY,
indexed expression, multi-element rows, NULL rows, an n-gram that matches but whose full
token fails the re-check, and a post-`VACUUM (REFRESH_TABLE)` round-trip.

`wildcard` cells added to the tokenizer x LIST/ARRAY matrix in
`inverted_index_matrix_tokenizer_list_g17.test`, which described itself as covering all
tokenizers but had only `keyword`, `ngram` and `text` -- exactly the tokenizers with no
store column, so it covered every cell where the list path has nothing extra to do and
omitted the only one where it does. Those cells assert `ts_like` results rather than
`count(*)`: a bare count over the index passes even with an empty store column, since the
n-gram postings are written either way, and that is why the matrix missed this. There is a
note in the file header to keep it that way.

Both new guards were checked by reverting only the writer fix and confirming they fire:
the targeted repro throws instead of returning 0, and g17 fails at the wildcard cell.

Verified green after restoring: full `sdb/**` on release (only `encrypted.test`, which
needs a TLS port), `sdb/pg/index/*` under the TSan debug build with no races,
`wal_index_recovery_wildcard`, `wal_index_recovery_wildcard_no_include`,
`wal_index_recovery_geo` and `wal_index_recovery_geo_source` on the debug build, and all
geo sqllogic tests since `geo_filter` is touched.

On 500k wiki docs indexed through `(ts_split_by_non_alpha(body, true))`, a wildcard
dictionary with `position = true` answers `%nnec%` in ~2 ms against ~15 ms for the
automaton dictionary scan on a plain keyword dictionary, with identical results. The
wildcard path is proportional to selectivity where the automaton path is flat in
dictionary size, so the gap widens with corpus size. `position = true` is not optional
here: without positions the trigram conjunction is not positional, matches nearly every
doc and re-checks them all.

Follow-ups in #978: no single choke point for the store contract on the write side, and
`StoreAttr` carrying two incompatible codecs (wildcard's self-delimiting token sequence
vs geo's single encoded geometry) with nothing declaring which.
