### PR TITLE
fix: Make bm25(k1 = 0) score IDF instead of zero

### DIFF
--- a/libs/iresearch/include/iresearch/search/bm25.cpp
+++ b/libs/iresearch/include/iresearch/search/bm25.cpp
@@ -303,6 +303,20 @@ void BM25::collect(byte_type* stats_buf, const irs::FieldCollector* field,
 }
 
 ScoreFunction BM25::PrepareScorer(const ScoreContext& ctx) const {
+  auto* filter_boost = [&] {
+    auto* attr = irs::get<BoostBlockAttr>(ctx.doc_attrs);
+    return attr ? attr->value : nullptr;
+  }();
+
+  if (IsBM1()) {
+    auto* bm1_stats = stats_cast(ctx.stats);
+    if (!filter_boost) {
+      return ScoreFunction::Constant(ctx.boost * (_k + 1) * bm1_stats->idf);
+    }
+    return ScoreFunction::Make<Bm1Score>(_k, ctx.boost, *bm1_stats,
+                                         filter_boost);
+  }
+
   auto* freq = irs::get<FreqBlockAttr>(ctx.doc_attrs);
 
   if (!freq) {
@@ -315,23 +329,9 @@ ScoreFunction BM25::PrepareScorer(const ScoreContext& ctx) const {
     return ScoreFunction::Constant(ctx.boost);
   }
 
-  auto* filter_boost = [&] {
-    auto* attr = irs::get<BoostBlockAttr>(ctx.doc_attrs);
-    return attr ? attr->value : nullptr;
-  }();
-
   auto* stats = stats_cast(ctx.stats);
 
   return ResolveBool(filter_boost != nullptr, [&]<bool HasBoost>() {
-    if (IsBM1()) {
-      if constexpr (HasBoost) {
-        return ScoreFunction::Make<Bm1Score>(_k, ctx.boost, *stats,
-                                             filter_boost);
-      } else {
-        return ScoreFunction::Constant(ctx.boost * (_k + 1) * stats->idf);
-      }
-    }
-
     if (IsBM15()) {
       return ScoreFunction::Make<Bm15Score<HasBoost>>(_k, ctx.boost, *stats,
                                                       freq, filter_boost);

--- a/libs/iresearch/include/iresearch/search/bm25.cpp
+++ b/libs/iresearch/include/iresearch/search/bm25.cpp
@@ -62,7 +62,7 @@ IRS_FORCE_INLINE void Bm1Boost(score_t* IRS_RESTRICT res, scores_size_t n,
                                const score_t* IRS_RESTRICT boost,
                                score_t num) noexcept {
   for (scores_size_t i = 0; i != n; ++i) {
-    res[i] = boost[i] * num;
+    Merge<MergeType>(res[i], boost[i] * num);
   }
 }
 
@@ -108,7 +108,6 @@ IRS_FORCE_INLINE void Bm25(score_t* IRS_RESTRICT res, scores_size_t n,
   }
 }
 
-template<bool HasFilterBoost>
 struct Bm1Score : public ScoreOperator {
   Bm1Score(score_t k, score_t boost, const BM25Stats& stats,
            const score_t* fb) noexcept
@@ -117,11 +116,7 @@ struct Bm1Score : public ScoreOperator {
   template<ScoreMergeType MergeType = ScoreMergeType::Noop>
   IRS_FORCE_INLINE void ScoreImpl(score_t* res,
                                   scores_size_t n) const noexcept {
-    if constexpr (HasFilterBoost) {
-      Bm1Boost<MergeType>(res, n, filter_boost, num);
-    } else {
-      std::memset(res, 0, sizeof(score_t) * n);
-    }
+    Bm1Boost<MergeType>(res, n, filter_boost, num);
   }
 
   score_t Score() const noexcept final {
@@ -154,10 +149,8 @@ struct Bm1Score : public ScoreOperator {
     ScoreImpl(res, kPostingBlock);
   }
 
-  [[no_unique_address]] utils::Need<HasFilterBoost, const score_t*>
-    filter_boost;
-  [[no_unique_address]] utils::Need<HasFilterBoost, score_t>
-    num;  // partially precomputed numerator : boost * (k + 1) * idf
+  const score_t* filter_boost;
+  score_t num;  // partially precomputed numerator : boost * (k + 1) * idf
 };
 
 template<bool HasFilterBoost>
@@ -331,8 +324,12 @@ ScoreFunction BM25::PrepareScorer(const ScoreContext& ctx) const {
 
   return ResolveBool(filter_boost != nullptr, [&]<bool HasBoost>() {
     if (IsBM1()) {
-      return ScoreFunction::Make<Bm1Score<HasBoost>>(_k, ctx.boost, *stats,
-                                                     filter_boost);
+      if constexpr (HasBoost) {
+        return ScoreFunction::Make<Bm1Score>(_k, ctx.boost, *stats,
+                                             filter_boost);
+      } else {
+        return ScoreFunction::Constant(ctx.boost * (_k + 1) * stats->idf);
+      }
     }
 
     if (IsBM15()) {

--- a/libs/iresearch/include/iresearch/search/bm25.hpp
+++ b/libs/iresearch/include/iresearch/search/bm25.hpp
@@ -90,6 +90,10 @@ class BM25 final : public irs::ScorerBase<BM25, BM25Stats> {
                const irs::TermCollector* term) const final;
 
   IndexFeatures GetIndexFeatures() const noexcept final {
+    if (IsBM1()) {
+      return IndexFeatures::None;
+    }
+
     if (NeedsNorm()) {
       return IndexFeatures::Freq | IndexFeatures::Norm;
     }

--- a/tests/libs/iresearch/search/bm25_test.cpp
+++ b/tests/libs/iresearch/search/bm25_test.cpp
@@ -335,7 +335,7 @@ TEST_P(Bm25TestCase, test_bm1_idf_only) {
   auto impl = irs::BM25::Make(irs::BM25::Options{.k1 = 0.f});
   ASSERT_NE(nullptr, impl);
   ASSERT_TRUE(dynamic_cast<irs::BM25&>(*impl).IsBM1());
-  ASSERT_EQ(irs::IndexFeatures::Freq, impl->GetIndexFeatures());
+  ASSERT_EQ(irs::IndexFeatures::None, impl->GetIndexFeatures());
 
   auto index = open_reader(irs::tests::DefaultReaderOptions());
   ASSERT_EQ(1, index->size());

--- a/tests/libs/iresearch/search/bm25_test.cpp
+++ b/tests/libs/iresearch/search/bm25_test.cpp
@@ -31,6 +31,7 @@
 #include "iresearch/search/boolean_filter.hpp"
 #include "iresearch/search/column_collector.hpp"
 #include "iresearch/search/filter_optimizer.hpp"
+#include "iresearch/search/ngram_similarity_filter.hpp"
 #include "iresearch/search/phrase_filter.hpp"
 #include "iresearch/search/prefix_filter.hpp"
 #include "iresearch/search/range_filter.hpp"
@@ -296,6 +297,145 @@ TEST_P(Bm25TestCase, test_normalize_features) {
     ASSERT_NE(nullptr, scorer);
     ASSERT_EQ(irs::IndexFeatures::Freq, scorer->GetIndexFeatures());
   }
+}
+
+TEST_P(Bm25TestCase, test_bm1_idf_only) {
+  auto analyzed_json_field_factory =
+    [](tests::Document& doc, const std::string& name,
+       const tests::JsonDocGenerator::JsonValue& data) {
+      typedef TextField<std::string> TextField;
+
+      class StringField : public tests::StringField {
+       public:
+        StringField(const std::string& name, const std::string_view& value)
+          : tests::StringField(name, value) {
+          this->index_features = irs::IndexFeatures::Freq;
+        }
+      };
+
+      if (data.is_string()) {
+        const auto anl_name = std::string(name.c_str()) + "_anl";
+        auto analyzed = std::make_shared<TextField>(anl_name, data.str);
+        analyzed->id = tests::FieldIdFor(anl_name);
+        doc.indexed.push_back(std::move(analyzed));
+
+        auto field = std::make_shared<StringField>(name, data.str);
+        field->id = tests::FieldIdFor(name);
+        doc.insert(std::move(field));
+      }
+    };
+
+  {
+    tests::JsonDocGenerator gen(resource("phrase_sequential.json"),
+                                analyzed_json_field_factory);
+    add_segment(gen, irs::kOmCreate, irs::tests::DefaultWriterOptions(),
+                StoreName());
+  }
+
+  auto impl = irs::BM25::Make(irs::BM25::Options{.k1 = 0.f});
+  ASSERT_NE(nullptr, impl);
+  ASSERT_TRUE(dynamic_cast<irs::BM25&>(*impl).IsBM1());
+  ASSERT_EQ(irs::IndexFeatures::Freq, impl->GetIndexFeatures());
+
+  auto index = open_reader(irs::tests::DefaultReaderOptions());
+  ASSERT_EQ(1, index->size());
+  auto& segment = *(index.begin());
+
+  MaxMemoryCounter counter;
+  irs::ColumnArgsFetcher fetcher;
+
+  auto collect = [&](const irs::Filter& filter) {
+    std::map<irs::doc_id_t, irs::score_t> scores;
+    tests::PreparedFilter prepared_filter{filter, *index, impl.get(), counter};
+    fetcher.Clear();
+    auto docs = prepared_filter.Execute(0);
+    auto score = docs->PrepareScore({
+      .scorer = impl.get(),
+      .segment = &segment,
+      .fetcher = &fetcher,
+    });
+    while (!irs::doc_limits::eof(docs->advance())) {
+      fetcher.Fetch(docs->value());
+      docs->FetchScoreArgs(0);
+      irs::score_t value{};
+      score.Score(&value, 1);
+      scores.emplace(docs->value(), value);
+    }
+    return scores;
+  };
+
+  auto make_term = [](irs::ByTerm& filter, std::string_view term) {
+    *filter.mutable_field_id() = kPhraseAnl;
+    filter.mutable_options()->term = irs::ViewCast<irs::byte_type>(term);
+  };
+
+  irs::ByTerm cookies;
+  make_term(cookies, "cookies");
+  irs::ByTerm meringue;
+  make_term(meringue, "meringue");
+
+  const auto cookies_scores = collect(cookies);
+  const auto meringue_scores = collect(meringue);
+  ASSERT_FALSE(cookies_scores.empty());
+  ASSERT_FALSE(meringue_scores.empty());
+
+  for (const auto& [doc, value] : cookies_scores) {
+    ASSERT_GT(value, 0.f);
+    ASSERT_FLOAT_EQ(cookies_scores.begin()->second, value);
+  }
+  for (const auto& [doc, value] : meringue_scores) {
+    ASSERT_GT(value, 0.f);
+    ASSERT_FLOAT_EQ(meringue_scores.begin()->second, value);
+  }
+  if (cookies_scores.size() != meringue_scores.size()) {
+    ASSERT_NE(cookies_scores.begin()->second, meringue_scores.begin()->second);
+  }
+
+  auto make_ngram = [](std::initializer_list<std::string_view> ngrams) {
+    auto filter = std::make_unique<irs::ByNGramSimilarity>();
+    *filter->mutable_field_id() = kPhraseAnl;
+    auto& opts = *filter->mutable_options();
+    for (auto ngram : ngrams) {
+      opts.ngrams.emplace_back(irs::ViewCast<irs::byte_type>(ngram));
+    }
+    opts.threshold = 0.5f;
+    opts.allow_phrase = false;
+    return filter;
+  };
+
+  auto lower = [&](irs::Filter::ptr filter) {
+    irs::Optimize(filter, {.scored = true});
+    return filter;
+  };
+
+  const auto left_scores = collect(*lower(make_ngram({"cookies", "cake"})));
+  const auto right_scores =
+    collect(*lower(make_ngram({"biscuit", "meringue"})));
+  ASSERT_FALSE(left_scores.empty());
+  ASSERT_FALSE(right_scores.empty());
+
+  auto disjunction = std::make_unique<irs::Or>();
+  disjunction->add(make_ngram({"cookies", "cake"}));
+  disjunction->add(make_ngram({"biscuit", "meringue"}));
+  const auto disjunction_scores = collect(*lower(std::move(disjunction)));
+
+  size_t overlapped = 0;
+  for (const auto& [doc, left_value] : left_scores) {
+    const auto right = right_scores.find(doc);
+    if (right == right_scores.end()) {
+      continue;
+    }
+    ASSERT_GT(left_value, 0.f);
+    ASSERT_GT(right->second, 0.f);
+    ++overlapped;
+    const auto merged = disjunction_scores.find(doc);
+    ASSERT_NE(disjunction_scores.end(), merged);
+    ASSERT_FLOAT_EQ(left_value + right->second, merged->second);
+  }
+  ASSERT_GT(overlapped, 0);
+
+  EXPECT_EQ(counter.current, 0);
+  counter.Reset();
 }
 
 TEST_P(Bm25TestCase, test_phrase) {

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score.test
@@ -1756,5 +1756,56 @@ statement ok
 DROP TABLE bm1_docs;
 
 
+# IDF-only reads neither the frequency nor the norm, so it asks for no index
+# features and scores a keyword column indexed without a dictionary -- where
+# default BM25 has no frequency to work with and scores 0.
+
+statement ok
+CREATE TABLE bm1_kw (id INTEGER PRIMARY KEY, tag VARCHAR);
+
+
+statement ok
+CREATE INDEX bm1_kw_idx ON bm1_kw USING inverted(id, tag)
+  WITH (compaction_interval = 0);
+
+
+statement ok
+INSERT INTO bm1_kw VALUES (1, 'red'), (2, 'red'), (3, 'blue'), (4, 'green');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) bm1_kw;
+
+
+query
+SELECT id, round(BM25(bm1_kw_idx.tableoid, 0, 0.75)::DOUBLE, 6) AS score
+FROM bm1_kw_idx WHERE tag @@ 'red' ORDER BY id;
+----
+id	score
+1	0.693147
+2	0.693147
+
+
+query
+SELECT id, round(BM25(bm1_kw_idx.tableoid)::DOUBLE, 6) AS score
+FROM bm1_kw_idx WHERE tag @@ 'red' ORDER BY id;
+----
+id	score
+1	0
+2	0
+
+
+query
+SELECT id, round(BM25(bm1_kw_idx.tableoid, 0, 0.75)::DOUBLE, 6) AS score
+FROM bm1_kw_idx WHERE tag @@ 'blue' ORDER BY id;
+----
+id	score
+3	1.203973
+
+
+statement ok
+DROP TABLE bm1_kw;
+
+
 statement ok
 SET disabled_optimizers = '';

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score.test
@@ -1682,5 +1682,79 @@ statement ok
 DROP TABLE idf_tk;
 
 
+# ============================================================================
+# bm25(k1 = 0) -- the IDF-only (BM1) mode. Term frequency and the length
+# norm both drop out of the formula, so every document matching a term
+# scores exactly that term's IDF.
+# ============================================================================
+
+statement ok
+CREATE TABLE bm1_docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX bm1_idx ON bm1_docs USING inverted(id, body en)
+  WITH (compaction_interval = 0);
+
+
+statement ok
+INSERT INTO bm1_docs VALUES
+    (1, 'alpha alpha alpha beta'), (2, 'alpha gamma'),
+    (3, 'beta'), (4, 'delta');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) bm1_docs;
+
+
+# 'alpha' occurs in 2 of the 4 documents, so its IDF is
+# log1p(2.5 / 2.5) = ln 2. Doc 1 carries the term three times and doc 2
+# once; IDF-only scores them identically.
+query
+SELECT id, round(BM25(bm1_idx.tableoid, 0, 0.75)::DOUBLE, 6) AS score
+FROM bm1_idx WHERE body @@ ts_phrase('alpha') ORDER BY id;
+----
+id	score
+1	0.693147
+2	0.693147
+
+
+# Default BM25 over the same two documents does weigh term frequency.
+query
+SELECT id, round(BM25(bm1_idx.tableoid)::DOUBLE, 6) AS score
+FROM bm1_idx WHERE body @@ ts_phrase('alpha') ORDER BY id;
+----
+id	score
+1	0.897014
+2	0.693147
+
+
+# A rarer term carries a higher IDF: 'gamma' occurs in 1 of 4 documents,
+# log1p(3.5 / 1.5) = ln 10/3.
+query
+SELECT id, round(BM25(bm1_idx.tableoid, 0, 0.75)::DOUBLE, 6) AS score
+FROM bm1_idx WHERE body @@ ts_phrase('gamma') ORDER BY id;
+----
+id	score
+2	1.203973
+
+
+# The in-scan top-k collects IDF-only hits like any other.
+query
+SELECT id, score FROM (
+  SELECT id, round(BM25(bm1_idx.tableoid, 0, 0.75)::DOUBLE, 6) AS score
+  FROM bm1_idx WHERE body @@ ts_phrase('beta')
+  ORDER BY BM25(bm1_idx.tableoid, 0, 0.75) DESC LIMIT 5
+) t ORDER BY id;
+----
+id	score
+1	0.693147
+3	0.693147
+
+
+statement ok
+DROP TABLE bm1_docs;
+
+
 statement ok
 SET disabled_optimizers = '';


### PR DESCRIPTION
## Problem

`bm25(k1 = 0)` selects BM1, the IDF-only mode: term frequency and the length norm drop out and every document matching a term should score that term's IDF. Instead every document scored **0**, so ranking by an IDF-only scorer was meaningless.

`Bm1Score`'s constructor computes the numerator and the no-filter-boost path then discards it:

```cpp
Bm1Score(...) : filter_boost{fb}, num{boost * (k + 1) * stats.idf} {}   // computed…
ScoreImpl(res, n) {
  if constexpr (HasFilterBoost) Bm1Boost<MergeType>(res, n, filter_boost, num);
  else std::memset(res, 0, sizeof(score_t) * n);                        // …discarded
}
```

Separately, `Bm1Boost` takes a `MergeType` template parameter and ignores it, assigning `res[i] = boost[i] * num` where `Bm15` and `Bm25` both call `Merge<MergeType>`. Under a Sum disjunction that overwrites sibling contributions instead of adding to them.

And BM1 asked for the wrong index features. It reads neither the frequency nor the norm, yet `GetIndexFeatures()` returned `Freq` and `PrepareScorer` checked for a frequency attribute *before* looking at `IsBM1()`. On a field indexed without frequency -- a keyword column with no dictionary -- that sent `bm25(k1 = 0)` down the `!freq` path, which returns `Default()` or the bare boost rather than the IDF.

## Fix

- Return `ScoreFunction::Constant(num)` for the no-filter-boost case. `PrepareScorer` already uses `Constant` for the no-frequency case, and `ConstanScore` merges correctly under Sum and Max.
- Make `Bm1Boost` merge like its two siblings.
- Report `IndexFeatures::None` for BM1 and take the `IsBM1()` branch first. BM1 already writes no score bounds (`PrepareScoreBoundWriter` returns `{}`), and the writer folds the top-k scorer's features into `scorers_features` (`index_writer.cpp:1141`), so asking for `Freq` was also forcing frequency into an index that never read it.

## Verification

BM1 had no scoring coverage at all — `bm25_test.cpp` asserted only the `IsBM11`/`IsBM15` flags. Added both a gtest and sqllogic coverage, and confirmed each fails without the fix:

- gtest `test_bm1_idf_only`: `Expected: (value) > (0.f), actual: 0 vs 0`
- sqllogic: `-1 0.693147 / -2 0.693147`

The sqllogic expectations are hand-checkable. With 4 documents, `alpha` occurring in 2 of them gives `log1p(2.5/2.5) = ln 2 = 0.693147`, and `gamma` in 1 of them gives `log1p(3.5/1.5) = ln 10/3 = 1.203973`. The paired assertion against default BM25 over the same two documents (`0.897014` vs `0.693147`, one carrying the term three times) shows IDF-only really does drop term frequency.

Both the analyzed-field and the dictionary-less keyword-column cases are asserted.

Also green: 237 bm25/tfidf/score-prune gtests, and the whole `sdb/pg/index` sqllogic suite (424 OK) on both wire engines.

## Note on the merge fix

Reaching `Bm1Boost` needs BM1 combined with a volatile filter boost under a Sum merge. Neither a variadic phrase nor `ByNGramSimilarity` produces that combination, so the path appears latent today and the merge change is made by symmetry with `Bm15`/`Bm25` rather than driven by a failing test.

## Behaviour change

Anyone currently issuing `bm25(k1 = 0)` gets 0 today and real IDF scores after this. An index declared with `optimize_top_k = 'bm25(0, ...)'` also stops forcing frequency into the index.
