### PR TITLE
feat: Add an explicit idf() scorer

### DIFF
--- a/libs/iresearch/include/iresearch/CMakeLists.txt
+++ b/libs/iresearch/include/iresearch/CMakeLists.txt
@@ -164,6 +164,7 @@ set(IResearch_core_sources
     ./search/lm_dirichlet.cpp
     ./search/indri_dirichlet.cpp
     ./search/dfi.cpp
+    ./search/idf.cpp
     ./search/raw_boost.cpp
     ./search/raw_tf.cpp
     ./search/raw_dl.cpp

--- a/libs/iresearch/include/iresearch/search/idf.cpp
+++ b/libs/iresearch/include/iresearch/search/idf.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -15,31 +15,43 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 ///
-/// Copyright holder is ArangoDB GmbH, Cologne, Germany
-///
-/// @author Andrey Abramov
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "raw_boost.hpp"
+#include "idf.hpp"
 
-#include <absl/container/inlined_vector.h>
+#include <cmath>
 
-#include "basics/shared.hpp"
+#include "basics/assert.h"
 #include "iresearch/analysis/token_attributes.hpp"
-#include "iresearch/index/field_meta.hpp"
+#include "iresearch/search/collectors.hpp"
 #include "iresearch/search/volatile_boost_score.hpp"
 
 namespace irs {
 
-ScoreFunction RawBoost::PrepareScorer(const ScoreContext& ctx) const {
+void IDF::collect(byte_type* stats_buf, const FieldCollector* field,
+                  const TermCollector* term) const {
+  const auto docs_with_field = field ? field->docs_with_field : 0;
+  const auto docs_with_term = term ? term->docs_with_term : 0;
+
+  auto* stats = stats_cast(stats_buf);
+  stats->value += static_cast<score_t>(
+    std::log1p((static_cast<double>(docs_with_field - docs_with_term) + 0.5) /
+               (static_cast<double>(docs_with_term) + 0.5)));
+  SDB_ASSERT(stats->value >= 0.f);
+}
+
+ScoreFunction IDF::PrepareScorer(const ScoreContext& ctx) const {
+  const auto* stats = stats_cast(ctx.stats);
+  const auto value = ctx.boost * stats->value;
+
   const auto* volatile_boost = irs::get<BoostBlockAttr>(ctx.doc_attrs);
 
   if (!volatile_boost) {
-    return ScoreFunction::Constant(ctx.boost);
+    return ScoreFunction::Constant(value);
   }
 
-  return ScoreFunction::Make<VolatileBoostScore>(volatile_boost->value,
-                                                 ctx.boost);
+  return ScoreFunction::Make<VolatileBoostScore>(volatile_boost->value, value);
 }
 
 }  // namespace irs

--- a/libs/iresearch/include/iresearch/search/idf.hpp
+++ b/libs/iresearch/include/iresearch/search/idf.hpp
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "iresearch/search/scorer.hpp"
+
+namespace irs {
+
+struct IDFStats {
+  score_t value;
+};
+
+class IDF final : public irs::ScorerBase<IDF, IDFStats> {
+ public:
+  static constexpr std::string_view type_name() noexcept { return "idf"; }
+
+  struct Options {
+    using Owner = IDF;
+    bool operator==(const Options&) const = default;
+  };
+
+  static std::unique_ptr<IDF> Make(const Options& /*opts*/) {
+    return std::make_unique<IDF>();
+  }
+
+  void collect(byte_type* stats_buf, const irs::FieldCollector* field,
+               const irs::TermCollector* term) const final;
+
+  IndexFeatures GetIndexFeatures() const noexcept final {
+    return IndexFeatures::None;
+  }
+
+  ScoreFunction PrepareScorer(const ScoreContext& ctx) const final;
+};
+
+}  // namespace irs

--- a/libs/iresearch/include/iresearch/search/volatile_boost_score.hpp
+++ b/libs/iresearch/include/iresearch/search/volatile_boost_score.hpp
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "basics/assert.h"
+#include "iresearch/search/score_function.hpp"
+#include "iresearch/search/scorer.hpp"
+
+namespace irs {
+
+class VolatileBoostScore : public ScoreOperator {
+ public:
+  VolatileBoostScore(const score_t* volatile_boost, score_t constant) noexcept
+    : _constant{constant}, _volatile_boost{volatile_boost} {
+    SDB_ASSERT(volatile_boost);
+  }
+
+  template<ScoreMergeType MergeType = ScoreMergeType::Noop>
+  IRS_FORCE_INLINE void ScoreImpl(score_t* res, size_t n) const noexcept {
+    for (scores_size_t i = 0; i != n; ++i) {
+      Merge<MergeType>(res[i], _volatile_boost[i] * _constant);
+    }
+  }
+
+  score_t Score() const noexcept final {
+    score_t res{};
+    ScoreImpl(&res, 1);
+    return res;
+  }
+
+  void Score(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl(res, n);
+  }
+  void ScoreSum(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, n);
+  }
+  void ScoreMax(score_t* res, scores_size_t n) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, n);
+  }
+
+  void ScoreBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kScoreBlock);
+  }
+  void ScoreSumBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Sum>(res, kScoreBlock);
+  }
+  void ScoreMaxBlock(score_t* res) const noexcept final {
+    ScoreImpl<ScoreMergeType::Max>(res, kScoreBlock);
+  }
+
+  void ScorePostingBlock(score_t* res) const noexcept final {
+    ScoreImpl(res, kPostingBlock);
+  }
+
+ private:
+  score_t _constant;
+  const score_t* _volatile_boost;
+};
+
+}  // namespace irs

