### PR TITLE
fix: Don't drop zero-score hits from top-k

### DIFF
--- a/libs/iresearch/include/iresearch/search/bm25.cpp
+++ b/libs/iresearch/include/iresearch/search/bm25.cpp
@@ -365,9 +365,11 @@ ScoreFunction BM25::PrepareScorer(const ScoreContext& ctx) const {
 
 ScoreBoundWriter::ptr BM25::PrepareScoreBoundWriter(size_t max_levels) const {
   if (IsBM1()) {
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::None);
     return {};
   }
   if (IsBM15()) {
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::MaxFreq);
     return std::make_unique<FreqNormWriter<kScoreBoundMaxFreq>>(max_levels);
   }
   if (IsBM11()) {
@@ -380,8 +382,10 @@ ScoreBoundWriter::ptr BM25::PrepareScoreBoundWriter(size_t max_levels) const {
     // x / (k * ((1 - b) / dl + b / avg_dl) + x)
     // b == 1
     // x / (k / avg_dl + x)
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::DivNorm);
     return std::make_unique<FreqNormWriter<kScoreBoundDivNorm>>(max_levels);
   }
+  SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::MinNorm);
   if (_approximate) {
     // It's not precise if we have more than 1 segment.
     // But search is distributed and we don't compute cluster wide avg_dl,
@@ -396,16 +400,19 @@ ScoreBoundWriter::ptr BM25::PrepareScoreBoundWriter(size_t max_levels) const {
 
 ScoreBoundSource::ptr BM25::PrepareScoreBoundSource() const {
   if (IsBM1()) {
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::None);
     return {};
   }
   if (IsBM15()) {
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::MaxFreq);
     return std::make_unique<FreqNormSource<kScoreBoundFreq>>();
   }
+  SDB_ASSERT(BoundTypeOf(GetOptions()) != ScoreBoundType::None);
   return std::make_unique<FreqNormSource<kScoreBoundFreq | kScoreBoundNorm>>();
 }
 
 bool BM25::Compatible(const ScorerOptions& persisted) const noexcept {
-  const auto type = BoundTypeOf({.k1 = _k, .b = _b});
+  const auto type = BoundTypeOf(GetOptions());
   if (type == ScoreBoundType::None || type != irs::BoundTypeOf(persisted)) {
     return false;
   }

--- a/libs/iresearch/include/iresearch/search/bm25.hpp
+++ b/libs/iresearch/include/iresearch/search/bm25.hpp
@@ -126,6 +126,13 @@ class BM25 final : public irs::ScorerBase<BM25, BM25Stats> {
 
   std::string ToString() const final;
 
+  Options GetOptions() const noexcept {
+    return {.k1 = _k,
+            .b = _b,
+            .boost_as_score = _boost_as_score,
+            .approximate = _approximate};
+  }
+
   score_t k() const noexcept { return _k; }
 
   score_t b() const noexcept { return _b; }

--- a/libs/iresearch/include/iresearch/search/doc_collector.hpp
+++ b/libs/iresearch/include/iresearch/search/doc_collector.hpp
@@ -54,7 +54,7 @@ inline uint64_t ExecuteTopKWithCount(const DirectoryReader& reader,
   }
   const auto stats = prepare_collector->Finish(IResourceManager::gNoop);
 
-  score_t score_threshold = std::numeric_limits<score_t>::min();
+  score_t score_threshold = std::numeric_limits<score_t>::lowest();
   LoserScoreCollector collector{score_threshold, hits};
   ColumnArgsFetcher fetcher;
   uint32_t seg_idx = 0;
@@ -97,7 +97,7 @@ inline uint64_t ExecuteTopK(const DirectoryReader& reader, const Filter& filter,
   }
   const auto stats = prepare_collector->Finish(IResourceManager::gNoop);
 
-  score_t score_threshold = std::numeric_limits<score_t>::min();
+  score_t score_threshold = std::numeric_limits<score_t>::lowest();
   LoserScoreCollector collector{score_threshold, hits};
   ColumnArgsFetcher fetcher;
   uint32_t seg_idx = 0;

--- a/libs/iresearch/include/iresearch/search/max_score_iterator.hpp
+++ b/libs/iresearch/include/iresearch/search/max_score_iterator.hpp
@@ -573,7 +573,7 @@ class MaxScoreIterator : public DocIterator {
   uint32_t _num_outer_windows = 0;
   doc_id_t _min_window_size = 1;
   ColumnArgsFetcher _fetcher;
-  score_t _next_threshold = std::numeric_limits<score_t>::min();
+  score_t _next_threshold = std::numeric_limits<score_t>::lowest();
   Attributes _attrs;
 };
 

--- a/libs/iresearch/include/iresearch/search/max_score_iterator.hpp
+++ b/libs/iresearch/include/iresearch/search/max_score_iterator.hpp
@@ -424,6 +424,7 @@ class MaxScoreIterator : public DocIterator {
                                          doc_id_t max) {
     _num_candidates += cand_docs.size();
     const score_t threshold = std::get<ScoreThresholdAttr>(_attrs).value;
+    SDB_ASSERT(threshold > 0);
 
     const auto first_required = _first_required;
     for (auto it = _first_essential; it != _itrs_sorted.begin();) {

--- a/libs/iresearch/include/iresearch/search/tfidf.cpp
+++ b/libs/iresearch/include/iresearch/search/tfidf.cpp
@@ -197,21 +197,25 @@ ScoreBoundWriter::ptr TFIDF::PrepareScoreBoundWriter(size_t max_levels) const {
     // idf * sqrt(tf) / sqrt(dl)
     // sqrt(tf) / sqrt(dl)
     // tf / dl
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::DivNorm);
     return std::make_unique<FreqNormWriter<kScoreBoundDivNorm>>(max_levels);
   }
+  SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::MaxFreq);
   return std::make_unique<FreqNormWriter<kScoreBoundMaxFreq>>(max_levels);
 }
 
 ScoreBoundSource::ptr TFIDF::PrepareScoreBoundSource() const {
   if (_normalize) {
+    SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::DivNorm);
     return std::make_unique<
       FreqNormSource<kScoreBoundFreq | kScoreBoundNorm>>();
   }
+  SDB_ASSERT(BoundTypeOf(GetOptions()) == ScoreBoundType::MaxFreq);
   return std::make_unique<FreqNormSource<kScoreBoundFreq>>();
 }
 
 bool TFIDF::Compatible(const ScorerOptions& persisted) const noexcept {
-  return irs::BoundTypeOf(persisted) == BoundTypeOf({.with_norms = _normalize});
+  return irs::BoundTypeOf(persisted) == BoundTypeOf(GetOptions());
 }
 
 std::string TFIDF::ToString() const {

--- a/libs/iresearch/include/iresearch/search/tfidf.hpp
+++ b/libs/iresearch/include/iresearch/search/tfidf.hpp
@@ -81,6 +81,10 @@ class TFIDF final : public irs::ScorerBase<TFIDF, TFIDFStats> {
 
   std::string ToString() const final;
 
+  Options GetOptions() const noexcept {
+    return {.with_norms = _normalize, .boost_as_score = _boost_as_score};
+  }
+
   bool normalize() const noexcept { return _normalize; }
 
   bool use_boost_as_score() const noexcept { return _boost_as_score; }

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -979,9 +979,9 @@ void RerankHits(IResearchScanGlobalState& g, std::span<irs::ScoreDoc> hits) {
   }
 }
 
-// Current lower-bound score from the dynamic TOP_N boundary, or min() when it
-// is not yet initialized or is not a lower bound (text-only path: scores
-// are strictly positive). Seeds the streaming prune threshold; the exact
+// Current lower-bound score from the dynamic TOP_N boundary, or lowest() when
+// it is not yet initialized or is not a lower bound (no bound yet, and a score
+// of 0 is a legal hit). Seeds the streaming prune threshold; the exact
 // boundary is still enforced by the HitBatcher score filter, so an over-loose
 // threshold only skips fewer blocks (never wrong). Score pruning is strict
 // (skips `block_max <= threshold`), so a `>=` boundary steps one ulp down --
@@ -993,12 +993,13 @@ irs::score_t CurrentPruneThreshold(duckdb::DynamicFilterData& dyn) {
       (dyn.comparison_type != duckdb::ExpressionType::COMPARE_GREATERTHAN &&
        dyn.comparison_type !=
          duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO)) {
-    return std::numeric_limits<irs::score_t>::min();
+    return std::numeric_limits<irs::score_t>::lowest();
   }
   const auto boundary = dyn.constant.GetValue<float>();
   if (dyn.comparison_type ==
       duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
-    return std::nextafter(boundary, std::numeric_limits<irs::score_t>::min());
+    return std::nextafter(boundary,
+                          std::numeric_limits<irs::score_t>::lowest());
   }
   return boundary;
 }
