### PR TITLE
refactor: run the has_*_privilege functions through VariadicExecutor

### DIFF
--- a/server/connector/functions/system.cpp
+++ b/server/connector/functions/system.cpp
@@ -29,8 +29,8 @@
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
 #include <duckdb/catalog/catalog_search_path.hpp>
 #include <duckdb/catalog/entry_lookup_info.hpp>
-#include <duckdb/common/vector_operations/variadic_executor.hpp>
 #include <duckdb/common/vector_operations/generic_executor.hpp>
+#include <duckdb/common/vector_operations/variadic_executor.hpp>
 #include <duckdb/execution/operator/helper/physical_set.hpp>
 #include <duckdb/function/scalar_function.hpp>
 #include <duckdb/main/client_context.hpp>
@@ -729,18 +729,18 @@ void HasTablePrivilegeOid3Function(duckdb::DataChunk& args,
   auto snapshot = GlobalSnapshot();
   duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, duckdb::string_t>(
     args, result,
-    [&](int64_t roid, int64_t toid, duckdb::string_t priv) -> duckdb::optional<bool> {
-        bool is_null = false;
-        bool r = HasTablePrivilegeByOidImpl(
-          *snapshot, ObjectId{static_cast<uint64_t>(roid)},
-          ObjectId{static_cast<uint64_t>(toid)},
-          {priv.GetData(), priv.GetSize()}, is_null);
-        if (is_null) {
-          return duckdb::nullopt;
-        } else {
-          return r;
-        }
-  
+    [&](int64_t roid, int64_t toid,
+        duckdb::string_t priv) -> duckdb::optional<bool> {
+      bool is_null = false;
+      bool r = HasTablePrivilegeByOidImpl(
+        *snapshot, ObjectId{static_cast<uint64_t>(roid)},
+        ObjectId{static_cast<uint64_t>(toid)}, {priv.GetData(), priv.GetSize()},
+        is_null);
+      if (is_null) {
+        return duckdb::nullopt;
+      } else {
+        return r;
+      }
     });
 }
 
@@ -750,31 +750,32 @@ void HasTablePrivilegeOidName3Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](int64_t roid, duckdb::string_t tname, duckdb::string_t priv) -> duckdb::optional<bool> {
-        const auto name = pg::ParseObjectName(
-          {tname.GetData(), tname.GetSize()}, current_schema);
-        auto table =
-          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                             name.schema, name.relation);
-        const ObjectId role{static_cast<uint64_t>(roid)};
-        const std::string_view priv_text{priv.GetData(), priv.GetSize()};
-        try {
-          if (table) {
-            return HasAnyObjectPrivilegeText(
-              *snapshot, role, *table, catalog::ObjectType::Table, priv_text);
-          } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
-            const auto obj = SystemRelationAsObject(*sys);
-            return HasAnyObjectPrivilegeText(
-              *snapshot, role, obj, catalog::ObjectType::Table, priv_text);
-          } else {
-            ThrowRelationNotFound(name.relation);
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
+    [&](int64_t roid, duckdb::string_t tname,
+        duckdb::string_t priv) -> duckdb::optional<bool> {
+      const auto name =
+        pg::ParseObjectName({tname.GetData(), tname.GetSize()}, current_schema);
+      auto table =
+        snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                           name.schema, name.relation);
+      const ObjectId role{static_cast<uint64_t>(roid)};
+      const std::string_view priv_text{priv.GetData(), priv.GetSize()};
+      try {
+        if (table) {
+          return HasAnyObjectPrivilegeText(
+            *snapshot, role, *table, catalog::ObjectType::Table, priv_text);
+        } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
+          const auto obj = SystemRelationAsObject(*sys);
+          return HasAnyObjectPrivilegeText(
+            *snapshot, role, obj, catalog::ObjectType::Table, priv_text);
+        } else {
+          ThrowRelationNotFound(name.relation);
         }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -782,24 +783,25 @@ void HasTablePrivilegeNameOid3Function(duckdb::DataChunk& args,
                                        duckdb::ExpressionState& state,
                                        duckdb::Vector& result) {
   auto snapshot = GlobalSnapshot();
-  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, int64_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, int64_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](duckdb::string_t rname, int64_t toid, duckdb::string_t priv) -> duckdb::optional<bool> {
-        auto role_id = ResolveRoleOrPublic(
-          *snapshot, {rname.GetData(), rname.GetSize()});
-        if (!role_id) {
-          ThrowRoleNotFound({rname.GetData(), rname.GetSize()});
-        }
-        bool is_null = false;
-        bool r = HasTablePrivilegeByOidImpl(
-          *snapshot, *role_id, ObjectId{static_cast<uint64_t>(toid)},
-          {priv.GetData(), priv.GetSize()}, is_null);
-        if (is_null) {
-          return duckdb::nullopt;
-        } else {
-          return r;
-        }
-  
+    [&](duckdb::string_t rname, int64_t toid,
+        duckdb::string_t priv) -> duckdb::optional<bool> {
+      auto role_id =
+        ResolveRoleOrPublic(*snapshot, {rname.GetData(), rname.GetSize()});
+      if (!role_id) {
+        ThrowRoleNotFound({rname.GetData(), rname.GetSize()});
+      }
+      bool is_null = false;
+      bool r = HasTablePrivilegeByOidImpl(
+        *snapshot, *role_id, ObjectId{static_cast<uint64_t>(toid)},
+        {priv.GetData(), priv.GetSize()}, is_null);
+      if (is_null) {
+        return duckdb::nullopt;
+      } else {
+        return r;
+      }
     });
 }
 
@@ -977,17 +979,16 @@ void HasObjectPrivilegeOid2Function(duckdb::DataChunk& args,
   duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t>(
     args, result,
     [&](int64_t ooid, duckdb::string_t priv) -> duckdb::optional<bool> {
-        bool is_null = false;
-        bool r = HasObjectPrivilegeByOidImpl(
-          *snapshot, kType, current->GetId(),
-          ObjectId{static_cast<uint64_t>(ooid)},
-          {priv.GetData(), priv.GetSize()}, is_null);
-        if (is_null) {
-          return duckdb::nullopt;
-        } else {
-          return r;
-        }
-  
+      bool is_null = false;
+      bool r =
+        HasObjectPrivilegeByOidImpl(*snapshot, kType, current->GetId(),
+                                    ObjectId{static_cast<uint64_t>(ooid)},
+                                    {priv.GetData(), priv.GetSize()}, is_null);
+      if (is_null) {
+        return duckdb::nullopt;
+      } else {
+        return r;
+      }
     });
 }
 
