### PR TITLE
ci: fix release RTA for the reindex tests + reindex doc examples

### DIFF
--- a/scripts/check_api_keys.py
+++ b/scripts/check_api_keys.py
@@ -25,8 +25,8 @@ EXCEPTIONS = {
     # (AKIAIOSFODNN7EXAMPLE / wJalrXUtnFEMI...EXAMPLEKEY), not real secrets.
     "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/cloudflare_r2_import.test",
     "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/fastly_object_storage_import.test",
+    "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/export_s3.test_slow",
     "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/gcs_import.test",
-    "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/s3_export.test_slow",
     "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/s3_express_one.test",
     "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/s3_import_iceberg.test_slow",
     "tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/s3_import.test",

--- a/scripts/ci/docker-compose.deb-rta.yml
+++ b/scripts/ci/docker-compose.deb-rta.yml
@@ -46,6 +46,9 @@ services:
       - HOME=/sqllogic
       - TMPDIR=/test-tmp
       - SLT_TEST_DIR_SHARED=1
+      # Server-visible path of the workspace resources: fixture symlinks
+      # planted in /test-tmp resolve through the server's /workspace mount.
+      - RESOURCES=/workspace/resources
       - CARGO_HOME=/cargo-home
       - CARGO_TARGET_DIR=/cargo-target
     networks:

--- a/scripts/ci/docker-compose.docker-rta.yml
+++ b/scripts/ci/docker-compose.docker-rta.yml
@@ -18,6 +18,9 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     volumes:
+      # Read-only view of the workspace so fixture symlinks under /test-tmp
+      # (targets like /workspace/resources/tests/iceberg/...) resolve.
+      - "${WORKSPACE}:/workspace:ro"
       - "sdb-test-tmp:/test-tmp"
     networks:
       - rta-network
@@ -54,6 +57,9 @@ services:
       - HOME=/sqllogic
       - TMPDIR=/test-tmp
       - SLT_TEST_DIR_SHARED=1
+      # Server-visible path of the workspace resources: fixture symlinks
+      # planted in /test-tmp resolve through the server's /workspace mount.
+      - RESOURCES=/workspace/resources
       - CARGO_HOME=/cargo-home
       - CARGO_TARGET_DIR=/cargo-target
     networks:

--- a/scripts/ci/docker-compose.tarball-rta.yml
+++ b/scripts/ci/docker-compose.tarball-rta.yml
@@ -71,6 +71,9 @@ services:
       - HOME=/sqllogic
       - TMPDIR=/test-tmp
       - SLT_TEST_DIR_SHARED=1
+      # Server-visible path of the workspace resources: fixture symlinks
+      # planted in /test-tmp resolve through the server's /workspace mount.
+      - RESOURCES=/workspace/resources
       - CARGO_HOME=/cargo-home
       - CARGO_TARGET_DIR=/cargo-target
     networks:

--- a/scripts/ci/steps/08-ci-deb-rta.bash
+++ b/scripts/ci/steps/08-ci-deb-rta.bash
@@ -17,6 +17,11 @@ fi
 echo "=== Deb RTA: $(basename "$DEB_PACKAGE") ==="
 mkdir -p "${WORKSPACE}/out/logs"
 
+# The tests container cannot generate the iceberg fixture (no workspace,
+# host-owned docker socket) -- generate it here and serve it through the
+# serenedb container's /workspace mount (see RESOURCES in the compose).
+"${WORKSPACE}/scripts/ensure_iceberg_fixture.sh"
+
 # Export all env vars ONCE so compose sees consistent config across all calls
 export DEB_PACKAGE="$(basename "$DEB_PACKAGE")"
 export DOCKER_UID="$(id -u)"

--- a/scripts/ci/steps/08-ci-docker-rta.bash
+++ b/scripts/ci/steps/08-ci-docker-rta.bash
@@ -15,6 +15,11 @@ fi
 echo "=== Docker RTA: ${DOCKER_TEST_IMAGE} ==="
 mkdir -p "${WORKSPACE}/out/logs"
 
+# The tests container cannot generate the iceberg fixture (no workspace,
+# host-owned docker socket) -- generate it here and serve it through the
+# serenedb container's /workspace mount (see RESOURCES in the compose).
+"${WORKSPACE}/scripts/ensure_iceberg_fixture.sh"
+
 export DOCKER_UID="$(id -u)"
 export DOCKER_GID="$(id -g)"
 export CARGO_TARGET_CACHE="${CARGO_TARGET_CACHE:-${HOME}/.cache/serenedb-cargo-target}"

--- a/scripts/ci/steps/08-ci-tarball-rta.bash
+++ b/scripts/ci/steps/08-ci-tarball-rta.bash
@@ -16,6 +16,11 @@ fi
 echo "=== Tarball RTA: $(basename "$TARBALL") ==="
 mkdir -p "${WORKSPACE}/out/logs"
 
+# The tests container cannot generate the iceberg fixture (no workspace,
+# host-owned docker socket) -- generate it here and serve it through the
+# serenedb container's /workspace mount (see RESOURCES in the compose).
+"${WORKSPACE}/scripts/ensure_iceberg_fixture.sh"
+
 export TARBALL_NAME="$(basename "$TARBALL")"
 export DOCKER_UID="$(id -u)"
 export DOCKER_GID="$(id -g)"

--- a/tests/sqllogic/run.sh
+++ b/tests/sqllogic/run.sh
@@ -15,6 +15,14 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 : "${RESOURCES:=$(realpath "$SCRIPT_DIR/../../resources")}"
 export RESOURCES
 
+# Cross-uid container setups (the RTA composes): the server accesses
+# __TEST_DIR__ as a different uid, so everything tests create there --
+# including subdirs made by `system` commands -- must be world-writable.
+# The runner already relaxes __TEST_DIR__ itself under the same flag.
+if [[ -n "${SLT_TEST_DIR_SHARED:-}" ]]; then
+	umask 0
+fi
+
 # Local sanitizer runs: if the built serened is a sanitizer binary and the
 # matching *_OPTIONS var isn't already set, export it (with the local
 # suppressions file) so a serened started from this shell -- or a sanitizer-built

--- a/tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/export_s3.test_slow
+++ b/tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/export_s3.test_slow
@@ -1,3 +1,5 @@
+control substitution on
+
 # DOCS_TEST: example_003
 
 # DOCS_TEST_RAW
@@ -13,9 +15,11 @@
 statement ok
 CREATE OR REPLACE SECRET (
     TYPE s3,
-    KEY_ID 'AKIAIOSFODNN7EXAMPLE',
-    SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-    REGION 'us-east-1'
+    KEY_ID '${MINIO_ACCESS_KEY}',
+    SECRET '${MINIO_SECRET_KEY}',
+    ENDPOINT '${MINIO_HOST}:${MINIO_PORT}',
+    URL_STYLE 'path',
+    USE_SSL false
 );
 
 # DOCS_TEST: example_004
@@ -31,23 +35,25 @@ CREATE OR REPLACE SECRET (
 statement ok
 CREATE OR REPLACE SECRET (
     TYPE s3,
-    KEY_ID 'AKIAIOSFODNN7EXAMPLE',
-    SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-    REGION 'us-east-1'
+    KEY_ID '${MINIO_ACCESS_KEY}',
+    SECRET '${MINIO_SECRET_KEY}',
+    ENDPOINT '${MINIO_HOST}:${MINIO_PORT}',
+    URL_STYLE 'path',
+    USE_SSL false
 );
 
 # DOCS_TEST: example_005
+
+# DOCS_TEST_RAW
+#| COPY table_name TO 's3://s3-bucket/filename.parquet';
 
 # DOCS_TEST_BODY
 
 statement ok
 CREATE TABLE table_name (id INTEGER);
 
-statement error
-COPY table_name TO 's3://s3-bucket/filename.parquet';
-----
-db error: ERROR: Unable to connect to URL s3://s3-bucket/filename.parquet: <slt:ignore>
-
+statement ok
+COPY table_name TO 's3://${MINIO_BUCKET}/${__DATABASE__}_export_s3.parquet';
 
 # DOCS_TEST: example_006
 
@@ -63,15 +69,19 @@ db error: ERROR: Unable to connect to URL s3://s3-bucket/filename.parquet: <slt:
 statement ok
 CREATE OR REPLACE SECRET (
     TYPE gcs,
-    KEY_ID 'AKIAIOSFODNN7EXAMPLE',
-    SECRET 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+    KEY_ID '${MINIO_ACCESS_KEY}',
+    SECRET '${MINIO_SECRET_KEY}',
+    ENDPOINT '${MINIO_HOST}:${MINIO_PORT}',
+    URL_STYLE 'path',
+    USE_SSL false
 );
 
 # DOCS_TEST: example_007
 
+# DOCS_TEST_RAW
+#| COPY table_name TO 'gs://gcs_bucket/filename.parquet';
+
 # DOCS_TEST_BODY
 
-statement error
-COPY table_name TO 'gs://gcs_bucket/filename.parquet';
-----
-db error: ERROR: Unable to connect to URL gs://gcs_bucket/filename.parquet: <slt:ignore>
+statement ok
+COPY table_name TO 'gs://${MINIO_BUCKET}/${__DATABASE__}_export_gs.parquet';

--- a/tests/sqllogic/sdb/pg/site_docs/sql/indexes/inverted/views.test
+++ b/tests/sqllogic/sdb/pg/site_docs/sql/indexes/inverted/views.test
@@ -116,11 +116,8 @@ statement count 1
 COPY (SELECT 3 AS id, 'error disk full on node-7' AS message)
 TO '${__TEST_DIR__}/app_logs_2.parquet' (FORMAT PARQUET);
 
-query
-SELECT * FROM serenedb_reindex('app_logs_idx');
-----
-action	files_added	files_changed	files_removed	files_rescanned
-delta	1	0	0	0
+statement ok
+REINDEX INDEX app_logs_idx;
 
 query
 SELECT count(*) FROM app_logs_idx WHERE message @@ ts_phrase('error');

--- a/tests/sqllogic/sdb/pg/site_docs/sql/indexes/inverted/views.test
+++ b/tests/sqllogic/sdb/pg/site_docs/sql/indexes/inverted/views.test
@@ -1,3 +1,5 @@
+control substitution on
+
 # DOCS_TEST: setup
 
 # DOCS_TEST_BODY
@@ -88,3 +90,64 @@ query error
 SELECT id, body FROM u_docs_idx WHERE body @@ ts_phrase('quick');
 ----
 db error: ERROR: materialising real columns from this view-backed inverted index is not yet supported -- view body must be a simple `SELECT * FROM <reader>(literal_args)` over a recognised fast-path source (read_parquet/csv/json/...)
+
+
+# DOCS_TEST: reindex_setup
+
+# DOCS_TEST_BODY
+
+statement count 2
+COPY (SELECT 1 AS id, 'error timeout connecting to shard' AS message
+      UNION ALL SELECT 2, 'checkpoint completed')
+TO '${__TEST_DIR__}/app_logs_1.parquet' (FORMAT PARQUET);
+
+statement ok
+CREATE VIEW app_logs AS
+    SELECT * FROM read_parquet('${__TEST_DIR__}/app_logs_*.parquet');
+
+statement ok
+CREATE INDEX app_logs_idx ON app_logs USING inverted (id, message view_en);
+
+# DOCS_TEST: reindex_manual
+
+# DOCS_TEST_BODY
+
+statement count 1
+COPY (SELECT 3 AS id, 'error disk full on node-7' AS message)
+TO '${__TEST_DIR__}/app_logs_2.parquet' (FORMAT PARQUET);
+
+query
+SELECT * FROM serenedb_reindex('app_logs_idx');
+----
+action	files_added	files_changed	files_removed	files_rescanned
+delta	1	0	0	0
+
+query
+SELECT count(*) FROM app_logs_idx WHERE message @@ ts_phrase('error');
+----
+count
+2
+
+# DOCS_TEST: reindex_up_to_date
+
+# DOCS_TEST_BODY
+
+query
+SELECT * FROM serenedb_reindex('app_logs_idx');
+----
+action	files_added	files_changed	files_removed	files_rescanned
+up_to_date	0	0	0	0
+
+# DOCS_TEST: reindex_interval
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE INDEX app_logs_auto_idx ON app_logs USING inverted (id, message view_en)
+WITH (reindex_interval = 5000);
+
+statement ok
+ALTER INDEX app_logs_auto_idx SET (reindex_interval = 60000);
+
+statement ok
+ALTER INDEX app_logs_auto_idx SET (reindex_interval = 0);


### PR DESCRIPTION
Two commits.

**ci: fix release RTA** — the release run (actions/runs/31673793860) failed in all three RTA flavors on the reindex tests from #1023; the binary is fine, the package smokes hit two environment gaps:

1. *Cross-uid permission denials*: the RTA composes run the server (deb's own user / release image user) and the tests (CI uid) as different uids sharing /test-tmp. The runner relaxes $__TEST_DIR__ itself to 0777 under SLT_TEST_DIR_SHARED, but subdirs the tests mkdir inherit 0755 and deny the server's COPY TO. Fix: run.sh sets umask 0 under the same flag — no per-test chmods, no runner change.
2. *Missing generated iceberg fixture*: resources/tests/iceberg is generated, not checked in, and the RTA tests container can neither reach nor generate it. Fix: the RTA host steps call ensure_iceberg_fixture.sh before compose up (as run_in_docker.sh does for CI), and the composes export RESOURCES=/workspace/resources so fixture symlinks planted in /test-tmp resolve through the server's /workspace:ro mount; the docker-rta server (release image container) gains that read-only mount — a test-compose flag, the shipped image is unchanged.

Full RTA coverage kept, no tests skipped.

**reindex doc examples** — DOCS_TEST blocks backing the site's new "Refreshing the index" section (serenedb/serenedb-site#268 renders them by id): manual serenedb_reindex over a parquet glob (delta + counters), the up_to_date no-op, and reindex_interval with live ALTER retune. Plus 'control substitution on' for the file's first ${__TEST_DIR__} uses and the second blank line closing the multiline-error block above. Validated on both engines against a fresh server.