### PR TITLE
fix(docker): make the quick-start stack connectable

### DIFF
--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -40,11 +40,6 @@ RUN \
          /usr/share/doc/* /usr/share/man/* /usr/share/info/* \
          /usr/share/locale/* /usr/share/i18n/* /root/.cache /tmp/*
 
-# The bundled OpenSSL resolves its default verify paths at build time, which do
-# not match Ubuntu's store, so point it at the installed bundle explicitly.
-ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
-    SSL_CERT_DIR=/etc/ssl/certs
-
 VOLUME ["/var/lib/serenedb"]
 EXPOSE 7890
 

--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -16,8 +16,10 @@ RUN \
   rm /tmp/install.tar.gz && \
   # numactl: NUMA optimization for multi-socket systems
   # postgresql-client: psql for debugging, pg_isready for health checks
+  # ca-certificates: root store for outbound TLS (attaching a remote
+  #   ClickHouse/Postgres over TLS fails without it)
   apt-get update && \
-  apt-get install -y --no-install-recommends numactl postgresql-client && \
+  apt-get install -y --no-install-recommends numactl postgresql-client ca-certificates && \
   # Create non-root user for running serened
   groupadd -r serenedb && \
   useradd -r -g serenedb -d /var/lib/serenedb -s /usr/sbin/nologin serenedb && \
@@ -37,6 +39,11 @@ RUN \
   rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/log/* \
          /usr/share/doc/* /usr/share/man/* /usr/share/info/* \
          /usr/share/locale/* /usr/share/i18n/* /root/.cache /tmp/*
+
+# The bundled OpenSSL resolves its default verify paths at build time, which do
+# not match Ubuntu's store, so point it at the installed bundle explicitly.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_DIR=/etc/ssl/certs
 
 VOLUME ["/var/lib/serenedb"]
 EXPOSE 7890

--- a/packages/docker/entrypoint.sh
+++ b/packages/docker/entrypoint.sh
@@ -18,6 +18,37 @@ if [ "$1" = "serened" ]; then
 		echo "Config: $RUNTIME_CONFIG"
 	fi
 
+	: "${SERENEDB_HOST_AUTH_METHOD:=}"
+	if [ -n "$SERENEDB_HOST_AUTH_METHOD" ]; then
+		RUNTIME_HBA="/tmp/pg_hba.conf"
+		{
+			echo "# Generated from SERENEDB_HOST_AUTH_METHOD by the container entrypoint."
+			if [ "$SERENEDB_HOST_AUTH_METHOD" = "trust" ]; then
+				echo "# warning: trust is enabled for all connections"
+				echo "# https://www.postgresql.org/docs/current/auth-trust.html"
+			fi
+			echo "local all all $SERENEDB_HOST_AUTH_METHOD"
+			echo "host  all all 0.0.0.0/0 $SERENEDB_HOST_AUTH_METHOD"
+			echo "host  all all ::/0      $SERENEDB_HOST_AUTH_METHOD"
+		} >"$RUNTIME_HBA"
+		set -- "$@" "--hba_config=$RUNTIME_HBA"
+		echo "Auth: $SERENEDB_HOST_AUTH_METHOD ($RUNTIME_HBA)"
+
+		if [ "$SERENEDB_HOST_AUTH_METHOD" = "trust" ]; then
+			cat >&2 <<-'EOWARN'
+				********************************************************************************
+				WARNING: SERENEDB_HOST_AUTH_METHOD has been set to "trust". This will allow
+				         anyone with access to the SereneDB port to connect as any role
+				         without a password. In Docker's default configuration that is
+				         effectively any other container on the same system.
+
+				         Fine for a laptop and a demo. For anything else, set
+				         SERENEDB_HOST_AUTH_METHOD=scram-sha-256 and give the role a password.
+				********************************************************************************
+			EOWARN
+		fi
+	fi
+
 	# TODO: benchmark NUMA policy on multi-socket systems.
 	# numactl --interleave=all spreads memory across all NUMA nodes evenly,
 	# but jemalloc (our allocator) has its own NUMA-aware per-CPU arenas

--- a/packages/docker/entrypoint.sh
+++ b/packages/docker/entrypoint.sh
@@ -20,6 +20,19 @@ if [ "$1" = "serened" ]; then
 
 	: "${SERENEDB_HOST_AUTH_METHOD:=}"
 	if [ -n "$SERENEDB_HOST_AUTH_METHOD" ]; then
+		# Only the methods serened evaluates itself. The parser accepts more
+		# (ident, peer, gss, ldap, cert, ...) but they are either unenforced or
+		# refuse the connection, so a typo would silently cost you access: the
+		# server logs a parse error and falls back to requiring a password.
+		case "$SERENEDB_HOST_AUTH_METHOD" in
+		trust | reject | password | md5 | scram-sha-256) ;;
+		*)
+			echo >&2 "SERENEDB_HOST_AUTH_METHOD=\"$SERENEDB_HOST_AUTH_METHOD\" is not supported."
+			echo >&2 "Use one of: trust, scram-sha-256, md5, password, reject."
+			exit 1
+			;;
+		esac
+
 		RUNTIME_HBA="/tmp/pg_hba.conf"
 		{
 			echo "# Generated from SERENEDB_HOST_AUTH_METHOD by the container entrypoint."

--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -4,10 +4,17 @@
 # Override tags:
 #   SERENEDB_TAG=v1.2.3 SERENE_UI_TAG=v0.5.0 PSQL_TAG=16 \
 #     curl -fsSL https://install.serenedb.com | sh
+# Require a password instead of the quick-start default:
+#   SERENEDB_HOST_AUTH_METHOD=scram-sha-256 \
+#     curl -fsSL https://install.serenedb.com | sh
 
 SERENEDB_TAG="${SERENEDB_TAG:-latest}"
 SERENE_UI_TAG="${SERENE_UI_TAG:-latest}"
 PSQL_TAG="${PSQL_TAG:-latest}"
+
+# A throwaway local stack is worth no friction, so connections are trusted
+# unless the caller asks for something stricter.
+SERENEDB_HOST_AUTH_METHOD="${SERENEDB_HOST_AUTH_METHOD:-trust}"
 
 DIR="/tmp/serenedb-quick"
 COMPOSE_FILE="${DIR}/docker-compose.yml"
@@ -76,6 +83,8 @@ services:
     image: serenedb/serenedb:${SERENEDB_TAG}
     restart: on-failure
     stop_grace_period: 5s
+    environment:
+      SERENEDB_HOST_AUTH_METHOD: ${SERENEDB_HOST_AUTH_METHOD}
     ports:
       - "7890-7895:7890"
 


### PR DESCRIPTION
## What

`curl -fsSL https://install.serenedb.com | sh` brings the stack up and then leaves you with no way in. Two independent blockers, both reproduced against the published `serenedb/serenedb:latest` (26.07.5):

**1. No route to a psql prompt.** A passwordless role is trusted only over loopback *inside* the container, no password is ever provisioned, and no `pg_hba.conf` is shipped. So `psql -h localhost` fails, and so does the compose `psql` service that the installer itself prints as the next step — it is a separate container, i.e. a network connection:

```
$ docker compose -f /tmp/serenedb-quick/docker-compose.yml run --rm psql
psql: error: ... FATAL:  password authentication failed for user "postgres"   (exit 2)
```

**2. No CA store.** `/etc/ssl/certs` is empty in the image, so attaching a TLS remote fails:

```
could not connect foreign server "play": Failed to verify SSL connection,
X509_v error: 20 unable to get local issuer certificate
```

Installing `ca-certificates` alone is not enough: the bundled OpenSSL resolves its default verify paths at build time and they do not match Ubuntu's, so `SSL_CTX_set_default_verify_paths()` looks in the wrong place. Copying the bundle to `/etc/ssl/certs` changed nothing; `SSL_CERT_FILE` fixed it.

## How

`SERENEDB_HOST_AUTH_METHOD`, mirroring `POSTGRES_HOST_AUTH_METHOD` from the postgres image. The entrypoint renders a `pg_hba.conf` from it and passes `--hba_config` (the flag already existed; nothing in the server changes). `trust` warns loudly on stderr and in the generated file, as the postgres image does.

### Accepted values

`trust`, `scram-sha-256`, `md5`, `password`, `reject` — the five methods serened evaluates
itself (`MethodExecutability` → `Native` in `server/network/pg/hba.cpp`). The hba parser
accepts nine more (`ident`, `peer`, `gss`, `sspi`, `pam`, `bsd`, `ldap`, `cert`, `oauth`)
but they are either unenforced or refuse the connection outright, so the entrypoint rejects
anything outside the five and says what is allowed.

That guard matters because the failure was silent otherwise: a typo makes serened log
`hba config file ... failed to parse ... -- keeping default` and fall back to requiring a
password, which surfaces to the user only as `password authentication failed`.

`install_docker.sh` defaults it to `trust` for a throwaway local stack; callers override it:

```sh
SERENEDB_HOST_AUTH_METHOD=scram-sha-256 curl -fsSL https://install.serenedb.com | sh
```

Plus `ca-certificates` and `ENV SSL_CERT_FILE` / `SSL_CERT_DIR` in the Dockerfile.

## Verified

Against the published image with the patched entrypoint mounted in:

| mode | result |
|---|---|
| `SERENEDB_HOST_AUTH_METHOD=trust` | connects from the host with no password; warning printed; hba generated |
| `SERENEDB_HOST_AUTH_METHOD=scram-sha-256` | passwordless connect refused; no warning |
| unset | no hba written, behaviour unchanged (backwards compatible) |

End to end through the fixed container — attach ClickHouse's public playground over TLS, index it, search it:

```sql
CREATE SERVER play FOREIGN DATA WRAPPER clickhouse_fdw
  OPTIONS (host 'play.clickhouse.com', port '9440', database 'default', user 'play', secure 'true');
CREATE VIEW hn AS SELECT id, title, "by", score, url FROM play.default.hackernews
  WHERE type = 'story' AND score > 500 LIMIT 1024;
CREATE INDEX hn_fts ON hn USING inverted(id, title en) INCLUDE ("by");
SELECT title, "by", score FROM hn_fts WHERE title @@ ts_phrase('rust') ORDER BY score DESC LIMIT 4;
```

```
 A half-hour to learn Rust                      | selvan       | 1444
 Tauri: An Electron alternative written in Rust | metalwhale   | 1113
 Async-await on stable Rust                     | pietroalbini | 1102
 Rust for Windows                               | dsr12        |  785
```

The Dockerfile change was validated by effect (mounted bundle + env), **not** by building the image — that needs the release tarball.

## Worth arguing about

Defaulting the quick-start to `trust` publishes a passwordless port, which in Docker's default networking is any other container on the same host. The postgres image made the opposite call: strict by default, `trust` opt-in. The quick-start is explicitly a throwaway demo stack, so trading that for zero friction seems right — but say so if you disagree and I will flip it to a generated password printed at the end.

Unrelated and untouched: the compose publishes `7890-7895:7890`, so the host port is not stable across runs (I saw 7890 through 7895 over several runs).