### PR TITLE
feat: SQL/PGQ property graph queries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -221,3 +221,7 @@
 	path = third_party/libxml2
 	url = https://github.com/serenedb/libxml2.git
 	shallow = true
+[submodule "third_party/duckpgq"]
+	path = third_party/duckpgq
+	url = https://github.com/serenedb/duckpgq.git
+	shallow = true

--- a/scripts/check_submodule_pointers.py
+++ b/scripts/check_submodule_pointers.py
@@ -29,6 +29,7 @@ VERSION_BRANCH = re.compile(r"^v20\d{2}\.\d{2}\.\d{2}$")
 CHECKED = {
     "third_party/duckdb": VERSION_BRANCH,
     "third_party/duckdb_iceberg": VERSION_BRANCH,
+    "third_party/duckpgq": re.compile(r"^serenedb$"),
 }
 
 
@@ -195,9 +196,13 @@ def check(path: str, pattern: re.Pattern, override_sha: str | None) -> bool:
         return True
     main_sha = main_gitlink(path)
     if main_sha is None:
-        print(f"{path}: cannot resolve origin/main gitlink", file=sys.stderr)
-        return False
-    if gitlink == main_sha:
+        # A submodule not on origin/main yet: no ordering to enforce, but the
+        # gitlink must still be reachable from a matching branch.
+        if git("rev-parse", "--verify", "origin/main^{commit}") is None:
+            print(f"{path}: cannot resolve origin/main gitlink", file=sys.stderr)
+            return False
+        main_sha = gitlink
+    elif gitlink == main_sha:
         return True
     url = submodule_url(path)
     if url is None:

--- a/server/connector/duckdb_client_state.cpp
+++ b/server/connector/duckdb_client_state.cpp
@@ -268,6 +268,34 @@ void SereneDBClientState::QueryEnd(duckdb::ClientContext& context) {
   _connection_ctx->OnStatementEnd();
 }
 
+SereneDBClientState::~SereneDBClientState() {
+  if (drain_notices_on_destroy) {
+    _connection_ctx->ConsumeNotices([](auto&) {});
+  }
+  if (progress_source) {
+    progress_source->Detach();
+    pg::ProgressRegistry::Instance().Unregister(progress_source.get());
+  }
+}
+
+duckdb::shared_ptr<duckdb::Connection> CreateBlessedInternalConnection(
+  duckdb::ClientContext& parent) {
+  auto connection = duckdb::make_shared_ptr<duckdb::Connection>(*parent.db);
+  auto* parent_ctx = GetSereneDBContextPtr(parent);
+  if (!parent_ctx) {
+    return connection;
+  }
+  auto ctx = std::make_shared<ConnectionContext>(
+    *connection->context, parent_ctx->user(), parent_ctx->GetRoleId(),
+    parent_ctx->GetDatabase(), parent_ctx->GetDatabaseId(),
+    parent_ctx->GetDatabasePtr(), nullptr, nullptr, /*backend_pid=*/0, nullptr);
+  auto& state = SereneDBClientState::Register(*connection->context, ctx);
+  state.drain_notices_on_destroy = true;
+  connection->context->session_user = parent.session_user;
+  ctx->AcquireCatalogSnapshot();
+  return connection;
+}
+
 ConnectionContext* GetSereneDBContextPtr(duckdb::ClientContext& context) {
   auto state =
     context.registered_state->Get<SereneDBClientState>(kSereneDBClientStateKey);

--- a/server/connector/duckdb_client_state.h
+++ b/server/connector/duckdb_client_state.h
@@ -64,14 +64,11 @@ class SereneDBClientState final : public duckdb::ClientContextState {
     std::shared_ptr<ConnectionContext> connection_ctx)
     : _connection_ctx{std::move(connection_ctx)} {}
 
-  ~SereneDBClientState() final {
-    if (progress_source) {
-      progress_source->Detach();
-      pg::ProgressRegistry::Instance().Unregister(progress_source.get());
-    }
-  }
+  ~SereneDBClientState() final;
 
   ConnectionContext& GetConnectionContext() const { return *_connection_ctx; }
+
+  bool drain_notices_on_destroy = false;
 
   // The connection's row in sdb_progress. Execution paths write the
   // command-specific counters straight into Progress(); the registry snapshots
@@ -139,5 +136,8 @@ class SereneDBClientState final : public duckdb::ClientContextState {
 // Helper to get the ConnectionContext from a DuckDB ClientContext.
 ConnectionContext* GetSereneDBContextPtr(duckdb::ClientContext& context);
 ConnectionContext& GetSereneDBContext(duckdb::ClientContext& context);
+
+duckdb::shared_ptr<duckdb::Connection> CreateBlessedInternalConnection(
+  duckdb::ClientContext& parent);
 
 }  // namespace sdb::connector

--- a/server/connector/duckdb_index_scan_entry.cpp
+++ b/server/connector/duckdb_index_scan_entry.cpp
@@ -167,8 +167,14 @@ duckdb::vector<duckdb::column_t> TableInvertedIndexScanEntry::GetRowIdColumns()
 
 duckdb::virtual_column_map_t TableInvertedIndexScanEntry::GetVirtualColumns()
   const {
-  return SereneDBTableEntry::BuildVirtualColumns(*_sdb_table,
-                                                 _indexed_col_indices);
+  auto result =
+    SereneDBTableEntry::BuildVirtualColumns(*_sdb_table, _indexed_col_indices);
+  if (_sdb_table->GetEngine() != catalog::TableEngine::Search &&
+      !result.contains(kColumnIdentifierGeneratedPk)) {
+    result.emplace(kColumnIdentifierGeneratedPk,
+                   duckdb::TableColumn("rowid", duckdb::LogicalType::ROW_TYPE));
+  }
+  return result;
 }
 
 ViewInvertedIndexScanEntry::ViewInvertedIndexScanEntry(

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -330,6 +330,14 @@ std::optional<duckdb::LogicalType> GeneratedPkTypeOf(
       return fp->GeneratedPkType();
     }
   }
+  if (bind.IsInvertedIndexEntry() && !bind.IsViewBacked()) {
+    const auto& tbd = bind.As<TableScanBindData>();
+    if (tbd.table && tbd.table->GetEngine() != catalog::TableEngine::Search) {
+      // Table-backed index: the postings carry the store-table rowid, so the
+      // stored pk column decodes to it directly.
+      return duckdb::LogicalType::ROW_TYPE;
+    }
+  }
   return std::nullopt;
 }
 

--- a/server/query/server_engine.cpp
+++ b/server/query/server_engine.cpp
@@ -30,6 +30,7 @@
 
 #include "basics/number_of_cores.h"
 #include "catalog/store/store.h"
+#include "connector/duckdb_client_state.h"
 #include "connector/duckdb_copy_filesystem.h"
 #include "connector/duckdb_foreign_server_function.h"
 #include "connector/duckdb_pg_binary_copy.h"