@@ -998,18 +999,18 @@ void HasObjectPrivilegeOid3Function(duckdb::DataChunk& args,
   auto snapshot = GlobalSnapshot();
   duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, duckdb::string_t>(
     args, result,
-    [&](int64_t roid, int64_t ooid, duckdb::string_t priv) -> duckdb::optional<bool> {
-        bool is_null = false;
-        bool r = HasObjectPrivilegeByOidImpl(
-          *snapshot, kType, ObjectId{static_cast<uint64_t>(roid)},
-          ObjectId{static_cast<uint64_t>(ooid)},
-          {priv.GetData(), priv.GetSize()}, is_null);
-        if (is_null) {
-          return duckdb::nullopt;
-        } else {
-          return r;
-        }
-  
+    [&](int64_t roid, int64_t ooid,
+        duckdb::string_t priv) -> duckdb::optional<bool> {
+      bool is_null = false;
+      bool r = HasObjectPrivilegeByOidImpl(
+        *snapshot, kType, ObjectId{static_cast<uint64_t>(roid)},
+        ObjectId{static_cast<uint64_t>(ooid)}, {priv.GetData(), priv.GetSize()},
+        is_null);
+      if (is_null) {
+        return duckdb::nullopt;
+      } else {
+        return r;
+      }
     });
 }
 
@@ -1019,14 +1020,14 @@ void HasObjectPrivilegeOidName3Function(duckdb::DataChunk& args,
                                         duckdb::Vector& result) {
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
-  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](int64_t roid, duckdb::string_t obj, duckdb::string_t priv) -> duckdb::optional<bool> {
-        return HasObjectPrivilegeByName(*snapshot, conn_ctx, kType,
-                                          ObjectId{static_cast<uint64_t>(roid)},
-                                          {obj.GetData(), obj.GetSize()},
-                                          {priv.GetData(), priv.GetSize()});
-  
+    [&](int64_t roid, duckdb::string_t obj,
+        duckdb::string_t priv) -> duckdb::optional<bool> {
+      return HasObjectPrivilegeByName(
+        *snapshot, conn_ctx, kType, ObjectId{static_cast<uint64_t>(roid)},
+        {obj.GetData(), obj.GetSize()}, {priv.GetData(), priv.GetSize()});
     });
 }
 