--- a/server/catalog/persistence/scorer_options.h
+++ b/server/catalog/persistence/scorer_options.h
@@ -22,6 +22,7 @@
 
 #include <iresearch/search/bm25.hpp>
 #include <iresearch/search/dfi.hpp>
+#include <iresearch/search/idf.hpp>
 #include <iresearch/search/indri_dirichlet.hpp>
 #include <iresearch/search/lm_dirichlet.hpp>
 #include <iresearch/search/lm_jelinek_mercer.hpp>
@@ -48,9 +49,10 @@ struct ScorerOptions {
   using RawBoost = irs::RawBoost::Options;
   using RawTf = irs::RawTF::Options;
   using RawDL = irs::RawDL::Options;
+  using Idf = irs::IDF::Options;
 
   using Params = std::variant<Bm25, Tfidf, LmJm, LmDirichlet, IndriDirichlet,
-                              Dfi, RawBoost, RawTf, RawDL>;
+                              Dfi, RawBoost, RawTf, RawDL, Idf>;
 
   Params params;
 

--- a/server/catalog/scorer_options.cpp
+++ b/server/catalog/scorer_options.cpp
@@ -75,6 +75,8 @@ std::string ScorerOptions::ToString() const {
         return "raw_tf()";
       } else if constexpr (std::is_same_v<P, RawDL>) {
         return "raw_dl()";
+      } else if constexpr (std::is_same_v<P, Idf>) {
+        return "idf()";
       }
     },
     params);
@@ -190,12 +192,14 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = S::RawTf{};
   } else if (name == S::RawDL::Owner::type_name()) {
     scorer.params = S::RawDL{};
+  } else if (name == S::Idf::Owner::type_name()) {
+    scorer.params = S::Idf{};
   } else {
     THROW_SQL_ERROR(
       ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
       ERR_MSG("Unknown scorer '", name, "'"),
       ERR_HINT("Expected one of: bm25, tfidf, lm_jm, lm_dirichlet, "
-               "indri_dirichlet, dfi, raw_boost, raw_tf, raw_dl"));
+               "indri_dirichlet, dfi, idf, raw_boost, raw_tf, raw_dl"));
   }
   return scorer;
 }