@@ -227,6 +228,8 @@ namespace sdb::server::query {
 void ConfigureServerDBConfig(duckdb::DBConfig& config) {
   connector::RegisterSereneDBStorage(config);
   connector::RegisterConfigVariables(config);
+  config.internal_connection_factory =
+    connector::CreateBlessedInternalConnection;
   // DuckDB's own auto-detect uses std::thread::hardware_concurrency(), which
   // ignores cgroup CPU limits and would over-thread in a container. Pin it to
   // our cgroup-aware logical core count when unset (SET threads=N still wins at

--- a/tests/sqllogic/recovery/join_filter_after_replay.test
+++ b/tests/sqllogic/recovery/join_filter_after_replay.test
@@ -1,0 +1,52 @@
+control substitution on
+
+
+statement ok
+SET GLOBAL checkpoint_threshold = '10GB';
+
+statement ok
+CREATE TABLE jfr_person (id BIGINT PRIMARY KEY, val BIGINT);
+
+statement ok
+INSERT INTO jfr_person SELECT range, range % 1000 FROM range(100000);
+
+statement ok
+CREATE TABLE jfr_knows (src BIGINT, dst BIGINT);
+
+statement ok
+INSERT INTO jfr_knows SELECT range % 100000, (range * 7 + 13) % 100000 FROM range(1000000);
+
+query
+SELECT count(*) FROM jfr_knows k JOIN jfr_person a ON k.src = a.id;
+----
+count
+1000000
+
+
+statement ok
+SET sdb_faults = 'crash_on_packet';
+
+statement error connection closed
+SELECT 1;
+
+
+connection after_replay
+query ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+SELECT count(*) FROM jfr_person;
+----
+count
+100000
+
+
+query
+SELECT count(*) FROM jfr_knows k JOIN jfr_person a ON k.src = a.id;
+----
+count
+1000000
+
+
+query
+SELECT count(*) FROM jfr_knows k JOIN jfr_person a ON k.src = a.id WHERE k.src < 100;
+----
+count
+1000

--- a/tests/sqllogic/run_recovery_tests.sh
+++ b/tests/sqllogic/run_recovery_tests.sh
@@ -166,6 +166,7 @@ echo "Pre-building sqllogictest..."
 # few times before giving up instead of failing the whole suite.
 build_exit_code=0
 build_attempts="${SDB_SQLLOGIC_BUILD_ATTEMPTS:-3}"
+[[ "${SDB_SKIP_SQLLOGIC_BUILD:-0}" == "1" ]] && build_attempts=0
 for attempt in $(seq 1 "$build_attempts"); do
 	cargo build --manifest-path "$SQLLOGIC_RUNNER/sqllogictest-bin/Cargo.toml" \
 		--target-dir "$SQLLOGIC_TARGET" --release --quiet

--- a/tests/sqllogic/sdb/pg/index/rowid_projection.test
+++ b/tests/sqllogic/sdb/pg/index/rowid_projection.test
@@ -1,0 +1,78 @@
+# The store-table rowid projects through a table-backed inverted-index scan
+# (postings carry it; the stored pk column decodes to it), plain and under a
+# full-text filter.
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY rp_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true,
+    norm = true
+);
+
+
+statement ok
+CREATE TABLE rp_t (id BIGINT PRIMARY KEY, body VARCHAR);
+
+
+statement ok
+CREATE INDEX rp_idx ON rp_t USING inverted(id, body rp_en);
+
+
+statement count 3
+INSERT INTO rp_t VALUES (10, 'quick fox'), (20, 'lazy dog'), (30, 'quick turtle');
+
+
+statement ok
+VACUUM (REFRESH_TABLE) rp_t;
+
+
+query
+SELECT rowid, id FROM rp_idx ORDER BY rowid;
+----
+rowid	id
+0	10
+1	20
+2	30
+
+
+query
+SELECT rowid, id FROM rp_idx WHERE body @@ ts_phrase('quick') ORDER BY rowid;
+----
+rowid	id
+0	10
+2	30
+
+
+query
+EXPLAIN SELECT rowid, id FROM rp_idx WHERE body @@ ts_phrase('quick') ORDER BY rowid;
+----
+QUERY PLAN
+╭─ ORDER_BY ─────────────────╮
+│ Order By: rp_idx.rowid ASC │
+│ ~1 row                     │
+╰──────────────┬─────────────╯
+╭─ IRESEARCH_SCAN ───────────╮
+│ Index: rp_idx              │
+│ Lookup: table              │
+│ Index Filter:              │
+│ ╭─ Term ──────────────╮    │
+│ │ Field: body(string) │    │
+│ │ Value: quick        │    │
+│ ╰─────────────────────╯    │
+│ Projections: generated_pk, │
+│              id            │
+│ ~1 row                     │
+╰────────────────────────────╯
+
+
+statement ok
+DROP TABLE rp_t;
+
+
+statement ok
+DROP TEXT SEARCH DICTIONARY rp_en;

--- a/tests/sqllogic/sdb/pg/pgq/deletes.test
+++ b/tests/sqllogic/sdb/pg/pgq/deletes.test
@@ -1,0 +1,99 @@
+# Path-finding over tables with deleted rows. The CSR arrays are indexed by
+# rowid, so they are sized by max(rowid) + 1 rather than count(*): deletes
+# leave rowid gaps (here rowids 0, 3, 4 for three rows), and sizing by count
+# used to write past the end of the vertex array and abort the server.
+
+statement ok
+CREATE TABLE dl_person (id BIGINT PRIMARY KEY, name VARCHAR);
+
+
+statement ok
+CREATE TABLE dl_knows (src BIGINT, dst BIGINT);
+
+
+statement count 5
+INSERT INTO dl_person VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+
+statement count 4
+INSERT INTO dl_knows VALUES (1, 2), (2, 3), (3, 4), (4, 5);
+
+
+statement count 2
+DELETE FROM dl_person WHERE id IN (2, 3);
+
+
+statement count 3
+DELETE FROM dl_knows WHERE src IN (2, 3) OR dst IN (2, 3);
+
+
+statement count 1
+INSERT INTO dl_knows VALUES (1, 4);
+
+
+# EXPLAIN over property-graph DDL is not supported
+statement error
+EXPLAIN CREATE PROPERTY GRAPH dl_g
+  VERTEX TABLES (dl_person)
+  EDGE TABLES (dl_knows SOURCE KEY (src) REFERENCES dl_person (id)
+                        DESTINATION KEY (dst) REFERENCES dl_person (id));
+
+
+statement ok
+CREATE PROPERTY GRAPH dl_g
+  VERTEX TABLES (dl_person)
+  EDGE TABLES (dl_knows SOURCE KEY (src) REFERENCES dl_person (id)
+                        DESTINATION KEY (dst) REFERENCES dl_person (id));
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (dl_g MATCH (a:dl_person)-[k:dl_knows]->(b:dl_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (dl_g MATCH (a:dl_person)-[k:dl_knows]->(b:dl_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	d
+d	e
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (dl_g MATCH p = ANY SHORTEST (a:dl_person WHERE a.name='a')-[k:dl_knows]->*(b:dl_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (dl_g MATCH p = ANY SHORTEST (a:dl_person WHERE a.name='a')-[k:dl_knows]->*(b:dl_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+a	0
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (dl_g MATCH (a:dl_person WHERE a.name='a')-[k:dl_knows]->{1,2}(b:dl_person) COLUMNS (b.name AS bn)) ORDER BY bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (dl_g MATCH (a:dl_person WHERE a.name='a')-[k:dl_knows]->{1,2}(b:dl_person) COLUMNS (b.name AS bn)) ORDER BY bn;
+----
+bn
+d
+e
+
+
+statement error
+EXPLAIN DROP PROPERTY GRAPH dl_g;
+
+
+statement ok
+DROP PROPERTY GRAPH dl_g;
+
+
+statement ok
+DROP TABLE dl_knows;
+
+
+statement ok
+DROP TABLE dl_person;

--- a/tests/sqllogic/sdb/pg/pgq/match.test
+++ b/tests/sqllogic/sdb/pg/pgq/match.test
@@ -1,0 +1,262 @@
+# GRAPH_TABLE MATCH coverage beyond the basics: multi-hop and reversed
+# patterns, edge properties, WHERE at edge/vertex/graph-table level, multiple
+# comma-separated path patterns, MATCH under CTE/JOIN/CTAS/INSERT (the
+# statement shapes duckpgq rewrites), bounded quantifiers with ANY SHORTEST,
+# and liveness of graph data after CREATE PROPERTY GRAPH.
+
+statement ok
+CREATE TABLE mt_person (id BIGINT, name VARCHAR);
+
+
+statement count 5
+INSERT INTO mt_person VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+
+statement ok
+CREATE TABLE mt_knows (src BIGINT, dst BIGINT, since INT);
+
+
+statement count 5
+INSERT INTO mt_knows VALUES (1, 2, 2020), (2, 3, 2021), (3, 4, 2022), (1, 4, 2023), (4, 5, 2024);
+
+
+statement ok
+CREATE PROPERTY GRAPH mt_g
+  VERTEX TABLES (mt_person)
+  EDGE TABLES (mt_knows SOURCE KEY (src) REFERENCES mt_person (id)
+                        DESTINATION KEY (dst) REFERENCES mt_person (id));
+
+
+# two-edge path pattern
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k1:mt_knows]->(b:mt_person)-[k2:mt_knows]->(c:mt_person) COLUMNS (a.name AS an, b.name AS bn, c.name AS cn)) ORDER BY an, bn, cn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k1:mt_knows]->(b:mt_person)-[k2:mt_knows]->(c:mt_person) COLUMNS (a.name AS an, b.name AS bn, c.name AS cn)) ORDER BY an, bn, cn;
+----
+an	bn	cn
+a	b	c
+a	d	e
+b	c	d
+c	d	e
+
+
+# reversed edge direction
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)<-[k:mt_knows]-(b:mt_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)<-[k:mt_knows]-(b:mt_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+b	a
+c	b
+d	a
+d	c
+e	d
+
+
+# edge properties are projectable
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, k.since AS since, b.name AS bn)) ORDER BY since;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, k.since AS since, b.name AS bn)) ORDER BY since;
+----
+an	since	bn
+a	2020	b
+b	2021	c
+c	2022	d
+a	2023	d
+d	2024	e
+
+
+# WHERE inside the edge pattern
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows WHERE k.since >= 2022]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows WHERE k.since >= 2022]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	d
+c	d
+d	e
+
+
+# WHERE at graph-table level, referencing pattern variables
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) WHERE b.name = 'd' COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) WHERE b.name = 'd' COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an;
+----
+an	bn
+a	d
+c	d
+
+
+# comma-separated path patterns sharing a vertex variable
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k1:mt_knows]->(b:mt_person), (a:mt_person)-[k2:mt_knows]->(c:mt_person) WHERE b.name < c.name COLUMNS (a.name AS an, b.name AS bn, c.name AS cn)) ORDER BY an, bn, cn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k1:mt_knows]->(b:mt_person), (a:mt_person)-[k2:mt_knows]->(c:mt_person) WHERE b.name < c.name COLUMNS (a.name AS an, b.name AS bn, c.name AS cn)) ORDER BY an, bn, cn;
+----
+an	bn	cn
+a	b	d
+
+
+# aggregation over match results
+statement ok
+EXPLAIN SELECT an, count(*) AS c FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an)) GROUP BY an ORDER BY an;
+
+
+query
+SELECT an, count(*) AS c FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an)) GROUP BY an ORDER BY an;
+----
+an	c
+a	2
+b	1
+c	1
+d	1
+
+
+# GRAPH_TABLE inside a CTE
+statement ok
+EXPLAIN WITH m AS (SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn))) SELECT an, bn FROM m WHERE an = 'a' ORDER BY bn;
+
+
+query
+WITH m AS (SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn))) SELECT an, bn FROM m WHERE an = 'a' ORDER BY bn;
+----
+an	bn
+a	b
+a	d
+
+
+# GRAPH_TABLE joined with a regular table
+statement ok
+EXPLAIN SELECT p.id, gt.bn FROM mt_person p JOIN GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn)) gt ON p.name = gt.an WHERE p.id <= 2 ORDER BY p.id, gt.bn;
+
+
+query
+SELECT p.id, gt.bn FROM mt_person p JOIN GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn)) gt ON p.name = gt.an WHERE p.id <= 2 ORDER BY p.id, gt.bn;
+----
+id	bn
+1	b
+1	d
+2	c
+
+
+# bounded quantifier under ANY SHORTEST; a->d is the direct edge, not a-b-c-d
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH p = ANY SHORTEST (a:mt_person WHERE a.name = 'a')-[k:mt_knows]->{1,3}(b:mt_person) COLUMNS (a.name AS an, b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH p = ANY SHORTEST (a:mt_person WHERE a.name = 'a')-[k:mt_knows]->{1,3}(b:mt_person) COLUMNS (a.name AS an, b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+an	bn	len
+a	b	1
+a	c	2
+a	d	1
+a	e	2
+
+
+# CTAS over a match
+statement ok
+EXPLAIN CREATE TABLE mt_pairs AS SELECT an, bn FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn));
+
+
+statement ok
+CREATE TABLE mt_pairs AS SELECT an, bn FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn));
+
+
+query
+SELECT count(*) AS c FROM mt_pairs;
+----
+c
+5
+
+
+# INSERT ... SELECT over a match
+statement ok
+EXPLAIN INSERT INTO mt_pairs SELECT an, bn FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) WHERE a.name = 'a' COLUMNS (a.name AS an, b.name AS bn));
+
+
+statement ok
+INSERT INTO mt_pairs SELECT an, bn FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) WHERE a.name = 'a' COLUMNS (a.name AS an, b.name AS bn));
+
+
+query
+SELECT count(*) AS c FROM mt_pairs;
+----
+c
+7
+
+
+statement ok
+DROP TABLE mt_pairs;
+
+
+# the graph reads live table data: rows added after CREATE PROPERTY GRAPH match
+statement count 1
+INSERT INTO mt_knows VALUES (5, 1, 2025);
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person WHERE a.name = 'e')-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn));
+
+
+query
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person WHERE a.name = 'e')-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an, b.name AS bn));
+----
+an	bn
+e	a
+
+
+statement count 1
+DELETE FROM mt_knows WHERE src = 5;
+
+
+statement ok
+EXPLAIN SELECT count(*) AS c FROM GRAPH_TABLE (mt_g MATCH (a:mt_person WHERE a.name = 'e')-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an));
+
+
+query
+SELECT count(*) AS c FROM GRAPH_TABLE (mt_g MATCH (a:mt_person WHERE a.name = 'e')-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an));
+----
+c
+0
+
+
+statement error
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:nosuchlabel)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an));
+
+
+# a real binder error inside a PGQ statement surfaces as itself, not as
+# duckpgq's internal bind-fallback marker ("use duckpgq_bind instead")
+statement error
+SELECT * FROM GRAPH_TABLE (mt_g MATCH (a:mt_person)-[k:mt_knows]->(b:mt_person) COLUMNS (a.name AS an)) WHERE mt_no_such_fn(an);
+----
+db error: ERROR: Scalar Function with name mt_no_such_fn does not exist!
+Did you mean "month"?
+
+
+statement ok
+DROP PROPERTY GRAPH mt_g;
+
+
+statement ok
+DROP TABLE mt_knows;
+
+
+statement ok
+DROP TABLE mt_person;