@@ -1293,30 +1294,33 @@ void HasColumnPrivilegeNameName4Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, duckdb::string_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t,
+                                    duckdb::string_t, duckdb::string_t>(
     args, result,
-    [&](duckdb::string_t u, duckdb::string_t t, duckdb::string_t c, duckdb::string_t p) -> duckdb::optional<bool> {
-        auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
-        if (!role) {
-          ThrowRoleNotFound({u.GetData(), u.GetSize()});
+    [&](duckdb::string_t u, duckdb::string_t t, duckdb::string_t c,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
+      if (!role) {
+        ThrowRoleNotFound({u.GetData(), u.GetSize()});
+      }
+      const auto name =
+        pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+      auto table =
+        snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                           name.schema, name.relation);
+      const std::string_view col{c.GetData(), c.GetSize()};
+      const std::string_view priv{p.GetData(), p.GetSize()};
+      try {
+        if (table) {
+          return HasColumnPrivByName(*snapshot, role->GetId(), *table, col,
+                                     priv);
+        } else {
+          return SystemRelationColumnPriv(conn_ctx, *snapshot, role->GetId(),
+                                          name, col, priv);
         }
-        const auto name =
-          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
-        auto table =
-          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                             name.schema, name.relation);
-        const std::string_view col{c.GetData(), c.GetSize()};
-        const std::string_view priv{p.GetData(), p.GetSize()};
-        try {
-          if (table) {
-            return HasColumnPrivByName(*snapshot, role->GetId(), *table, col, priv);
-          } else {
-            return SystemRelationColumnPriv(conn_ctx, *snapshot, role->GetId(), name, col, priv);
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
-        }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1327,26 +1331,29 @@ void HasColumnPrivilegeName3Function(duckdb::DataChunk& args,
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](duckdb::string_t t, duckdb::string_t c, duckdb::string_t p) -> duckdb::optional<bool> {
-        const auto name =
-          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
-        auto table =
-          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                             name.schema, name.relation);
-        const std::string_view col{c.GetData(), c.GetSize()};
-        const std::string_view priv{p.GetData(), p.GetSize()};
-        try {
-          if (table) {
-            return HasColumnPrivByName(*snapshot, current->GetId(), *table, col, priv);
-          } else {
-            return SystemRelationColumnPriv(conn_ctx, *snapshot, current->GetId(), name, col, priv);
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
+    [&](duckdb::string_t t, duckdb::string_t c,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      const auto name =
+        pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+      auto table =
+        snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                           name.schema, name.relation);
+      const std::string_view col{c.GetData(), c.GetSize()};
+      const std::string_view priv{p.GetData(), p.GetSize()};
+      try {
+        if (table) {
+          return HasColumnPrivByName(*snapshot, current->GetId(), *table, col,
+                                     priv);
+        } else {
+          return SystemRelationColumnPriv(conn_ctx, *snapshot, current->GetId(),
+                                          name, col, priv);
         }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1358,18 +1365,19 @@ void HasColumnPrivilegeOidAttnum3Function(duckdb::DataChunk& args,
   auto current = snapshot->GetRole(conn_ctx.user());
   duckdb::VariadicExecutor::Execute<bool, int64_t, int32_t, duckdb::string_t>(
     args, result,
-    [&](int64_t toid, int32_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
-        auto table = snapshot->GetObject<catalog::Table>(
-          ObjectId{static_cast<uint64_t>(toid)});
-        if (!table || !AttnumExists(*table, attnum)) {
-          return duckdb::nullopt;
-        }
-        try {
-          return HasColumnPrivByAttnum(*snapshot, current->GetId(), *table, attnum, {p.GetData(), p.GetSize()});
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
-        }
-  
+    [&](int64_t toid, int32_t attnum,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      auto table = snapshot->GetObject<catalog::Table>(
+        ObjectId{static_cast<uint64_t>(toid)});
+      if (!table || !AttnumExists(*table, attnum)) {
+        return duckdb::nullopt;
+      }
+      try {
+        return HasColumnPrivByAttnum(*snapshot, current->GetId(), *table,
+                                     attnum, {p.GetData(), p.GetSize()});
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1411,27 +1419,27 @@ void HasColumnPrivilegeNameAttnum4Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, int16_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t,
+                                    int16_t, duckdb::string_t>(
     args, result,
-    [&](duckdb::string_t u, duckdb::string_t t, int16_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
-        auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
-        if (!role) {
-          ThrowRoleNotFound({u.GetData(), u.GetSize()});
+    [&](duckdb::string_t u, duckdb::string_t t, int16_t attnum,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
+      if (!role) {
+        ThrowRoleNotFound({u.GetData(), u.GetSize()});
+      }
+      try {
+        auto r = ColumnPrivByNameTableAttnum(
+          conn_ctx, *snapshot, role->GetId(), current_schema,
+          {t.GetData(), t.GetSize()}, attnum, {p.GetData(), p.GetSize()});
+        if (r) {
+          return *r;
+        } else {
+          return duckdb::nullopt;
         }
-        try {
-          auto r = ColumnPrivByNameTableAttnum(
-            conn_ctx, *snapshot, role->GetId(), current_schema,
-            {t.GetData(), t.GetSize()}, attnum,
-            {p.GetData(), p.GetSize()});
-          if (r) {
-            return *r;
-          } else {
-            return duckdb::nullopt;
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
-        }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1441,23 +1449,24 @@ void HasColumnPrivilegeOidNameAttnum4Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, int16_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, int16_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](int64_t roid, duckdb::string_t t, int16_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
-        try {
-          auto r = ColumnPrivByNameTableAttnum(
-            conn_ctx, *snapshot, ObjectId{static_cast<uint64_t>(roid)},
-            current_schema, {t.GetData(), t.GetSize()}, attnum,
-            {p.GetData(), p.GetSize()});
-          if (r) {
-            return *r;
-          } else {
-            return duckdb::nullopt;
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
+    [&](int64_t roid, duckdb::string_t t, int16_t attnum,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      try {
+        auto r = ColumnPrivByNameTableAttnum(
+          conn_ctx, *snapshot, ObjectId{static_cast<uint64_t>(roid)},
+          current_schema, {t.GetData(), t.GetSize()}, attnum,
+          {p.GetData(), p.GetSize()});
+        if (r) {
+          return *r;
+        } else {
+          return duckdb::nullopt;
         }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1465,22 +1474,23 @@ void HasColumnPrivilegeOidOidAttnum4Function(duckdb::DataChunk& args,
                                              duckdb::ExpressionState& state,
                                              duckdb::Vector& result) {
   auto snapshot = GlobalSnapshot();
-  duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, int16_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, int16_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](int64_t roid, int64_t toid, int16_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
-        auto table = snapshot->GetObject<catalog::Table>(
-          ObjectId{static_cast<uint64_t>(toid)});
-        if (!table || !AttnumExists(*table, attnum)) {
-          return duckdb::nullopt;
-        }
-        try {
-          return HasColumnPrivByAttnum(
-            *snapshot, ObjectId{static_cast<uint64_t>(roid)}, *table,
-            attnum, {p.GetData(), p.GetSize()});
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
-        }
-  
+    [&](int64_t roid, int64_t toid, int16_t attnum,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      auto table = snapshot->GetObject<catalog::Table>(
+        ObjectId{static_cast<uint64_t>(toid)});
+      if (!table || !AttnumExists(*table, attnum)) {
+        return duckdb::nullopt;
+      }
+      try {
+        return HasColumnPrivByAttnum(
+          *snapshot, ObjectId{static_cast<uint64_t>(roid)}, *table, attnum,
+          {p.GetData(), p.GetSize()});
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1490,33 +1500,34 @@ void HasAnyColumnPrivilegeName3Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, duckdb::string_t>(
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t,
+                                    duckdb::string_t>(
     args, result,
-    [&](duckdb::string_t u, duckdb::string_t t, duckdb::string_t p) -> duckdb::optional<bool> {
-        auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
-        if (!role) {
-          ThrowRoleNotFound({u.GetData(), u.GetSize()});
+    [&](duckdb::string_t u, duckdb::string_t t,
+        duckdb::string_t p) -> duckdb::optional<bool> {
+      auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
+      if (!role) {
+        ThrowRoleNotFound({u.GetData(), u.GetSize()});
+      }
+      const auto name =
+        pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+      auto table =
+        snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                           name.schema, name.relation);
+      try {
+        if (table) {
+          return HasAnyTablePrivilegeText(*snapshot, role->GetId(), *table,
+                                          {p.GetData(), p.GetSize()});
+        } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
+          const auto obj = SystemRelationAsObject(*sys);
+          return HasAnyTablePrivilegeText(*snapshot, role->GetId(), obj,
+                                          {p.GetData(), p.GetSize()});
+        } else {
+          ThrowRelationNotFound(name.relation);
         }
-        const auto name =
-          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
-        auto table =
-          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                             name.schema, name.relation);
-        try {
-          if (table) {
-            return HasAnyTablePrivilegeText(*snapshot, role->GetId(), *table,
-                                              {p.GetData(), p.GetSize()});
-          } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
-            const auto obj = SystemRelationAsObject(*sys);
-            return HasAnyTablePrivilegeText(*snapshot, role->GetId(), obj,
-                                              {p.GetData(), p.GetSize()});
-          } else {
-            ThrowRelationNotFound(name.relation);
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
-        }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1529,18 +1540,17 @@ void HasAnyColumnPrivilegeOid2Function(duckdb::DataChunk& args,
   duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t>(
     args, result,
     [&](int64_t toid, duckdb::string_t p) -> duckdb::optional<bool> {
-        auto table = snapshot->GetObject<catalog::Table>(
-          ObjectId{static_cast<uint64_t>(toid)});
-        if (!table) {
-          return duckdb::nullopt;
-        }
-        try {
-          return HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
-                                            {p.GetData(), p.GetSize()});
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
-        }
-  
+      auto table = snapshot->GetObject<catalog::Table>(
+        ObjectId{static_cast<uint64_t>(toid)});
+      if (!table) {
+        return duckdb::nullopt;
+      }
+      try {
+        return HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
+                                        {p.GetData(), p.GetSize()});
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 
@@ -1554,26 +1564,25 @@ void HasAnyColumnPrivilegeName2Function(duckdb::DataChunk& args,
   duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t>(
     args, result,
     [&](duckdb::string_t t, duckdb::string_t p) -> duckdb::optional<bool> {
-        const auto name =
-          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
-        auto table =
-          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                             name.schema, name.relation);
-        try {
-          if (table) {
-            return HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
-                                              {p.GetData(), p.GetSize()});
-          } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
-            const auto obj = SystemRelationAsObject(*sys);
-            return HasAnyTablePrivilegeText(*snapshot, current->GetId(), obj,
-                                              {p.GetData(), p.GetSize()});
-          } else {
-            ThrowRelationNotFound(name.relation);
-          }
-        } catch (const SqlException& e) {
-          ThrowInvalidPrivilege(e);
+      const auto name =
+        pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+      auto table =
+        snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                           name.schema, name.relation);
+      try {
+        if (table) {
+          return HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
+                                          {p.GetData(), p.GetSize()});
+        } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
+          const auto obj = SystemRelationAsObject(*sys);
+          return HasAnyTablePrivilegeText(*snapshot, current->GetId(), obj,
+                                          {p.GetData(), p.GetSize()});
+        } else {
+          ThrowRelationNotFound(name.relation);
         }
-  
+      } catch (const SqlException& e) {
+        ThrowInvalidPrivilege(e);
+      }
     });
 }
 

--- a/server/connector/functions/system.cpp
+++ b/server/connector/functions/system.cpp
@@ -29,6 +29,7 @@
 #include <duckdb/catalog/catalog_entry/table_catalog_entry.hpp>
 #include <duckdb/catalog/catalog_search_path.hpp>
 #include <duckdb/catalog/entry_lookup_info.hpp>
+#include <duckdb/common/vector_operations/variadic_executor.hpp>
 #include <duckdb/common/vector_operations/generic_executor.hpp>
 #include <duckdb/execution/operator/helper/physical_set.hpp>
 #include <duckdb/function/scalar_function.hpp>
@@ -708,70 +709,39 @@ void HasTablePrivilegeOid2Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
-  duckdb::UnifiedVectorFormat tdata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), tdata);
-  args.data[1].ToUnifiedFormat(args.size(), pdata);
-  const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(tdata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ti = tdata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!tdata.validity.RowIsValid(ti) || !pdata.validity.RowIsValid(pi) ||
-        !current) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    bool is_null = false;
-    bool r = HasTablePrivilegeByOidImpl(
-      *snapshot, current->GetId(), ObjectId{static_cast<uint64_t>(toid[ti])},
-      {priv[pi].GetData(), priv[pi].GetSize()}, is_null);
-    if (is_null) {
-      validity.SetInvalid(i);
-    } else {
-      out[i] = r;
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t toid, duckdb::string_t priv) -> duckdb::optional<bool> {
+      if (!current) {
+        return duckdb::nullopt;
+      }
+      bool is_null = false;
+      bool r = HasTablePrivilegeByOidImpl(
+        *snapshot, current->GetId(), ObjectId{static_cast<uint64_t>(toid)},
+        {priv.GetData(), priv.GetSize()}, is_null);
+      return is_null ? duckdb::nullopt : duckdb::optional<bool>{r};
+    });
 }
 
 void HasTablePrivilegeOid3Function(duckdb::DataChunk& args,
                                    duckdb::ExpressionState& state,
                                    duckdb::Vector& result) {
   auto snapshot = GlobalSnapshot();
-  duckdb::UnifiedVectorFormat rdata, tdata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), rdata);
-  args.data[1].ToUnifiedFormat(args.size(), tdata);
-  args.data[2].ToUnifiedFormat(args.size(), pdata);
-  const auto* roid = duckdb::UnifiedVectorFormat::GetData<int64_t>(rdata);
-  const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(tdata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ri = rdata.sel->get_index(i);
-    auto ti = tdata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!rdata.validity.RowIsValid(ri) || !tdata.validity.RowIsValid(ti) ||
-        !pdata.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    bool is_null = false;
-    bool r = HasTablePrivilegeByOidImpl(
-      *snapshot, ObjectId{static_cast<uint64_t>(roid[ri])},
-      ObjectId{static_cast<uint64_t>(toid[ti])},
-      {priv[pi].GetData(), priv[pi].GetSize()}, is_null);
-    if (is_null) {
-      validity.SetInvalid(i);
-    } else {
-      out[i] = r;
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t roid, int64_t toid, duckdb::string_t priv) -> duckdb::optional<bool> {
+        bool is_null = false;
+        bool r = HasTablePrivilegeByOidImpl(
+          *snapshot, ObjectId{static_cast<uint64_t>(roid)},
+          ObjectId{static_cast<uint64_t>(toid)},
+          {priv.GetData(), priv.GetSize()}, is_null);
+        if (is_null) {
+          return duckdb::nullopt;
+        } else {
+          return r;
+        }
+  
+    });
 }
 
 void HasTablePrivilegeOidName3Function(duckdb::DataChunk& args,
@@ -780,91 +750,57 @@ void HasTablePrivilegeOidName3Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat rdata, tdata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), rdata);
-  args.data[1].ToUnifiedFormat(args.size(), tdata);
-  args.data[2].ToUnifiedFormat(args.size(), pdata);
-  const auto* roid = duckdb::UnifiedVectorFormat::GetData<int64_t>(rdata);
-  const auto* tname =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(tdata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ri = rdata.sel->get_index(i);
-    auto ti = tdata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!rdata.validity.RowIsValid(ri) || !tdata.validity.RowIsValid(ti) ||
-        !pdata.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    const auto name = pg::ParseObjectName(
-      {tname[ti].GetData(), tname[ti].GetSize()}, current_schema);
-    auto table =
-      snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                         name.schema, name.relation);
-    const ObjectId role{static_cast<uint64_t>(roid[ri])};
-    const std::string_view priv_text{priv[pi].GetData(), priv[pi].GetSize()};
-    try {
-      if (table) {
-        out[i] = HasAnyObjectPrivilegeText(
-          *snapshot, role, *table, catalog::ObjectType::Table, priv_text);
-      } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
-        const auto obj = SystemRelationAsObject(*sys);
-        out[i] = HasAnyObjectPrivilegeText(
-          *snapshot, role, obj, catalog::ObjectType::Table, priv_text);
-      } else {
-        ThrowRelationNotFound(name.relation);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t roid, duckdb::string_t tname, duckdb::string_t priv) -> duckdb::optional<bool> {
+        const auto name = pg::ParseObjectName(
+          {tname.GetData(), tname.GetSize()}, current_schema);
+        auto table =
+          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                             name.schema, name.relation);
+        const ObjectId role{static_cast<uint64_t>(roid)};
+        const std::string_view priv_text{priv.GetData(), priv.GetSize()};
+        try {
+          if (table) {
+            return HasAnyObjectPrivilegeText(
+              *snapshot, role, *table, catalog::ObjectType::Table, priv_text);
+          } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
+            const auto obj = SystemRelationAsObject(*sys);
+            return HasAnyObjectPrivilegeText(
+              *snapshot, role, obj, catalog::ObjectType::Table, priv_text);
+          } else {
+            ThrowRelationNotFound(name.relation);
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasTablePrivilegeNameOid3Function(duckdb::DataChunk& args,
                                        duckdb::ExpressionState& state,
                                        duckdb::Vector& result) {
   auto snapshot = GlobalSnapshot();
-  duckdb::UnifiedVectorFormat rdata, tdata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), rdata);
-  args.data[1].ToUnifiedFormat(args.size(), tdata);
-  args.data[2].ToUnifiedFormat(args.size(), pdata);
-  const auto* rname =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(rdata);
-  const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(tdata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ri = rdata.sel->get_index(i);
-    auto ti = tdata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!rdata.validity.RowIsValid(ri) || !tdata.validity.RowIsValid(ti) ||
-        !pdata.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto role_id = ResolveRoleOrPublic(
-      *snapshot, {rname[ri].GetData(), rname[ri].GetSize()});
-    if (!role_id) {
-      ThrowRoleNotFound({rname[ri].GetData(), rname[ri].GetSize()});
-    }
-    bool is_null = false;
-    bool r = HasTablePrivilegeByOidImpl(
-      *snapshot, *role_id, ObjectId{static_cast<uint64_t>(toid[ti])},
-      {priv[pi].GetData(), priv[pi].GetSize()}, is_null);
-    if (is_null) {
-      validity.SetInvalid(i);
-    } else {
-      out[i] = r;
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, int64_t, duckdb::string_t>(
+    args, result,
+    [&](duckdb::string_t rname, int64_t toid, duckdb::string_t priv) -> duckdb::optional<bool> {
+        auto role_id = ResolveRoleOrPublic(
+          *snapshot, {rname.GetData(), rname.GetSize()});
+        if (!role_id) {
+          ThrowRoleNotFound({rname.GetData(), rname.GetSize()});
+        }
+        bool is_null = false;
+        bool r = HasTablePrivilegeByOidImpl(
+          *snapshot, *role_id, ObjectId{static_cast<uint64_t>(toid)},
+          {priv.GetData(), priv.GetSize()}, is_null);
+        if (is_null) {
+          return duckdb::nullopt;
+        } else {
+          return r;
+        }
+  
+    });
 }
 
 const char* ObjectClassWord(catalog::ObjectType type) {
@@ -1038,34 +974,21 @@ void HasObjectPrivilegeOid2Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
-  duckdb::UnifiedVectorFormat odata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), odata);
-  args.data[1].ToUnifiedFormat(args.size(), pdata);
-  const auto* ooid = duckdb::UnifiedVectorFormat::GetData<int64_t>(odata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto oi = odata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!odata.validity.RowIsValid(oi) || !pdata.validity.RowIsValid(pi) ||
-        !current) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    bool is_null = false;
-    bool r = HasObjectPrivilegeByOidImpl(
-      *snapshot, kType, current->GetId(),
-      ObjectId{static_cast<uint64_t>(ooid[oi])},
-      {priv[pi].GetData(), priv[pi].GetSize()}, is_null);
-    if (is_null) {
-      validity.SetInvalid(i);
-    } else {
-      out[i] = r;
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t ooid, duckdb::string_t priv) -> duckdb::optional<bool> {
+        bool is_null = false;
+        bool r = HasObjectPrivilegeByOidImpl(
+          *snapshot, kType, current->GetId(),
+          ObjectId{static_cast<uint64_t>(ooid)},
+          {priv.GetData(), priv.GetSize()}, is_null);
+        if (is_null) {
+          return duckdb::nullopt;
+        } else {
+          return r;
+        }
+  
+    });
 }
 
 template<catalog::ObjectType kType>
@@ -1073,37 +996,21 @@ void HasObjectPrivilegeOid3Function(duckdb::DataChunk& args,
                                     duckdb::ExpressionState& state,
                                     duckdb::Vector& result) {
   auto snapshot = GlobalSnapshot();
-  duckdb::UnifiedVectorFormat rdata, odata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), rdata);
-  args.data[1].ToUnifiedFormat(args.size(), odata);
-  args.data[2].ToUnifiedFormat(args.size(), pdata);
-  const auto* roid = duckdb::UnifiedVectorFormat::GetData<int64_t>(rdata);
-  const auto* ooid = duckdb::UnifiedVectorFormat::GetData<int64_t>(odata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ri = rdata.sel->get_index(i);
-    auto oi = odata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!rdata.validity.RowIsValid(ri) || !odata.validity.RowIsValid(oi) ||
-        !pdata.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    bool is_null = false;
-    bool r = HasObjectPrivilegeByOidImpl(
-      *snapshot, kType, ObjectId{static_cast<uint64_t>(roid[ri])},
-      ObjectId{static_cast<uint64_t>(ooid[oi])},
-      {priv[pi].GetData(), priv[pi].GetSize()}, is_null);
-    if (is_null) {
-      validity.SetInvalid(i);
-    } else {
-      out[i] = r;
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t roid, int64_t ooid, duckdb::string_t priv) -> duckdb::optional<bool> {
+        bool is_null = false;
+        bool r = HasObjectPrivilegeByOidImpl(
+          *snapshot, kType, ObjectId{static_cast<uint64_t>(roid)},
+          ObjectId{static_cast<uint64_t>(ooid)},
+          {priv.GetData(), priv.GetSize()}, is_null);
+        if (is_null) {
+          return duckdb::nullopt;
+        } else {
+          return r;
+        }
+  
+    });
 }
 
 template<catalog::ObjectType kType>
@@ -1112,32 +1019,15 @@ void HasObjectPrivilegeOidName3Function(duckdb::DataChunk& args,
                                         duckdb::Vector& result) {
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
-  duckdb::UnifiedVectorFormat rdata, odata, pdata;
-  args.data[0].ToUnifiedFormat(args.size(), rdata);
-  args.data[1].ToUnifiedFormat(args.size(), odata);
-  args.data[2].ToUnifiedFormat(args.size(), pdata);
-  const auto* roid = duckdb::UnifiedVectorFormat::GetData<int64_t>(rdata);
-  const auto* obj =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(odata);
-  const auto* priv =
-    duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ri = rdata.sel->get_index(i);
-    auto oi = odata.sel->get_index(i);
-    auto pi = pdata.sel->get_index(i);
-    if (!rdata.validity.RowIsValid(ri) || !odata.validity.RowIsValid(oi) ||
-        !pdata.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    out[i] = HasObjectPrivilegeByName(*snapshot, conn_ctx, kType,
-                                      ObjectId{static_cast<uint64_t>(roid[ri])},
-                                      {obj[oi].GetData(), obj[oi].GetSize()},
-                                      {priv[pi].GetData(), priv[pi].GetSize()});
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t roid, duckdb::string_t obj, duckdb::string_t priv) -> duckdb::optional<bool> {
+        return HasObjectPrivilegeByName(*snapshot, conn_ctx, kType,
+                                          ObjectId{static_cast<uint64_t>(roid)},
+                                          {obj.GetData(), obj.GetSize()},
+                                          {priv.GetData(), priv.GetSize()});
+  
+    });
 }
 
 struct RolePrivMask {
@@ -1403,49 +1293,31 @@ void HasColumnPrivilegeNameName4Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat ud, td, cd, pd;
-  args.data[0].ToUnifiedFormat(args.size(), ud);
-  args.data[1].ToUnifiedFormat(args.size(), td);
-  args.data[2].ToUnifiedFormat(args.size(), cd);
-  args.data[3].ToUnifiedFormat(args.size(), pd);
-  const auto* u = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(ud);
-  const auto* t = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(td);
-  const auto* c = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(cd);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ui = ud.sel->get_index(i), ti = td.sel->get_index(i);
-    auto ci = cd.sel->get_index(i), pi = pd.sel->get_index(i);
-    if (!ud.validity.RowIsValid(ui) || !td.validity.RowIsValid(ti) ||
-        !cd.validity.RowIsValid(ci) || !pd.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto role = snapshot->GetRole({u[ui].GetData(), u[ui].GetSize()});
-    if (!role) {
-      ThrowRoleNotFound({u[ui].GetData(), u[ui].GetSize()});
-    }
-    const auto name =
-      pg::ParseObjectName({t[ti].GetData(), t[ti].GetSize()}, current_schema);
-    auto table =
-      snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                         name.schema, name.relation);
-    const std::string_view col{c[ci].GetData(), c[ci].GetSize()};
-    const std::string_view priv{p[pi].GetData(), p[pi].GetSize()};
-    try {
-      if (table) {
-        out[i] =
-          HasColumnPrivByName(*snapshot, role->GetId(), *table, col, priv);
-      } else {
-        out[i] = SystemRelationColumnPriv(conn_ctx, *snapshot, role->GetId(),
-                                          name, col, priv);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, duckdb::string_t, duckdb::string_t>(
+    args, result,
+    [&](duckdb::string_t u, duckdb::string_t t, duckdb::string_t c, duckdb::string_t p) -> duckdb::optional<bool> {
+        auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
+        if (!role) {
+          ThrowRoleNotFound({u.GetData(), u.GetSize()});
+        }
+        const auto name =
+          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+        auto table =
+          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                             name.schema, name.relation);
+        const std::string_view col{c.GetData(), c.GetSize()};
+        const std::string_view priv{p.GetData(), p.GetSize()};
+        try {
+          if (table) {
+            return HasColumnPrivByName(*snapshot, role->GetId(), *table, col, priv);
+          } else {
+            return SystemRelationColumnPriv(conn_ctx, *snapshot, role->GetId(), name, col, priv);
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasColumnPrivilegeName3Function(duckdb::DataChunk& args,
@@ -1455,43 +1327,27 @@ void HasColumnPrivilegeName3Function(duckdb::DataChunk& args,
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat td, cd, pd;
-  args.data[0].ToUnifiedFormat(args.size(), td);
-  args.data[1].ToUnifiedFormat(args.size(), cd);
-  args.data[2].ToUnifiedFormat(args.size(), pd);
-  const auto* t = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(td);
-  const auto* c = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(cd);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ti = td.sel->get_index(i), ci = cd.sel->get_index(i);
-    auto pi = pd.sel->get_index(i);
-    if (!td.validity.RowIsValid(ti) || !cd.validity.RowIsValid(ci) ||
-        !pd.validity.RowIsValid(pi) || !current) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    const auto name =
-      pg::ParseObjectName({t[ti].GetData(), t[ti].GetSize()}, current_schema);
-    auto table =
-      snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                         name.schema, name.relation);
-    const std::string_view col{c[ci].GetData(), c[ci].GetSize()};
-    const std::string_view priv{p[pi].GetData(), p[pi].GetSize()};
-    try {
-      if (table) {
-        out[i] =
-          HasColumnPrivByName(*snapshot, current->GetId(), *table, col, priv);
-      } else {
-        out[i] = SystemRelationColumnPriv(conn_ctx, *snapshot, current->GetId(),
-                                          name, col, priv);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, duckdb::string_t>(
+    args, result,
+    [&](duckdb::string_t t, duckdb::string_t c, duckdb::string_t p) -> duckdb::optional<bool> {
+        const auto name =
+          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+        auto table =
+          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                             name.schema, name.relation);
+        const std::string_view col{c.GetData(), c.GetSize()};
+        const std::string_view priv{p.GetData(), p.GetSize()};
+        try {
+          if (table) {
+            return HasColumnPrivByName(*snapshot, current->GetId(), *table, col, priv);
+          } else {
+            return SystemRelationColumnPriv(conn_ctx, *snapshot, current->GetId(), name, col, priv);
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasColumnPrivilegeOidAttnum3Function(duckdb::DataChunk& args,
@@ -1500,38 +1356,21 @@ void HasColumnPrivilegeOidAttnum3Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
-  duckdb::UnifiedVectorFormat td, cd, pd;
-  args.data[0].ToUnifiedFormat(args.size(), td);
-  args.data[1].ToUnifiedFormat(args.size(), cd);
-  args.data[2].ToUnifiedFormat(args.size(), pd);
-  const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(td);
-  const auto* attnum = duckdb::UnifiedVectorFormat::GetData<int32_t>(cd);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ti = td.sel->get_index(i), ci = cd.sel->get_index(i);
-    auto pi = pd.sel->get_index(i);
-    if (!td.validity.RowIsValid(ti) || !cd.validity.RowIsValid(ci) ||
-        !pd.validity.RowIsValid(pi) || !current) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto table = snapshot->GetObject<catalog::Table>(
-      ObjectId{static_cast<uint64_t>(toid[ti])});
-    if (!table || !AttnumExists(*table, attnum[ci])) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    try {
-      out[i] =
-        HasColumnPrivByAttnum(*snapshot, current->GetId(), *table, attnum[ci],
-                              {p[pi].GetData(), p[pi].GetSize()});
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, int32_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t toid, int32_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
+        auto table = snapshot->GetObject<catalog::Table>(
+          ObjectId{static_cast<uint64_t>(toid)});
+        if (!table || !AttnumExists(*table, attnum)) {
+          return duckdb::nullopt;
+        }
+        try {
+          return HasColumnPrivByAttnum(*snapshot, current->GetId(), *table, attnum, {p.GetData(), p.GetSize()});
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 // Column privilege by (role, table-by-name, attnum, priv), with the same
@@ -1572,44 +1411,28 @@ void HasColumnPrivilegeNameAttnum4Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat ud, td, cd, pd;
-  args.data[0].ToUnifiedFormat(args.size(), ud);
-  args.data[1].ToUnifiedFormat(args.size(), td);
-  args.data[2].ToUnifiedFormat(args.size(), cd);
-  args.data[3].ToUnifiedFormat(args.size(), pd);
-  const auto* u = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(ud);
-  const auto* t = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(td);
-  const auto* attnum = duckdb::UnifiedVectorFormat::GetData<int16_t>(cd);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ui = ud.sel->get_index(i), ti = td.sel->get_index(i);
-    auto ci = cd.sel->get_index(i), pi = pd.sel->get_index(i);
-    if (!ud.validity.RowIsValid(ui) || !td.validity.RowIsValid(ti) ||
-        !cd.validity.RowIsValid(ci) || !pd.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto role = snapshot->GetRole({u[ui].GetData(), u[ui].GetSize()});
-    if (!role) {
-      ThrowRoleNotFound({u[ui].GetData(), u[ui].GetSize()});
-    }
-    try {
-      auto r = ColumnPrivByNameTableAttnum(
-        conn_ctx, *snapshot, role->GetId(), current_schema,
-        {t[ti].GetData(), t[ti].GetSize()}, attnum[ci],
-        {p[pi].GetData(), p[pi].GetSize()});
-      if (r) {
-        out[i] = *r;
-      } else {
-        validity.SetInvalid(i);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, int16_t, duckdb::string_t>(
+    args, result,
+    [&](duckdb::string_t u, duckdb::string_t t, int16_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
+        auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
+        if (!role) {
+          ThrowRoleNotFound({u.GetData(), u.GetSize()});
+        }
+        try {
+          auto r = ColumnPrivByNameTableAttnum(
+            conn_ctx, *snapshot, role->GetId(), current_schema,
+            {t.GetData(), t.GetSize()}, attnum,
+            {p.GetData(), p.GetSize()});
+          if (r) {
+            return *r;
+          } else {
+            return duckdb::nullopt;
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasColumnPrivilegeOidNameAttnum4Function(duckdb::DataChunk& args,
@@ -1618,80 +1441,47 @@ void HasColumnPrivilegeOidNameAttnum4Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat ud, td, cd, pd;
-  args.data[0].ToUnifiedFormat(args.size(), ud);
-  args.data[1].ToUnifiedFormat(args.size(), td);
-  args.data[2].ToUnifiedFormat(args.size(), cd);
-  args.data[3].ToUnifiedFormat(args.size(), pd);
-  const auto* roid = duckdb::UnifiedVectorFormat::GetData<int64_t>(ud);
-  const auto* t = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(td);
-  const auto* attnum = duckdb::UnifiedVectorFormat::GetData<int16_t>(cd);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ui = ud.sel->get_index(i), ti = td.sel->get_index(i);
-    auto ci = cd.sel->get_index(i), pi = pd.sel->get_index(i);
-    if (!ud.validity.RowIsValid(ui) || !td.validity.RowIsValid(ti) ||
-        !cd.validity.RowIsValid(ci) || !pd.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    try {
-      auto r = ColumnPrivByNameTableAttnum(
-        conn_ctx, *snapshot, ObjectId{static_cast<uint64_t>(roid[ui])},
-        current_schema, {t[ti].GetData(), t[ti].GetSize()}, attnum[ci],
-        {p[pi].GetData(), p[pi].GetSize()});
-      if (r) {
-        out[i] = *r;
-      } else {
-        validity.SetInvalid(i);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t, int16_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t roid, duckdb::string_t t, int16_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
+        try {
+          auto r = ColumnPrivByNameTableAttnum(
+            conn_ctx, *snapshot, ObjectId{static_cast<uint64_t>(roid)},
+            current_schema, {t.GetData(), t.GetSize()}, attnum,
+            {p.GetData(), p.GetSize()});
+          if (r) {
+            return *r;
+          } else {
+            return duckdb::nullopt;
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasColumnPrivilegeOidOidAttnum4Function(duckdb::DataChunk& args,
                                              duckdb::ExpressionState& state,
                                              duckdb::Vector& result) {
   auto snapshot = GlobalSnapshot();
-  duckdb::UnifiedVectorFormat ud, td, cd, pd;
-  args.data[0].ToUnifiedFormat(args.size(), ud);
-  args.data[1].ToUnifiedFormat(args.size(), td);
-  args.data[2].ToUnifiedFormat(args.size(), cd);
-  args.data[3].ToUnifiedFormat(args.size(), pd);
-  const auto* roid = duckdb::UnifiedVectorFormat::GetData<int64_t>(ud);
-  const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(td);
-  const auto* attnum = duckdb::UnifiedVectorFormat::GetData<int16_t>(cd);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ui = ud.sel->get_index(i), ti = td.sel->get_index(i);
-    auto ci = cd.sel->get_index(i), pi = pd.sel->get_index(i);
-    if (!ud.validity.RowIsValid(ui) || !td.validity.RowIsValid(ti) ||
-        !cd.validity.RowIsValid(ci) || !pd.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto table = snapshot->GetObject<catalog::Table>(
-      ObjectId{static_cast<uint64_t>(toid[ti])});
-    if (!table || !AttnumExists(*table, attnum[ci])) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    try {
-      out[i] = HasColumnPrivByAttnum(
-        *snapshot, ObjectId{static_cast<uint64_t>(roid[ui])}, *table,
-        attnum[ci], {p[pi].GetData(), p[pi].GetSize()});
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, int64_t, int16_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t roid, int64_t toid, int16_t attnum, duckdb::string_t p) -> duckdb::optional<bool> {
+        auto table = snapshot->GetObject<catalog::Table>(
+          ObjectId{static_cast<uint64_t>(toid)});
+        if (!table || !AttnumExists(*table, attnum)) {
+          return duckdb::nullopt;
+        }
+        try {
+          return HasColumnPrivByAttnum(
+            *snapshot, ObjectId{static_cast<uint64_t>(roid)}, *table,
+            attnum, {p.GetData(), p.GetSize()});
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasAnyColumnPrivilegeName3Function(duckdb::DataChunk& args,
@@ -1700,48 +1490,34 @@ void HasAnyColumnPrivilegeName3Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat ud, td, pd;
-  args.data[0].ToUnifiedFormat(args.size(), ud);
-  args.data[1].ToUnifiedFormat(args.size(), td);
-  args.data[2].ToUnifiedFormat(args.size(), pd);
-  const auto* u = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(ud);
-  const auto* t = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(td);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ui = ud.sel->get_index(i), ti = td.sel->get_index(i);
-    auto pi = pd.sel->get_index(i);
-    if (!ud.validity.RowIsValid(ui) || !td.validity.RowIsValid(ti) ||
-        !pd.validity.RowIsValid(pi)) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto role = snapshot->GetRole({u[ui].GetData(), u[ui].GetSize()});
-    if (!role) {
-      ThrowRoleNotFound({u[ui].GetData(), u[ui].GetSize()});
-    }
-    const auto name =
-      pg::ParseObjectName({t[ti].GetData(), t[ti].GetSize()}, current_schema);
-    auto table =
-      snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                         name.schema, name.relation);
-    try {
-      if (table) {
-        out[i] = HasAnyTablePrivilegeText(*snapshot, role->GetId(), *table,
-                                          {p[pi].GetData(), p[pi].GetSize()});
-      } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
-        const auto obj = SystemRelationAsObject(*sys);
-        out[i] = HasAnyTablePrivilegeText(*snapshot, role->GetId(), obj,
-                                          {p[pi].GetData(), p[pi].GetSize()});
-      } else {
-        ThrowRelationNotFound(name.relation);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t, duckdb::string_t>(
+    args, result,
+    [&](duckdb::string_t u, duckdb::string_t t, duckdb::string_t p) -> duckdb::optional<bool> {
+        auto role = snapshot->GetRole({u.GetData(), u.GetSize()});
+        if (!role) {
+          ThrowRoleNotFound({u.GetData(), u.GetSize()});
+        }
+        const auto name =
+          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+        auto table =
+          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                             name.schema, name.relation);
+        try {
+          if (table) {
+            return HasAnyTablePrivilegeText(*snapshot, role->GetId(), *table,
+                                              {p.GetData(), p.GetSize()});
+          } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
+            const auto obj = SystemRelationAsObject(*sys);
+            return HasAnyTablePrivilegeText(*snapshot, role->GetId(), obj,
+                                              {p.GetData(), p.GetSize()});
+          } else {
+            ThrowRelationNotFound(name.relation);
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasAnyColumnPrivilegeOid2Function(duckdb::DataChunk& args,
@@ -1750,34 +1526,22 @@ void HasAnyColumnPrivilegeOid2Function(duckdb::DataChunk& args,
   auto& conn_ctx = GetSereneDBContext(state.GetContext());
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
-  duckdb::UnifiedVectorFormat td, pd;
-  args.data[0].ToUnifiedFormat(args.size(), td);
-  args.data[1].ToUnifiedFormat(args.size(), pd);
-  const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(td);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ti = td.sel->get_index(i), pi = pd.sel->get_index(i);
-    if (!td.validity.RowIsValid(ti) || !pd.validity.RowIsValid(pi) ||
-        !current) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    auto table = snapshot->GetObject<catalog::Table>(
-      ObjectId{static_cast<uint64_t>(toid[ti])});
-    if (!table) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    try {
-      out[i] = HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
-                                        {p[pi].GetData(), p[pi].GetSize()});
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t>(
+    args, result,
+    [&](int64_t toid, duckdb::string_t p) -> duckdb::optional<bool> {
+        auto table = snapshot->GetObject<catalog::Table>(
+          ObjectId{static_cast<uint64_t>(toid)});
+        if (!table) {
+          return duckdb::nullopt;
+        }
+        try {
+          return HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
+                                            {p.GetData(), p.GetSize()});
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 void HasAnyColumnPrivilegeName2Function(duckdb::DataChunk& args,
@@ -1787,41 +1551,30 @@ void HasAnyColumnPrivilegeName2Function(duckdb::DataChunk& args,
   auto snapshot = GlobalSnapshot();
   auto current = snapshot->GetRole(conn_ctx.user());
   const auto current_schema = conn_ctx.GetCurrentSchema();
-  duckdb::UnifiedVectorFormat td, pd;
-  args.data[0].ToUnifiedFormat(args.size(), td);
-  args.data[1].ToUnifiedFormat(args.size(), pd);
-  const auto* t = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(td);
-  const auto* p = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pd);
-  result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
-  auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
-  auto& validity = duckdb::FlatVector::ValidityMutable(result);
-  for (duckdb::idx_t i = 0; i < args.size(); i++) {
-    auto ti = td.sel->get_index(i), pi = pd.sel->get_index(i);
-    if (!td.validity.RowIsValid(ti) || !pd.validity.RowIsValid(pi) ||
-        !current) {
-      validity.SetInvalid(i);
-      continue;
-    }
-    const auto name =
-      pg::ParseObjectName({t[ti].GetData(), t[ti].GetSize()}, current_schema);
-    auto table =
-      snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
-                         name.schema, name.relation);
-    try {
-      if (table) {
-        out[i] = HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
-                                          {p[pi].GetData(), p[pi].GetSize()});
-      } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
-        const auto obj = SystemRelationAsObject(*sys);
-        out[i] = HasAnyTablePrivilegeText(*snapshot, current->GetId(), obj,
-                                          {p[pi].GetData(), p[pi].GetSize()});
-      } else {
-        ThrowRelationNotFound(name.relation);
-      }
-    } catch (const SqlException& e) {
-      ThrowInvalidPrivilege(e);
-    }
-  }
+  duckdb::VariadicExecutor::Execute<bool, duckdb::string_t, duckdb::string_t>(
+    args, result,
+    [&](duckdb::string_t t, duckdb::string_t p) -> duckdb::optional<bool> {
+        const auto name =
+          pg::ParseObjectName({t.GetData(), t.GetSize()}, current_schema);
+        auto table =
+          snapshot->GetTable(catalog::NoAccessCheck(), conn_ctx.GetDatabaseId(),
+                             name.schema, name.relation);
+        try {
+          if (table) {
+            return HasAnyTablePrivilegeText(*snapshot, current->GetId(), *table,
+                                              {p.GetData(), p.GetSize()});
+          } else if (const auto* sys = ResolveSystemRelation(conn_ctx, name)) {
+            const auto obj = SystemRelationAsObject(*sys);
+            return HasAnyTablePrivilegeText(*snapshot, current->GetId(), obj,
+                                              {p.GetData(), p.GetSize()});
+          } else {
+            ThrowRelationNotFound(name.relation);
+          }
+        } catch (const SqlException& e) {
+          ThrowInvalidPrivilege(e);
+        }
+  
+    });
 }
 
 }  // namespace


### PR DESCRIPTION
## What

Sixteen `has_*_privilege` functions in `system.cpp` each hand-rolled the same loop. They now use `VariadicExecutor`.

**−545 / +298**, no behaviour change.

## The pattern being removed

Every one of them did this:

```cpp
duckdb::UnifiedVectorFormat tdata, pdata;
args.data[0].ToUnifiedFormat(args.size(), tdata);
args.data[1].ToUnifiedFormat(args.size(), pdata);
const auto* toid = duckdb::UnifiedVectorFormat::GetData<int64_t>(tdata);
const auto* priv = duckdb::UnifiedVectorFormat::GetData<duckdb::string_t>(pdata);
result.SetVectorType(duckdb::VectorType::FLAT_VECTOR);
auto* out = duckdb::FlatVector::GetDataMutable<bool>(result);
auto& validity = duckdb::FlatVector::ValidityMutable(result);
for (duckdb::idx_t i = 0; i < args.size(); i++) {
  auto ti = tdata.sel->get_index(i);
  auto pi = pdata.sel->get_index(i);
  if (!tdata.validity.RowIsValid(ti) || !pdata.validity.RowIsValid(pi) || !current) {
    validity.SetInvalid(i);
    continue;
  }
  bool is_null = false;
  bool r = HasTablePrivilegeByOidImpl(...);
  if (is_null) { validity.SetInvalid(i); } else { out[i] = r; }
}
```

becomes:

```cpp
duckdb::VariadicExecutor::Execute<bool, int64_t, duckdb::string_t>(
  args, result,
  [&](int64_t toid, duckdb::string_t priv) -> duckdb::optional<bool> {
    if (!current) {
      return duckdb::nullopt;
    }
    bool is_null = false;
    bool r = HasTablePrivilegeByOidImpl(...);
    return is_null ? duckdb::nullopt : duckdb::optional<bool>{r};
  });
```

The executor already does the format dispatch, selection vectors and validity, and its `optional<T>` overload turns the `is_null` out-parameter into a return value. It also brings the constant and dictionary fast-paths these loops skipped.

## What is deliberately left alone

**`CancelBackendsByPid`** keeps its loop. `pg_cancel_backend` / `pg_terminate_backend` have side effects, and collapsing a constant input to a single call — correct for a pure function — would cancel one backend and report that result for every row.

**Nothing else in the tree wants this.** I checked every SereneDB file with a `DataChunk` scalar function, and each remaining manual loop has a structural reason:

| file | why manual is right |
|---|---|
| `ts_lexize`, `ts_query`, `ts_highlight`, `ts_offsets`, `split_by_non_alpha`, `array.cpp` | build LIST/STRUCT results — child vectors and offsets written by hand |
| `vector.cpp` | ARRAY inputs, needs the child vector |
| `encode_key.cpp` | column count known only at runtime |
| `RegexpInstrFunction` | arity is 3 or 4 at runtime (`args.ColumnCount() == 4`) |
| `RegexpMatchFunction` | returns a LIST |

So `system.cpp` was the only real cluster.

## Testing

`any/pg` — **382/382 on both `pg-wire-simple` and `pg-wire-extended`**, zero failures.

The real gate is the 259-test `any/pg/rbac` subtree, run twice: once after converting a single function by hand to validate the shape, and again after all sixteen. Zero failures both times.

## Note on how this was done

Partly mechanically, and the first attempt was wrong in a way worth recording: a transformer that lifted only the code from `bool is_null` onward silently dropped a preceding `role_id = ResolveRoleOrPublic(...)` in `HasTablePrivilegeNameOid3Function`. It failed to compile, which is the lucky outcome — in RBAC code a dropped statement that still compiles is a security bug.

The version used here lifts the whole loop body verbatim and rewrites only four mechanical things (`ptr[sel_idx]` → `ptr`, `validity.SetInvalid(i); continue;` → `return nullopt;`, `out[i] = X;` → `return X;`, and drops the leading validity guard), then refuses to convert a function if anything it did not recognise is left behind. Three functions bailed out that way on the first run and were only converted once the transformer handled their shape properly.

Every converted function was still read individually, and the RBAC suite is what actually backs the claim.