### PR TITLE
fix: Emit pg_attribute rows for views

### DIFF
--- a/server/pg/pg_catalog/pg_attribute.cpp
+++ b/server/pg/pg_catalog/pg_attribute.cpp
@@ -29,6 +29,7 @@
 #include "catalog/table.h"
 #include "catalog/table_options.h"
 #include "catalog/user_type.h"
+#include "catalog/view.h"
 #include "pg/pg_catalog/fwd.h"
 #include "pg/pg_types.h"
 #include "pg/system_catalog.h"
@@ -159,6 +160,42 @@ void EmitColumnsForTable(const catalog::Table& table,
   }
 }
 
+void EmitColumnsForView(const catalog::PgSqlView& view,
+                        std::vector<PgAttribute>& values) {
+  const auto& info = view.GetInfo();
+
+  for (size_t i = 0; i < info.names.size(); ++i) {
+    auto type_oid = Type2Oid(info.types[i]);
+    auto phys = GetPhysicalInfo(type_oid);
+    const auto& name =
+      i < info.aliases.size() ? info.aliases[i] : info.names[i];
+
+    PgAttribute row{
+      .attrelid = view.GetId().id(),
+      .attname = name.GetIdentifierName(),
+      .atttypid = type_oid,
+      .attlen = phys.attlen,
+      .attnum = static_cast<int16_t>(i + 1),
+      .atttypmod = -1,
+      .attndims = 0,
+      .attbyval = phys.attbyval,
+      .attalign = phys.attalign,
+      .attstorage = phys.attstorage,
+      .attcompression = PgAttribute::Attcompression::None,
+      .attnotnull = false,
+      .atthasdef = false,
+      .atthasmissing = false,
+      .attidentity = PgAttribute::Attidentity::None,
+      .attgenerated = PgAttribute::Attgenerated::None,
+      .attisdropped = false,
+      .attislocal = true,
+      .attinhcount = 0,
+      .attcollation = GetCollationForType(type_oid),
+    };
+    values.push_back(std::move(row));
+  }
+}
+
 void EmitColumnsForSystemTable(const catalog::VirtualTable& table,
                                std::vector<PgAttribute>& values) {
   auto row_type = table.RowType();
@@ -252,6 +289,10 @@ catalog::MaterializedData SystemTableSnapshot<PgAttribute>::GetTableData() {
     for (const auto& table :
          catalog->GetTables(GetDatabaseId(), schema->GetName())) {
       EmitColumnsForTable(*table, values);
+    }
+    for (const auto& view :
+         catalog->GetViews(GetDatabaseId(), schema->GetName())) {
+      EmitColumnsForView(*view, values);
     }
     for (const auto& type :
          catalog->GetTypes(GetDatabaseId(), schema->GetName())) {

--- a/server/pg/pg_catalog/pg_class.cpp
+++ b/server/pg/pg_catalog/pg_class.cpp
@@ -196,6 +196,7 @@ void RetrieveObjects(ObjectId database_id, std::vector<PgClass>& values,
     for (const auto& view : catalog.GetViews(database_id, schema->GetName())) {
       auto row = MakeBaseRow(schema_id, *view, view->GetOwner());
       row.relkind = PgClass::Relkind::View;
+      row.relnatts = static_cast<int16_t>(view->GetInfo().names.size());
       row.relacl = {view->GetAcl()};
       values.push_back(std::move(row));
     }

--- a/tests/sqllogic/any/pg/system/view_columns.test
+++ b/tests/sqllogic/any/pg/system/view_columns.test
@@ -1,0 +1,123 @@
+# Views must report their columns in pg_attribute.
+#
+# pg_attribute is the source information_schema.columns is built from, so a
+# view with no attribute rows is invisible to every client that introspects
+# columns the standard way: dbt's adapter.get_columns_in_relation returns an
+# empty list, breaking dbt_utils.star and model contracts, and dbt docs
+# generate silently drops view models from catalog.json.
+
+statement ok
+CREATE TABLE viewcol_base(a INTEGER, b TEXT);
+
+statement ok
+CREATE VIEW viewcol_plain AS SELECT a, b FROM viewcol_base;
+
+statement ok
+CREATE VIEW viewcol_renamed(x, y) AS SELECT a, b FROM viewcol_base;
+
+statement ok
+CREATE VIEW viewcol_expr AS SELECT a + 1 AS computed, upper(b) AS shouted FROM viewcol_base;
+
+
+# The three probes from the bug report, which all returned 0 for a view.
+query
+SELECT 'attributes' AS probe, count(*) AS n
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'viewcol_plain') AND attnum > 0
+UNION ALL
+SELECT 'columns', count(*)
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'viewcol_plain'
+UNION ALL
+SELECT 'relnatts', relnatts::bigint
+FROM pg_class WHERE relname = 'viewcol_plain'
+ORDER BY probe;
+----
+probe	n
+attributes	2
+columns	2
+relnatts	2
+
+
+query
+SELECT attnum, attname, format_type(atttypid, atttypmod) AS type
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'viewcol_plain') AND attnum > 0
+ORDER BY attnum;
+----
+attnum	attname	type
+1	a	integer
+2	b	text
+
+
+# A view column is nullable, local, and not inherited.
+query
+SELECT attname, attnotnull, attislocal, attinhcount
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'viewcol_plain') AND attnum > 0
+ORDER BY attnum;
+----
+attname	attnotnull	attislocal	attinhcount
+a	f	t	0
+b	f	t	0
+
+
+# A column list on CREATE VIEW renames the columns: attname must report the
+# view's own names, not the names of the underlying query.
+query
+SELECT attnum, attname, format_type(atttypid, atttypmod) AS type
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'viewcol_renamed') AND attnum > 0
+ORDER BY attnum;
+----
+attnum	attname	type
+1	x	integer
+2	y	text
+
+
+query
+SELECT ordinal_position, column_name
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'viewcol_renamed'
+ORDER BY ordinal_position;
+----
+ordinal_position	column_name
+1	x
+2	y
+
+
+# Expression columns take their name and type from the select list.
+query
+SELECT attnum, attname, format_type(atttypid, atttypmod) AS type
+FROM pg_attribute
+WHERE attrelid = (SELECT oid FROM pg_class WHERE relname = 'viewcol_expr') AND attnum > 0
+ORDER BY attnum;
+----
+attnum	attname	type
+1	computed	integer
+2	shouted	text
+
+
+query
+SELECT relname, relkind, relnatts
+FROM pg_class
+WHERE relname IN ('viewcol_plain', 'viewcol_renamed', 'viewcol_expr')
+ORDER BY relname;
+----
+relname	relkind	relnatts
+viewcol_expr	v	2
+viewcol_plain	v	2
+viewcol_renamed	v	2
+
+
+statement ok
+DROP VIEW viewcol_expr;
+
+statement ok
+DROP VIEW viewcol_renamed;
+
+statement ok
+DROP VIEW viewcol_plain;
+
+statement ok
+DROP TABLE viewcol_base;