--- a/tests/sqllogic/sdb/pg/pgq/pg_compat.test
+++ b/tests/sqllogic/sdb/pg/pgq/pg_compat.test
@@ -1,0 +1,176 @@
+# PostgreSQL 19 SQL/PGQ surface compatibility: NODE/RELATIONSHIP synonyms,
+# element KEY clauses (validated against the primary key), REFERENCES without
+# a column list (defaults to the vertex table's primary key), LABEL before or
+# after PROPERTIES, DEFAULT LABEL, and label-only / anonymous graph elements.
+
+# for the pinned EXPLAIN below: these optimizers key on storage-dependent
+# statistics that arrive with the background segment flush, so their output
+# is not stable between a fresh and a reused server
+statement ok
+SET disabled_optimizers = 'compressed_materialization,join_order,statistics_propagation';
+
+
+statement ok
+CREATE TABLE pgc_person (id BIGINT PRIMARY KEY, name VARCHAR);
+
+
+statement count 4
+INSERT INTO pgc_person VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+
+
+statement ok
+CREATE TABLE pgc_knows (src BIGINT, dst BIGINT, since INT);
+
+
+statement count 4
+INSERT INTO pgc_knows VALUES (1, 2, 2020), (2, 3, 2021), (1, 3, 2022), (3, 4, 2023);
+
+
+statement ok
+CREATE TABLE pgc_nopk (id BIGINT, name VARCHAR);
+
+
+# NODE / RELATIONSHIP synonyms, element KEY, REFERENCES without a column list
+statement ok
+CREATE PROPERTY GRAPH pgc_g1
+  NODE TABLES (pgc_person KEY (id) LABEL person PROPERTIES (name))
+  RELATIONSHIP TABLES (pgc_knows SOURCE KEY (src) REFERENCES pgc_person
+                                 DESTINATION KEY (dst) REFERENCES pgc_person
+                                 LABEL knows PROPERTIES (since));
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (a:person)-[k:knows]->(b:person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (a:person)-[k:knows]->(b:person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	b
+a	c
+b	c
+c	d
+
+
+# anonymous edge with IS label (PG example style), anonymous label-only vertex
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (a:person)-[IS knows]->(IS person) COLUMNS (a.name AS an)) ORDER BY an;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (a:person)-[IS knows]->(IS person) COLUMNS (a.name AS an)) ORDER BY an;
+----
+an
+a
+a
+b
+c
+
+
+# two anonymous elements in one pattern get distinct bindings
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (IS person)-[IS knows]->(b:person) COLUMNS (b.name AS bn)) ORDER BY bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (IS person)-[IS knows]->(b:person) COLUMNS (b.name AS bn)) ORDER BY bn;
+----
+bn
+b
+c
+c
+d
+
+
+# anonymous edge with a WHERE clause
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (a:person)-[IS knows WHERE since >= 2022]->(b:person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH (a:person)-[IS knows WHERE since >= 2022]->(b:person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	c
+c	d
+
+
+# fully anonymous elements are not supported yet
+statement error
+SELECT * FROM GRAPH_TABLE (pgc_g1 MATCH ()-[IS knows]->(b:person) COLUMNS (b.name AS bn));
+----
+db error: ERROR: Graph elements without a label are not supported yet
+
+
+statement ok
+DROP PROPERTY GRAPH pgc_g1;
+
+
+# PROPERTIES before LABEL, and DEFAULT LABEL
+statement ok
+CREATE PROPERTY GRAPH pgc_g2
+  VERTEX TABLES (pgc_person PROPERTIES (name) DEFAULT LABEL)
+  EDGE TABLES (pgc_knows SOURCE KEY (src) REFERENCES pgc_person (id)
+                         DESTINATION KEY (dst) REFERENCES pgc_person (id)
+                         PROPERTIES (since) LABEL knows);
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgc_g2 MATCH (a:pgc_person)-[k:knows]->(b:pgc_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgc_g2 MATCH (a:pgc_person)-[k:knows]->(b:pgc_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	b
+a	c
+b	c
+c	d
+
+
+statement ok
+DROP PROPERTY GRAPH pgc_g2;
+
+
+# element KEY must match the table's primary key
+statement error
+CREATE PROPERTY GRAPH pgc_bad1
+  VERTEX TABLES (pgc_person KEY (name))
+  EDGE TABLES (pgc_knows SOURCE KEY (src) REFERENCES pgc_person (id)
+                         DESTINATION KEY (dst) REFERENCES pgc_person (id));
+----
+db error: ERROR: KEY (name) does not match the PRIMARY KEY (id) of table pgc_person
+
+
+# element KEY on a table without a primary key
+statement error
+CREATE PROPERTY GRAPH pgc_bad2
+  VERTEX TABLES (pgc_nopk KEY (id))
+  EDGE TABLES (pgc_knows SOURCE KEY (src) REFERENCES pgc_nopk (id)
+                         DESTINATION KEY (dst) REFERENCES pgc_nopk (id));
+----
+db error: ERROR: KEY (id) specified, but table pgc_nopk has no PRIMARY KEY
+
+
+# REFERENCES without a column list requires a primary key on the vertex table
+statement error
+CREATE PROPERTY GRAPH pgc_bad3
+  VERTEX TABLES (pgc_nopk)
+  EDGE TABLES (pgc_knows SOURCE KEY (src) REFERENCES pgc_nopk
+                         DESTINATION KEY (dst) REFERENCES pgc_nopk);
+----
+db error: ERROR: SOURCE KEY ... REFERENCES pgc_nopk without a column list requires the table to have a PRIMARY KEY
+
+
+statement ok
+DROP TABLE pgc_person;
+
+
+statement ok
+DROP TABLE pgc_knows;
+
+
+statement ok
+DROP TABLE pgc_nopk;

--- a/tests/sqllogic/sdb/pg/pgq/property_graph.test
+++ b/tests/sqllogic/sdb/pg/pgq/property_graph.test
@@ -1,0 +1,147 @@
+# SQL/PGQ via the duckpgq extension: CREATE/DROP PROPERTY GRAPH, GRAPH_TABLE
+# MATCH (fixed patterns, inline WHERE, ANY SHORTEST), metadata persistence in
+# __duckpgq_internal, and cross-connection visibility of a created graph.
+
+# for the pinned EXPLAIN below: these optimizers key on storage-dependent
+# statistics that arrive with the background segment flush, so their output
+# is not stable between a fresh and a reused server
+statement ok
+SET disabled_optimizers = 'compressed_materialization,join_order,statistics_propagation';
+
+
+statement ok
+CREATE TABLE pgq_person (id BIGINT, name VARCHAR);
+
+
+statement count 3
+INSERT INTO pgq_person VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+
+statement ok
+CREATE TABLE pgq_knows (src BIGINT, dst BIGINT);
+
+
+statement count 3
+INSERT INTO pgq_knows VALUES (1, 2), (2, 3), (1, 3);
+
+
+statement ok
+CREATE PROPERTY GRAPH pgq_g
+  VERTEX TABLES (pgq_person)
+  EDGE TABLES (pgq_knows SOURCE KEY (src) REFERENCES pgq_person (id)
+                         DESTINATION KEY (dst) REFERENCES pgq_person (id));
+
+
+statement error
+CREATE PROPERTY GRAPH pgq_g VERTEX TABLES (pgq_person);
+
+
+# EXPLAIN over CREATE PROPERTY GRAPH is not supported
+statement error
+EXPLAIN CREATE PROPERTY GRAPH pgq_g2 VERTEX TABLES (pgq_person);
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person)-[k:pgq_knows]->(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person)-[k:pgq_knows]->(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	b
+a	c
+b	c
+
+
+statement ok
+EXPLAIN SELECT an, bn FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person WHERE a.name <> 'b')-[k:pgq_knows]->(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT an, bn FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person WHERE a.name <> 'b')-[k:pgq_knows]->(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	b
+a	c
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgq_g MATCH p = ANY SHORTEST (a:pgq_person)-[k:pgq_knows]->*(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn, path_length(p) AS len)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (pgq_g MATCH p = ANY SHORTEST (a:pgq_person)-[k:pgq_knows]->*(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn, path_length(p) AS len)) ORDER BY an, bn;
+----
+an	bn	len
+a	a	0
+a	b	1
+a	c	1
+b	b	0
+b	c	1
+c	c	0
+
+
+# the graph definition is persisted, one row per vertex/edge table
+query
+SELECT count(*) AS c FROM __duckpgq_internal WHERE property_graph = 'pgq_g';
+----
+c
+2
+
+
+# the one join-free plan shape: pinned in full; multi-join MATCH plans are
+# checked as `statement ok` only, their physical shape depends on storage
+# statistics (see tests/sqllogic/sdb/pg/explain, which pins no joins either)
+query
+EXPLAIN SELECT * FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person) COLUMNS (a.name AS an)) ORDER BY an;
+----
+QUERY PLAN
+╭─ ORDER_BY ────────────────────────╮
+│ Order By: unnamed_subquery.an ASC │
+│ ~3 rows                           │
+╰─────────────────┬─────────────────╯
+╭─ SEQ_SCAN ──────┴─────────────────╮
+│ Table: pgq_person                 │
+│ Type: Sequential Scan             │
+│ Projections: name                 │
+│ ~0 rows                           │
+╰───────────────────────────────────╯
+
+
+# a connection opened after CREATE sees the graph
+connection c2 user=postgres
+query
+SELECT * FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person)-[k:pgq_knows]->(b:pgq_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	b
+a	c
+b	c
+
+
+statement ok
+DROP PROPERTY GRAPH pgq_g;
+
+
+statement error
+SELECT * FROM GRAPH_TABLE (pgq_g MATCH (a:pgq_person) COLUMNS (a.name));
+
+
+statement error
+DROP PROPERTY GRAPH pgq_g;
+
+
+query
+SELECT count(*) AS c FROM __duckpgq_internal;
+----
+c
+0
+
+
+statement ok
+DROP TABLE pgq_knows;
+
+
+statement ok
+DROP TABLE pgq_person;

--- a/tests/sqllogic/sdb/pg/pgq/quantifiers.test
+++ b/tests/sqllogic/sdb/pg/pgq/quantifiers.test
@@ -1,0 +1,177 @@
+# Edge-pattern quantifiers on GRAPH_TABLE MATCH: *, +, ?, {n}, {n,m}, {n,},
+# {,m}, {0,m}, a bare bounded quantifier without a search prefix, and the
+# lower > upper error. Graph: chain a->b->c->d->e plus shortcut a->d, so
+# bounds and shortest-path lengths separate (d is 1 hop via the shortcut,
+# 3 hops via the chain). Under ANY SHORTEST the bounds filter the SHORTEST
+# path length: {2,3} excludes d because its shortest path is 1.
+# Each query has an EXPLAIN twin pinning that the rewrite also plans.
+
+statement ok
+CREATE TABLE qt_person (id BIGINT, name VARCHAR);
+
+
+statement count 5
+INSERT INTO qt_person VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+
+statement ok
+CREATE TABLE qt_knows (src BIGINT, dst BIGINT);
+
+
+statement count 5
+INSERT INTO qt_knows VALUES (1, 2), (2, 3), (3, 4), (4, 5), (1, 4);
+
+
+statement ok
+CREATE PROPERTY GRAPH qt_g
+  VERTEX TABLES (qt_person)
+  EDGE TABLES (qt_knows SOURCE KEY (src) REFERENCES qt_person (id)
+                        DESTINATION KEY (dst) REFERENCES qt_person (id));
+
+
+# * : zero or more, includes the zero-length path to the start vertex
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->*(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+a	0
+b	1
+c	2
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->*(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# + : one or more
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->+(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+b	1
+c	2
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->+(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# ? : at most one hop; the zero-length path is not produced
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='c')-[k:qt_knows]->?(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+d	1
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='c')-[k:qt_knows]->?(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# {n} : fixed length
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{2}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+c	2
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{2}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# {n,m} : d is excluded, its shortest path (the a->d shortcut) is below the
+# lower bound
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{2,3}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+c	2
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{2,3}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# {n,} : open upper bound
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{1,}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+b	1
+c	2
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{1,}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# {,m} : open lower bound includes the zero-length path
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{,2}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+a	0
+b	1
+c	2
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{,2}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# {0,m} : explicit zero lower bound, same as {,m}
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{0,2}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+a	0
+b	1
+c	2
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{0,2}(b:qt_person) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# bounded quantifier without a path variable or search prefix
+query
+SELECT * FROM GRAPH_TABLE (qt_g MATCH (a:qt_person WHERE a.name='a')-[k:qt_knows]->{1,2}(b:qt_person) COLUMNS (b.name AS bn)) ORDER BY bn;
+----
+bn
+b
+c
+d
+e
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (qt_g MATCH (a:qt_person WHERE a.name='a')-[k:qt_knows]->{1,2}(b:qt_person) COLUMNS (b.name AS bn)) ORDER BY bn;
+
+
+statement error
+SELECT * FROM GRAPH_TABLE (qt_g MATCH p = ANY SHORTEST (a:qt_person WHERE a.name='a')-[k:qt_knows]->{3,2}(b:qt_person) COLUMNS (b.name AS bn));
+
+
+statement ok
+DROP PROPERTY GRAPH qt_g;
+
+
+statement ok
+DROP TABLE qt_knows;
+
+
+statement ok
+DROP TABLE qt_person;

--- a/tests/sqllogic/sdb/pg/pgq/scorers.test
+++ b/tests/sqllogic/sdb/pg/pgq/scorers.test
@@ -1,0 +1,187 @@
+# Scorers and vector search through GRAPH_TABLE over an index relation with a
+# text column and an ivf vector column in one inverted index. BM25 binds
+# through the pattern variable (BM25(a.tableoid)) and runs as a scored
+# IRESEARCH_SCAN; ANN top-k composes by joining the match with an
+# ORDER BY <-> LIMIT subquery over the index relation (Top pushed into the
+# scan); a distance range predicate inside a pattern works as a plain filter.
+# All bios are two tokens (dl == avgdl), so the BM25 scores are exact.
+
+statement ok
+SET profiling_renderer_settings = {'deterministic': true};
+
+
+# for the pinned EXPLAIN below: these optimizers key on storage-dependent
+# statistics that arrive with the background segment flush, so their output
+# is not stable between a fresh and a reused server
+statement ok
+SET disabled_optimizers = 'compressed_materialization,join_order,statistics_propagation';
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY sc_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true,
+    norm = true
+);
+
+
+statement ok
+CREATE TABLE sc_person (id BIGINT PRIMARY KEY, name VARCHAR, bio VARCHAR, emb FLOAT[3]);
+
+
+statement ok
+CREATE INDEX sc_idx ON sc_person USING inverted(id, bio sc_en, emb ivf (metric = 'l2'));
+
+
+statement count 3
+INSERT INTO sc_person VALUES
+  (1, 'a', 'quick fox', [1, 0, 0]::FLOAT[3]),
+  (2, 'b', 'lazy dog', [0, 1, 0]::FLOAT[3]),
+  (3, 'c', 'quick turtle', [0, 0, 1]::FLOAT[3]);
+
+
+statement ok
+CREATE TABLE sc_knows (src BIGINT, dst BIGINT);
+
+
+statement count 3
+INSERT INTO sc_knows VALUES (1, 2), (2, 3), (1, 3);
+
+
+statement ok
+VACUUM (REFRESH_TABLE) sc_person;
+
+
+# EXPLAIN over property-graph DDL is not supported
+statement error
+EXPLAIN CREATE PROPERTY GRAPH sc_g
+  VERTEX TABLES (sc_idx)
+  EDGE TABLES (sc_knows SOURCE KEY (src) REFERENCES sc_idx (id)
+                        DESTINATION KEY (dst) REFERENCES sc_idx (id));
+
+
+statement ok
+CREATE PROPERTY GRAPH sc_g
+  VERTEX TABLES (sc_idx)
+  EDGE TABLES (sc_knows SOURCE KEY (src) REFERENCES sc_idx (id)
+                        DESTINATION KEY (dst) REFERENCES sc_idx (id));
+
+
+# BM25 scoped to a pattern variable, scored inside the match
+query
+SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx WHERE a.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, BM25(a.tableoid) AS s)) ORDER BY an;
+----
+an	s
+a	0.47000366
+c	0.47000366
+
+
+# join-free: the plan is a scored inverted-index scan
+query
+EXPLAIN SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx WHERE a.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, BM25(a.tableoid) AS s)) ORDER BY an;
+----
+QUERY PLAN
+╭─ ORDER_BY ─────────────────────────────╮
+│ Order By: unnamed_subquery.an ASC      │
+│ ~1 row                                 │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: sc_idx                          │
+│ Lookup: table                          │
+│ Index Filter:                          │
+│ ╭─ Term ─────────────╮                 │
+│ │ Field: bio(string) │                 │
+│ │ Value: quick       │                 │
+│ ╰────────────────────╯                 │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Projections: name,                     │
+│              sdb_inverted_index_score  │
+│ ~0 rows                                │
+╰────────────────────────────────────────╯
+
+
+# only pattern variables are visible inside COLUMNS
+statement error
+SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx WHERE a.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, BM25(sc_idx.tableoid) AS s)) ORDER BY an;
+
+
+statement error
+EXPLAIN SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx WHERE a.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, BM25(sc_idx.tableoid) AS s)) ORDER BY an;
+
+
+statement ok
+EXPLAIN SELECT gt.an, s.sc FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx) COLUMNS (a.name AS an, b.id AS bid)) gt JOIN (SELECT id, BM25(sc_idx.tableoid) AS sc FROM sc_idx WHERE bio @@ ts_phrase('quick')) s ON gt.bid = s.id ORDER BY an, sc;
+
+
+# BM25 computed over the index relation, joined onto match results
+query
+SELECT gt.an, s.sc FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx) COLUMNS (a.name AS an, b.id AS bid)) gt JOIN (SELECT id, BM25(sc_idx.tableoid) AS sc FROM sc_idx WHERE bio @@ ts_phrase('quick')) s ON gt.bid = s.id ORDER BY an, sc;
+----
+an	sc
+a	0.47000366
+b	0.47000366
+
+
+statement ok
+EXPLAIN SELECT gt.an, gt.bn FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx) COLUMNS (a.name AS an, b.name AS bn, b.id AS bid)) gt JOIN (SELECT id FROM sc_idx ORDER BY emb <-> [0.0, 0.0, 1.0]::FLOAT[3] LIMIT 1) s ON gt.bid = s.id ORDER BY an;
+
+
+# ANN top-k over the index relation, joined onto the match: edges into the
+# vertex nearest to the query vector
+query
+SELECT gt.an, gt.bn FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx) COLUMNS (a.name AS an, b.name AS bn, b.id AS bid)) gt JOIN (SELECT id FROM sc_idx ORDER BY emb <-> [0.0, 0.0, 1.0]::FLOAT[3] LIMIT 1) s ON gt.bid = s.id ORDER BY an;
+----
+an	bn
+a	c
+b	c
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx) COLUMNS (a.name AS an, b.name AS bn, b.emb AS bemb)) ORDER BY bemb <-> [0.0, 0.0, 1.0]::FLOAT[3], an LIMIT 2;
+
+
+# vector columns project through COLUMNS; distance ordering over match output
+query
+SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx) COLUMNS (a.name AS an, b.name AS bn, b.emb AS bemb)) ORDER BY bemb <-> [0.0, 0.0, 1.0]::FLOAT[3], an LIMIT 2;
+----
+an	bn	bemb
+a	c	{0,0,1}
+b	c	{0,0,1}
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx WHERE b.emb <-> [0.0, 0.0, 1.0]::FLOAT[3] < 0.5) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an;
+
+
+# distance range predicate inside a pattern (plain filter, not accelerated)
+query
+SELECT * FROM GRAPH_TABLE (sc_g MATCH (a:sc_idx)-[k:sc_knows]->(b:sc_idx WHERE b.emb <-> [0.0, 0.0, 1.0]::FLOAT[3] < 0.5) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an;
+----
+an	bn
+a	c
+b	c
+
+
+statement error
+EXPLAIN DROP PROPERTY GRAPH sc_g;
+
+
+statement ok
+DROP PROPERTY GRAPH sc_g;
+
+
+statement ok
+DROP TABLE sc_knows;
+
+
+statement ok
+DROP TABLE sc_person;
+
+
+statement ok
+DROP TEXT SEARCH DICTIONARY sc_en;

--- a/tests/sqllogic/sdb/pg/pgq/search_paths.test
+++ b/tests/sqllogic/sdb/pg/pgq/search_paths.test
@@ -1,0 +1,214 @@
+# Path-finding combined with search. The index relation exposes the store
+# rowid for table-backed indexes, so ANY SHORTEST and quantifiers run over an
+# index-relation graph directly, with @@ predicates on the path endpoints.
+# BM25 inside a path-finding COLUMNS clause is not wired through the rewrite
+# and yields 0 (pinned below); score paths by joining the match with a scored
+# index-relation subquery instead. Graph: chain a->b->c->d->e plus shortcut
+# a->d. All bios are two tokens, so the BM25 scores are exact.
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY sp_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true,
+    norm = true
+);
+
+
+statement ok
+CREATE TABLE sp_person (id BIGINT PRIMARY KEY, name VARCHAR, bio VARCHAR, emb FLOAT[3]);
+
+
+statement ok
+CREATE INDEX sp_idx ON sp_person USING inverted(id, bio sp_en, emb ivf (metric = 'l2'));
+
+
+statement count 5
+INSERT INTO sp_person VALUES
+  (1, 'a', 'quick fox', [1, 0, 0]::FLOAT[3]),
+  (2, 'b', 'lazy dog', [0, 1, 0]::FLOAT[3]),
+  (3, 'c', 'calm cat', [0, 1, 1]::FLOAT[3]),
+  (4, 'd', 'quick turtle', [0, 0, 1]::FLOAT[3]),
+  (5, 'e', 'quick crow', [1, 1, 1]::FLOAT[3]);
+
+
+statement ok
+CREATE TABLE sp_knows (src BIGINT, dst BIGINT);
+
+
+statement count 5
+INSERT INTO sp_knows VALUES (1, 2), (2, 3), (3, 4), (1, 4), (4, 5);
+
+
+statement ok
+VACUUM (REFRESH_TABLE) sp_person;
+
+
+# EXPLAIN over property-graph DDL is not supported
+statement error
+EXPLAIN CREATE PROPERTY GRAPH sp_g
+  VERTEX TABLES (sp_idx)
+  EDGE TABLES (sp_knows SOURCE KEY (src) REFERENCES sp_idx (id)
+                        DESTINATION KEY (dst) REFERENCES sp_idx (id));
+
+
+statement ok
+CREATE PROPERTY GRAPH sp_g
+  VERTEX TABLES (sp_idx)
+  EDGE TABLES (sp_knows SOURCE KEY (src) REFERENCES sp_idx (id)
+                        DESTINATION KEY (dst) REFERENCES sp_idx (id));
+
+
+statement error
+EXPLAIN CREATE PROPERTY GRAPH sp_gb
+  VERTEX TABLES (sp_person)
+  EDGE TABLES (sp_knows SOURCE KEY (src) REFERENCES sp_person (id)
+                        DESTINATION KEY (dst) REFERENCES sp_person (id));
+
+
+statement ok
+CREATE PROPERTY GRAPH sp_gb
+  VERTEX TABLES (sp_person)
+  EDGE TABLES (sp_knows SOURCE KEY (src) REFERENCES sp_person (id)
+                        DESTINATION KEY (dst) REFERENCES sp_person (id));
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.name='a')-[k:sp_knows]->*(b:sp_idx) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# shortest paths over the index-relation graph (rowid-backed CSR)
+query
+SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.name='a')-[k:sp_knows]->*(b:sp_idx) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+a	0
+b	1
+c	2
+d	1
+e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.bio @@ ts_phrase('fox'))-[k:sp_knows]->*(b:sp_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# full-text predicates on both endpoints of a shortest-path pattern
+query
+SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.bio @@ ts_phrase('fox'))-[k:sp_knows]->*(b:sp_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+an	bn	len
+a	a	0
+a	d	1
+a	e	2
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sp_g MATCH (a:sp_idx WHERE a.name='a')-[k:sp_knows]->{1,2}(b:sp_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (b.name AS bn)) ORDER BY bn;
+
+
+# bounded quantifier over the index-relation graph with a filtered endpoint
+query
+SELECT * FROM GRAPH_TABLE (sp_g MATCH (a:sp_idx WHERE a.name='a')-[k:sp_knows]->{1,2}(b:sp_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (b.name AS bn)) ORDER BY bn;
+----
+bn
+d
+e
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.name='a')-[k:sp_knows]->*(b:sp_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (b.name AS bn, path_length(p) AS len, BM25(b.tableoid) AS s)) ORDER BY bn;
+
+
+# known gap: a scorer in a path-finding COLUMNS clause is not wired through
+# the rewrite and yields 0; join a scored index-relation subquery instead
+query
+SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.name='a')-[k:sp_knows]->*(b:sp_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (b.name AS bn, path_length(p) AS len, BM25(b.tableoid) AS s)) ORDER BY bn;
+----
+bn	len	s
+a	0	0
+d	1	0
+e	2	0
+
+
+statement ok
+EXPLAIN SELECT gt.bn, gt.len, s.sc FROM GRAPH_TABLE (sp_gb MATCH p = ANY SHORTEST (a:sp_person WHERE a.name='a')-[k:sp_knows]->{1,2}(b:sp_person) COLUMNS (b.name AS bn, b.id AS bid, path_length(p) AS len)) gt JOIN (SELECT id, BM25(sp_idx.tableoid) AS sc FROM sp_idx WHERE bio @@ ts_phrase('quick')) s ON gt.bid = s.id ORDER BY bn;
+
+
+# real scores on paths: join the match with a scored index-relation subquery
+query
+SELECT gt.bn, gt.len, s.sc FROM GRAPH_TABLE (sp_gb MATCH p = ANY SHORTEST (a:sp_person WHERE a.name='a')-[k:sp_knows]->{1,2}(b:sp_person) COLUMNS (b.name AS bn, b.id AS bid, path_length(p) AS len)) gt JOIN (SELECT id, BM25(sp_idx.tableoid) AS sc FROM sp_idx WHERE bio @@ ts_phrase('quick')) s ON gt.bid = s.id ORDER BY bn;
+----
+bn	len	sc
+d	1	0.5389965
+e	2	0.5389965
+
+
+statement ok
+EXPLAIN SELECT gt.bn, gt.len FROM GRAPH_TABLE (sp_gb MATCH p = ANY SHORTEST (a:sp_person WHERE a.name='a')-[k:sp_knows]->*(b:sp_person) COLUMNS (b.name AS bn, b.id AS bid, path_length(p) AS len)) gt JOIN (SELECT id FROM sp_idx ORDER BY emb <-> [0.0, 0.0, 1.0]::FLOAT[3] LIMIT 1) s ON gt.bid = s.id;
+
+
+# shortest path to the vertex nearest the query vector (d, via the shortcut)
+query
+SELECT gt.bn, gt.len FROM GRAPH_TABLE (sp_gb MATCH p = ANY SHORTEST (a:sp_person WHERE a.name='a')-[k:sp_knows]->*(b:sp_person) COLUMNS (b.name AS bn, b.id AS bid, path_length(p) AS len)) gt JOIN (SELECT id FROM sp_idx ORDER BY emb <-> [0.0, 0.0, 1.0]::FLOAT[3] LIMIT 1) s ON gt.bid = s.id;
+----
+bn	len
+d	1
+
+
+statement count 1
+DELETE FROM sp_person WHERE id = 2;
+
+
+statement count 2
+DELETE FROM sp_knows WHERE src = 2 OR dst = 2;
+
+
+statement ok
+VACUUM (REFRESH_TABLE) sp_person;
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.name='a')-[k:sp_knows]->*(b:sp_idx) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+
+
+# rowid gaps from deletes: the index-relation CSR stays in bounds
+query
+SELECT * FROM GRAPH_TABLE (sp_g MATCH p = ANY SHORTEST (a:sp_idx WHERE a.name='a')-[k:sp_knows]->*(b:sp_idx) COLUMNS (b.name AS bn, path_length(p) AS len)) ORDER BY bn;
+----
+bn	len
+a	0
+d	1
+e	2
+
+
+statement error
+EXPLAIN DROP PROPERTY GRAPH sp_g;
+
+
+statement ok
+DROP PROPERTY GRAPH sp_g;
+
+
+statement error
+EXPLAIN DROP PROPERTY GRAPH sp_gb;
+
+
+statement ok
+DROP PROPERTY GRAPH sp_gb;
+
+
+statement ok
+DROP TABLE sp_knows;
+
+
+statement ok
+DROP TABLE sp_person;
+
+
+statement ok
+DROP TEXT SEARCH DICTIONARY sp_en;