--- a/server/connector/functions/search.cpp
+++ b/server/connector/functions/search.cpp
@@ -156,6 +156,7 @@ void RegisterScorerFunctions(duckdb::ExtensionLoader& loader) {
     {S::RawBoost::Owner::type_name(), {}},
     {S::RawTf::Owner::type_name(), {}},
     {S::RawDL::Owner::type_name(), {}},
+    {S::Idf::Owner::type_name(), {}},
   };
   for (const auto& [name, params] : scorers) {
     duckdb::ScalarFunctionSet set{duckdb::Identifier{name}};

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -470,7 +470,7 @@ bool IsScorerFunctionName(std::string_view name) {
     S::LmJm::Owner::type_name(),           S::LmDirichlet::Owner::type_name(),
     S::IndriDirichlet::Owner::type_name(), S::Dfi::Owner::type_name(),
     S::RawBoost::Owner::type_name(),       S::RawTf::Owner::type_name(),
-    S::RawDL::Owner::type_name(),
+    S::RawDL::Owner::type_name(),          S::Idf::Owner::type_name(),
   };
   return kScorerNames.contains(name);
 }

--- a/tests/libs/iresearch/CMakeLists.txt
+++ b/tests/libs/iresearch/CMakeLists.txt
@@ -64,6 +64,7 @@ set(iresearch-tests_sources
     ./search/score_prune_test.cpp
     ./search/score_prune_norm_merge_test.cpp
     ./search/bm25_test.cpp
+    ./search/idf_test.cpp
     ./search/raw_tf_test.cpp
     ./search/lm_test.cpp
     ./search/indri_dirichlet_test.cpp

--- a/tests/libs/iresearch/search/idf_test.cpp
+++ b/tests/libs/iresearch/search/idf_test.cpp
@@ -1,0 +1,210 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2026 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cmath>
+#include <map>
+
+#include "filter_test_case_base.hpp"
+#include "index/index_tests.hpp"
+#include "iresearch/index/index_features.hpp"
+#include "iresearch/search/idf.hpp"
+#include "iresearch/search/scorer.hpp"
+#include "iresearch/search/term_filter.hpp"
+#include "tests_shared.hpp"
+
+namespace {
+
+using namespace tests;
+
+inline constexpr irs::field_id kBodyId = 1;
+
+irs::score_t ExpectedIdf(double docs_with_field, double docs_with_term) {
+  return static_cast<irs::score_t>(std::log1p(
+    (docs_with_field - docs_with_term + 0.5) / (docs_with_term + 0.5)));
+}
+
+TEST(idf_test, consts) { static_assert("idf" == irs::Type<irs::IDF>::name()); }
+
+TEST(idf_test, load) {
+  auto scorer = irs::IDF::Make(irs::IDF::Options{});
+  ASSERT_NE(nullptr, scorer);
+  ASSERT_EQ(irs::Type<irs::IDF>::id(), scorer->type());
+  ASSERT_EQ(irs::IndexFeatures::None, scorer->GetIndexFeatures());
+}
+
+TEST(idf_test, equals) {
+  auto a = std::make_unique<irs::IDF>();
+  auto b = std::make_unique<irs::IDF>();
+  ASSERT_TRUE(a->equals(*b));
+}
+
+// Fixture (4 documents, every one carrying the field):
+//   doc1: "fox fox dog"  -- 'fox' twice, so term frequency is observable
+//   doc2: "fox cat"
+//   doc3: "dog rabbit"
+//   doc4: "cat"
+// 'fox' matches 2 of 4 documents, 'rabbit' matches 1 of 4.
+class IdfIndexTest : public IndexTestBase {
+ protected:
+  void BuildAnalyzed();
+  void BuildKeyword();
+
+  std::map<irs::doc_id_t, irs::score_t> Score(std::string_view term);
+};
+
+void IdfIndexTest::BuildAnalyzed() {
+  using TextField = tests::TextField<std::string>;
+
+  auto make_body = [&](std::string value) {
+    auto field =
+      std::make_shared<TextField>("body", std::move(value),
+                                  /*payload=*/false, irs::IndexFeatures::Norm);
+    field->id = kBodyId;
+    return field;
+  };
+
+  tests::Document doc1;
+  doc1.insert(make_body("fox fox dog"), true, false);
+  tests::Document doc2;
+  doc2.insert(make_body("fox cat"), true, false);
+  tests::Document doc3;
+  doc3.insert(make_body("dog rabbit"), true, false);
+  tests::Document doc4;
+  doc4.insert(make_body("cat"), true, false);
+
+  auto writer = open_writer(irs::kOmCreate, irs::IndexWriterOptions{});
+  ASSERT_NE(nullptr, writer);
+  ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc4.indexed.begin(), doc4.indexed.end()));
+  writer->RefreshCommit();
+}
+
+// The same document frequencies, on a field carrying no index features at
+// all: IDF needs none of them.
+void IdfIndexTest::BuildKeyword() {
+  auto make_tag = [&](std::string value) {
+    auto field = std::make_shared<tests::StringField>("body", std::move(value));
+    field->id = kBodyId;
+    return field;
+  };
+
+  tests::Document doc1;
+  doc1.insert(make_tag("fox"), true, false);
+  tests::Document doc2;
+  doc2.insert(make_tag("fox"), true, false);
+  tests::Document doc3;
+  doc3.insert(make_tag("rabbit"), true, false);
+  tests::Document doc4;
+  doc4.insert(make_tag("cat"), true, false);
+
+  auto writer = open_writer(irs::kOmCreate, irs::IndexWriterOptions{});
+  ASSERT_NE(nullptr, writer);
+  ASSERT_TRUE(tests::Insert(*writer, doc1.indexed.begin(), doc1.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc2.indexed.begin(), doc2.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc3.indexed.begin(), doc3.indexed.end()));
+  ASSERT_TRUE(tests::Insert(*writer, doc4.indexed.begin(), doc4.indexed.end()));
+  writer->RefreshCommit();
+}
+
+std::map<irs::doc_id_t, irs::score_t> IdfIndexTest::Score(
+  std::string_view term) {
+  auto impl = std::make_unique<irs::IDF>();
+
+  auto index = open_reader();
+  EXPECT_EQ(1, index->size());
+  auto& segment = *(index.begin());
+
+  irs::ByTerm filter;
+  *filter.mutable_field_id() = kBodyId;
+  filter.mutable_options()->term = irs::ViewCast<irs::byte_type>(term);
+
+  MaxMemoryCounter counter;
+  tests::PreparedFilter prepared{filter, *index, impl.get(), counter};
+
+  irs::ColumnArgsFetcher fetcher;
+  auto docs = prepared.Execute(0);
+  auto score = docs->PrepareScore({
+    .scorer = impl.get(),
+    .segment = &segment,
+    .fetcher = &fetcher,
+  });
+
+  std::map<irs::doc_id_t, irs::score_t> seen;
+  while (!irs::doc_limits::eof(docs->advance())) {
+    fetcher.Fetch(docs->value());
+    docs->FetchScoreArgs(0);
+    irs::score_t s{};
+    score.Score(&s, 1);
+    seen.emplace(docs->value(), s);
+  }
+  return seen;
+}
+
+TEST_P(IdfIndexTest, scores_idf_ignoring_term_frequency) {
+  BuildAnalyzed();
+
+  const auto fox = Score("fox");
+  ASSERT_EQ(2u, fox.size());
+
+  // doc1 carries 'fox' twice and doc2 once, yet both score the same: the
+  // IDF-only scorer never looks at the frequency.
+  const auto expected = ExpectedIdf(4, 2);
+  for (const auto& [doc, value] : fox) {
+    ASSERT_GT(value, 0.f);
+    ASSERT_FLOAT_EQ(expected, value);
+  }
+}
+
+TEST_P(IdfIndexTest, rarer_term_scores_higher) {
+  BuildAnalyzed();
+
+  const auto fox = Score("fox");
+  const auto rabbit = Score("rabbit");
+  ASSERT_EQ(2u, fox.size());
+  ASSERT_EQ(1u, rabbit.size());
+
+  ASSERT_FLOAT_EQ(ExpectedIdf(4, 2), fox.begin()->second);
+  ASSERT_FLOAT_EQ(ExpectedIdf(4, 1), rabbit.begin()->second);
+  ASSERT_GT(rabbit.begin()->second, fox.begin()->second);
+}
+
+TEST_P(IdfIndexTest, scores_field_without_frequency) {
+  BuildKeyword();
+
+  const auto fox = Score("fox");
+  ASSERT_EQ(2u, fox.size());
+
+  const auto expected = ExpectedIdf(4, 2);
+  for (const auto& [doc, value] : fox) {
+    ASSERT_GT(value, 0.f);
+    ASSERT_FLOAT_EQ(expected, value);
+  }
+}
+
+static constexpr auto kTestDirs = tests::GetDirectories<tests::kTypesDefault>();
+
+INSTANTIATE_TEST_SUITE_P(idf_test, IdfIndexTest,
+                         ::testing::Combine(::testing::ValuesIn(kTestDirs),
+                                            ::testing::Values("1_5simd")),
+                         IdfIndexTest::to_string);
+
+}  // namespace

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score.test
@@ -1534,5 +1534,153 @@ statement ok
 DROP TABLE prefix_docs;
 
 
