### PR TITLE
fix: make SereneDB usable as a Postgres logical-replication target

### DIFF
--- a/server/connector/functions/system.cpp
+++ b/server/connector/functions/system.cpp
@@ -322,6 +322,19 @@ duckdb::unique_ptr<duckdb::Expression> BindPgTypeof(
   return duckdb::make_uniq<duckdb::BoundConstantExpression>(std::move(val));
 }
 
+void ToRegtypeFunction(duckdb::DataChunk& args, duckdb::ExpressionState&,
+                       duckdb::Vector& result) {
+  duckdb::UnaryExecutor::Execute<duckdb::string_t, int64_t>(
+    args.data[0], result, args.size(),
+    [&](duckdb::string_t name) -> duckdb::optional<int64_t> {
+      auto oid = pg::RegtypeIn(name.GetString());
+      if (oid == pg::kInvalidOid) {
+        return duckdb::nullopt;
+      }
+      return static_cast<int64_t>(oid);
+    });
+}
+
 // format_type(oid, typmod) -> text
 // TODO(Pasha) Account typmod?
 // Keyed on the oid only (UnaryExecutor): psql calls format_type(oid, NULL),
@@ -1806,6 +1819,21 @@ void RegisterPgSystemFunctions(duckdb::DatabaseInstance& db) {
                                                  {pg::XID8()},
                                                  duckdb::LogicalType::VARCHAR,
                                                  not_supported});
+
+  {
+    duckdb::ScalarFunction to_regtype_fn{
+      "to_regtype",
+      {duckdb::LogicalType::VARCHAR},
+      pg::REGTYPE(),
+      ToRegtypeFunction,
+    };
+    to_regtype_fn.SetNullHandling(
+      duckdb::FunctionNullHandling::SPECIAL_HANDLING);
+    duckdb::CreateScalarFunctionInfo info{std::move(to_regtype_fn)};
+    info.SetSchema("pg_catalog");
+    info.on_conflict = duckdb::OnCreateConflict::REPLACE_ON_CONFLICT;
+    loader.RegisterFunction(std::move(info));
+  }
 
   {
     duckdb::ScalarFunction format_type_fn{

--- a/server/pg/system_table.h
+++ b/server/pg/system_table.h
@@ -123,7 +123,7 @@ void WriteField(duckdb::Vector& vec, duckdb::idx_t row, const Field& field,
       duckdb::StringVector::AddString(vec, field);
   } else if constexpr (std::is_same_v<Field, char>) {
     duckdb::FlatVector::GetDataMutable<duckdb::string_t>(vec)[row] =
-      duckdb::StringVector::AddString(vec, &field, 1);
+      duckdb::StringVector::AddString(vec, &field, field ? 1 : 0);
   } else if constexpr (std::is_same_v<Field, bool>) {
     duckdb::FlatVector::GetDataMutable<bool>(vec)[row] = field;
   } else if constexpr (std::is_same_v<Field, int8_t>) {

--- a/tests/sqllogic/any/pg/system/attr_char_columns.test
+++ b/tests/sqllogic/any/pg/system/attr_char_columns.test
@@ -1,0 +1,69 @@
+# pg_attribute's "char" columns render an unset value as the empty string.
+#
+# Postgres stores attidentity/attgenerated/attcompression as the internal
+# "char" type and outputs them through charout, which NUL-terminates: a zero
+# byte comes back as '' rather than a one-character string. Replication tools
+# read these columns to decide which columns they may write, with predicates
+# like `attgenerated != ''`. Emitting a one-byte value made every column look
+# generated, so pgstream built an INSERT with no columns and dropped the row.
+
+statement ok
+CREATE TABLE attchar(id INTEGER, name TEXT);
+
+
+query
+SELECT attname, length(attgenerated::text) AS gen_len, length(attidentity::text) AS ident_len
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'attchar') AND attnum > 0
+ORDER BY attnum;
+----
+attname	gen_len	ident_len
+id	0	0
+name	0	0
+
+
+# The predicates replication tools actually issue.
+query
+SELECT count(*) AS generated_cols
+FROM pg_attribute
+WHERE attnum > 0
+  AND attrelid = (SELECT c.oid FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relname = 'attchar' AND n.nspname = 'public')
+  AND attgenerated != '';
+----
+generated_cols
+0
+
+
+query
+SELECT count(*) AS identity_cols
+FROM pg_attribute
+WHERE attnum > 0
+  AND attrelid = (SELECT c.oid FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relname = 'attchar' AND n.nspname = 'public')
+  AND attidentity = 'a';
+----
+identity_cols
+0
+
+
+query
+SELECT attname FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'attchar') AND attnum > 0 AND attgenerated = ''
+ORDER BY attnum;
+----
+attname
+id
+name
+
+
+# A "char" column that does carry a value still renders that one character.
+query
+SELECT DISTINCT length(attstorage::text) AS storage_len
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'attchar') AND attnum > 0;
+----
+storage_len
+1
+
+
+statement ok
+DROP TABLE attchar;

