### PR TITLE
fix: Fix column filter selection data reuse between segments

### DIFF
--- a/libs/iresearch/include/iresearch/index/hit_batcher.cpp
+++ b/libs/iresearch/include/iresearch/index/hit_batcher.cpp
@@ -277,6 +277,7 @@ void HitBatcher::ScatterGroup() {
   const auto hits = _len - _group;
   const uint64_t anchor = Row(_group);
   const auto span = static_cast<duckdb::idx_t>(Row(_len - 1) - anchor + 1);
+  _sel.Initialize(_sel_data);
   for (duckdb::idx_t i = 0; i < hits; ++i) {
     _sel.set_index(i, Row(_group + i) - anchor);
   }
@@ -403,6 +404,7 @@ HitBatcher::Batch HitBatcher::Emit(duckdb::DataChunk& output) {
   if (_ready == Pending::Dense) {
     const uint64_t anchor = Row(0);
     const auto span = static_cast<duckdb::idx_t>(Row(_batch - 1) - anchor + 1);
+    _sel.Initialize(_sel_data);
     for (duckdb::idx_t i = 0; i < _batch; ++i) {
       _sel.set_index(i, Row(i) - anchor);
     }

--- a/tests/sqllogic/recovery/inverted_index_colfilter_sel_reuse.test
+++ b/tests/sqllogic/recovery/inverted_index_colfilter_sel_reuse.test
@@ -1,0 +1,69 @@
+# Regression: HitBatcher::_sel is a reused member initialized once to
+# STANDARD_VECTOR_SIZE, but ColumnSegment::FilterSelection repoints it at the
+# filter executor's own result buffer, whose capacity is only the filtered
+# window's hit count. BeginSegment does not restored it and it asserted,
+# `threads = 1` forces both segments onto one worker's batcher reproducing the issue; 
+
+onlyif serenedb
+statement ok
+SET threads = 1
+
+
+onlyif serenedb
+statement ok
+CREATE TEXT SEARCH DICTIONARY cf_en
+  (template = 'delimiter', delimiter = ' ', frequency = true, position = true)
+
+
+onlyif serenedb
+statement ok
+CREATE TABLE cf (id INT PRIMARY KEY, body TEXT, g INT)
+
+
+# g is INCLUDE-only (no posting list), so a filter on it is a `.col` column
+# filter rather than an index term. compaction_interval = 0 keeps the two
+# segments below from being consolidated into one.
+onlyif serenedb
+statement ok
+CREATE INDEX cf_idx ON cf USING inverted (id, body cf_en) INCLUDE (g)
+  WITH (compaction_interval = 0)
+
+
+# Segment 1: g straddles the predicate, so the filter narrows the window and
+# leaves _sel pointing at the executor's capacity-2 buffer.
+onlyif serenedb
+statement ok
+INSERT INTO cf VALUES (1, 'alpha', 50), (2, 'alpha', 150)
+
+
+onlyif serenedb
+statement ok
+VACUUM (REFRESH_TABLE) cf
+
+
+# Segment 2: every g < 100, so the zonemap answers the filter and it is dropped
+# for this segment -- no filters, and the unguarded write path.
+onlyif serenedb
+statement ok
+INSERT INTO cf VALUES (3, 'alpha', 1), (4, 'alpha', 2), (5, 'alpha', 3)
+
+
+onlyif serenedb
+statement ok
+VACUUM (REFRESH_TABLE) cf
+
+
+onlyif serenedb
+query
+SELECT id, g FROM cf_idx WHERE body @@ 'alpha' AND g < 100 ORDER BY id;
+----
+id	g
+1	50
+3	1
+4	2
+5	3
+
+
+onlyif serenedb
+statement ok
+RESET threads

--- a/tests/sqllogic/recovery/inverted_index_fault_isolation.test
+++ b/tests/sqllogic/recovery/inverted_index_fault_isolation.test
@@ -40,6 +40,7 @@ CREATE TABLE doc (
 
 statement ok
 CREATE INDEX doc_idx ON doc USING inverted(pk, body en) INCLUDE (label, tag)
+  WITH (refresh_interval = 0, compaction_interval = 0)
 
 
 statement ok

--- a/tests/sqllogic/recovery/inverted_index_scan_order_multiunit.test
+++ b/tests/sqllogic/recovery/inverted_index_scan_order_multiunit.test
@@ -94,3 +94,8 @@ rk
 200000
 199999
 199998
+
+
+onlyif serenedb
+statement ok
+RESET threads


### PR DESCRIPTION
1. Assert "ERROR: Assertion triggered in file "/serenedb/third_party/duckdb/src/include/duckdb/common/types/selection_vector.hpp" on line 125: idx < capacity"
Cause:
HitBatcher::_sel is a reused member that owns a STANDARD_VECTOR_SIZE buffer (_sel_data). When it's passed down a filtered window — ColFilterChain::FilterWindow → ColumnReader::GatherFilter → duckdb::ColumnSegment::FilterSelection — DuckDB's fast filter executors re-point it at their own result_sel on narrowing, and that buffer is sized to exactly the window's pre-filter hit count (PrepareCapacity(count)), not vector size. BeginSegment resets everything else but not _sel, so the shrunken, foreign buffer survives into the next segment.
If that next segment's zonemap proves the .col filter FILTER_ALWAYS_TRUE, the filter is dropped from the active set, HasFilters() goes false, and the batch no longer routes through EmitFiltered (the one path that re-initializes _sel). Emit()'s dense arm and ScatterGroup() then write _sel[0..batch) with the stale capacity. 
Fix:
Re-initialize _sel same way as EmitFiltered does.

2.  Make tests/sqllogic/recovery/inverted_index_scan_order_multiunit.test reset threads values it sets. So when tests run on standalone server under debug it is not poisoned. CI was fine as is  - it just restarts servers anyway.
3.  Fix flaky tests/sqllogic/recovery/inverted_index_fault_isolation.test - it relied on index is not refreshed at some point but background refresh was enabled.