### PR DESCRIPTION
`GetTableData()` for pg_attribute loops over tables, composite types and system
tables, but not views. Views therefore get no rows in pg_attribute, and since
information_schema.columns is a view over pg_attribute, it comes back empty for
them as well. pg_class.relnatts is left at its default of 0.

Repro:

```sql
create table t (a int, b text);
create view v as select a, b from t;
```

pg_attribute, information_schema.columns and relnatts all report 0 columns for
v. Postgres reports 2.

This breaks anything that introspects columns the standard way. dbt's
`adapter.get_columns_in_relation` returns an empty list, which takes out
`dbt_utils.star` and model contracts, and `dbt docs generate` drops view models
from catalog.json without reporting an error.

Changes:

* add `EmitColumnsForView` to pg_attribute.cpp, modelled on the existing
  `EmitColumnsForSystemTable` since a view has no primary key, check
  constraints or defaults
* call it from the schema loop in `GetTableData()`, next to the existing table
  and type loops
* set relnatts on the view row in pg_class.cpp

information_schema.columns needs no change of its own.

One thing worth flagging for review: attname reads `aliases[i]` when there is
one and falls back to `names[i]`. `CreateViewInfo::names` holds the names of
the underlying query, so `create view v(x, y) as select a, b from t` would
otherwise report a and b instead of x and y. The two vectors are positionally
aligned, and aliases can be shorter than names, so the check is per column
rather than once up front.

The test goes under tests/sqllogic/any/ so it runs against Postgres as well as
SereneDB. It covers a plain view, a view with a column alias list, and a view
with expression columns, checking attname, attnum, format_type(), the
information_schema counts and relnatts.

Closes #997