@@ -1705,9 +1706,6 @@ duckdb::unique_ptr<duckdb::LocalTableFunctionState> IResearchScanInitLocal(
   }
   if (gstate.mode == ScanMode::TopK) {
     auto lstate = duckdb::make_uniq<TopKScanLocalState>();
-    if (!gstate.vector_scorer) {
-      lstate->local_threshold = std::numeric_limits<irs::score_t>::min();
-    }
     lstate->hit_buf.resize(CollectorPoolSize(gstate, bd));
     lstate->hit_slice = std::span<irs::ScoreDoc>{lstate->hit_buf};
     BuildOffsetsEntries(*lstate, input, bd);

--- a/tests/bench/search-benchmark-game/executor.cpp
+++ b/tests/bench/search-benchmark-game/executor.cpp
@@ -212,7 +212,7 @@ EmitResult Executor::ExecuteEmitDocs(std::string_view query, Report report) {
       }
       if (report.print) {
         for (uint32_t i = 0; i != n; ++i) {
-          absl::FPrintF(stderr, "doc=%u\n", _emit_docs[i]);
+          absl::FPrintF(_print_out, "doc=%u\n", _emit_docs[i]);
         }
       }
       min = docs->value();
@@ -266,7 +266,7 @@ EmitResult Executor::ExecuteEmitScoredDocs(std::string_view query,
       }
       if (report.print) {
         for (uint32_t i = 0; i != n; ++i) {
-          absl::FPrintF(stderr, "doc=%u score=%.6f\n", _emit_docs[i],
+          absl::FPrintF(_print_out, "doc=%u score=%.6f\n", _emit_docs[i],
                         _emit_scores[i]);
         }
       }

--- a/tests/bench/search-benchmark-game/executor.h
+++ b/tests/bench/search-benchmark-game/executor.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdio>
 #include <iresearch/analysis/analyzer.hpp>
 #include <iresearch/formats/formats.hpp>
 #include <iresearch/index/directory_reader.hpp>
@@ -90,6 +91,10 @@ class Executor {
   size_t ExecuteCount(std::string_view query);
   size_t HashResults() const;
   void PrintResults() const;
+
+  // Where `Report::print` writes. The benchmark harness reads stderr; a test
+  // that only asserts on the documents can point this at /dev/null.
+  void SetPrintSink(std::FILE* out) noexcept { _print_out = out; }
   EmitResult ExecuteEmitDocs(std::string_view query, Report report = {});
   EmitResult ExecuteEmitScoredDocs(std::string_view query, Report report = {});
 
@@ -110,6 +115,7 @@ class Executor {
   static constexpr size_t kEmitWindow = STANDARD_VECTOR_SIZE;
 
   std::vector<irs::ScoreDoc> _results;
+  std::FILE* _print_out = stderr;
   std::array<irs::doc_id_t, kEmitWindow> _emit_docs;
   std::array<irs::score_t, kEmitWindow> _emit_scores;
   size_t _result_count{0};

--- a/tests/libs/iresearch/search/load_test.cpp
+++ b/tests/libs/iresearch/search/load_test.cpp
@@ -673,6 +673,23 @@ class LoadTest : public TestBase {
     }
   }
 
+  void SetUp() override {
+    TestBase::SetUp();
+    _null_sink = std::fopen("/dev/null", "w");
+    ASSERT_NE(nullptr, _null_sink);
+  }
+
+  void TearDown() override {
+    if (gExecutor) {
+      gExecutor->SetPrintSink(stderr);
+    }
+    if (_null_sink) {
+      std::fclose(_null_sink);
+      _null_sink = nullptr;
+    }
+    TestBase::TearDown();
+  }
+
   void RunAndValidate(std::string_view name) {
     const auto res_dir = resource("iresearch-load") / name;
     const auto queries_path = res_dir / "queries.json";
@@ -799,6 +816,8 @@ class LoadTest : public TestBase {
   static inline Mode gMode = Mode::Validate;
   static inline bool gGzip = false;
   static inline bool gDropIndex = true;
+
+  std::FILE* _null_sink = nullptr;
 };
 
 TEST_F(LoadTest, WikiSmall) { RunAndValidate("wiki_small"); }
@@ -1126,9 +1145,7 @@ TEST_F(LoadTest, ReportIsOnlyAWayOfLooking) {
 
   // Every hit printed, over this corpus, is tens of millions of lines in a CI
   // log. These assertions are about the documents, never the text.
-  static std::FILE* const kNullSink = std::fopen("/dev/null", "w");
-  ASSERT_NE(nullptr, kNullSink);
-  gExecutor->SetPrintSink(kNullSink);
+  gExecutor->SetPrintSink(_null_sink);
 
   for (auto query : kQueries) {
     SCOPED_TRACE(query);

--- a/tests/libs/iresearch/search/load_test.cpp
+++ b/tests/libs/iresearch/search/load_test.cpp
@@ -24,12 +24,16 @@
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_replace.h>
 #include <absl/strings/str_split.h>
+#include <fcntl.h>
 #include <simdjson.h>
+#include <unistd.h>
 #include <zlib.h>
 
 #include <bit>
+#include <cstdio>
 #include <fstream>
 #include <functional>
+#include <memory>
 #include <span>
 #include <string>
 #include <vector>
@@ -1119,6 +1123,12 @@ TEST_F(LoadTest, DisjunctionScoreAccuracy) {
 // line per matching document, thousands of them over the query set.
 TEST_F(LoadTest, ReportIsOnlyAWayOfLooking) {
   ASSERT_NE(nullptr, gExecutor);
+
+  // Every hit printed, over this corpus, is tens of millions of lines in a CI
+  // log. These assertions are about the documents, never the text.
+  static std::FILE* const kNullSink = std::fopen("/dev/null", "w");
+  ASSERT_NE(nullptr, kNullSink);
+  gExecutor->SetPrintSink(kNullSink);
 
   for (auto query : kQueries) {
     SCOPED_TRACE(query);

--- a/tests/server/basics/CMakeLists.txt
+++ b/tests/server/basics/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
     duckdb_roundtrip_test.cpp
     catalog_persistence_test.cpp
     catalog_table_info_test.cpp
+    scorer_bounds_test.cpp
     network_http_test.cpp
     network_router_test.cpp
     network_listen_spec_test.cpp

--- a/tests/server/basics/scorer_bounds_test.cpp
+++ b/tests/server/basics/scorer_bounds_test.cpp
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "catalog/scorer_options.h"
+
+namespace {
+
+using Params = sdb::catalog::ScorerOptions::Params;
+using BoundType = irs::Scorer::ScoreBoundType;
+
+// A scorer that persists per-block bounds has to agree with itself in three
+// places: the bound type its options classify to, the writer and source it
+// builds, and the Compatible() answer the pruning gate asks for. Getting the
+// last one half-right is the failure this pins -- comparing bound types but
+// forgetting the parameterisation lets a scorer read a pair that is not its
+// argmax and prune away qualifying rows.
+template<typename P>
+void CheckAlternative() {
+  const sdb::catalog::ScorerOptions own{P{}};
+  SCOPED_TRACE(own.Name());
+
+  auto scorer = sdb::catalog::MakeScorer(own);
+  ASSERT_TRUE(scorer);
+
+  const bool bounded = irs::BoundTypeOf(own) != BoundType::None;
+
+  EXPECT_EQ(bounded, static_cast<bool>(scorer->PrepareScoreBoundWriter(4)));
+  EXPECT_EQ(bounded, static_cast<bool>(scorer->PrepareScoreBoundSource()));
+  EXPECT_EQ(bounded, scorer->Compatible(own));
+
+  // bm25 with 0 < b < 1 stores the argmax for that b under that avg_dl mode,
+  // so nobody else may read it. Every alternative added to the variant is
+  // checked here, which is the point: a new scorer cannot skip this.
+  if constexpr (!std::is_same_v<P, irs::BM25::Options>) {
+    const sdb::catalog::ScorerOptions bm25_min_norm{
+      irs::BM25::Options{.k1 = 1.2f, .b = 0.75f}};
+    ASSERT_EQ(BoundType::MinNorm, irs::BoundTypeOf(bm25_min_norm));
+    EXPECT_FALSE(scorer->Compatible(bm25_min_norm));
+  }
+}
+
+TEST(scorer_bounds_test, every_scorer_agrees_with_its_bound_classification) {
+  []<std::size_t... I>(std::index_sequence<I...>) {
+    (CheckAlternative<std::variant_alternative_t<I, Params>>(), ...);
+  }(std::make_index_sequence<std::variant_size_v<Params>>{});
+}
+
+}  // namespace

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score.test
@@ -1535,6 +1535,120 @@ DROP TABLE prefix_docs;
 
 
 # ============================================================================
+# sdb_scored_terms_limit -- how many terms a multi-term filter scores.
+# Terms past the cap still match, they just contribute nothing to the
+# score, so the cap never moves the result set -- top-k included.
+# ============================================================================
+
+statement ok
+CREATE TABLE stl_docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX stl_idx ON stl_docs USING inverted(id, body en)
+  WITH (compaction_interval = 0);
+
+
+statement ok
+INSERT INTO stl_docs VALUES
+    (1, 'cat cat dog'), (2, 'cat'), (3, 'cat bird'),
+    (4, 'car'), (5, 'cap'), (6, 'zebra');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) stl_docs;
+
+
+# Every expanded term is scored under the default cap.
+query
+SELECT id, BM25(stl_idx.tableoid) > 0 AS scored FROM stl_idx
+WHERE body @@ ts_like('ca%') ORDER BY id;
+----
+id	scored
+1	t
+2	t
+3	t
+4	t
+5	t
+
+
+statement ok
+SET sdb_scored_terms_limit = 0;
+
+
+# 0 turns scored-term collection off entirely: every hit scores 0 and
+# every hit is still a hit.
+query
+SELECT id, BM25(stl_idx.tableoid) AS score FROM stl_idx
+WHERE body @@ ts_like('ca%') ORDER BY id;
+----
+id	score
+1	0
+2	0
+3	0
+4	0
+5	0
+
+
+# ... and the in-scan top-k returns the same rows rather than dropping
+# the whole all-zero result set.
+query
+SELECT id, score FROM (
+  SELECT id, BM25(stl_idx.tableoid) AS score FROM stl_idx
+  WHERE body @@ ts_like('ca%')
+  ORDER BY BM25(stl_idx.tableoid) DESC LIMIT 10
+) t ORDER BY id;
+----
+id	score
+1	0
+2	0
+3	0
+4	0
+5	0
+
+
+statement ok
+SET sdb_scored_terms_limit = 1;
+
+
+# A cap below the expansion scores the widest term only ('cat', 3 docs);
+# documents reached solely through the unscored terms keep their place.
+query
+SELECT id, score > 0 AS scored FROM (
+  SELECT id, BM25(stl_idx.tableoid) AS score FROM stl_idx
+  WHERE body @@ ts_like('ca%')
+  ORDER BY BM25(stl_idx.tableoid) DESC LIMIT 10
+) t ORDER BY id;
+----
+id	scored
+1	t
+2	t
+3	t
+4	f
+5	f
+
+
+# A top-k narrower than the match set still fills k from them.
+query
+SELECT count(*) FROM (
+  SELECT id, BM25(stl_idx.tableoid) AS score FROM stl_idx
+  WHERE body @@ ts_like('ca%')
+  ORDER BY BM25(stl_idx.tableoid) DESC LIMIT 4
+) t;
+----
+count
+4
+
+
+statement ok
+RESET sdb_scored_terms_limit;
+
+
+statement ok
+DROP TABLE stl_docs;
+
+
+# ============================================================================
 # idf() -- scores by the inverse document frequency of the matched term
 # alone. No term frequency, no length norm, and no index features, so it
 # also scores columns indexed without a dictionary.


### PR DESCRIPTION
## Problem

`ORDER BY BM25(idx.tableoid) DESC LIMIT k` silently returned fewer rows than the same `WHERE` without the top-k — in the worst case, none at all.

The in-scan top-k collector seeded its threshold with `std::numeric_limits<float>::min()` — the smallest *positive* float (`1.18e-38`), not `lowest()` — while `LoserScoreCollector::TryPush` admits a hit only when `score > threshold`. A hit scoring exactly `0` could never enter the heap, not even while the heap was empty. The same value is the WAND skip bound (`SetScoreThreshold` rebinds the collector's pointer to the iterator's `ScoreThresholdAttr`), so `MaxScoreIterator::Split()` also demoted every zero-max-score branch to non-essential and skipped whole windows.

Zero is a legal score, and three ordinary setups produce it:

| case | before | after |
| --- | --- | --- |
| keyword column, no text dictionary, `LIMIT 10` | 0 rows | all matches |
| `sdb_scored_terms_limit = 0`, `LIMIT 3` | 0 rows | 3 rows, score 0 |
| `sdb_scored_terms_limit = 1`, `LIMIT 3` over 5 matches | 1 row | 3 rows |

The first needs no unusual settings at all: `BM25::PrepareScorer` returns `ScoreFunction::Default()` when the field carries no frequency feature, and that scores every document `0`.

## Fix

Seed with `lowest()`, which is what the value is supposed to mean — the k-th best score so far, or −∞ while fewer than k hits are held. As soon as `Push` fills the heap, `threshold = max(threshold, _root.score)` installs the real k-th score and both consumers behave exactly as before: pruning engages, and zero-score hits are rejected again because `0 > kth` fails once `kth >= 0`.

`CurrentPruneThreshold` carried the same "text scores are strictly positive" assumption in the streaming path, including a `nextafter(boundary, min())` that steps *up* rather than down for a `>=` bound. The two `ExecuteTopK` helpers in `doc_collector.hpp` are updated so the library's own top-k mirrors the engine.

## Verification

- New sqllogic coverage in `inverted_index_score.test`: zero-score top-k on a keyword column, `sdb_scored_terms_limit = 0` plain and top-k, the partial-cap case, and a k narrower than the match set.
- Green: full `sdb/pg/index` suite on both wire engines, `inverted_index_topk.test_slow`, `inverted_index_score_prune.test{,_slow}`, `inverted_index_lazy_seek.test_slow`, site_docs + es + tsquery suites, 3/3 score-prune recovery tests, 213/213 iresearch scoring gtests.
- No ranking change where the old code was already correct: on a 2M-doc `wiki_small` index, all 962 `TOP_100_DEBUG` result hashes are identical before and after.
- No measurable cost, hot = min of runs 2-3 over 962 queries × 20 reps:

| | before | after |
| --- | --- | --- |
| TOP_10 | 3.82 s | 3.77 s |
| TOP_100 | 4.70 s | 4.70 s |
| TOP_1000 | 6.87 s | 6.86 s |