+# ============================================================================
+# idf() -- scores by the inverse document frequency of the matched term
+# alone. No term frequency, no length norm, and no index features, so it
+# also scores columns indexed without a dictionary.
+# ============================================================================
+
+statement ok
+CREATE TABLE idf_docs (id INTEGER PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX idf_idx ON idf_docs USING inverted(id, body en)
+  WITH (compaction_interval = 0);
+
+
+statement ok
+INSERT INTO idf_docs VALUES
+    (1, 'alpha alpha alpha beta'), (2, 'alpha gamma'),
+    (3, 'beta'), (4, 'delta');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) idf_docs;
+
+
+# 'alpha' occurs in 2 of the 4 documents, so its IDF is
+# log1p(2.5 / 2.5) = ln 2. Doc 1 carries the term three times and doc 2
+# once, and they score identically.
+query
+SELECT id, round(IDF(idf_idx.tableoid)::DOUBLE, 6) AS score
+FROM idf_idx WHERE body @@ ts_phrase('alpha') ORDER BY id;
+----
+id	score
+1	0.693147
+2	0.693147
+
+
+# Default BM25 over the same two documents does weigh term frequency.
+query
+SELECT id, round(BM25(idf_idx.tableoid)::DOUBLE, 6) AS score
+FROM idf_idx WHERE body @@ ts_phrase('alpha') ORDER BY id;
+----
+id	score
+1	0.897014
+2	0.693147
+
+
+# 'gamma' occurs in 1 of 4 documents: log1p(3.5 / 1.5) = ln 10/3.
+query
+SELECT id, round(IDF(idf_idx.tableoid)::DOUBLE, 6) AS score
+FROM idf_idx WHERE body @@ ts_phrase('gamma') ORDER BY id;
+----
+id	score
+2	1.203973
+
+
+# The in-scan top-k collects IDF hits like any other.
+query
+SELECT id, score FROM (
+  SELECT id, round(IDF(idf_idx.tableoid)::DOUBLE, 6) AS score
+  FROM idf_idx WHERE body @@ ts_phrase('beta')
+  ORDER BY IDF(idf_idx.tableoid) DESC LIMIT 5
+) t ORDER BY id;
+----
+id	score
+1	0.693147
+3	0.693147
+
+
+# One scorer per index scan, same as every other scorer.
+query error
+SELECT id FROM idf_idx WHERE body @@ ts_phrase('alpha')
+  AND IDF(idf_idx.tableoid) > 0
+ORDER BY BM25(idf_idx.tableoid) DESC LIMIT 2;
+----
+db error: ERROR: Only one scorer function is allowed per inverted index
+HINT: Use UNION to combine different score functions for the same inverted index
+
+
+statement ok
+DROP TABLE idf_docs;
+
+
+# A keyword column indexed without a dictionary carries no frequency, and
+# idf() scores it all the same.
+
+statement ok
+CREATE TABLE idf_kw (id INTEGER PRIMARY KEY, tag VARCHAR);
+
+
+statement ok
+CREATE INDEX idf_kw_idx ON idf_kw USING inverted(id, tag)
+  WITH (compaction_interval = 0);
+
+
+statement ok
+INSERT INTO idf_kw VALUES (1, 'red'), (2, 'red'), (3, 'blue'), (4, 'green');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) idf_kw;
+
+
+query
+SELECT id, round(IDF(idf_kw_idx.tableoid)::DOUBLE, 6) AS score
+FROM idf_kw_idx WHERE tag @@ 'red' ORDER BY id;
+----
+id	score
+1	0.693147
+2	0.693147
+
+
+statement ok
+DROP TABLE idf_kw;
+
+
+# idf() is also accepted as an index's optimize_top_k scorer.
+
+statement ok
+CREATE TABLE idf_tk (id INTEGER PRIMARY KEY, tag VARCHAR);
+
+
+statement ok
+CREATE INDEX idf_tk_idx ON idf_tk USING inverted(id, tag)
+  WITH (compaction_interval = 0, optimize_top_k = 'idf()');
+
+
+statement ok
+INSERT INTO idf_tk VALUES (1, 'red'), (2, 'red'), (3, 'blue'), (4, 'green');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) idf_tk;
+
+
+query
+SELECT id, round(IDF(idf_tk_idx.tableoid)::DOUBLE, 6) AS score
+FROM idf_tk_idx WHERE tag @@ 'red' ORDER BY id;
+----
+id	score
+1	0.693147
+2	0.693147
+
+
+statement ok
+DROP TABLE idf_tk;
+
+
 statement ok
 SET disabled_optimizers = '';


