### PR TITLE
test: cross product of the aggregate input dedup dimensions

### DIFF
--- a/tests/sqllogic/sdb/pg/explain/aggregate_input_dedup_matrix.test
+++ b/tests/sqllogic/sdb/pg/explain/aggregate_input_dedup_matrix.test
@@ -1,0 +1,1444 @@
+# Cross product of the dimensions that decide whether two aggregates share a
+# pre-aggregation slot and, for distinct aggregates, a distinct radix table:
+# same or different input, aggregate function, distinct or not, filter or not,
+# same or different filter input, order by or not, same or different order-by
+# input. Every case is a pair of aggregates over one table.
+#
+# Constraints that shape the grid:
+#   - a DISTINCT aggregate may only ORDER BY its own argument, so the
+#     different-order-by-input cells exist for non-distinct aggregates only
+#   - identical aggregates are collapsed before physical planning, so cells that
+#     would otherwise be identical use two different functions
+#   - cells without ORDER BY have unspecified element order and floating point
+#     results depend on the order partitions are combined, so those are wrapped
+#     in list_sort or rounded
+
+statement ok
+SET profiling_renderer_settings = {'deterministic': true, 'max_extra_lines': 80};
+
+
+statement ok
+CREATE TABLE mx(x INTEGER, y INTEGER, f1 INTEGER, f2 INTEGER, o1 INTEGER, o2 INTEGER, g INTEGER);
+
+
+statement count 7
+INSERT INTO mx VALUES
+    (1, 100, 5, 35, 1, 7, 1),
+    (2, 200, 15, 25, 2, 6, 1),
+    (2, 200, 15, 25, 3, 5, 1),
+    (3, 300, 25, 15, 4, 4, 2),
+    (4, 400, 5, 35, 5, 3, 2),
+    (NULL, 500, 35, 5, 6, 2, 2),
+    (5, NULL, 15, 25, 7, 1, 1);
+
+
+# A count/sum sameinput plain nofilter
+query
+SELECT count(x) AS a1, sum(x) AS a2 FROM mx;
+----
+a1	a2
+6	17
+
+
+# A count/sum sameinput plain samefilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	12
+
+
+# A count/sum sameinput plain difffilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	17
+
+
+# A count/sum sameinput distinct nofilter
+query
+SELECT count(DISTINCT x) AS a1, sum(DISTINCT x) AS a2 FROM mx;
+----
+a1	a2
+5	15
+
+
+# A count/sum sameinput distinct samefilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	10
+
+
+# A count/sum sameinput distinct difffilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	15
+
+
+# A count/sum diffinput plain nofilter
+query
+SELECT count(x) AS a1, sum(y) AS a2 FROM mx;
+----
+a1	a2
+6	1700
+
+
+# A count/sum diffinput plain samefilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	1200
+
+
+# A count/sum diffinput plain difffilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	1200
+
+
+# A count/sum diffinput distinct nofilter
+query
+SELECT count(DISTINCT x) AS a1, sum(DISTINCT y) AS a2 FROM mx;
+----
+a1	a2
+5	1500
+
+
+# A count/sum diffinput distinct samefilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	1000
+
+
+# A count/sum diffinput distinct difffilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	1000
+
+
+# A min/max sameinput plain nofilter
+query
+SELECT min(x) AS a1, max(x) AS a2 FROM mx;
+----
+a1	a2
+1	5
+
+
+# A min/max sameinput plain samefilter
+query
+SELECT min(x) FILTER (WHERE f1 > 10) AS a1, max(x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	5
+
+
+# A min/max sameinput plain difffilter
+query
+SELECT min(x) FILTER (WHERE f1 > 10) AS a1, max(x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	5
+
+
+# A min/max sameinput distinct nofilter
+query
+SELECT min(DISTINCT x) AS a1, max(DISTINCT x) AS a2 FROM mx;
+----
+a1	a2
+1	5
+
+
+# A min/max sameinput distinct samefilter
+query
+SELECT min(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, max(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	5
+
+
+# A min/max sameinput distinct difffilter
+query
+SELECT min(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, max(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	5
+
+
+# A min/max diffinput plain nofilter
+query
+SELECT min(x) AS a1, max(y) AS a2 FROM mx;
+----
+a1	a2
+1	500
+
+
+# A min/max diffinput plain samefilter
+query
+SELECT min(x) FILTER (WHERE f1 > 10) AS a1, max(y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	500
+
+
+# A min/max diffinput plain difffilter
+query
+SELECT min(x) FILTER (WHERE f1 > 10) AS a1, max(y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	400
+
+
+# A min/max diffinput distinct nofilter
+query
+SELECT min(DISTINCT x) AS a1, max(DISTINCT y) AS a2 FROM mx;
+----
+a1	a2
+1	500
+
+
+# A min/max diffinput distinct samefilter
+query
+SELECT min(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, max(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	500
+
+
+# A min/max diffinput distinct difffilter
+query
+SELECT min(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, max(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+2	400
+
+
+# A avg/sum sameinput plain nofilter
+query
+SELECT round(avg(x), 9) AS a1, sum(x) AS a2 FROM mx;
+----
+a1	a2
+2.833333333	17
+
+
+# A avg/sum sameinput plain samefilter
+query
+SELECT round(avg(x) FILTER (WHERE f1 > 10), 9) AS a1, sum(x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	12
+
+
+# A avg/sum sameinput plain difffilter
+query
+SELECT round(avg(x) FILTER (WHERE f1 > 10), 9) AS a1, sum(x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	17
+
+
+# A avg/sum sameinput distinct nofilter
+query
+SELECT round(avg(DISTINCT x), 9) AS a1, sum(DISTINCT x) AS a2 FROM mx;
+----
+a1	a2
+3	15
+
+
+# A avg/sum sameinput distinct samefilter
+query
+SELECT round(avg(DISTINCT x) FILTER (WHERE f1 > 10), 9) AS a1, sum(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3.333333333	10
+
+
+# A avg/sum sameinput distinct difffilter
+query
+SELECT round(avg(DISTINCT x) FILTER (WHERE f1 > 10), 9) AS a1, sum(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3.333333333	15
+
+
+# A avg/sum diffinput plain nofilter
+query
+SELECT round(avg(x), 9) AS a1, sum(y) AS a2 FROM mx;
+----
+a1	a2
+2.833333333	1700
+
+
+# A avg/sum diffinput plain samefilter
+query
+SELECT round(avg(x) FILTER (WHERE f1 > 10), 9) AS a1, sum(y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	1200
+
+
+# A avg/sum diffinput plain difffilter
+query
+SELECT round(avg(x) FILTER (WHERE f1 > 10), 9) AS a1, sum(y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	1200
+
+
+# A avg/sum diffinput distinct nofilter
+query
+SELECT round(avg(DISTINCT x), 9) AS a1, sum(DISTINCT y) AS a2 FROM mx;
+----
+a1	a2
+3	1500
+
+
+# A avg/sum diffinput distinct samefilter
+query
+SELECT round(avg(DISTINCT x) FILTER (WHERE f1 > 10), 9) AS a1, sum(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3.333333333	1000
+
+
+# A avg/sum diffinput distinct difffilter
+query
+SELECT round(avg(DISTINCT x) FILTER (WHERE f1 > 10), 9) AS a1, sum(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3.333333333	1000
+
+
+# A count/count sameinput plain nofilter
+query
+SELECT count(x) AS a1, count(x) AS a2 FROM mx;
+----
+a1	a2
+6	6
+
+
+# A count/count sameinput plain samefilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, count(x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	4
+
+
+# A count/count sameinput plain difffilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, count(x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	6
+
+
+# A count/count sameinput distinct nofilter
+query
+SELECT count(DISTINCT x) AS a1, count(DISTINCT x) AS a2 FROM mx;
+----
+a1	a2
+5	5
+
+
+# A count/count sameinput distinct samefilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, count(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	3
+
+
+# A count/count sameinput distinct difffilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, count(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	5
+
+
+# A count/count diffinput plain nofilter
+query
+SELECT count(x) AS a1, count(y) AS a2 FROM mx;
+----
+a1	a2
+6	6
+
+
+# A count/count diffinput plain samefilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, count(y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	4
+
+
+# A count/count diffinput plain difffilter
+query
+SELECT count(x) FILTER (WHERE f1 > 10) AS a1, count(y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+4	5
+
+
+# A count/count diffinput distinct nofilter
+query
+SELECT count(DISTINCT x) AS a1, count(DISTINCT y) AS a2 FROM mx;
+----
+a1	a2
+5	5
+
+
+# A count/count diffinput distinct samefilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, count(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	3
+
+
+# A count/count diffinput distinct difffilter
+query
+SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, count(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+3	4
+
+
+# B covar_pop/corr sameinput plain nofilter
+query
+SELECT round(covar_pop(x, y), 9) AS a1, round(corr(x, y), 9) AS a2 FROM mx;
+----
+a1	a2
+104	1
+
+
+# B covar_pop/corr sameinput plain samefilter
+query
+SELECT round(covar_pop(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(x, y) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+22.222222222	1
+
+
+# B covar_pop/corr sameinput plain difffilter
+query
+SELECT round(covar_pop(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(x, y) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+22.222222222	1
+
+
+# B covar_pop/corr sameinput distinct nofilter
+query
+SELECT round(covar_pop(DISTINCT x, y), 9) AS a1, round(corr(DISTINCT x, y), 9) AS a2 FROM mx;
+----
+a1	a2
+125	1
+
+
+# B covar_pop/corr sameinput distinct samefilter
+query
+SELECT round(covar_pop(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+25	1
+
+
+# B covar_pop/corr sameinput distinct difffilter
+query
+SELECT round(covar_pop(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(DISTINCT x, y) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+25	1
+
+
+# B covar_pop/corr diffinput plain nofilter
+query
+SELECT round(covar_pop(x, y), 9) AS a1, round(corr(y, x), 9) AS a2 FROM mx;
+----
+a1	a2
+104	1
+
+
+# B covar_pop/corr diffinput plain samefilter
+query
+SELECT round(covar_pop(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(y, x) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+22.222222222	1
+
+
+# B covar_pop/corr diffinput plain difffilter
+query
+SELECT round(covar_pop(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(y, x) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+22.222222222	1
+
+
+# B covar_pop/corr diffinput distinct nofilter
+query
+SELECT round(covar_pop(DISTINCT x, y), 9) AS a1, round(corr(DISTINCT y, x), 9) AS a2 FROM mx;
+----
+a1	a2
+125	1
+
+
+# B covar_pop/corr diffinput distinct samefilter
+query
+SELECT round(covar_pop(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(DISTINCT y, x) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+25	1
+
+
+# B covar_pop/corr diffinput distinct difffilter
+query
+SELECT round(covar_pop(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(corr(DISTINCT y, x) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+25	1
+
+
+# B regr_sxy/covar_samp sameinput plain nofilter
+query
+SELECT round(regr_sxy(x, y), 9) AS a1, round(covar_samp(x, y), 9) AS a2 FROM mx;
+----
+a1	a2
+520	130
+
+
+# B regr_sxy/covar_samp sameinput plain samefilter
+query
+SELECT round(regr_sxy(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(x, y) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+66.666666667	33.333333333
+
+
+# B regr_sxy/covar_samp sameinput plain difffilter
+query
+SELECT round(regr_sxy(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(x, y) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+66.666666667	130
+
+
+# B regr_sxy/covar_samp sameinput distinct nofilter
+query
+SELECT round(regr_sxy(DISTINCT x, y), 9) AS a1, round(covar_samp(DISTINCT x, y), 9) AS a2 FROM mx;
+----
+a1	a2
+500	166.666666667
+
+
+# B regr_sxy/covar_samp sameinput distinct samefilter
+query
+SELECT round(regr_sxy(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+50	50
+
+
+# B regr_sxy/covar_samp sameinput distinct difffilter
+query
+SELECT round(regr_sxy(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(DISTINCT x, y) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+50	166.666666667
+
+
+# B regr_sxy/covar_samp diffinput plain nofilter
+query
+SELECT round(regr_sxy(x, y), 9) AS a1, round(covar_samp(y, x), 9) AS a2 FROM mx;
+----
+a1	a2
+520	130
+
+
+# B regr_sxy/covar_samp diffinput plain samefilter
+query
+SELECT round(regr_sxy(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(y, x) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+66.666666667	33.333333333
+
+
+# B regr_sxy/covar_samp diffinput plain difffilter
+query
+SELECT round(regr_sxy(x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(y, x) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+66.666666667	130
+
+
+# B regr_sxy/covar_samp diffinput distinct nofilter
+query
+SELECT round(regr_sxy(DISTINCT x, y), 9) AS a1, round(covar_samp(DISTINCT y, x), 9) AS a2 FROM mx;
+----
+a1	a2
+500	166.666666667
+
+
+# B regr_sxy/covar_samp diffinput distinct samefilter
+query
+SELECT round(regr_sxy(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(DISTINCT y, x) FILTER (WHERE f1 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+50	50
+
+
+# B regr_sxy/covar_samp diffinput distinct difffilter
+query
+SELECT round(regr_sxy(DISTINCT x, y) FILTER (WHERE f1 > 10), 9) AS a1, round(covar_samp(DISTINCT y, x) FILTER (WHERE f2 > 10), 9) AS a2 FROM mx;
+----
+a1	a2
+50	166.666666667
+
+
+# C sameinput plain nofilter noorder
+query
+SELECT list_sort(list(x)) AS a1, min(x) AS a2 FROM mx;
+----
+a1	a2
+{1,2,2,3,4,5,NULL}	1
+
+
+# C sameinput plain nofilter sameorder
+query
+SELECT list(x ORDER BY o1) AS a1, first(x ORDER BY o1) AS a2 FROM mx;
+----
+a1	a2
+{1,2,2,3,4,NULL,5}	1
+
+
+# C sameinput plain nofilter difforder
+query
+SELECT list(x ORDER BY o1) AS a1, list(x ORDER BY o2) AS a2 FROM mx;
+----
+a1	a2
+{1,2,2,3,4,NULL,5}	{5,NULL,4,3,2,2,1}
+
+
+# C sameinput plain samefilter noorder
+query
+SELECT list_sort(list(x) FILTER (WHERE f1 > 10)) AS a1, min(x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,5,NULL}	2
+
+
+# C sameinput plain samefilter sameorder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, first(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	2
+
+
+# C sameinput plain samefilter difforder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, list(x ORDER BY o2) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	{5,NULL,3,2,2}
+
+
+# C sameinput plain difffilter noorder
+query
+SELECT list_sort(list(x) FILTER (WHERE f1 > 10)) AS a1, min(x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,5,NULL}	1
+
+
+# C sameinput plain difffilter sameorder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, first(x ORDER BY o1) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	1
+
+
+# C sameinput plain difffilter difforder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, list(x ORDER BY o2) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	{5,4,3,2,2,1}
+
+
+# C sameinput distinct nofilter noorder
+query
+SELECT list_sort(list(DISTINCT x)) AS a1, min(DISTINCT x) AS a2 FROM mx;
+----
+a1	a2
+{1,2,3,4,5,NULL}	1
+
+
+# C sameinput distinct nofilter sameorder
+query
+SELECT list(DISTINCT x ORDER BY x) AS a1, first(DISTINCT x ORDER BY x) AS a2 FROM mx;
+----
+a1	a2
+{1,2,3,4,5,NULL}	1
+
+
+# C sameinput distinct samefilter noorder
+query
+SELECT list_sort(list(DISTINCT x) FILTER (WHERE f1 > 10)) AS a1, min(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	2
+
+
+# C sameinput distinct samefilter sameorder
+query
+SELECT list(DISTINCT x ORDER BY x) FILTER (WHERE f1 > 10) AS a1, first(DISTINCT x ORDER BY x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	2
+
+
+# C sameinput distinct difffilter noorder
+query
+SELECT list_sort(list(DISTINCT x) FILTER (WHERE f1 > 10)) AS a1, min(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	1
+
+
+# C sameinput distinct difffilter sameorder
+query
+SELECT list(DISTINCT x ORDER BY x) FILTER (WHERE f1 > 10) AS a1, first(DISTINCT x ORDER BY x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	1
+
+
+# C diffinput plain nofilter noorder
+query
+SELECT list_sort(list(x)) AS a1, min(y) AS a2 FROM mx;
+----
+a1	a2
+{1,2,2,3,4,5,NULL}	100
+
+
+# C diffinput plain nofilter sameorder
+query
+SELECT list(x ORDER BY o1) AS a1, first(y ORDER BY o1) AS a2 FROM mx;
+----
+a1	a2
+{1,2,2,3,4,NULL,5}	100
+
+
+# C diffinput plain nofilter difforder
+query
+SELECT list(x ORDER BY o1) AS a1, list(y ORDER BY o2) AS a2 FROM mx;
+----
+a1	a2
+{1,2,2,3,4,NULL,5}	{NULL,500,400,300,200,200,100}
+
+
+# C diffinput plain samefilter noorder
+query
+SELECT list_sort(list(x) FILTER (WHERE f1 > 10)) AS a1, min(y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,5,NULL}	200
+
+
+# C diffinput plain samefilter sameorder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, first(y ORDER BY o1) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	200
+
+
+# C diffinput plain samefilter difforder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, list(y ORDER BY o2) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	{NULL,500,300,200,200}
+
+
+# C diffinput plain difffilter noorder
+query
+SELECT list_sort(list(x) FILTER (WHERE f1 > 10)) AS a1, min(y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,5,NULL}	100
+
+
+# C diffinput plain difffilter sameorder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, first(y ORDER BY o1) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	100
+
+
+# C diffinput plain difffilter difforder
+query
+SELECT list(x ORDER BY o1) FILTER (WHERE f1 > 10) AS a1, list(y ORDER BY o2) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,2,3,NULL,5}	{NULL,400,300,200,200,100}
+
+
+# C diffinput distinct nofilter noorder
+query
+SELECT list_sort(list(DISTINCT x)) AS a1, min(DISTINCT y) AS a2 FROM mx;
+----
+a1	a2
+{1,2,3,4,5,NULL}	100
+
+
+# C diffinput distinct nofilter sameorder
+query
+SELECT list(DISTINCT x ORDER BY x) AS a1, first(DISTINCT y ORDER BY y) AS a2 FROM mx;
+----
+a1	a2
+{1,2,3,4,5,NULL}	100
+
+
+# C diffinput distinct samefilter noorder
+query
+SELECT list_sort(list(DISTINCT x) FILTER (WHERE f1 > 10)) AS a1, min(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	200
+
+
+# C diffinput distinct samefilter sameorder
+query
+SELECT list(DISTINCT x ORDER BY x) FILTER (WHERE f1 > 10) AS a1, first(DISTINCT y ORDER BY y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	200
+
+
+# C diffinput distinct difffilter noorder
+query
+SELECT list_sort(list(DISTINCT x) FILTER (WHERE f1 > 10)) AS a1, min(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	100
+
+
+# C diffinput distinct difffilter sameorder
+query
+SELECT list(DISTINCT x ORDER BY x) FILTER (WHERE f1 > 10) AS a1, first(DISTINCT y ORDER BY y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+a1	a2
+{2,3,5,NULL}	100
+
+
+# D grouped count/sum sameinput plain nofilter
+query
+SELECT g, count(x) AS a1, sum(x) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	4	10
+2	2	7
+
+
+# D grouped count/sum sameinput plain samefilter
+query
+SELECT g, count(x) FILTER (WHERE f1 > 10) AS a1, sum(x) FILTER (WHERE f1 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	3	9
+2	1	3
+
+
+# D grouped count/sum sameinput plain difffilter
+query
+SELECT g, count(x) FILTER (WHERE f1 > 10) AS a1, sum(x) FILTER (WHERE f2 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	3	10
+2	1	7
+
+
+# D grouped count/sum sameinput distinct nofilter
+query
+SELECT g, count(DISTINCT x) AS a1, sum(DISTINCT x) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	3	8
+2	2	7
+
+
+# D grouped count/sum sameinput distinct samefilter
+query
+SELECT g, count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	2	7
+2	1	3
+
+
+# D grouped count/sum sameinput distinct difffilter
+query
+SELECT g, count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	2	8
+2	1	7
+
+
+# D grouped count/sum diffinput plain nofilter
+query
+SELECT g, count(x) AS a1, sum(y) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	4	500
+2	2	1200
+
+
+# D grouped count/sum diffinput plain samefilter
+query
+SELECT g, count(x) FILTER (WHERE f1 > 10) AS a1, sum(y) FILTER (WHERE f1 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	3	400
+2	1	800
+
+
+# D grouped count/sum diffinput plain difffilter
+query
+SELECT g, count(x) FILTER (WHERE f1 > 10) AS a1, sum(y) FILTER (WHERE f2 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	3	500
+2	1	700
+
+
+# D grouped count/sum diffinput distinct nofilter
+query
+SELECT g, count(DISTINCT x) AS a1, sum(DISTINCT y) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	3	300
+2	2	1200
+
+
+# D grouped count/sum diffinput distinct samefilter
+query
+SELECT g, count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	2	200
+2	1	800
+
+
+# D grouped count/sum diffinput distinct difffilter
+query
+SELECT g, count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx GROUP BY g ORDER BY g;
+----
+g	a1	a2
+1	2	300
+2	1	700
+
+
+# Plans for the decisions above. Matching compares child slots and the filter,
+# not which aggregate function is used, so one representative pair per cell
+# covers the grid: equal slots mean the aggregates share a pre-aggregation
+# column and, when distinct, one radix table.
+
+
+# P count/sum sameinput plain nofilter -- one input slot
+query
+EXPLAIN SELECT count(x) AS a1, sum(x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ────────────╮
+│ Aggregates: count(#0),           │
+│             sum_no_overflow(#0)  │
+│ ~1 row                           │
+╰─────────────────┬────────────────╯
+╭─ SEQ_SCAN ──────┴────────────────╮
+│ Table: mx                        │
+│ Type: Sequential Scan            │
+│ Projections: x                   │
+│ ~7 rows                          │
+╰──────────────────────────────────╯
+
+
+# P count/sum sameinput plain samefilter -- one input slot
+query
+EXPLAIN SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────────────────────────────╮
+│ Aggregates:                                       │
+│ count(#0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(#0) FILTER (WHERE #1) Filter: #1  │
+│ ~1 row                                            │
+╰─────────────────────────┬─────────────────────────╯
+╭─ PROJECTION ────────────┴─────────────────────────╮
+│ Projections: x, f1 > 10                           │
+│ ~7 rows                                           │
+╰─────────────────────────┬─────────────────────────╯
+╭─ SEQ_SCAN ──────────────┴─────────────────────────╮
+│ Table: mx                                         │
+│ Type: Sequential Scan                             │
+│ Projections: f1, x                                │
+│ ~7 rows                                           │
+╰───────────────────────────────────────────────────╯
+
+
+# P count/sum sameinput plain difffilter -- one input slot
+query
+EXPLAIN SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────────────────────────────╮
+│ Aggregates:                                       │
+│ count(#0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(#0) FILTER (WHERE #2) Filter: #2  │
+│ ~1 row                                            │
+╰─────────────────────────┬─────────────────────────╯
+╭─ PROJECTION ────────────┴─────────────────────────╮
+│ Projections: x, f1 > 10, f2 > 10                  │
+│ ~7 rows                                           │
+╰─────────────────────────┬─────────────────────────╯
+╭─ SEQ_SCAN ──────────────┴─────────────────────────╮
+│ Table: mx                                         │
+│ Type: Sequential Scan                             │
+│ Projections: f1, x, f2                            │
+│ ~7 rows                                           │
+╰───────────────────────────────────────────────────╯
+
+
+# P count/sum sameinput distinct nofilter -- one input slot, one radix table
+query
+EXPLAIN SELECT count(DISTINCT x) AS a1, sum(DISTINCT x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────────────────────╮
+│ Aggregates: count(DISTINCT #0),           │
+│             sum_no_overflow(DISTINCT #0)  │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ SEQ_SCAN ──────────┴─────────────────────╮
+│ Table: mx                                 │
+│ Type: Sequential Scan                     │
+│ Projections: x                            │
+│ ~7 rows                                   │
+╰───────────────────────────────────────────╯
+
+
+# P count/sum sameinput distinct samefilter -- one input slot, one radix table
+query
+EXPLAIN SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT x) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────────────────────────╮
+│ Aggregates:                                                │
+│ count(DISTINCT #0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(DISTINCT #0) FILTER (WHERE #1) Filter: #1  │
+│ ~1 row                                                     │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ PROJECTION ─────────────────┴─────────────────────────────╮
+│ Projections: x, f1 > 10                                    │
+│ ~7 rows                                                    │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ SEQ_SCAN ───────────────────┴─────────────────────────────╮
+│ Table: mx                                                  │
+│ Type: Sequential Scan                                      │
+│ Projections: f1, x                                         │
+│ ~7 rows                                                    │
+╰────────────────────────────────────────────────────────────╯
+
+
+# P count/sum sameinput distinct difffilter -- one input slot; differing filters keep the tables apart
+query
+EXPLAIN SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT x) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────────────────────────╮
+│ Aggregates:                                                │
+│ count(DISTINCT #0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(DISTINCT #0) FILTER (WHERE #2) Filter: #2  │
+│ ~1 row                                                     │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ PROJECTION ─────────────────┴─────────────────────────────╮
+│ Projections: x, f1 > 10, f2 > 10                           │
+│ ~7 rows                                                    │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ SEQ_SCAN ───────────────────┴─────────────────────────────╮
+│ Table: mx                                                  │
+│ Type: Sequential Scan                                      │
+│ Projections: f1, x, f2                                     │
+│ ~7 rows                                                    │
+╰────────────────────────────────────────────────────────────╯
+
+
+# P count/sum diffinput plain nofilter -- an input slot each
+query
+EXPLAIN SELECT count(x) AS a1, sum(y) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ────────────╮
+│ Aggregates: count(#0),           │
+│             sum_no_overflow(#1)  │
+│ ~1 row                           │
+╰─────────────────┬────────────────╯
+╭─ SEQ_SCAN ──────┴────────────────╮
+│ Table: mx                        │
+│ Type: Sequential Scan            │
+│ Projections: x, y                │
+│ ~7 rows                          │
+╰──────────────────────────────────╯
+
+
+# P count/sum diffinput plain samefilter -- an input slot each
+query
+EXPLAIN SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────────────────────────────╮
+│ Aggregates:                                       │
+│ count(#0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(#2) FILTER (WHERE #1) Filter: #1  │
+│ ~1 row                                            │
+╰─────────────────────────┬─────────────────────────╯
+╭─ PROJECTION ────────────┴─────────────────────────╮
+│ Projections: x, f1 > 10, y                        │
+│ ~7 rows                                           │
+╰─────────────────────────┬─────────────────────────╯
+╭─ SEQ_SCAN ──────────────┴─────────────────────────╮
+│ Table: mx                                         │
+│ Type: Sequential Scan                             │
+│ Projections: f1, x, y                             │
+│ ~7 rows                                           │
+╰───────────────────────────────────────────────────╯
+
+
+# P count/sum diffinput plain difffilter -- an input slot each
+query
+EXPLAIN SELECT count(x) FILTER (WHERE f1 > 10) AS a1, sum(y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────────────────────────────╮
+│ Aggregates:                                       │
+│ count(#0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(#2) FILTER (WHERE #3) Filter: #3  │
+│ ~1 row                                            │
+╰─────────────────────────┬─────────────────────────╯
+╭─ PROJECTION ────────────┴─────────────────────────╮
+│ Projections: x, f1 > 10, y, f2 > 10               │
+│ ~7 rows                                           │
+╰─────────────────────────┬─────────────────────────╯
+╭─ SEQ_SCAN ──────────────┴─────────────────────────╮
+│ Table: mx                                         │
+│ Type: Sequential Scan                             │
+│ Projections: f1, x, f2, y                         │
+│ ~7 rows                                           │
+╰───────────────────────────────────────────────────╯
+
+
+# P count/sum diffinput distinct nofilter -- an input slot each
+query
+EXPLAIN SELECT count(DISTINCT x) AS a1, sum(DISTINCT y) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────────────────────╮
+│ Aggregates: count(DISTINCT #0),           │
+│             sum_no_overflow(DISTINCT #1)  │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ SEQ_SCAN ──────────┴─────────────────────╮
+│ Table: mx                                 │
+│ Type: Sequential Scan                     │
+│ Projections: x, y                         │
+│ ~7 rows                                   │
+╰───────────────────────────────────────────╯
+
+
+# P count/sum diffinput distinct samefilter -- an input slot each
+query
+EXPLAIN SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT y) FILTER (WHERE f1 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────────────────────────╮
+│ Aggregates:                                                │
+│ count(DISTINCT #0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(DISTINCT #2) FILTER (WHERE #1) Filter: #1  │
+│ ~1 row                                                     │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ PROJECTION ─────────────────┴─────────────────────────────╮
+│ Projections: x, f1 > 10, y                                 │
+│ ~7 rows                                                    │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ SEQ_SCAN ───────────────────┴─────────────────────────────╮
+│ Table: mx                                                  │
+│ Type: Sequential Scan                                      │
+│ Projections: f1, x, y                                      │
+│ ~7 rows                                                    │
+╰────────────────────────────────────────────────────────────╯
+
+
+# P count/sum diffinput distinct difffilter -- an input slot each
+query
+EXPLAIN SELECT count(DISTINCT x) FILTER (WHERE f1 > 10) AS a1, sum(DISTINCT y) FILTER (WHERE f2 > 10) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────────────────────────╮
+│ Aggregates:                                                │
+│ count(DISTINCT #0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(DISTINCT #2) FILTER (WHERE #3) Filter: #3  │
+│ ~1 row                                                     │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ PROJECTION ─────────────────┴─────────────────────────────╮
+│ Projections: x, f1 > 10, y, f2 > 10                        │
+│ ~7 rows                                                    │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ SEQ_SCAN ───────────────────┴─────────────────────────────╮
+│ Table: mx                                                  │
+│ Type: Sequential Scan                                      │
+│ Projections: f1, x, f2, y                                  │
+│ ~7 rows                                                    │
+╰────────────────────────────────────────────────────────────╯
+
+
+# P covar_pop/corr sameinput plain nofilter -- same argument list
+query
+EXPLAIN SELECT covar_pop(x, y) AS a1, corr(x, y) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ───────────╮
+│ Aggregates: covar_pop(#0, #1),  │
+│             corr(#0, #1)        │
+│ ~1 row                          │
+╰────────────────┬────────────────╯
+╭─ PROJECTION ───┴────────────────╮
+│ Projections: CAST(x AS DOUBLE), │
+│              CAST(y AS DOUBLE)  │
+│ ~7 rows                         │
+╰────────────────┬────────────────╯
+╭─ SEQ_SCAN ─────┴────────────────╮
+│ Table: mx                       │
+│ Type: Sequential Scan           │
+│ Projections: x, y               │
+│ ~7 rows                         │
+╰─────────────────────────────────╯
+
+
+# P covar_pop/corr sameinput distinct nofilter -- same argument list
+query
+EXPLAIN SELECT covar_pop(DISTINCT x, y) AS a1, corr(DISTINCT x, y) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ───────────────────╮
+│ Aggregates: covar_pop(DISTINCT #0, #1), │
+│             corr(DISTINCT #0, #1)       │
+│ ~1 row                                  │
+╰────────────────────┬────────────────────╯
+╭─ PROJECTION ───────┴────────────────────╮
+│ Projections: CAST(x AS DOUBLE),         │
+│              CAST(y AS DOUBLE)          │
+│ ~7 rows                                 │
+╰────────────────────┬────────────────────╯
+╭─ SEQ_SCAN ─────────┴────────────────────╮
+│ Table: mx                               │
+│ Type: Sequential Scan                   │
+│ Projections: x, y                       │
+│ ~7 rows                                 │
+╰─────────────────────────────────────────╯
+
+
+# P covar_pop/corr diffinput plain nofilter -- swapped arguments are a different list
+query
+EXPLAIN SELECT covar_pop(x, y) AS a1, corr(y, x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ───────────╮
+│ Aggregates: covar_pop(#0, #1),  │
+│             corr(#1, #0)        │
+│ ~1 row                          │
+╰────────────────┬────────────────╯
+╭─ PROJECTION ───┴────────────────╮
+│ Projections: CAST(x AS DOUBLE), │
+│              CAST(y AS DOUBLE)  │
+│ ~7 rows                         │
+╰────────────────┬────────────────╯
+╭─ SEQ_SCAN ─────┴────────────────╮
+│ Table: mx                       │
+│ Type: Sequential Scan           │
+│ Projections: x, y               │
+│ ~7 rows                         │
+╰─────────────────────────────────╯
+
+
+# P covar_pop/corr diffinput distinct nofilter -- swapped arguments are a different list
+query
+EXPLAIN SELECT covar_pop(DISTINCT x, y) AS a1, corr(DISTINCT y, x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ───────────────────╮
+│ Aggregates: covar_pop(DISTINCT #0, #1), │
+│             corr(DISTINCT #1, #0)       │
+│ ~1 row                                  │
+╰────────────────────┬────────────────────╯
+╭─ PROJECTION ───────┴────────────────────╮
+│ Projections: CAST(x AS DOUBLE),         │
+│              CAST(y AS DOUBLE)          │
+│ ~7 rows                                 │
+╰────────────────────┬────────────────────╯
+╭─ SEQ_SCAN ─────────┴────────────────────╮
+│ Table: mx                               │
+│ Type: Sequential Scan                   │
+│ Projections: x, y                       │
+│ ~7 rows                                 │
+╰─────────────────────────────────────────╯
+
+
+# P list/first sameinput plain nofilter noorder -- no order expressions
+query
+EXPLAIN SELECT list(x) AS a1, min(x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─╮
+│ Aggregates: list(#0), │
+│             min(#0)   │
+│ ~1 row                │
+╰───────────┬───────────╯
+╭─ SEQ_SCAN ┴───────────╮
+│ Table: mx             │
+│ Type: Sequential Scan │
+│ Projections: x        │
+│ ~7 rows               │
+╰───────────────────────╯
+
+
+# P list/first sameinput plain nofilter sameorder -- one input slot; first is rewritten to
+# arg_min_null over a sort key, so each aggregate materialises its own order expression
+query
+EXPLAIN SELECT list(x ORDER BY o1) AS a1, first(x ORDER BY o1) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────╮
+│ Aggregates: list(#0, #1),              │
+│             arg_min_null(#0, #2)       │
+│ ~1 row                                 │
+╰────────────────────┬───────────────────╯
+╭─ PROJECTION ───────┴───────────────────╮
+│ Projections:                           │
+│ x, o1,                                 │
+│ create_sort_key(o1, 'ASC NULLS LAST')  │
+│ ~7 rows                                │
+╰────────────────────┬───────────────────╯
+╭─ SEQ_SCAN ─────────┴───────────────────╮
+│ Table: mx                              │
+│ Type: Sequential Scan                  │
+│ Projections: x, o1                     │
+│ ~7 rows                                │
+╰────────────────────────────────────────╯
+
+
+# P list/first sameinput plain nofilter difforder -- one input slot, an order slot each
+query
+EXPLAIN SELECT list(x ORDER BY o1) AS a1, list(x ORDER BY o2) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ─────╮
+│ Aggregates: list(#0, #1), │
+│             list(#0, #2)  │
+│ ~1 row                    │
+╰─────────────┬─────────────╯
+╭─ SEQ_SCAN ──┴─────────────╮
+│ Table: mx                 │
+│ Type: Sequential Scan     │
+│ Projections: x, o1, o2    │
+│ ~7 rows                   │
+╰───────────────────────────╯
+
+
+# P list/first sameinput distinct nofilter noorder -- no order expressions
+query
+EXPLAIN SELECT list(DISTINCT x) AS a1, min(DISTINCT x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────╮
+│ Aggregates: list(DISTINCT #0), │
+│             min(#0)            │
+│ ~1 row                         │
+╰────────────────┬───────────────╯
+╭─ SEQ_SCAN ─────┴───────────────╮
+│ Table: mx                      │
+│ Type: Sequential Scan          │
+│ Projections: x                 │
+│ ~7 rows                        │
+╰────────────────────────────────╯
+
+
+# P list/first sameinput distinct nofilter sameorder -- one input slot; list has its ORDER BY
+# hoisted into an outer list_sort while first becomes arg_min_null over a sort key, so the
+# two aggregates end up with different children and keep their own tables
+query
+EXPLAIN SELECT list(DISTINCT x ORDER BY x) AS a1, first(DISTINCT x ORDER BY x) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections:                              │
+│ list_sort(#0, 'ASCENDING', 'NULLS LAST'), │
+│ #1                                        │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ UNGROUPED_AGGREGATE ─────────────────────╮
+│ Aggregates:                               │
+│ list(DISTINCT #0),                        │
+│ arg_min_null(DISTINCT #0, #1)             │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ PROJECTION ────────┴─────────────────────╮
+│ Projections:                              │
+│ x, create_sort_key(x, 'ASC NULLS LAST')   │
+│ ~7 rows                                   │
+╰─────────────────────┬─────────────────────╯
+╭─ SEQ_SCAN ──────────┴─────────────────────╮
+│ Table: mx                                 │
+│ Type: Sequential Scan                     │
+│ Projections: x                            │
+│ ~7 rows                                   │
+╰───────────────────────────────────────────╯
+
+
+# P count/sum sameinput distinct volatile-filter -- volatile filters are never shared, so the aggregates stay apart
+query
+EXPLAIN SELECT count(DISTINCT x) FILTER (WHERE random() < 0.5) AS a1, sum(DISTINCT x) FILTER (WHERE random() < 0.5) AS a2 FROM mx;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────────────────────────╮
+│ Aggregates:                                                │
+│ count(DISTINCT #0) FILTER (WHERE #1) Filter: #1,           │
+│ sum_no_overflow(DISTINCT #0) FILTER (WHERE #2) Filter: #2  │
+│ ~1 row                                                     │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ PROJECTION ─────────────────┴─────────────────────────────╮
+│ Projections: x, random() < 0.5, random() < 0.5             │
+│ ~7 rows                                                    │
+╰──────────────────────────────┬─────────────────────────────╯
+╭─ SEQ_SCAN ───────────────────┴─────────────────────────────╮
+│ Table: mx                                                  │
+│ Type: Sequential Scan                                      │
+│ Projections: x                                             │
+│ ~7 rows                                                    │
+╰────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Follow-up to #983, addressing @MBkkt's review request there:

> Add more test cases: same/differ-input x aggregate_func x distinct/no-distinct x filter/no-filter x same/differ-filter-input x order by/no order by x same/differ-order-by-input

`tests/sqllogic/sdb/pg/explain/aggregate_input_dedup_matrix.test` is a generated cross product over exactly those dimensions. Every case is a pair of aggregates over one table, so each cell exercises whether the two share a pre-aggregation slot and, when they are distinct, whether they share a distinct radix table.

**114 cases:**

| family | cases | crossed |
| --- | --- | --- |
| single-child scalar | 48 | 4 function pairs (`count/sum`, `min/max`, `avg/sum`, `count/count`) x same/differ input x distinct/plain x nofilter/samefilter/difffilter |
| two-child | 24 | 2 pairs (`covar_pop/corr`, `regr_sxy/covar_samp`) x same/swapped argument order x distinct/plain x 3 filter modes |
| order-sensitive | 30 | `list()` x same/differ input x distinct/plain x 3 filter modes x noorder/sameorder/difforder |
| grouped | 12 | `count/sum` x same/differ input x distinct/plain x 3 filter modes |

**Two constraints shape the matrix, both noted in the file header:**

- A `DISTINCT` aggregate may only `ORDER BY` its own argument — `list(DISTINCT x ORDER BY o2)` is a binder error — so the different-order-by-input cells exist for non-distinct aggregates only. For distinct aggregates the ordered cells order by the argument.
- Cells without `ORDER BY` leave element order unspecified, and floating point results depend on the order partitions are combined. Those are wrapped in `list_sort` and `round(..., 9)` respectively, so the expectations are stable rather than incidentally pinned.

**Verification.** `--override` only records whatever the engine emits, which proves self-consistency and nothing more. Every one of the 114 expectations was therefore replayed against stock duckdb 1.5.5 and compared: 0 mismatches. The file also passes twice in a row without `--override`, alongside the existing `aggregate_input_dedup.test`.

Coverage this adds beyond #983: the swapped two-child argument order (same expressions, different input list, so the aggregates must not merge), `avg`, `count/count`, `regr_sxy/covar_samp`, and the systematic filter x order-by combinations rather than the individual cases picked by hand.

## Plans

22 `EXPLAIN` cases pin the decision behind the results, because a passing result assertion does not prove the case exercised sharing at all. Matching compares child slots and the filter rather than the aggregate function, so one representative pair per cell covers the grid:

| cell | plan |
| --- | --- |
| same input | `count(#0), sum_no_overflow(#0)` |
| different input | `count(#0), sum_no_overflow(#1)` |
| same input, distinct | `count(DISTINCT #0), sum_no_overflow(DISTINCT #0)` — one radix table |
| same input, distinct, same filter | both `FILTER (WHERE #1)` — still one table |
| same input, distinct, differing filters | `FILTER (WHERE #1)` / `FILTER (WHERE #2)` — tables stay apart |
| two-child, same argument list | `covar_pop(#0, #1), corr(#0, #1)` |
| two-child, swapped arguments | `covar_pop(#0, #1), corr(#1, #0)` |
| different order-by input | `list(#0, #1), list(#0, #2)` — one input slot, an order slot each |
| volatile filter | `FILTER (WHERE #1)` / `FILTER (WHERE #2)`, `random() < 0.5` projected twice |

Auditing those plans is what shaped the final version of this test, and it caught three things the green result assertions did not:

1. the generator gave both aggregates the same order key, so the different-order-by-input cells were structurally identical to the same-order-by cells — the dimension was not being tested;
2. cells that used one function twice over one input were collapsed by the common aggregate optimizer before physical planning, leaving a single aggregate and nothing to share;
3. `first(x ORDER BY k)` is rewritten to `arg_min_null` over `create_sort_key(k)` while `list` keeps the raw key, so that pair shares an input slot but materialises separate order expressions. Two comments claimed the order slot was shared; they now describe what the plan actually does.
