### PR TITLE
fix: view-backed CREATE INDEX crashes: bound-vs-parsed kept positions, case-sensitive name maps, stale views

### DIFF
--- a/server/connector/duckdb_catalog.cpp
+++ b/server/connector/duckdb_catalog.cpp
@@ -569,36 +569,46 @@ duckdb::PhysicalOperator& SereneDBCatalog::PlanCreateTableAs(
 namespace {
 
 std::vector<duckdb::idx_t> ComputeKeptViewPositions(
-  const duckdb::vector<duckdb::unique_ptr<duckdb::ParsedExpression>>&
-    parsed_index_exprs,
-  const duckdb::ParsedExpression* predicate,
-  const duckdb::ViewColumnInfo& column_info) {
+  duckdb::Binder& binder, duckdb::CreateIndexInfo& info) {
   std::vector<duckdb::idx_t> kept;
-  auto add = [&](const duckdb::Identifier& name) {
-    for (size_t i = 0; i < column_info.names.size(); ++i) {
-      if (column_info.names[i] == name) {
-        kept.push_back(i);
-      }
+  auto collect = [&](this auto& self, const duckdb::Expression& e) -> void {
+    if (e.GetExpressionClass() == duckdb::ExpressionClass::BOUND_COLUMN_REF) {
+      kept.push_back(e.Cast<duckdb::BoundColumnRefExpression>()
+                       .Binding()
+                       .column_index.GetIndex());
     }
+    duckdb::ExpressionIterator::EnumerateChildren(
+      e, [&](const duckdb::Expression& c) { self(c); });
   };
-  auto collect = [&](this auto& self,
-                     const duckdb::ParsedExpression& e) -> void {
-    if (e.GetExpressionType() == duckdb::ExpressionType::COLUMN_REF) {
-      add(e.Cast<duckdb::ColumnRefExpression>().GetColumnName());
-      return;
-    }
-    duckdb::ParsedExpressionIterator::EnumerateChildren(
-      e, [&](const duckdb::ParsedExpression& c) { self(c); });
-  };
-  for (const auto& expr : parsed_index_exprs) {
-    collect(*expr);
+  duckdb::IndexBinder index_binder(binder, binder.context);
+  for (const auto& expr : info.expressions) {
+    auto copy = expr->Copy();
+    collect(*index_binder.Bind(copy));
   }
-  if (predicate) {
-    collect(*predicate);
+  if (info.where_clause) {
+    auto copy = info.where_clause->Copy();
+    collect(*index_binder.Bind(copy));
   }
   absl::c_sort(kept);
   kept.erase(std::unique(kept.begin(), kept.end()), kept.end());
   return kept;
+}
+
+void EnsureViewDefinitionCurrent(const catalog::PgSqlView& view,
+                                 const duckdb::ViewColumnInfo& column_info,
+                                 const std::vector<duckdb::idx_t>& kept) {
+  const auto& vinfo = view.GetInfo();
+  for (const auto p : kept) {
+    if (p >= vinfo.names.size() || p >= column_info.names.size() ||
+        vinfo.names[p] != column_info.names[p] ||
+        vinfo.types[p] != column_info.types[p]) {
+      THROW_SQL_ERROR(
+        ERR_CODE(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+        ERR_MSG("view \"", view.GetName(),
+                "\" is out of date with its underlying relation; recreate "
+                "the view before creating an index on it"));
+    }
+  }
 }
 
 // Wrap `plan` in a LogicalProjection that enumerates only the kept view
@@ -878,6 +888,7 @@ duckdb::unique_ptr<duckdb::LogicalOperator> SereneDBCatalog::BindCreateIndex(
   std::optional<ViewFastPath> view_fast_path;
   int64_t pinned_iceberg_snapshot_id = 0;
   std::optional<std::vector<duckdb::idx_t>> kept_view_positions;
+  std::optional<std::vector<duckdb::idx_t>> view_referenced_positions;
   const auto partial_view_index =
     !!stmt.info->Cast<duckdb::CreateIndexInfo>().where_clause;
   std::optional<std::vector<duckdb::column_t>> vcols_opt;
@@ -1012,9 +1023,11 @@ duckdb::unique_ptr<duckdb::LogicalOperator> SereneDBCatalog::BindCreateIndex(
                  "view must be bound by the time fp && leaf_get holds -- "
                  "the leaf get came from binding the view body");
       auto kept = ComputeKeptViewPositions(
-        stmt.info->Cast<duckdb::CreateIndexInfo>().parsed_expressions,
-        stmt.info->Cast<duckdb::CreateIndexInfo>().where_clause.get(),
-        *column_info);
+        binder, stmt.info->Cast<duckdb::CreateIndexInfo>());
+      EnsureViewDefinitionCurrent(
+        basics::downCast<const catalog::PgSqlView>(*relation_obj),
+        *column_info, kept);
+      view_referenced_positions = kept;
       if (kept.size() < column_info->names.size() || partial_view_index) {
         plan = InsertBackfillFilterProjection(
           std::move(plan), kept, column_info->names.size(), vcols.size(),
@@ -1025,9 +1038,14 @@ duckdb::unique_ptr<duckdb::LogicalOperator> SereneDBCatalog::BindCreateIndex(
       auto& view_entry = target.Cast<duckdb::ViewCatalogEntry>();
       if (auto column_info = view_entry.GetColumnInfo()) {
         auto kept = ComputeKeptViewPositions(
-          stmt.info->Cast<duckdb::CreateIndexInfo>().parsed_expressions,
-          stmt.info->Cast<duckdb::CreateIndexInfo>().where_clause.get(),
-          *column_info);
+          binder, stmt.info->Cast<duckdb::CreateIndexInfo>());
+        if (relation_obj &&
+            relation_obj->GetType() == catalog::ObjectType::View) {
+          EnsureViewDefinitionCurrent(
+            basics::downCast<const catalog::PgSqlView>(*relation_obj),
+            *column_info, kept);
+        }
+        view_referenced_positions = kept;
         if (kept.size() < column_info->names.size() || partial_view_index) {
           plan = InsertBackfillFilterProjection(
             std::move(plan), kept, column_info->names.size(),
@@ -1149,11 +1167,24 @@ duckdb::unique_ptr<duckdb::LogicalOperator> SereneDBCatalog::BindCreateIndex(
     duckdb::ParsedExpressionIterator::EnumerateChildren(
       e, [&](const duckdb::ParsedExpression& child) { self(child); });
   };
-  for (auto& expr : create_index_info->parsed_expressions) {
-    collect(*expr);
-  }
-  if (create_index_info->where_clause) {
-    collect(*create_index_info->where_clause);
+  if (view_backed && view_referenced_positions) {
+    for (const auto p : *view_referenced_positions) {
+      const auto idx =
+        kept_view_positions
+          ? static_cast<duckdb::idx_t>(std::distance(
+              kept_view_positions->begin(),
+              std::ranges::lower_bound(*kept_view_positions, p)))
+          : p;
+      create_index_info->column_ids.emplace_back(idx);
+      create_index_info->scan_types.emplace_back(rel_columns[idx].second);
+    }
+  } else {
+    for (auto& expr : create_index_info->parsed_expressions) {
+      collect(*expr);
+    }
+    if (create_index_info->where_clause) {
+      collect(*create_index_info->where_clause);
+    }
   }
   create_index_info->scan_types.emplace_back(duckdb::LogicalType::ROW_TYPE);
 

--- a/server/connector/duckdb_catalog.cpp
+++ b/server/connector/duckdb_catalog.cpp
@@ -574,20 +574,17 @@ std::vector<duckdb::idx_t> ComputeKeptViewPositions(
   const duckdb::ParsedExpression* predicate,
   const duckdb::ViewColumnInfo& column_info) {
   std::vector<duckdb::idx_t> kept;
-  auto add = [&](std::string_view name) {
+  auto add = [&](const duckdb::Identifier& name) {
     for (size_t i = 0; i < column_info.names.size(); ++i) {
-      if (column_info.names[i].GetIdentifierName() == name) {
+      if (column_info.names[i] == name) {
         kept.push_back(i);
-        break;
       }
     }
   };
   auto collect = [&](this auto& self,
                      const duckdb::ParsedExpression& e) -> void {
     if (e.GetExpressionType() == duckdb::ExpressionType::COLUMN_REF) {
-      add(e.Cast<duckdb::ColumnRefExpression>()
-            .GetColumnName()
-            .GetIdentifierName());
+      add(e.Cast<duckdb::ColumnRefExpression>().GetColumnName());
       return;
     }
     duckdb::ParsedExpressionIterator::EnumerateChildren(

--- a/server/connector/index_source_external_lookup.cpp
+++ b/server/connector/index_source_external_lookup.cpp
@@ -82,11 +82,11 @@ ExternalLookupIndexSource::ExternalLookupIndexSource(
   auto names = entry.GetColumns().GetColumnNames();
   auto types = entry.GetColumns().GetColumnTypes();
 
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> name_to_col;
+  duckdb::identifier_map_t<duckdb::idx_t> name_to_col;
   if (!_fast_path.projection_columns.empty()) {
     name_to_col.reserve(names.size());
     for (duckdb::idx_t i = 0; i < names.size(); ++i) {
-      name_to_col.emplace(names[i], i);
+      name_to_col.emplace(duckdb::Identifier{names[i]}, i);
     }
   }
   std::vector<std::string> select_names;
@@ -94,7 +94,7 @@ ExternalLookupIndexSource::ExternalLookupIndexSource(
   InitProjection(
     context, projected_columns, projected_types, bind_column_ids,
     [&](std::string_view name) {
-      auto it = name_to_col.find(name);
+      auto it = name_to_col.find(duckdb::Identifier{name});
       SDB_ASSERT(it != name_to_col.end());
       return it->second;
     },

--- a/server/connector/index_source_view_file.cpp
+++ b/server/connector/index_source_view_file.cpp
@@ -40,18 +40,18 @@ ViewFileIndexSourceBase::ViewFileIndexSourceBase(
   _lookup_func = MakeFastPathLookupFunction(_fast_path);
 
   auto& multi_bd = _bind_data->Cast<duckdb::MultiFileBindData>();
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> name_to_file_col;
+  duckdb::identifier_map_t<duckdb::idx_t> name_to_file_col;
   if (!_fast_path.projection_columns.empty()) {
     name_to_file_col.reserve(multi_bd.names.size());
     for (duckdb::idx_t i = 0; i < multi_bd.names.size(); ++i) {
-      name_to_file_col.emplace(multi_bd.names[i].GetIdentifierName(), i);
+      name_to_file_col.emplace(multi_bd.names[i], i);
     }
   }
   _column_indexes.reserve(projected_columns.size());
   InitProjection(
     context, projected_columns, projected_types, bind_column_ids,
     [&](std::string_view name) {
-      auto it = name_to_file_col.find(name);
+      auto it = name_to_file_col.find(duckdb::Identifier{name});
       SDB_ASSERT(it != name_to_file_col.end());
       return it->second;
     },

--- a/server/connector/index_source_view_table.cpp
+++ b/server/connector/index_source_view_table.cpp
@@ -145,18 +145,18 @@ ViewTableIndexSource::ViewTableIndexSource(
   // alive for the query even if it is detached concurrently.
   duckdb::DuckTransaction::Get(context, table.ParentCatalog());
   const auto& columns = table.GetColumns();
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> name_to_col;
+  duckdb::identifier_map_t<duckdb::idx_t> name_to_col;
   if (!_fast_path.projection_columns.empty()) {
     name_to_col.reserve(columns.LogicalColumnCount());
     duckdb::idx_t logical = 0;
     for (const auto& col : columns.Logical()) {
-      name_to_col.emplace(col.Name().GetIdentifierName(), logical++);
+      name_to_col.emplace(col.Name(), logical++);
     }
   }
   InitProjection(
     context, projected_columns, projected_types, bind_column_ids,
     [&](std::string_view name) {
-      auto it = name_to_col.find(name);
+      auto it = name_to_col.find(duckdb::Identifier{name});
       SDB_ASSERT(it != name_to_col.end());
       return it->second;
     },

--- a/server/connector/view_fast_path.cpp
+++ b/server/connector/view_fast_path.cpp
@@ -219,9 +219,11 @@ std::optional<ExternalKeyColumn> FindKeyColumn(
     return std::nullopt;
   }
   const auto& col = columns.GetColumn(id);
-  // ExternalKeyColumn::name outlives this scope (it drives the re-fetch), so it
-  // owns; everything up to here only reads.
-  return ExternalKeyColumn{.name = std::string{name},
+  // ExternalKeyColumn::name outlives this scope (it drives the re-fetch), so
+  // it owns. Store the catalog's spelling, not the caller's: the name is
+  // persisted and later quoted verbatim into remote SQL, where a
+  // case-divergent user spelling breaks the (case-sensitive) remote lookup.
+  return ExternalKeyColumn{.name = std::string{col.Name().GetIdentifierName()},
                            .source_index = col.Logical().index,
                            .type = col.GetType()};
 }

--- a/tests/sqllogic/sdb/pg/duckdb_postgres/inverted_index_pgscan.test_slow
+++ b/tests/sqllogic/sdb/pg/duckdb_postgres/inverted_index_pgscan.test_slow
@@ -260,6 +260,81 @@ statement ok
 DROP TABLE pg_${__DATABASE__}.iipgscan_docs.shards;
 
 
+# ===== key_columns spelled in a case the source catalog does not use =====
+# The persisted key column name must be the catalog's spelling, not the
+# user's: it is quoted verbatim into the remote re-fetch SQL, where postgres
+# resolves it case-sensitively.
+statement ok
+CREATE VIEW pg_kc_v_${__DATABASE__} AS
+  SELECT id, body, views FROM pg_${__DATABASE__}.iipgscan_docs.articles;
+
+
+statement ok
+CREATE INDEX pg_kc_v_idx_${__DATABASE__}
+  ON pg_kc_v_${__DATABASE__}
+  USING inverted(body pg_en_${__DATABASE__})
+  WITH (key_columns = 'ID');
+
+
+query
+SELECT body, views FROM pg_kc_v_idx_${__DATABASE__}
+WHERE body @@ ts_phrase('pudge') ORDER BY views DESC;
+----
+body	views
+pudge goes mid and dominates the lane	1200
+pudge plays again in a ranked match	870
+mom reviews pudge highlight reel	12
+
+
+statement ok
+DROP VIEW pg_kc_v_${__DATABASE__};
+
+
+# ===== remote columns whose case the view's select list does not repeat =====
+# Materialising resolves the view-typed names against the remote catalog's
+# names case-insensitively (like the binder), and the remote re-fetch SQL
+# quotes the catalog's spelling.
+statement ok
+CREATE TABLE pg_${__DATABASE__}.iipgscan_docs.cased (
+  id BIGINT PRIMARY KEY,
+  "Body" TEXT,
+  "ViewCount" INTEGER
+);
+
+
+statement count 2
+INSERT INTO pg_${__DATABASE__}.iipgscan_docs.cased VALUES
+  (1, 'pudge goes mid', 11),
+  (2, 'anchin reads manga', 22);
+
+
+statement ok
+CREATE VIEW pg_cased_v_${__DATABASE__} AS
+  SELECT id, body, viewcount FROM pg_${__DATABASE__}.iipgscan_docs.cased;
+
+
+statement ok
+CREATE INDEX pg_cased_v_idx_${__DATABASE__}
+  ON pg_cased_v_${__DATABASE__}
+  USING inverted(body pg_en_${__DATABASE__});
+
+
+query
+SELECT viewcount FROM pg_cased_v_idx_${__DATABASE__}
+WHERE body @@ ts_phrase('pudge');
+----
+viewcount
+11
+
+
+statement ok
+DROP VIEW pg_cased_v_${__DATABASE__};
+
+
+statement ok
+DROP TABLE pg_${__DATABASE__}.iipgscan_docs.cased;
+
+
 # ===== arbitrary-type user keys: VARCHAR single, and a mixed 3-column key =====
 # The key columns can be ANY types (not just BIGINT): they are stored as one
 # struct column of their own types and re-fetched with literals rendered per

--- a/tests/sqllogic/sdb/pg/index/inverted_index_view_pruning.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_view_pruning.test
@@ -443,3 +443,53 @@ WHERE (regexp_split_to_array(lower(Body), '[^a-z0-9]+')) @@ ts_like('word0');
 ----
 count
 5
+
+
+# Case 14: view column whose declared case differs from the ref's folded
+# spelling (quoted alias "BodyText" vs unquoted ref bodytext). The kept-set
+# must match names case-insensitively like the binder does; a case-sensitive
+# match dropped the column from the prune and the remap asserted.
+
+statement ok
+CREATE VIEW prune_v14 AS
+  SELECT id, body AS "BodyText"
+  FROM read_parquet('${__TEST_DIR__}/view_prune.parquet');
+
+statement ok
+CREATE INDEX prune_idx14 ON prune_v14 USING inverted(
+    (lower(bodytext)) prune_en);
+
+query
+SELECT count(*) FROM prune_idx14 WHERE lower(bodytext) @@ ts_phrase('pudge');
+----
+count
+3
+
+
+# Case 15: keyword-derived alias keeps its typed case (TIMESTAMP ->
+# "Timestamp") while the index expression's unquoted ref folds to lowercase;
+# second expression key is the one referencing the case-divergent column.
+
+statement ok
+CREATE VIEW prune_v15 AS
+  SELECT (TIMESTAMP '2024-01-01 00:00:00' + INTERVAL (id) MINUTE) AS Timestamp,
+         body AS Body
+  FROM read_parquet('${__TEST_DIR__}/view_prune.parquet');
+
+statement ok
+CREATE INDEX prune_idx15 ON prune_v15 USING inverted(
+    (lower(Body)) prune_en,
+    (strftime(Timestamp, '%Y-%m-%d %H:%M')) prune_kw);
+
+query
+SELECT count(*) FROM prune_idx15 WHERE lower(Body) @@ ts_phrase('pudge');
+----
+count
+3
+
+query
+SELECT count(*) FROM prune_idx15
+WHERE strftime(Timestamp, '%Y-%m-%d %H:%M') @@ ts_like('2024-01-01 00:03');
+----
+count
+1

--- a/tests/sqllogic/sdb/pg/index/inverted_index_view_pruning.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_view_pruning.test
@@ -493,3 +493,117 @@ WHERE strftime(Timestamp, '%Y-%m-%d %H:%M') @@ ts_like('2024-01-01 00:03');
 ----
 count
 1
+
+
+# Case 16: struct-field expression key. The bound expression is a
+# struct_extract over column `s`, which the parsed text shows only as the
+# trailing field name -- the kept set must come from the bound refs.
+
+statement count 2
+COPY (SELECT {'f': 'hello world'} AS s, 1 AS id
+      UNION ALL SELECT {'f': 'bye now'}, 2)
+TO '${__TEST_DIR__}/struct_prune.parquet' (FORMAT PARQUET);
+
+statement ok
+CREATE VIEW prune_v16 AS
+  SELECT s, id FROM read_parquet('${__TEST_DIR__}/struct_prune.parquet');
+
+statement ok
+CREATE INDEX prune_idx16 ON prune_v16 USING inverted(
+    (lower(s.f)) prune_kw) WITH (store_pk = 'none');
+
+query
+SELECT count(*) FROM prune_idx16 WHERE lower(s.f) @@ ts_like('hello world');
+----
+count
+1
+
+
+# Case 17: positional reference key. The binder rewrites #1 into a column
+# ref the parsed expression never contains.
+
+statement ok
+CREATE VIEW prune_v17 AS
+  SELECT body, id FROM read_parquet('${__TEST_DIR__}/view_prune.parquet');
+
+statement ok
+CREATE INDEX prune_idx17 ON prune_v17 USING inverted((lower(#1)) prune_kw);
+
+query
+SELECT count(*) FROM prune_idx17 WHERE lower(body) @@ ts_like('pudge goes mid');
+----
+count
+1
+
+
+# Case 18: bare view name key -- binds as an implicit struct_pack over every
+# view column.
+
+statement ok
+CREATE VIEW prune_v18 AS
+  SELECT body, id FROM read_parquet('${__TEST_DIR__}/view_prune.parquet');
+
+statement ok
+CREATE INDEX prune_idx18 ON prune_v18 USING inverted(
+    (prune_v18::VARCHAR) prune_kw);
+
+query
+SELECT count(*) FROM prune_idx18;
+----
+count
+5
+
+
+# Case 19: a SELECT * view goes stale after ALTER TABLE on its base table --
+# the catalog's frozen view definition cannot resolve the new column, so
+# indexing it must fail cleanly; pre-existing columns stay indexable.
+
+statement ok
+CREATE TABLE prune_alter_base(a INTEGER, body TEXT);
+
+statement ok
+INSERT INTO prune_alter_base VALUES (1, 'hello');
+
+statement ok
+CREATE VIEW prune_v19 AS SELECT * FROM prune_alter_base;
+
+statement ok
+ALTER TABLE prune_alter_base ADD COLUMN extra TEXT;
+
+statement error
+CREATE INDEX prune_idx19 ON prune_v19 USING inverted((lower(extra)) prune_kw);
+----
+db error: ERROR: view "prune_v19" is out of date with its underlying relation; recreate the view before creating an index on it
+
+
+statement ok
+CREATE INDEX prune_idx19 ON prune_v19 USING inverted((lower(body)) prune_kw);
+
+query
+SELECT count(*) FROM prune_idx19 WHERE lower(body) @@ ts_like('hello');
+----
+count
+1
+
+
+# Case 20: source file columns with case the view's select list does not
+# repeat verbatim. Materialising a lookup column resolves the view-typed
+# names against the file's names case-insensitively, like the binder did.
+
+statement count 2
+COPY (SELECT 'aaa bbb' AS "Body", 7 AS "UserID"
+      UNION ALL SELECT 'ccc ddd', 8)
+TO '${__TEST_DIR__}/mixed_case.parquet' (FORMAT PARQUET);
+
+statement ok
+CREATE VIEW prune_v20 AS
+  SELECT body, userid FROM read_parquet('${__TEST_DIR__}/mixed_case.parquet');
+
+statement ok
+CREATE INDEX prune_idx20 ON prune_v20 USING inverted((lower(body)) prune_kw);
+
+query
+SELECT userid FROM prune_idx20 WHERE lower(body) @@ ts_like('aaa bbb');
+----
+userid
+7


### PR DESCRIPTION
Five server-killing crashes and one broken-index bug in view-backed inverted indexes, found by adversarial testing around the kept-positions machinery. All reproduced on main (Debug asserts; in release builds the same paths mis-map column positions or read out of bounds instead of dying loudly).

## 1. Bind-time crash family: kept positions diverged from the bound expressions

`ComputeKeptViewPositions` collected the view columns an index references by walking the **parsed** text for column refs, while the later remap of bound refs to narrowed positions walks the **bound** tree. The binder resolves names case-insensitively and synthesizes refs the parsed walk never sees, so each of these killed the server on `SDB_ASSERT(... "view col ref references a non-kept position")`:

```sql
-- case-divergent stored name (keyword alias keeps its typed case: "Timestamp")
CREATE INDEX i ON v USING inverted((strftime(Timestamp, '%Y-%m-%d %H:%M')) en);
-- struct-field key: parsed text shows only the field name `f`, bound tree references `s`
CREATE INDEX i ON v USING inverted((lower(s.f)) kw);
-- bare view name: binds as struct_pack over every view column
CREATE INDEX i ON v USING inverted((v::VARCHAR) kw);
-- positional ref: rewritten into a column ref at bind time
CREATE INDEX i ON v USING inverted((lower(#1)) kw);
```

Fix: probe-bind copies of the keys and predicate and collect kept positions from the bound refs — the collector and the remap can no longer disagree. View `column_ids` are derived from the same positions, so struct-field and positional keys now build and answer `@@` queries (previously rejected/crashed). Indexes with a full INCLUDE list dodged all of this by accident (`kept.size() == names.size()` skips pruning), which is why e.g. searchbench's create.sql never hit it.

## 2. Query-time crash: case-sensitive projection-name maps

`index_source_view_file` / `index_source_view_table` / `index_source_external_lookup` keyed their name→column maps by the source's raw spelling and looked them up with the view body's spelling. Mixed-case source columns are the norm for parquet/iceberg/ClickHouse, so this was trivially fatal:

```sql
-- parquet has "Body", "UserID"
CREATE VIEW v AS SELECT body, userid FROM read_parquet('mixed.parquet');
CREATE INDEX i ON v USING inverted((lower(body)) kw);   -- succeeds
SELECT userid FROM i WHERE lower(body) @@ ts_like('...'); -- server dies (assert) / OOB (release)
```

Fix: `identifier_map_t` (the binder's case-insensitive comparison) in all three sources.

## 3. Stale `SELECT *` view after ALTER TABLE

The index plan re-binds the view body (sees new columns), but the physical create and every later scan read names/types from the catalog's frozen view definition — indexing a post-ALTER column asserted at `duckdb_physical_create_index.cpp` (release: OOB reads; equal-count divergence silently persisted wrong name/type). Now fails closed at bind:

```
ERROR: view "v" is out of date with its underlying relation; recreate the view before creating an index on it
```

Pre-existing columns of a stale view stay indexable.

## 4. key_columns persisted the user's spelling

`WITH (key_columns = 'ID')` over a source column `id` resolved case-insensitively at CREATE INDEX, but persisted the user's spelling and later quoted it verbatim into the remote re-fetch SQL (`WHERE "ID" IN ...` / `` t.`userid` ``), where postgres and ClickHouse resolve case-sensitively — a permanently unusable index that could only be fixed by recreating it. Now the catalog's spelling is persisted.

## Tests

- `tests/sqllogic/sdb/pg/index/inverted_index_view_pruning.test`: cases 14-20 — quoted-alias and keyword-alias case divergence, struct-field key, positional key, bare-view-name key, stale-view error + still-indexable column, mixed-case parquet materialisation. Full `sdb/pg/index` suite: 366 passes across both wire engines.
- `tests/sqllogic/sdb/pg/duckdb_postgres/inverted_index_pgscan.test_slow`: case-divergent `key_columns = 'ID'`, and remote columns (`"Body"`, `"ViewCount"`) whose case the view's select list does not repeat — both engines, against a real postgres.

## Known follow-ups (out of scope)

- The parser-side case leak that makes keyword aliases store their typed case (`TransformIdentifierOrKeyword` returns keyword tokens as typed while identifiers fold) lives in the duckdb fork — needs a fork PR + submodule bump.
- `ResolveViewFastPath` resolves the fast path against the caller's search path while the leaf get was bound with the view's; a same-named shadowing table across attached DBs can splice mismatched plumbing (needs attached-DB repro).
- ALTER TABLE column-name matching in `server/catalog` (`DropTableColumn`, `ChangeColumnType`, `RenameColumn`, ...) compares raw strings the same way — error-level, separate change.