### PR DESCRIPTION
## What

An explicit `idf()` scorer: a document scores the inverse document frequency of the matched term alone, with no term frequency and no length normalisation. It is available anywhere a scorer is — `IDF(idx.tableoid)` in a query, `optimize_top_k = 'idf()'` on an index — and declaring `IndexFeatures::None` it also scores columns indexed without a dictionary.

## Why a scorer rather than a spelling of `bm25(k1 = 0)`

`bm25(k1 = 0)` is BM1, which is the same formula, so this is mostly about naming and ergonomics:

- `idf()` says what it computes. `bm25(0, 0.75)` requires knowing that `k1 = 0` collapses the tf term, and it carries a `b` that means nothing once the length norm is gone.
- `optimize_top_k = 'idf()'` reads as an intent; `optimize_top_k = 'bm25(0, 0.75)'` reads as a mistake.
- It is independent of BM25's option surface.

Worth being explicit about the overlap: with #1039 (which fixes BM1 to actually score, and lets it report `IndexFeatures::None`), the two produce identical scores in every case, including on frequency-less fields. If you would rather have one way to spell this and drop the scorer, that is a reasonable call — the BM1 fix alone covers the capability.

## Shape

`IDF` follows `raw_boost`: `ScorerBase<IDF, IDFStats>`, stats accumulating the same probabilistic IDF that BM25 collects, and null score-bound writer/source inherited from `ScorerBase`, so it does not participate in score pruning (like `raw_boost`, `raw_tf`, `raw_dl`). It registers through the five name-keyed sites that already drive every other scorer, so `ExtractScorerFromBound`, `ToString`, `RegisterScorerFunctions`, `IsScorerFunctionName` and the persistence variant all pick it up.

`raw_boost.cpp`'s per-doc-boost score operator moves to `volatile_boost_score.hpp` as `VolatileBoostScore`. IDF needs exactly that shape with the constant folded differently — the query boost times the IDF, rather than the query boost alone — so the two share one operator instead of duplicating the `Score`/`ScoreSum`/`ScoreMax`/`*Block` family.

## Tests

gtest `idf_test` (12 cases across the three directory types):

- the scorer reports `IndexFeatures::None`
- documents matching a term all score the same value regardless of how many times they carry it, and that value is the expected `log1p((N - df + 0.5) / (df + 0.5))`
- a rarer term outranks a common one, at its own exact IDF
- a field indexed with no features at all still scores

sqllogic in `inverted_index_score.test`, with hand-checkable values: a term in 2 of 4 documents scores `ln 2 = 0.693147`, one in 1 of 4 scores `ln 10/3 = 1.203973`, default BM25 over the same documents gives `0.897014` vs `0.693147` (so the tf contribution is visibly gone), the in-scan top-k collects IDF hits, a dictionary-less keyword column scores, `optimize_top_k = 'idf()'` binds, and mixing `IDF` with `BM25` in one scan still raises the one-scorer-per-index error.
