### PR TITLE
Improve `RaBitQ` with fast-scan

### DIFF
--- a/libs/iresearch/include/iresearch/formats/ivf/quantizer.cpp
+++ b/libs/iresearch/include/iresearch/formats/ivf/quantizer.cpp
@@ -82,7 +82,9 @@ size_t FastScanNsq(size_t m) noexcept { return m + (m & 1); }
 
 constexpr int64_t kRaBitQRotationSeed = 0x5a17b17c5eed5eedULL;
 
-uint32_t RotatedDim(uint32_t d) noexcept { return std::bit_ceil(d); }
+uint32_t RotatedDim(uint32_t d) noexcept {
+  return std::max<uint32_t>(kFastScanBits, std::bit_ceil(d));
+}
 
 void GenerateSigns(uint32_t rotated_d, int64_t seed,
                    std::vector<float>& signs) {
@@ -627,7 +629,8 @@ class RaBitQuantizerWriter final : public QuantizerWriter {
       _metric{FaissMetric(metric)},
       _storage{
         faiss::rabitq_utils::compute_per_vector_storage_size(nb_bits, _rd)},
-      _ex_code_size{(static_cast<size_t>(_rd) * _ex_bits + 7) / 8} {
+      _ex_code_size{(static_cast<size_t>(_rd) * _ex_bits + 7) / 8},
+      _sign_stride{FastScanNsq(_rd / kFastScanBits) / 2} {
     GenerateSigns(_rd, kRaBitQRotationSeed, _signs);
     _stats.resize(sizeof(RaBitQStatsHeader));
     WritePodHeader(RaBitQStatsHeader{nb_bits, d}, _stats.data());
@@ -641,7 +644,7 @@ class RaBitQuantizerWriter final : public QuantizerWriter {
   }
 
   void BeginCluster(size_t total_docs) final {
-    _sign_codes.assign(total_docs * (_rd / 8), 0);
+    _sign_codes.assign(total_docs * _sign_stride, 0);
     _aux.assign(total_docs * _storage, 0);
     _filled = 0;
   }
@@ -652,7 +655,7 @@ class RaBitQuantizerWriter final : public QuantizerWriter {
       return;
     }
     SDB_ASSERT(_centroid.size() == _rd);
-    const size_t sign_stride = _rd / 8;
+    const size_t sign_stride = _sign_stride;
     std::vector<float> rotated(_rd);
     std::vector<float> residual(_rd);
     for (size_t i = 0; i < n; ++i) {
@@ -724,6 +727,7 @@ class RaBitQuantizerWriter final : public QuantizerWriter {
   faiss::MetricType _metric;
   size_t _storage;
   size_t _ex_code_size;
+  size_t _sign_stride;
   std::vector<float> _signs;
   std::vector<float> _centroid;
   std::vector<byte_type> _stats;

--- a/libs/iresearch/include/iresearch/formats/ivf/quantizer.cpp
+++ b/libs/iresearch/include/iresearch/formats/ivf/quantizer.cpp
@@ -21,7 +21,8 @@
 #include "iresearch/formats/ivf/quantizer.hpp"
 
 #include <faiss/impl/ProductQuantizer.h>
-#include <faiss/impl/RaBitQuantizer.h>
+#include <faiss/impl/RaBitQUtils.h>
+#include <faiss/impl/RaBitQuantizerMultiBit.h>
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/impl/fast_scan/fast_scan.h>
 #include <faiss/utils/AlignedTable.h>
@@ -34,6 +35,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <vector>
 
@@ -69,6 +71,8 @@ std::span<const byte_type> FloatSpan(const std::vector<float>& v) noexcept {
 
 constexpr size_t kFastScanBbs = 32;
 constexpr uint32_t kPqNbits = 4;
+constexpr size_t kFastScanBits = 4;
+constexpr size_t kFastScanKsub = size_t{1} << kFastScanBits;
 
 size_t RoundUp(size_t n, size_t multiple) noexcept {
   return (n + multiple - 1) / multiple * multiple;
@@ -141,6 +145,10 @@ struct RaBitQStatsHeader {
   uint32_t nb_bits;
   uint32_t d;
 };
+
+constexpr uint8_t kRaBitQQueryBits = 8;
+constexpr bool kRaBitQCentered = false;
+constexpr size_t kRaBitQRefinePool = 64;
 
 class ScalarQuantizerWriter final : public QuantizerWriter {
  public:
@@ -612,7 +620,14 @@ std::shared_ptr<const QuantizerCodebook> ProductQuantizerStats::MakeCodebook(
 class RaBitQuantizerWriter final : public QuantizerWriter {
  public:
   RaBitQuantizerWriter(uint32_t d, VectorMetric metric, uint32_t nb_bits)
-    : _d{d}, _rd{RotatedDim(d)}, _rabitq{_rd, FaissMetric(metric), nb_bits} {
+    : _d{d},
+      _rd{RotatedDim(d)},
+      _nb_bits{nb_bits},
+      _ex_bits{nb_bits - 1},
+      _metric{FaissMetric(metric)},
+      _storage{
+        faiss::rabitq_utils::compute_per_vector_storage_size(nb_bits, _rd)},
+      _ex_code_size{(static_cast<size_t>(_rd) * _ex_bits + 7) / 8} {
     GenerateSigns(_rd, kRaBitQRotationSeed, _signs);
     _stats.resize(sizeof(RaBitQStatsHeader));
     WritePodHeader(RaBitQStatsHeader{nb_bits, d}, _stats.data());
@@ -625,21 +640,68 @@ class RaBitQuantizerWriter final : public QuantizerWriter {
     RotateInto(_signs.data(), centroid, _centroid.data(), _d, _rd);
   }
 
-  void EncodeCluster(IndexOutput& out, const float* vecs,
+  void BeginCluster(size_t total_docs) final {
+    _sign_codes.assign(total_docs * (_rd / 8), 0);
+    _aux.assign(total_docs * _storage, 0);
+    _filled = 0;
+  }
+
+  void EncodeCluster(IndexOutput& /*out*/, const float* vecs,
                      size_t n) const final {
     if (n == 0) {
       return;
     }
     SDB_ASSERT(_centroid.size() == _rd);
-    _rotated.resize(n * _rd);
+    const size_t sign_stride = _rd / 8;
+    std::vector<float> rotated(_rd);
+    std::vector<float> residual(_rd);
     for (size_t i = 0; i < n; ++i) {
-      RotateInto(_signs.data(), vecs + i * _d, _rotated.data() + i * _rd, _d,
-                 _rd);
+      RotateInto(_signs.data(), vecs + i * _d, rotated.data(), _d, _rd);
+      uint8_t* sign = _sign_codes.data() + (_filled + i) * sign_stride;
+      for (uint32_t j = 0; j < _rd; ++j) {
+        residual[j] = rotated[j] - _centroid[j];
+        if (residual[j] > 0.f) {
+          faiss::rabitq_utils::set_bit_fastscan(sign, j);
+        }
+      }
+      uint8_t* aux = _aux.data() + (_filled + i) * _storage;
+      const faiss::rabitq_utils::SignBitFactorsWithError f =
+        faiss::rabitq_utils::compute_vector_factors(
+          rotated.data(), _rd, _centroid.data(), _metric,
+          /*compute_error=*/_ex_bits > 0);
+      if (_ex_bits == 0) {
+        std::memcpy(aux, &f, sizeof(faiss::rabitq_utils::SignBitFactors));
+      } else {
+        std::memcpy(aux, &f,
+                    sizeof(faiss::rabitq_utils::SignBitFactorsWithError));
+        uint8_t* ex_code =
+          aux + sizeof(faiss::rabitq_utils::SignBitFactorsWithError);
+        faiss::rabitq_utils::ExtraBitsFactors ex;
+        faiss::rabitq_multibit::quantize_ex_bits(residual.data(), _rd, _nb_bits,
+                                                 ex_code, ex, _metric,
+                                                 _centroid.data());
+        std::memcpy(ex_code + _ex_code_size, &ex,
+                    sizeof(faiss::rabitq_utils::ExtraBitsFactors));
+      }
     }
-    _code.resize(n * _rabitq.code_size);
-    _rabitq.compute_codes_core(_rotated.data(), _code.data(), n,
-                               _centroid.data());
-    out.WriteData(_code.data(), _code.size());
+    _filled += n;
+  }
+
+  void FinishCluster(IndexOutput& out) final {
+    if (_filled == 0) {
+      return;
+    }
+    const size_t m = _rd / kFastScanBits;
+    const size_t nsq = FastScanNsq(m);
+    const size_t nb = RoundUp(_filled, kFastScanBbs);
+    _packed.assign(nb * nsq / 2, 0);
+    faiss::pq4_pack_codes(_sign_codes.data(), _filled, m, nb, kFastScanBbs, nsq,
+                          _packed.data());
+    out.WriteData(_packed.data(), _packed.size());
+    out.WriteData(_aux.data(), _filled * _storage);
+    _sign_codes.clear();
+    _aux.clear();
+    _packed.clear();
   }
 
   std::span<const byte_type> StatsBytes() const final {
@@ -651,18 +713,24 @@ class RaBitQuantizerWriter final : public QuantizerWriter {
   }
 
   uint32_t CodeSize() const noexcept final {
-    return static_cast<uint32_t>(_rabitq.code_size);
+    return static_cast<uint32_t>(_storage);
   }
 
  private:
   uint32_t _d;
   uint32_t _rd;
-  faiss::RaBitQuantizer _rabitq;
+  uint32_t _nb_bits;
+  uint32_t _ex_bits;
+  faiss::MetricType _metric;
+  size_t _storage;
+  size_t _ex_code_size;
   std::vector<float> _signs;
   std::vector<float> _centroid;
   std::vector<byte_type> _stats;
-  mutable std::vector<float> _rotated;
-  mutable std::vector<uint8_t> _code;
+  mutable std::vector<uint8_t> _sign_codes;
+  mutable std::vector<uint8_t> _aux;
+  mutable std::vector<uint8_t> _packed;
+  mutable size_t _filled = 0;
 };
 
 class RaBitQuantizerStats final : public QuantizerStats {
@@ -671,11 +739,10 @@ class RaBitQuantizerStats final : public QuantizerStats {
                       VectorMetric metric) {
     const RaBitQStatsHeader hdr = ReadPodHeader<RaBitQStatsHeader>(stats);
     if (hdr.nb_bits >= kRaBitQMinBits && hdr.nb_bits <= kRaBitQMaxBits &&
-        hdr.d == d && stats.size() >= 2 * sizeof(uint32_t)) {
+        hdr.d == d && stats.size() >= sizeof(RaBitQStatsHeader)) {
       _d = d;
       _rd = RotatedDim(d);
-      _rabitq = std::make_unique<faiss::RaBitQuantizer>(
-        _rd, FaissMetric(metric), hdr.nb_bits);
+      _nb_bits = hdr.nb_bits;
       GenerateSigns(_rd, kRaBitQRotationSeed, _signs);
       _metric = metric;
       _valid = true;
@@ -683,6 +750,7 @@ class RaBitQuantizerStats final : public QuantizerStats {
   }
 
   bool Valid() const noexcept { return _valid; }
+  uint32_t NbBits() const noexcept { return _nb_bits; }
 
   VectorQuantization Kind() const noexcept final {
     return VectorQuantization::RaBitQ;
@@ -691,7 +759,6 @@ class RaBitQuantizerStats final : public QuantizerStats {
   std::shared_ptr<const QuantizerCodebook> MakeCodebook(
     std::span<const float> query) const final;
 
-  const faiss::RaBitQuantizer& Rabitq() const noexcept { return *_rabitq; }
   const std::vector<float>& Signs() const noexcept { return _signs; }
   uint32_t SrcDim() const noexcept { return _d; }
   uint32_t RotDim() const noexcept { return _rd; }
@@ -700,7 +767,7 @@ class RaBitQuantizerStats final : public QuantizerStats {
  private:
   uint32_t _d = 0;
   uint32_t _rd = 0;
-  std::unique_ptr<faiss::RaBitQuantizer> _rabitq;
+  uint32_t _nb_bits = 0;
   std::vector<float> _signs;
   VectorMetric _metric = VectorMetric::L2Sqr;
   bool _valid = false;
@@ -719,15 +786,13 @@ class RaBitQuantizerCodebook final : public QuantizerCodebook {
   std::unique_ptr<QuantizerReader> MakeReader(
     std::unique_ptr<IndexInput> pay_in) const final;
 
-  const faiss::RaBitQuantizer& Rabitq() const noexcept {
-    return _stats->Rabitq();
-  }
   const std::vector<float>& Signs() const noexcept { return _stats->Signs(); }
   const std::vector<float>& RotatedQuery() const noexcept {
     return _rotated_query;
   }
   uint32_t SrcDim() const noexcept { return _stats->SrcDim(); }
   uint32_t RotDim() const noexcept { return _stats->RotDim(); }
+  uint32_t NbBits() const noexcept { return _stats->NbBits(); }
   VectorMetric Metric() const noexcept { return _stats->Metric(); }
 
  private:
@@ -741,7 +806,13 @@ class RaBitQuantizerReader final : public QuantizerReader {
                        std::unique_ptr<IndexInput> pay_in)
     : _cb{std::move(cb)},
       _pay_in{std::move(pay_in)},
-      _codes_reader{*_pay_in, static_cast<uint32_t>(_cb->Rabitq().code_size)} {}
+      _rd{_cb->RotDim()},
+      _m{_rd / kFastScanBits},
+      _nsq{FastScanNsq(_rd / kFastScanBits)},
+      _ex_bits{_cb->NbBits() - 1},
+      _storage{faiss::rabitq_utils::compute_per_vector_storage_size(
+        _cb->NbBits(), _rd)},
+      _ex_code_size{(static_cast<size_t>(_rd) * _ex_bits + 7) / 8} {}
 
   void StartCluster(uint64_t pay_start, size_t num_docs,
                     const float* centroid) final {
@@ -749,34 +820,142 @@ class RaBitQuantizerReader final : public QuantizerReader {
     if (_n == 0) {
       return;
     }
-    SDB_ASSERT(centroid != nullptr);
-    _rotated_centroid.resize(_cb->RotDim());
-    RotateInto(_cb->Signs().data(), centroid, _rotated_centroid.data(),
-               _cb->SrcDim(), _cb->RotDim());
-    _dc.reset(
-      _cb->Rabitq().get_distance_computer(0, _rotated_centroid.data(), false));
-    _dc->set_query(_cb->RotatedQuery().data());
-    _codes_reader.Reset(pay_start);
+    SDB_ASSERT(centroid);
+    std::vector<float> rotated_centroid(_rd);
+    RotateInto(_cb->Signs().data(), centroid, rotated_centroid.data(),
+               _cb->SrcDim(), _rd);
+
+    const faiss::MetricType metric = FaissMetric(_cb->Metric());
+    const bool is_l2 = _cb->Metric() == VectorMetric::L2Sqr;
+    std::vector<float> rotated_q;
+    std::vector<uint8_t> rotated_qq;
+    const faiss::rabitq_utils::QueryFactorsData qf =
+      faiss::rabitq_utils::compute_query_factors(
+        _cb->RotatedQuery().data(), _rd, rotated_centroid.data(),
+        kRaBitQQueryBits, kRaBitQCentered, metric, rotated_q, rotated_qq);
+
+    std::vector<float> lut(_m * kFastScanKsub);
+    for (size_t mi = 0; mi < _m; ++mi) {
+      const size_t dim_start = mi * kFastScanBits;
+      for (size_t code = 0; code < kFastScanKsub; ++code) {
+        float ip = 0.f;
+        int pc = 0;
+        for (size_t off = 0; off < kFastScanBits; ++off) {
+          if ((code >> off) & 1) {
+            ip += rotated_qq[dim_start + off];
+            ++pc;
+          }
+        }
+        lut[mi * kFastScanKsub + code] =
+          qf.c1 * ip + qf.c2 * static_cast<float>(pc);
+      }
+    }
+    float a;
+    float b;
+    _lutq.resize(_nsq * kFastScanKsub);
+    faiss::quantize_lut::quantize_LUT_and_bias(
+      1, _m, kFastScanKsub, false, lut.data(), nullptr, _lutq.data(), _nsq,
+      nullptr, &a, &b);
+    _packed_lut.resize(_nsq * kFastScanKsub);
+    faiss::pq4_pack_LUT(1, static_cast<int>(_nsq), _lutq.data(),
+                        _packed_lut.data());
+
+    const size_t nb = RoundUp(_n, kFastScanBbs);
+    const size_t packed_bytes = nb * _nsq / 2;
+    const size_t aux_bytes = _n * _storage;
+    const byte_type* buf =
+      _pay_in->ReadVolatile(pay_start, packed_bytes + aux_bytes);
+    if (!buf) {
+      _buf.resize(packed_bytes + aux_bytes);
+      _pay_in->ReadData(pay_start, _buf.data(), packed_bytes + aux_bytes);
+      buf = _buf.data();
+    }
+    const byte_type* codes = buf;
+    const byte_type* aux = buf + packed_bytes;
+
+    _accu.resize(nb);
+    faiss::accumulate_to_mem(1, nb, static_cast<int>(_nsq), codes,
+                             _packed_lut.data(), _accu.data());
+
+    _scores.resize(_n);
+    const float inv_a = 1.f / a;
+    for (size_t i = 0; i < _n; ++i) {
+      const float normalized = static_cast<float>(_accu[i]) * inv_a + b;
+      const auto* fac =
+        reinterpret_cast<const faiss::rabitq_utils::SignBitFactors*>(
+          aux + i * _storage);
+      _scores[i] = faiss::rabitq_utils::compute_1bit_adjusted_distance(
+        normalized, *fac, qf, kRaBitQCentered, kRaBitQQueryBits, _rd);
+    }
+
+    if (_ex_bits > 0) {
+      const size_t pool = kRaBitQRefinePool;
+      const bool is_sim = !is_l2;
+      float threshold;
+      if (pool >= _n) {
+        threshold = is_sim ? std::numeric_limits<float>::lowest()
+                           : std::numeric_limits<float>::max();
+      } else {
+        std::vector<float> tmp(_scores.begin(), _scores.end());
+        auto kth = tmp.begin() + static_cast<std::ptrdiff_t>(pool - 1);
+        if (is_sim) {
+          std::nth_element(tmp.begin(), kth, tmp.end(), std::greater<float>{});
+        } else {
+          std::nth_element(tmp.begin(), kth, tmp.end());
+        }
+        threshold = *kth;
+      }
+      std::vector<uint8_t> sign_bits((_rd + 7) / 8);
+      const size_t block_stride = (_nsq / 2) * kFastScanBbs;
+      for (size_t i = 0; i < _n; ++i) {
+        const byte_type* rec = aux + i * _storage;
+        const auto* fe =
+          reinterpret_cast<const faiss::rabitq_utils::SignBitFactorsWithError*>(
+            rec);
+        if (!faiss::rabitq_utils::should_refine_candidate(
+              _scores[i], fe->f_error, qf.g_error, threshold, is_sim)) {
+          continue;
+        }
+        faiss::rabitq_utils::unpack_sign_bits_from_packed(
+          codes, kFastScanBbs, _nsq, i, block_stride, sign_bits.data());
+        const uint8_t* ex_code =
+          rec + sizeof(faiss::rabitq_utils::SignBitFactorsWithError);
+        const auto* ex_fac =
+          reinterpret_cast<const faiss::rabitq_utils::ExtraBitsFactors*>(
+            ex_code + _ex_code_size);
+        const float qr_base = is_l2 ? qf.qr_to_c_L2sqr : qf.q_dot_c;
+        _scores[i] = faiss::rabitq_utils::compute_full_multibit_distance(
+          sign_bits.data(), ex_code, *ex_fac, rotated_q.data(), qr_base, _rd,
+          _ex_bits, metric);
+      }
+    }
+
+    if (is_l2) {
+      for (size_t i = 0; i < _n; ++i) {
+        _scores[i] = -_scores[i];
+      }
+    }
   }
 
   void ComputeBlock(size_t offset, size_t count, score_t* out) final {
-    SDB_ASSERT(_dc);
     SDB_ASSERT(offset + count <= _n);
-    const byte_type* block = _codes_reader.Read(offset, count);
-    const size_t cs = _cb->Rabitq().code_size;
-    const bool is_l2 = _cb->Metric() == VectorMetric::L2Sqr;
-    for (size_t i = 0; i < count; ++i) {
-      const auto d = _dc->distance_to_code(block + i * cs);
-      out[i] = is_l2 ? -d : d;
-    }
+    std::memcpy(out, _scores.data() + offset, count * sizeof(score_t));
   }
 
  private:
   std::shared_ptr<const RaBitQuantizerCodebook> _cb;
   std::unique_ptr<IndexInput> _pay_in;
-  std::unique_ptr<faiss::FlatCodesDistanceComputer> _dc;
-  VectorBlockReader _codes_reader;
-  std::vector<float> _rotated_centroid;
+  size_t _rd;
+  size_t _m;
+  size_t _nsq;
+  uint32_t _ex_bits;
+  size_t _storage;
+  size_t _ex_code_size;
+  std::vector<uint8_t> _lutq;
+  faiss::AlignedTable<uint8_t> _packed_lut;
+  std::vector<byte_type> _buf;
+  faiss::AlignedTable<uint16_t> _accu;
+  std::vector<score_t> _scores;
   size_t _n = 0;
 };
 

--- a/tests/libs/iresearch/formats/ivf/quantizer_test.cpp
+++ b/tests/libs/iresearch/formats/ivf/quantizer_test.cpp
@@ -118,7 +118,9 @@ TEST_P(rabitq_quantizer_test, roundtrip_ranking_across_dims) {
   {
     MemoryIndexOutput out{file};
     pay_start = out.Position();
+    writer->BeginCluster(n);
     writer->EncodeCluster(out, points.data(), n);
+    writer->FinishCluster(out);
     out.Flush();
   }
 
@@ -170,7 +172,9 @@ TEST(rabitq_quantizer_test, roundtrip_ranking_matches_exact_l2) {
   {
     MemoryIndexOutput out{file};
     pay_start = out.Position();
+    writer->BeginCluster(n);
     writer->EncodeCluster(out, points.data(), n);
+    writer->FinishCluster(out);
     out.Flush();
   }
 
@@ -240,7 +244,9 @@ TEST(rabitq_quantizer_test, roundtrip_ranking_matches_exact_inner_product) {
   {
     MemoryIndexOutput out{file};
     pay_start = out.Position();
+    writer->BeginCluster(n);
     writer->EncodeCluster(out, points.data(), n);
+    writer->FinishCluster(out);
     out.Flush();
   }
 


### PR DESCRIPTION
RaBitQ scoring was the slowest quantizer we ship, and `rabitq_bits = 1` — the
default — was its worst case: every candidate went through a per-vector
`faiss::RaBitQuantizer::get_distance_computer()` / `distance_to_code()` call, so a
kNN query paid a scalar distance computation per vector per probed cluster.

This replaces that with a single PQ4 fast-scan per cluster for **every** `nb_bits`,
so there is one code path instead of two:

- **Writer** buffers a whole cluster (`BeginCluster` / `FinishCluster`) and emits
  `[pq4_pack_codes(residual sign bits)][per-vector aux factors]`.
- **Reader** builds a 16-entry-per-group LUT from `compute_query_factors`, quantizes
  it to 8 bits (`quantize_LUT_and_bias` + `pq4_pack_LUT`), runs `accumulate_to_mem`
  over the cluster and finishes with `compute_1bit_adjusted_distance`.
- When `ex_bits = rabitq_bits - 1 > 0`, a second stage refines the top
  `kRaBitQRefinePool = 64` candidates per cluster with
  `compute_full_multibit_distance`.

No faiss changes; the on-disk payload layout changes, so indexes are not
cross-compatible with `main`.

## Benchmark

`dataset=dbpedia-100K dim=1536 metric=l2 k=10 nq=50 reps=3 quant=rabitq`

Both binaries were built from the same worktree with only
`libs/iresearch/include/iresearch/formats/ivf/quantizer.cpp` swapped between `main`
@ `8dec21d2e` and this branch, so faiss, duckdb, compiler and flags are identical.
Harness is checked in at `scripts/perf/rabitq_compare/`; full write-up in
`docs/RABITQ_MAIN_VS_BRANCH.md`.

The `scan` columns below are p50 of the server-side `Total Time` from
`EXPLAIN ANALYZE` **minus a measured 11.6 ms constant**: duckdb starts
`query.total_time` before the parser, so every raw measurement includes parsing the
~20 KB inlined 1536-float query literal. That floor was measured directly with the
same literals (`EXPLAIN ANALYZE SELECT <lit>::FLOAT[1536]`) and is the same on both
binaries (11.5 ms main / 11.6 ms branch). The literal cannot be avoided —
`iresearch_plan.cpp` requires a foldable constant, so a bound parameter drops the
query out of the ANN path.

recall@10 is micro-averaged against an exact `l2_distance` base-table scan computed
once and shared by all six variants. `rerank = 0` disables the raw-vector rerank so
the quantizer's own ranking is visible; `rerank = 4` is the shipping default.

### Build cost — unchanged

| bits | build_s main | build_s branch | index_MB main | index_MB branch |
|---:|---:|---:|---:|---:|
| 1 | 25.0 | 24.8 | 535 | 536 |
| 3 | 57.0 | 56.8 | 585 | 586 |
| 5 | 68.9 | 68.7 | 634 | 635 |

The 32-vector `pq4_pack_codes` padding plus the extra error float for `ex_bits > 0`
cost ~1 MB per variant at 100K rows.

### Headline: the 1-bit default

| bits | nprobe | rerank | scan main | scan branch | speedup | recall main | recall branch |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8 | 4 | 60.8 ms | 5.5 ms | **11.1x** | 0.884 | 0.878 |
| 1 | 32 | 4 | 226.5 ms | 8.2 ms | **27.6x** | 0.972 | 0.974 |
| 1 | 128 | 0 | 867.5 ms | 17.7 ms | **49.0x** | 0.846 | 0.862 |
| 3 | 32 | 4 | 92.5 ms | 26.0 ms | **3.6x** | 0.976 | 0.978 |
| 5 | 32 | 4 | 89.5 ms | 26.6 ms | **3.4x** | 0.966 | 0.968 |

<details>
<summary>Full matrix (3 bit widths × 5 nprobe × 2 rerank)</summary>

| bits | nprobe | rerank | scan main (ms) | scan branch (ms) | speedup | recall main | recall branch | Δrecall |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 0 | 11.6 | 4.5 | **2.6x** | 0.530 | 0.554 | +0.024 |
| 1 | 1 | 4 | 12.1 | 4.4 | **2.7x** | 0.584 | 0.576 | -0.008 |
| 1 | 4 | 0 | 32.6 | 4.2 | **7.8x** | 0.698 | 0.754 | +0.056 |
| 1 | 4 | 4 | 33.3 | 4.8 | **6.9x** | 0.792 | 0.818 | +0.026 |
| 1 | 8 | 0 | 60.5 | 4.6 | **13.2x** | 0.772 | 0.796 | +0.024 |
| 1 | 8 | 4 | 60.7 | 5.4 | **11.2x** | 0.884 | 0.878 | -0.006 |
| 1 | 32 | 0 | 225.4 | 7.3 | **30.9x** | 0.822 | 0.852 | +0.030 |
| 1 | 32 | 4 | 226.4 | 8.1 | **28.0x** | 0.972 | 0.974 | +0.002 |
| 1 | 128 | 0 | 867.4 | 17.6 | **49.3x** | 0.846 | 0.862 | +0.016 |
| 1 | 128 | 4 | 867.4 | 18.3 | **47.4x** | 1.000 | 1.000 | +0.000 |
| 3 | 1 | 0 | 7.3 | 4.7 | **1.6x** | 0.574 | 0.558 | -0.016 |
| 3 | 1 | 4 | 7.5 | 5.0 | **1.5x** | 0.578 | 0.558 | -0.020 |
| 3 | 4 | 0 | 15.0 | 6.3 | **2.4x** | 0.808 | 0.800 | -0.008 |
| 3 | 4 | 4 | 15.7 | 6.9 | **2.3x** | 0.816 | 0.812 | -0.004 |
| 3 | 8 | 0 | 26.5 | 8.8 | **3.0x** | 0.876 | 0.874 | -0.002 |
| 3 | 8 | 4 | 27.1 | 9.4 | **2.9x** | 0.894 | 0.890 | -0.004 |
| 3 | 32 | 0 | 91.4 | 25.3 | **3.6x** | 0.938 | 0.946 | +0.008 |
| 3 | 32 | 4 | 92.4 | 25.9 | **3.6x** | 0.976 | 0.978 | +0.002 |
| 3 | 128 | 0 | 344.4 | 93.4 | **3.7x** | 0.956 | 0.958 | +0.002 |
| 3 | 128 | 4 | 344.4 | 94.4 | **3.6x** | 1.000 | 0.998 | -0.002 |
| 5 | 1 | 0 | 7.3 | 5.4 | **1.4x** | 0.592 | 0.592 | +0.000 |
| 5 | 1 | 4 | 7.3 | 5.1 | **1.4x** | 0.592 | 0.596 | +0.004 |
| 5 | 4 | 0 | 15.2 | 6.3 | **2.4x** | 0.786 | 0.808 | +0.022 |
| 5 | 4 | 4 | 15.9 | 6.9 | **2.3x** | 0.788 | 0.812 | +0.024 |
| 5 | 8 | 0 | 25.9 | 9.0 | **2.9x** | 0.862 | 0.874 | +0.012 |
| 5 | 8 | 4 | 26.2 | 9.6 | **2.7x** | 0.864 | 0.880 | +0.016 |
| 5 | 32 | 0 | 89.4 | 26.0 | **3.4x** | 0.960 | 0.960 | +0.000 |
| 5 | 32 | 4 | 89.4 | 26.5 | **3.4x** | 0.966 | 0.968 | +0.002 |
| 5 | 128 | 0 | 340.4 | 95.4 | **3.6x** | 0.990 | 0.982 | -0.008 |
| 5 | 128 | 4 | 341.4 | 96.4 | **3.5x** | 1.000 | 1.000 | +0.000 |

</details>

### Findings

1. **The default configuration is the big win.** At `rabitq_bits = 1` the scan goes
   from 226 ms to 8.2 ms at nprobe=32 and from 868 ms to 18 ms at nprobe=128.
   `main`'s 1-bit path was also its *slowest* configuration — 868 ms vs 345 ms for
   its own 3-bit — so this removes a pathology, not just a constant factor.

2. **Recall does not regress; at 1 bit it improves.** With `rerank = 0`, where
   nothing masks a ranking error, branch 1-bit is ahead at all five nprobe points
   (+0.016 to +0.056). That is the estimator change, not noise in one cell:
   `compute_1bit_adjusted_distance` with an 8-bit quantized query is more accurate
   than `distance_to_code`, and it more than pays for quantizing the LUT. At 3 and 5
   bits the two agree within ±0.024, inside the ±0.026 binomial noise of 50 queries.

3. **One measurable cost.** The worst cell is `bits=5, nprobe=128, rerank=0`: 0.982
   vs 0.990 (−0.008) — the expected shape, since `main` refines every candidate's
   full multi-bit distance while this refines only the top 64 per cluster. It is
   gone at the default `rerank_factor = 4` (both 1.000).

4. **Multi-bit scales worse with nprobe than 1-bit.** Branch scan at nprobe=128 is
   18 ms at 1 bit but 94 ms at 3 bits (5.3x for two extra bits), because the refine
   stage is per probed cluster: 64 candidates × nprobe, independent of `k` and of
   `sdb_rerank_factor`. Worth noting that `kRaBitQRefinePool` is a fixed constant
   against a cluster size set by `sdb_ivf_posting_size` (default 1024), so the
   refine *fraction* — and the accuracy/latency trade-off with it — shifts if
   posting size changes.

### Caveats

- Query vectors are sampled from the dataset (same convention as
  `scripts/perf/vector_compare`), so each matches itself at distance 0 and all
  recall figures are inflated by a constant ~0.1. Identical on both sides, so
  Δrecall is unaffected.
- 50 queries ⇒ recall granularity 0.002, ~±0.026 noise at 95%. Only the 1-bit
  `rerank = 0` deltas clear that bar; 3/5-bit is parity.
- nprobe=128 is exhaustive at this scale (~100 leaves at
  `sdb_ivf_posting_size = 1024`; `nprobe` is clamped to the leaf count). Evidence:
  recall is exactly 1.000 at nprobe=128 / rerank=4 for all six variants. Read that
  row as pure scan throughput and as the quantizer's recall ceiling.
- Threads left at the machine default (128 cores).
- Cross-binary caveat for reviewers: `RaBitQStatsHeader` is `{nb_bits, d}` in both
  trees with no format discriminator, so a datadir built by one binary is silently
  mis-decoded by the other. The harness rebuilds every datadir from scratch.
