### PR TITLE
Google Cloud auth for Iceberg catalogs (BigLake): service-account JWT + metadata server + catalog_token delegation

### DIFF
--- a/tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/biglake_iceberg.test_slow
+++ b/tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/biglake_iceberg.test_slow
@@ -1,0 +1,120 @@
+# Cookbook: connect to a Google BigLake (Lakehouse) Iceberg REST catalog.
+# Every snippet needs live Google Cloud, so all bodies are noops; the RAW
+# blocks are what the site renders.
+
+# DOCS_TEST: example_secret_sa
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     PROVIDER google,
+#|     CLIENT_EMAIL '⟨engine@my-project.iam.gserviceaccount.com⟩',
+#|     PRIVATE_KEY '⟨-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n⟩',
+#|     PRIVATE_KEY_ID '⟨a1b2c3d4...⟩',
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_001 (i INTEGER);
+
+# DOCS_TEST: example_secret_vm
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     PROVIDER google,
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_002 (i INTEGER);
+
+# DOCS_TEST: example_secret_adc
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     OAUTH2_GRANT_TYPE 'refresh_token',
+#|     OAUTH2_SERVER_URI 'https://oauth2.googleapis.com/token',
+#|     CLIENT_ID '⟨client_id from the ADC file⟩',
+#|     CLIENT_SECRET '⟨client_secret from the ADC file⟩',
+#|     REFRESH_TOKEN '⟨refresh_token from the ADC file⟩',
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_003 (i INTEGER);
+
+# DOCS_TEST: example_secret_hmac
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcs_data (
+#|     TYPE GCS,
+#|     KEY_ID '⟨GOOG1E...⟩',
+#|     SECRET '⟨hmac secret⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_004 (i INTEGER);
+
+# DOCS_TEST: example_server
+
+# DOCS_TEST_RAW
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse 'bl://projects/⟨my-project⟩/catalogs/⟨my-catalog⟩',
+#|     endpoint 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
+#|     secret 'gcp',
+#|     access_delegation_mode 'catalog_token'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_005 (i INTEGER);
+
+# DOCS_TEST: example_server_hmac
+
+# DOCS_TEST_RAW
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse 'bl://projects/⟨my-project⟩/catalogs/⟨my-catalog⟩',
+#|     endpoint 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
+#|     secret 'gcp',
+#|     access_delegation_mode 'none'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_006 (i INTEGER);
+
+# DOCS_TEST: example_query
+
+# DOCS_TEST_RAW
+#| SELECT count(*) FROM lake.⟨namespace⟩.⟨table⟩;
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_007 (i INTEGER);
+
+# DOCS_TEST: example_write
+
+# DOCS_TEST_RAW
+#| CREATE SCHEMA lake.analytics;
+#|
+#| CREATE TABLE lake.analytics.events (id INTEGER, payload TEXT);
+#|
+#| INSERT INTO lake.analytics.events VALUES (1, 'hello iceberg');
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_008 (i INTEGER);


### PR DESCRIPTION
Bumps `third_party/duckdb_iceberg` to pull serenedb/duckdb-iceberg#9 — production Google Cloud auth for Iceberg REST catalogs.

## What this enables

One long-lived credential, fully self-refreshing — the same operator experience AWS catalogs already get from sigv4:

```sql
CREATE SECRET gcp (
    TYPE ICEBERG, PROVIDER google,
    CLIENT_EMAIL 'engine@proj.iam.gserviceaccount.com',
    PRIVATE_KEY '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n',
    EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': 'proj'}
);
CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
    warehouse 'bl://projects/<proj>/catalogs/<catalog>',
    endpoint 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
    secret 'gcp',
    access_delegation_mode 'catalog_token'
);
```

- Service-account JWT-bearer tokens (RS256 via duckdb's bundled mbedtls, no new deps), or keyless metadata-server tokens when serened runs on GCE/GKE.
- `catalog_token` access delegation covers the GCS data plane for catalogs that refuse credential vending (BigLake END_USER mode).
- Hourly token expiry is handled internally (proactive refresh + 401 retry); misconfiguration fails eagerly at CREATE SECRET.

## Validation

Live against a real BigLake catalog: 3.24M-row reads, write round-trips, forced-expiry re-mints against Google's real token endpoint; plus an offline mock that signature-verifies the produced JWTs, and a full error-matrix pass. See serenedb/duckdb-iceberg#9 for the implementation details.