--- a/tests/sqllogic/sdb/pg/pgq/search_tables.test
+++ b/tests/sqllogic/sdb/pg/pgq/search_tables.test
@@ -1,0 +1,214 @@
+# Property graphs over search-indexed tables. The graph is metadata over
+# ordinary tables, so an inverted index on a vertex table is orthogonal to
+# MATCH. Full-text predicates cannot appear on columns that came through the
+# GRAPH_TABLE rewrite of a base-table graph (the @@ acceleration needs a
+# direct inverted-indexed column reference); two compositions work: joining
+# the match with a filter over the index relation, or declaring the graph
+# over the index relation itself, which makes @@ predicates legal inside
+# MATCH patterns and drives the vertex scans through the inverted index.
+
+statement ok
+SET profiling_renderer_settings = {'deterministic': true};
+
+
+# for the pinned EXPLAIN below: these optimizers key on storage-dependent
+# statistics that arrive with the background segment flush, so their output
+# is not stable between a fresh and a reused server
+statement ok
+SET disabled_optimizers = 'compressed_materialization,join_order,statistics_propagation';
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY sg_en(
+    template = 'text',
+    locale = 'en_US.UTF-8',
+    case = 'none',
+    stemming = false,
+    accent = false,
+    frequency = true,
+    position = true,
+    norm = true
+);
+
+
+statement ok
+CREATE TABLE sg_person (id BIGINT PRIMARY KEY, name VARCHAR, bio VARCHAR);
+
+
+statement ok
+CREATE INDEX sg_person_idx ON sg_person USING inverted(id, bio sg_en);
+
+
+statement count 3
+INSERT INTO sg_person VALUES (1, 'a', 'likes quick foxes'), (2, 'b', 'trains lazy dogs'), (3, 'c', 'photographs quick turtles');
+
+
+statement ok
+CREATE TABLE sg_knows (src BIGINT, dst BIGINT);
+
+
+statement count 3
+INSERT INTO sg_knows VALUES (1, 2), (2, 3), (1, 3);
+
+
+statement ok
+VACUUM (REFRESH_TABLE) sg_person;
+
+
+# EXPLAIN over property-graph DDL is not supported
+statement error
+EXPLAIN CREATE PROPERTY GRAPH sg_g
+  VERTEX TABLES (sg_person)
+  EDGE TABLES (sg_knows SOURCE KEY (src) REFERENCES sg_person (id)
+                        DESTINATION KEY (dst) REFERENCES sg_person (id));
+
+
+statement ok
+CREATE PROPERTY GRAPH sg_g
+  VERTEX TABLES (sg_person)
+  EDGE TABLES (sg_knows SOURCE KEY (src) REFERENCES sg_person (id)
+                        DESTINATION KEY (dst) REFERENCES sg_person (id));
+
+
+# plain MATCH over the indexed table works like over any table
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	b
+a	c
+b	c
+
+
+# search predicate over the index relation joined with the match: edges whose
+# target's bio matches 'quick'
+statement ok
+EXPLAIN SELECT gt.an, gt.bn FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) COLUMNS (a.name AS an, b.name AS bn, b.id AS bid)) gt JOIN (SELECT id FROM sg_person_idx WHERE bio @@ ts_phrase('quick')) s ON gt.bid = s.id ORDER BY an, bn;
+
+
+query
+SELECT gt.an, gt.bn FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) COLUMNS (a.name AS an, b.name AS bn, b.id AS bid)) gt JOIN (SELECT id FROM sg_person_idx WHERE bio @@ ts_phrase('quick')) s ON gt.bid = s.id ORDER BY an, bn;
+----
+an	bn
+a	c
+b	c
+
+
+# a full-text predicate on a pattern variable is rejected: the column is no
+# longer a direct inverted-indexed reference after the rewrite
+# the rejection is execution-time: EXPLAIN still plans
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) WHERE b.bio @@ ts_phrase('quick') COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+statement error
+SELECT * FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) WHERE b.bio @@ ts_phrase('quick') COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+statement ok
+EXPLAIN SELECT an, bn FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) COLUMNS (a.name AS an, b.name AS bn, b.bio AS bbio)) WHERE bbio @@ ts_phrase('quick') ORDER BY an, bn;
+
+
+statement error
+SELECT an, bn FROM GRAPH_TABLE (sg_g MATCH (a:sg_person)-[k:sg_knows]->(b:sg_person) COLUMNS (a.name AS an, b.name AS bn, b.bio AS bbio)) WHERE bbio @@ ts_phrase('quick') ORDER BY an, bn;
+
+
+# a graph over the index relation: @@ works natively inside MATCH patterns
+statement error
+EXPLAIN CREATE PROPERTY GRAPH sg_gidx
+  VERTEX TABLES (sg_person_idx)
+  EDGE TABLES (sg_knows SOURCE KEY (src) REFERENCES sg_person_idx (id)
+                        DESTINATION KEY (dst) REFERENCES sg_person_idx (id));
+
+
+statement ok
+CREATE PROPERTY GRAPH sg_gidx
+  VERTEX TABLES (sg_person_idx)
+  EDGE TABLES (sg_knows SOURCE KEY (src) REFERENCES sg_person_idx (id)
+                        DESTINATION KEY (dst) REFERENCES sg_person_idx (id));
+
+
+# join-free single-vertex match over the index relation: the plan shows the
+# term filter running as an inverted-index scan
+query
+SELECT * FROM GRAPH_TABLE (sg_gidx MATCH (a:sg_person_idx WHERE a.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an)) ORDER BY an;
+----
+an
+a
+c
+
+
+query
+EXPLAIN SELECT * FROM GRAPH_TABLE (sg_gidx MATCH (a:sg_person_idx WHERE a.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an)) ORDER BY an;
+----
+QUERY PLAN
+╭─ ORDER_BY ────────────────────────╮
+│ Order By: unnamed_subquery.an ASC │
+│ ~1 row                            │
+╰─────────────────┬─────────────────╯
+╭─ IRESEARCH_SCAN ┴─────────────────╮
+│ Index: sg_person_idx              │
+│ Lookup: table                     │
+│ Index Filter:                     │
+│ ╭─ Term ─────────────╮            │
+│ │ Field: bio(string) │            │
+│ │ Value: quick       │            │
+│ ╰────────────────────╯            │
+│ Projections: name                 │
+│ ~0 rows                           │
+╰───────────────────────────────────╯
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sg_gidx MATCH (a:sg_person_idx)-[k:sg_knows]->(b:sg_person_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+
+
+query
+SELECT * FROM GRAPH_TABLE (sg_gidx MATCH (a:sg_person_idx)-[k:sg_knows]->(b:sg_person_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, b.name AS bn)) ORDER BY an, bn;
+----
+an	bn
+a	c
+b	c
+
+
+statement ok
+EXPLAIN SELECT * FROM GRAPH_TABLE (sg_gidx MATCH (a:sg_person_idx WHERE a.bio @@ ts_phrase('quick'))-[k:sg_knows]->(b:sg_person_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, b.name AS bn));
+
+
+query
+SELECT * FROM GRAPH_TABLE (sg_gidx MATCH (a:sg_person_idx WHERE a.bio @@ ts_phrase('quick'))-[k:sg_knows]->(b:sg_person_idx WHERE b.bio @@ ts_phrase('quick')) COLUMNS (a.name AS an, b.name AS bn));
+----
+an	bn
+a	c
+
+
+statement error
+EXPLAIN DROP PROPERTY GRAPH sg_gidx;
+
+
+statement ok
+DROP PROPERTY GRAPH sg_gidx;
+
+
+statement error
+EXPLAIN DROP PROPERTY GRAPH sg_g;
+
+
+statement ok
+DROP PROPERTY GRAPH sg_g;
+
+
+statement ok
+DROP TABLE sg_knows;
+
+
+statement ok
+DROP TABLE sg_person;
+
+
+statement ok
+DROP TEXT SEARCH DICTIONARY sg_en;

--- a/tests/sqllogic/sdb/pg/settings/show_all.test
+++ b/tests/sqllogic/sdb/pg/settings/show_all.test
@@ -14,7 +14,7 @@ allocator_flush_threshold	134217728B	Peak allocation threshold at which to flush
 allow_asterisks_in_http_paths	off	Allow '*' character in URLs users can query
 allow_community_extensions	on	Allow to load community built extensions
 allow_extensions_metadata_mismatch	off	Allow to load extensions with not compatible metadata
-allow_parser_override_extension	DEFAULT	Allow extensions to override the current parser
+allow_parser_override_extension	STRICT	Allow extensions to override the current parser
 allow_persistent_secrets	on	Allow the creation of persistent secrets, that are stored and loaded on restarts
 allow_unredacted_secrets	off	Allow printing unredacted secrets
 allow_unsigned_extensions	off	Allow to load extensions with invalid or missing signatures
@@ -350,7 +350,7 @@ allocator_flush_threshold	134217728B	Peak allocation threshold at which to flush
 allow_asterisks_in_http_paths	off	Allow '*' character in URLs users can query
 allow_community_extensions	on	Allow to load community built extensions
 allow_extensions_metadata_mismatch	off	Allow to load extensions with not compatible metadata
-allow_parser_override_extension	DEFAULT	Allow extensions to override the current parser
+allow_parser_override_extension	STRICT	Allow extensions to override the current parser
 allow_persistent_secrets	on	Allow the creation of persistent secrets, that are stored and loaded on restarts
 allow_unredacted_secrets	off	Allow printing unredacted secrets
 allow_unsigned_extensions	off	Allow to load extensions with invalid or missing signatures

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -748,6 +748,7 @@ set(BUILD_EXTENSIONS
 # these files after the BUILD_EXTENSIONS list is resolved.
 set(DUCKDB_EXTENSION_CONFIGS
     "${CMAKE_CURRENT_SOURCE_DIR}/duckdb_clickhouse/extension_config.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/duckpgq/extension_config.cmake"
     CACHE STRING
     ""
     FORCE
@@ -760,6 +761,7 @@ sdb_update_module(${GIT_EXECUTABLE} "duckdb_avro" ${CMAKE_CURRENT_SOURCE_DIR} "R
 sdb_update_module(${GIT_EXECUTABLE} "duckdb_iceberg" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
 sdb_update_module(${GIT_EXECUTABLE} "duckdb_postgres" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
 sdb_update_module(${GIT_EXECUTABLE} "duckdb_inet" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
+sdb_update_module(${GIT_EXECUTABLE} "duckpgq" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
 sdb_update_module(${GIT_EXECUTABLE} "database-connector" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
 
 # duckdb's in-tree extensions resolve their includes from directory scope (not from duckdb_static's
@@ -796,6 +798,7 @@ target_link_libraries(
         iceberg_extension
         postgres_scanner_extension
         clickhouse_scanner_extension
+        duckpgq_extension
         autocomplete_extension
         icu_extension
         inet_extension

--- a/third_party/LICENSES.md
+++ b/third_party/LICENSES.md
@@ -52,6 +52,7 @@
 * [duckdb-azure](https://github.com/duckdb/duckdb-azure)
 * [duckdb-iceberg](https://github.com/duckdb/duckdb-iceberg)
 * [duckdb-postgres](https://github.com/duckdb/postgres_scanner)
+* [duckpgq](https://github.com/cwida/duckpgq-extension)
 * [database-connector](https://github.com/duckdb/database-connector)
 * [Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp)
 * [libxml2](https://github.com/gnome/libxml2)


### PR DESCRIPTION
Vendors cwida/duckpgq-extension as the third_party/duckpgq submodule (serenedb fork, branch 'serenedb') and statically links it like the other DuckDB extensions. SQL/PGQ grammar and parse nodes live in the duckdb fork's PEG parser; duckpgq's parser_override (always on via allow_parser_override_extension=STRICT) parses with the core parser and wraps PGQ statements for its binder. Property-graph metadata persists in <session db>.public.__duckpgq_internal.

duckpgq's internal metadata connections are blessed through the new DBConfig::internal_connection_factory: CreateBlessedInternalConnection derives a ConnectionContext from the initiating session (same user and database, fresh catalog snapshot) so extension-side helper connections can reach the SereneDB catalog.

The DDL and pattern grammar follows PostgreSQL 19's SQL/PGQ surface: NODE/RELATIONSHIP as synonyms for VERTEX/EDGE, an element KEY clause (validated against the table's primary key at bind), REFERENCES without a column list (resolves to the referenced vertex table's primary key), LABEL and PROPERTIES in either order, DEFAULT LABEL, and label-only / anonymous pattern elements (`(IS person)`, `-[IS knows]->`) with deterministic generated bindings. Beyond PG19's fixed-length patterns, quantifiers, ANY SHORTEST + path_length, and search/vector/scorer integration work over both wire protocols.

Table-backed inverted-index scans project the store rowid, which makes index-relation property graphs path-finding capable: @@ predicates run natively inside MATCH patterns as IRESEARCH_SCANs, including under ANY SHORTEST and quantifiers, and BM25 binds through pattern variables. The fork also fixes ErrorData adopting an unrelated in-flight exception (which masked real binder errors inside PGQ statements), duckpgq's cross-connection registry and CSR races, and CSR sizing under deleted rows.