### PR TITLE
feat: Google service-account auth for Iceberg catalogs

### DIFF
--- a/scripts/check_submodule_pointers.py
+++ b/scripts/check_submodule_pointers.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Pre-commit hook: validate third_party submodule gitlinks.
 
-For each checked submodule the staged gitlink must
+Every staged submodule gitlink is checked, except the EXCLUDED paths
+(submodules whose remote we do not control and so cannot carry our
+version branches). For each checked submodule the staged gitlink must
   1. be reachable from one of the fork's version branches (vYYYY.MM.DD),
      i.e. the fork-side PR is merged -- not a feature-branch head, and
   2. not be older than origin/main's gitlink: its newest containing
@@ -26,10 +28,21 @@ import urllib.request
 
 VERSION_BRANCH = re.compile(r"^v20\d{2}\.\d{2}\.\d{2}$")
 
-CHECKED = {
-    "third_party/duckdb": VERSION_BRANCH,
-    "third_party/duckdb_iceberg": VERSION_BRANCH,
+EXCLUDED = {
+    "third_party/yaclib",  # upstream remote, no serenedb version branches
 }
+
+
+def checked_paths() -> list[str]:
+    out = git("ls-files", "-s")
+    if out is None:
+        return []
+    paths = []
+    for line in out.splitlines():
+        fields = line.split(None, 3)
+        if len(fields) == 4 and fields[0] == "160000" and fields[3] not in EXCLUDED:
+            paths.append(fields[3])
+    return paths
 
 
 def git(*args: str, cwd: str | None = None) -> str | None:
@@ -189,7 +202,8 @@ def validate_api(
     return result
 
 
-def check(path: str, pattern: re.Pattern, override_sha: str | None) -> bool:
+def check(path: str, override_sha: str | None) -> bool:
+    pattern = VERSION_BRANCH
     gitlink = override_sha or staged_gitlink(path)
     if gitlink is None:
         return True
@@ -238,10 +252,10 @@ parser.add_argument("--path", help="check only this submodule path")
 parser.add_argument("--sha", help="validate this sha instead of the staged gitlink")
 args, _ = parser.parse_known_args()
 
-paths = {args.path: CHECKED[args.path]} if args.path else CHECKED
+paths = [args.path] if args.path else checked_paths()
 failed = False
-for path, pattern in paths.items():
-    if not check(path, pattern, args.sha):
+for path in paths:
+    if not check(path, args.sha):
         failed = True
 
 sys.exit(1 if failed else 0)

--- a/tests/sqllogic/sdb/pg/site_docs/configuration/aws_credentials.test_slow
+++ b/tests/sqllogic/sdb/pg/site_docs/configuration/aws_credentials.test_slow
@@ -1,0 +1,75 @@
+# Configuration: AWS credentials reference.
+# Every snippet targets external AWS services, so all bodies are noops; the
+# RAW blocks are what the site renders.
+
+# DOCS_TEST: example_config
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET aws (
+#|     TYPE S3,
+#|     KEY_ID '⟨AKIA...⟩',
+#|     SECRET '⟨aws secret access key⟩',
+#|     REGION '⟨us-east-1⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_awscred_001 (i INTEGER);
+
+# DOCS_TEST: example_session
+
+# DOCS_TEST_RAW
+#| CREATE SECRET aws_temp (
+#|     TYPE S3,
+#|     KEY_ID '⟨ASIA...⟩',
+#|     SECRET '⟨temporary secret access key⟩',
+#|     SESSION_TOKEN '⟨session token⟩',
+#|     REGION '⟨us-east-1⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_awscred_002 (i INTEGER);
+
+# DOCS_TEST: example_compatible
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET minio (
+#|     TYPE S3,
+#|     KEY_ID '⟨key⟩',
+#|     SECRET '⟨secret⟩',
+#|     ENDPOINT '⟨minio.example.com:9000⟩',
+#|     URL_STYLE 'path',
+#|     USE_SSL false
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_awscred_003 (i INTEGER);
+
+# DOCS_TEST: example_scope
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET aws_finance (
+#|     TYPE S3,
+#|     KEY_ID '⟨AKIA...⟩',
+#|     SECRET '⟨secret⟩',
+#|     REGION '⟨eu-central-1⟩',
+#|     SCOPE 's3://finance-lake'
+#| );
+#|
+#| CREATE PERSISTENT SECRET aws_logs (
+#|     TYPE S3,
+#|     KEY_ID '⟨AKIA...⟩',
+#|     SECRET '⟨secret⟩',
+#|     REGION '⟨us-east-1⟩',
+#|     SCOPE 's3://log-archive'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_awscred_004 (i INTEGER);

--- a/tests/sqllogic/sdb/pg/site_docs/configuration/azure_credentials.test_slow
+++ b/tests/sqllogic/sdb/pg/site_docs/configuration/azure_credentials.test_slow
@@ -1,0 +1,87 @@
+# Configuration: Azure credentials reference.
+# Every snippet targets external Azure services, so all bodies are noops; the
+# RAW blocks are what the site renders.
+
+# DOCS_TEST: example_service_principal
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET azure (
+#|     TYPE AZURE,
+#|     PROVIDER service_principal,
+#|     TENANT_ID '⟨tenant from the az output⟩',
+#|     CLIENT_ID '⟨appId from the az output⟩',
+#|     CLIENT_SECRET '⟨password from the az output⟩',
+#|     ACCOUNT_NAME '⟨storage account⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_azcred_001 (i INTEGER);
+
+# DOCS_TEST: example_managed_identity
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET azure (
+#|     TYPE AZURE,
+#|     PROVIDER managed_identity,
+#|     ACCOUNT_NAME '⟨storage account⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_azcred_002 (i INTEGER);
+
+# DOCS_TEST: example_chain
+
+# DOCS_TEST_RAW
+#| CREATE SECRET azure (
+#|     TYPE AZURE,
+#|     PROVIDER credential_chain,
+#|     CHAIN 'cli;env',
+#|     ACCOUNT_NAME '⟨storage account⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_azcred_003 (i INTEGER);
+
+# DOCS_TEST: example_connection_string
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET azure (
+#|     TYPE AZURE,
+#|     CONNECTION_STRING '⟨DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_azcred_004 (i INTEGER);
+
+# DOCS_TEST: example_access_token
+
+# DOCS_TEST_RAW
+#| CREATE SECRET azure (
+#|     TYPE AZURE,
+#|     PROVIDER access_token,
+#|     ACCESS_TOKEN '⟨token⟩',
+#|     ACCOUNT_NAME '⟨storage account⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_azcred_005 (i INTEGER);
+
+# DOCS_TEST: example_query
+
+# DOCS_TEST_RAW
+#| SELECT count(*) FROM 'az://⟨container⟩/⟨path⟩/*.parquet';
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_azcred_006 (i INTEGER);

--- a/tests/sqllogic/sdb/pg/site_docs/configuration/iceberg_authentication.test_slow
+++ b/tests/sqllogic/sdb/pg/site_docs/configuration/iceberg_authentication.test_slow
@@ -1,0 +1,172 @@
+# Configuration: Iceberg catalog authentication reference.
+# Every snippet targets an external catalog, so all bodies are noops; the
+# RAW blocks are what the site renders.
+
+# DOCS_TEST: example_none
+
+# DOCS_TEST_RAW
+#| CREATE SERVER dev_lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse '⟨warehouse⟩',
+#|     endpoint 'http://localhost:8181',
+#|     authorization_type 'none'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_001 (i INTEGER);
+
+# DOCS_TEST: example_static_token
+
+# DOCS_TEST_RAW
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse '⟨warehouse⟩',
+#|     endpoint '⟨https://catalog.example.com/api/catalog⟩',
+#|     authorization_type 'oauth2',
+#|     token '⟨access token⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_002 (i INTEGER);
+
+# DOCS_TEST: example_client_credentials
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET catalog_oauth (
+#|     TYPE ICEBERG,
+#|     CLIENT_ID '⟨client id⟩',
+#|     CLIENT_SECRET '⟨client secret⟩',
+#|     OAUTH2_SERVER_URI '⟨https://idp.example.com/realms/lake/protocol/openid-connect/token⟩',
+#|     OAUTH2_SCOPE 'PRINCIPAL_ROLE:ALL'
+#| );
+#|
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse '⟨warehouse⟩',
+#|     endpoint '⟨https://catalog.example.com/api/catalog⟩',
+#|     secret 'catalog_oauth'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_003 (i INTEGER);
+
+# DOCS_TEST: example_google_sa
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     PROVIDER google,
+#|     CLIENT_EMAIL '⟨engine@my-project.iam.gserviceaccount.com⟩',
+#|     PRIVATE_KEY '⟨-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n⟩',
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_004 (i INTEGER);
+
+# DOCS_TEST: example_google_vm
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     PROVIDER google,
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_005 (i INTEGER);
+
+# DOCS_TEST: example_google_adc
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     OAUTH2_GRANT_TYPE 'refresh_token',
+#|     OAUTH2_SERVER_URI 'https://oauth2.googleapis.com/token',
+#|     CLIENT_ID '⟨client_id from the ADC file⟩',
+#|     CLIENT_SECRET '⟨client_secret from the ADC file⟩',
+#|     REFRESH_TOKEN '⟨refresh_token from the ADC file⟩',
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_006 (i INTEGER);
+
+# DOCS_TEST: example_sigv4_s3tables
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET aws (
+#|     TYPE S3,
+#|     KEY_ID '⟨AKIA...⟩',
+#|     SECRET '⟨aws secret access key⟩',
+#|     REGION '⟨us-east-1⟩'
+#| );
+#|
+#| CREATE SERVER tables FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse 'arn:aws:s3tables:⟨us-east-1⟩:⟨123456789012⟩:bucket/⟨my-table-bucket⟩',
+#|     endpoint_type 's3_tables',
+#|     secret 'aws'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_007 (i INTEGER);
+
+# DOCS_TEST: example_sigv4_glue
+
+# DOCS_TEST_RAW
+#| CREATE SERVER glue FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse '⟨123456789012⟩',
+#|     endpoint_type 'glue',
+#|     secret 'aws'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_008 (i INTEGER);
+
+# DOCS_TEST: example_vended
+
+# DOCS_TEST_RAW
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse '⟨warehouse⟩',
+#|     endpoint '⟨https://catalog.example.com/api/catalog⟩',
+#|     secret 'catalog_oauth'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_009 (i INTEGER);
+
+# DOCS_TEST: example_own_storage
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcs_data (
+#|     TYPE GCS,
+#|     KEY_ID '⟨GOOG1E...⟩',
+#|     SECRET '⟨hmac secret⟩'
+#| );
+#|
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse 'bl://projects/⟨my-project⟩/catalogs/⟨my-catalog⟩',
+#|     endpoint 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
+#|     secret 'gcp',
+#|     access_delegation_mode 'none'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_iceauth_010 (i INTEGER);

--- a/tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/biglake_iceberg.test_slow
+++ b/tests/sqllogic/sdb/pg/site_docs/cookbook/network_cloud_storage/biglake_iceberg.test_slow
@@ -1,0 +1,105 @@
+# Cookbook: connect to a Google BigLake (Lakehouse) Iceberg REST catalog.
+# Every snippet needs live Google Cloud, so all bodies are noops; the RAW
+# blocks are what the site renders.
+
+# DOCS_TEST: example_secret_sa
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     PROVIDER google,
+#|     CLIENT_EMAIL '⟨engine@my-project.iam.gserviceaccount.com⟩',
+#|     PRIVATE_KEY '⟨-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n⟩',
+#|     PRIVATE_KEY_ID '⟨a1b2c3d4...⟩',
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_001 (i INTEGER);
+
+# DOCS_TEST: example_secret_vm
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     PROVIDER google,
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_002 (i INTEGER);
+
+# DOCS_TEST: example_secret_adc
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcp (
+#|     TYPE ICEBERG,
+#|     OAUTH2_GRANT_TYPE 'refresh_token',
+#|     OAUTH2_SERVER_URI 'https://oauth2.googleapis.com/token',
+#|     CLIENT_ID '⟨client_id from the ADC file⟩',
+#|     CLIENT_SECRET '⟨client_secret from the ADC file⟩',
+#|     REFRESH_TOKEN '⟨refresh_token from the ADC file⟩',
+#|     EXTRA_HTTP_HEADERS MAP {'x-goog-user-project': '⟨my-project⟩'}
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_003 (i INTEGER);
+
+# DOCS_TEST: example_secret_hmac
+
+# DOCS_TEST_RAW
+#| CREATE PERSISTENT SECRET gcs_data (
+#|     TYPE GCS,
+#|     KEY_ID '⟨GOOG1E...⟩',
+#|     SECRET '⟨hmac secret⟩'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_004 (i INTEGER);
+
+# DOCS_TEST: example_server
+
+# DOCS_TEST_RAW
+#| CREATE SERVER lake FOREIGN DATA WRAPPER iceberg_fdw OPTIONS (
+#|     warehouse 'bl://projects/⟨my-project⟩/catalogs/⟨my-catalog⟩',
+#|     endpoint 'https://biglake.googleapis.com/iceberg/v1/restcatalog',
+#|     secret 'gcp',
+#|     access_delegation_mode 'none'
+#| );
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_005 (i INTEGER);
+
+# DOCS_TEST: example_query
+
+# DOCS_TEST_RAW
+#| SELECT count(*) FROM lake.⟨namespace⟩.⟨table⟩;
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_006 (i INTEGER);
+
+# DOCS_TEST: example_write
+
+# DOCS_TEST_RAW
+#| CREATE SCHEMA lake.analytics;
+#|
+#| CREATE TABLE lake.analytics.events (id INTEGER, payload TEXT);
+#|
+#| INSERT INTO lake.analytics.events VALUES (1, 'hello iceberg');
+
+# DOCS_TEST_BODY
+
+statement ok
+CREATE TABLE __docs_noop_biglake_007 (i INTEGER);


### PR DESCRIPTION
Bumps duckdb_iceberg to pull in serenedb/duckdb-iceberg#10: CREATE SECRET (TYPE ICEBERG, PROVIDER google) with service-account-key (RS256 jwt-bearer) and GCE metadata-server modes — auto-renewing BigLake catalog tokens under a machine identity, no user credentials involved.

Also adds the site_docs snippet sources for the new 'Iceberg catalog authentication' docs page and the updated BigLake cookbook (serenedb/serenedb-site PR to follow).

Verified live against a real BigLake catalog (attach via bl:// warehouse, 3.24M-row read, forced-expiry re-mint mid-session) and against a mock Google token endpoint that validates the JWT signature.