--- a/tests/sqllogic/sdb/pg/dml/insert_overriding_value.test
+++ b/tests/sqllogic/sdb/pg/dml/insert_overriding_value.test
@@ -1,0 +1,75 @@
+# INSERT ... OVERRIDING { SYSTEM | USER } VALUE.
+#
+# SQL:2003 identity-column syntax. It selects whether a user-supplied value is
+# allowed into a GENERATED ALWAYS AS IDENTITY column, or discarded in favour of
+# the generated one. SereneDB has no identity columns, so there is nothing to
+# override and the clause is a no-op -- but it must parse, because Postgres
+# logical-replication tools emit it unconditionally on every INSERT (they
+# cannot know whether the target column is GENERATED ALWAYS). Rejecting it
+# makes SereneDB unusable as a replication target.
+
+
+statement ok
+CREATE TABLE iov(id INTEGER, name TEXT);
+
+
+statement ok
+INSERT INTO iov(id, name) OVERRIDING SYSTEM VALUE VALUES (1, 'system');
+
+
+statement ok
+INSERT INTO iov(id, name) OVERRIDING USER VALUE VALUES (2, 'user');
+
+
+# The clause is positional: after the column list, before the values.
+statement ok
+INSERT INTO iov OVERRIDING SYSTEM VALUE VALUES (3, 'no column list');
+
+
+statement ok
+INSERT INTO iov(id, name) OVERRIDING SYSTEM VALUE SELECT 4, 'from select';
+
+
+statement ok
+INSERT INTO iov(id, name) OVERRIDING SYSTEM VALUE VALUES (5, 'returning') RETURNING id;
+
+
+query
+SELECT id, name FROM iov ORDER BY id;
+----
+id	name
+1	system
+2	user
+3	no column list
+4	from select
+5	returning
+
+
+# Both keywords are required, and only SYSTEM or USER are accepted.
+statement error
+INSERT INTO iov(id) OVERRIDING VALUE VALUES (6);
+----
+db error: ERROR: syntax error at or near "VALUE"
+
+
+statement error
+INSERT INTO iov(id) OVERRIDING BOGUS VALUE VALUES (6);
+----
+db error: ERROR: syntax error at or near "BOGUS"
+
+
+statement error
+INSERT INTO iov(id) OVERRIDING SYSTEM VALUES (6);
+----
+db error: ERROR: syntax error at or near "VALUES"
+
+
+# It belongs before the values, not after.
+statement error
+INSERT INTO iov(id) VALUES (6) OVERRIDING SYSTEM VALUE;
+----
+db error: ERROR: syntax error at or near "OVERRIDING"
+
+
+statement ok
+DROP TABLE iov;


### PR DESCRIPTION
## What

Three gaps that each stopped a Postgres logical-replication client cold, silently.

Found by pointing [pgstream](https://github.com/xataio/pgstream) (Postgres → webhook) at SereneDB and diffing the pg-wire capture against the same client aimed at a real Postgres. Each fix uncovered the next one.

## 1. `pg_attribute`'s `"char"` columns rendered an unset value as one byte

The one worth reading.

Postgres stores `attidentity` / `attgenerated` / `attcompression` as the internal `"char"` type and outputs them through `charout`, which NUL-terminates — so a zero byte comes back as the **empty string**, not a one-character string. SereneDB emitted one byte.

Replication tools read these columns to decide which columns they are allowed to write, with predicates like:

```sql
SELECT attname FROM pg_attribute
WHERE attrelid = ... AND attnum > 0 AND attgenerated != ''
```

Against SereneDB that matched **every** column. pgstream concluded the whole table was generated, built an `INSERT` with no columns at all, dropped the row, and — with strict mode off by default — logged nothing. The wire capture showed introspection completing and then silence.

Fixed generically in `WriteField`, so it covers any pg-catalog `"char"` column rather than just `pg_attribute`.

`attcompression` stays NULL: it is deliberately in `kNullMask` in `pg_attribute.cpp`, no client reads it, and changing that is a separate call.

## 2. `to_regtype(text)` was missing

Resolves a type name to its OID, returning **NULL** rather than throwing when no such type exists — the difference from a `::regtype` cast, and the whole point of the function.

pgx issues `SELECT to_regtype($1)::oid` on every connection to resolve parameter types, so its absence makes SereneDB unusable as a target for **any** pgx-based client, not just this one.

## 3. `INSERT ... OVERRIDING SYSTEM VALUE` did not parse

serenedb/duckdb#61, pinned here. **That one has to merge first.**

Replication writers emit the clause unconditionally, since they cannot know whether a target column is `GENERATED ALWAYS`.

## Result

pgstream now replicates into SereneDB end to end. Source → target over 500 inserts, 111 updates and 111 deletes:

```
        rows | renamed | should_be_zero
target   389 |     111 |              0
source   389 |     111 |              0
```

Full-column diff including timestamps: identical, zero differences.

## Testing

- `any/pg/system/attr_char_columns.test` — pins the `"char"` rendering and the two predicates replication tools actually issue, plus that a `"char"` column carrying a real value still renders it.
- `sdb/pg/dml/insert_overriding_value.test` — clause forms, positional placement, syntax errors.
- Full `any/pg` suite: **382/382 on both `pg-wire-simple` and `pg-wire-extended`**, zero failures. The `"char"` change touches every catalog column of that type, so the whole subtree was run rather than the obviously-related tests.