### PR TITLE
feat: Lucene query syntax, and the search bugs it uncovered

### DIFF
--- a/libs/iresearch/include/iresearch/formats/posting/reader.hpp
+++ b/libs/iresearch/include/iresearch/formats/posting/reader.hpp
@@ -229,8 +229,7 @@ class PostingsReaderImpl final : public PostingsReaderBase {
  private:
   DocIterator::ptr PruningIterator(IndexFeatures field_features,
                                    std::span<const PostingCookie> metas,
-                                   IteratorFieldOptions options,
-                                   ScoreMergeType type) const;
+                                   IteratorFieldOptions options) const;
 
   template<typename FieldTraits, typename Factory>
   static DocIterator::ptr IteratorImpl(IndexFeatures enabled,
@@ -449,7 +448,7 @@ auto ResolveScoreBoundType(IndexFeatures field_features, bool has_score_bounds,
 template<typename FormatTraits>
 DocIterator::ptr PostingsReaderImpl<FormatTraits>::PruningIterator(
   IndexFeatures field_features, std::span<const PostingCookie> metas,
-  IteratorFieldOptions options, ScoreMergeType type) const {
+  IteratorFieldOptions options) const {
   SDB_IF_FAILURE("irs::PruningIterator") {
     THROW_SQL_ERROR(ERR_MSG("intentional debug error"));
   }
@@ -511,13 +510,18 @@ DocIterator::ptr PostingsReaderImpl<FormatTraits>::Iterator(
   // (2) the field has score bounds persisted,
   // (3) the field exposes Freq,
   // (4) the query doesn't need positional/offset data,
-  // (5) min_match is 1.
+  // (5) min_match is 1,
+  // (6) there is nothing to merge, or the query adds its terms up --
+  //     `MaxScoreIterator` bounds a sum, and a query that takes the best of
+  //     its terms instead (a fuzzy one) would be scored as something else
+  //     entirely. Such a query still prunes, in the weak disjunction below,
+  //     which merges the way it was asked to.
   if (options.score_prune && options.has_score_bounds &&
       IndexFeatures::None != (field_features & IndexFeatures::Freq) &&
       IndexFeatures::None ==
         (required_features & (IndexFeatures::Pos | IndexFeatures::Offs)) &&
-      min_match == 1) {
-    return PruningIterator(field_features, metas, options, type);
+      min_match == 1 && (metas.size() == 1 || type == ScoreMergeType::Sum)) {
+    return PruningIterator(field_features, metas, options);
   }
 
   auto make_postings_iterator = [&](const PostingCookie& cookie) {

--- a/libs/iresearch/include/iresearch/parser/lucene_lexer.cpp
+++ b/libs/iresearch/include/iresearch/parser/lucene_lexer.cpp
@@ -365,8 +365,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 28
-#define YY_END_OF_BUFFER 29
+#define YY_NUM_RULES 56
+#define YY_END_OF_BUFFER 57
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -374,15 +374,28 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[62] =
+static const flex_int16_t yy_accept[186] =
     {   0,
-        0,    0,   29,   27,    1,    1,    4,   27,   27,    6,
-        7,   23,   15,   16,   27,   18,   12,   24,   25,   25,
-       25,   25,   25,    8,   27,    9,   13,   10,   27,   11,
-       14,    1,    0,   19,    0,    2,   24,   22,    0,    0,
-       20,    0,   21,    0,   18,   26,    0,   24,    0,   25,
-       25,    0,   25,    3,    5,   25,    3,   17,    2,    4,
-        0
+        0,    0,    0,    0,    0,    0,   57,   54,    1,    1,
+        5,   41,   55,   18,   19,   52,   37,   38,   55,   40,
+       28,   34,   36,   35,   53,   31,   54,   54,   54,   54,
+       20,   55,   55,   29,   54,   21,   55,   30,   48,   43,
+       43,   42,   47,   48,   49,   45,   27,   22,   27,   27,
+       23,   24,   54,   51,   53,    0,    1,    2,    3,   53,
+        0,    0,   50,    0,   54,   40,   32,   33,   54,   54,
+        4,    6,   54,   54,    4,    0,   30,   48,   46,   47,
+        0,   43,   47,    0,   48,   48,    0,   45,   27,   22,
+       27,    0,   27,   25,   39,    3,    5,    0,   30,   44,
+
+       45,   26,   26,    0,   26,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   26,   17,   17,   17,   17,    9,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,    7,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   17,    8,   17,   17,   11,   17,
+       17,   13,   17,   17,   12,   17,   17,   17,   17,   14,
+       17,   15,   16,   10,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -392,15 +405,15 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    4,    5,    1,    1,    1,    6,    1,    7,
         8,    9,   10,    1,   11,   12,   13,   14,   14,   14,
-       14,   14,   14,   14,   14,   14,   14,   15,    1,    1,
-        1,    1,   16,    1,   17,   18,   18,   19,   18,   18,
-       18,   18,   18,   18,   18,   18,   18,   20,   21,   18,
-       18,   22,   18,   23,   18,   18,   18,   18,   18,   18,
-       24,   25,   26,   27,   18,    1,   18,   18,   18,   18,
+       14,   14,   14,   14,   14,   14,   14,   15,    1,   16,
+       17,   18,   19,   20,   21,   22,   22,   23,   22,   22,
+       24,   22,   22,   22,   22,   25,   22,   26,   27,   22,
+       22,   28,   22,   29,   22,   22,   30,   22,   22,   22,
+       31,   32,   33,   34,   22,    1,   35,   22,   36,   37,
 
-       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
-       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
-       18,   18,   28,   29,   30,   31,    1,    1,    1,    1,
+       38,   39,   40,   41,   42,   22,   22,   43,   44,   45,
+       46,   47,   22,   48,   49,   50,   51,   22,   52,   53,
+       54,   55,   56,   57,   58,   59,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -417,76 +430,190 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[32] =
+static const YY_CHAR yy_meta[60] =
     {   0,
-        1,    1,    1,    2,    2,    2,    2,    2,    3,    2,
-        2,    1,    2,    4,    2,    3,    4,    4,    4,    4,
-        4,    4,    4,    2,    3,    2,    2,    2,    2,    2,
-        2
+        1,    2,    3,    4,    5,    1,    4,    4,    1,    1,
+        1,    1,    4,    6,    4,    4,    4,    4,    1,    4,
+        6,    6,    6,    6,    6,    6,    6,    6,    6,    6,
+        4,    1,    7,    4,    6,    6,    6,    6,    6,    6,
+        6,    6,    6,    6,    6,    6,    6,    6,    6,    6,
+        6,    6,    6,    6,    6,    4,    1,    7,    5
     } ;
 
-static const flex_int16_t yy_base[72] =
+static const flex_int16_t yy_base[198] =
     {   0,
-        0,    0,   88,  116,   30,   32,  116,   31,   81,  116,
-      116,   28,  116,  116,   25,   48,  116,   30,   38,   36,
-       65,   63,   62,  116,    0,  116,  116,  116,   51,  116,
-      116,   38,   54,  116,   75,  116,   65,   66,    0,   59,
-      116,   74,    0,   62,    0,   37,    0,    0,    0,    0,
-       29,    0,   20,    0,    0,    0,  116,   28,    0,    0,
-      116,   91,   93,   97,   99,  101,  104,  106,  108,  110,
-      112
+        0,    0,   58,   66,   71,   76,  406,   74,   62,   84,
+       86,  462,  399,  462,  462,  372,   89,   92,   69,   99,
+      462,  386,  462,  369,  353,  462,   88,  103,  114,  117,
+      462,    0,  462,  462,  118,  462,  327,  107,  119,  100,
+      113,  462,  351,  134,  150,  127,    0,  154,  156,  355,
+      462,  462,  145,  349,  348,  213,  165,  462,  462,  347,
+      271,  147,  462,  375,  161,  162,  462,  462,  163,  178,
+      164,  181,  192,  193,  462,  363,  191,  213,  344,  343,
+      160,  182,  342,  233,  234,  245,  359,  192,    0,  189,
+      265,  218,  278,    0,  276,  230,  233,  268,  358,  307,
+
+      357,    0,  462,  229,  329,    0,  320,  318,  333,  327,
+      318,  324,  319,  321,  231,   41,  305,  306,  310,  320,
+      308,  309,  311,  315,  314,  296,  298,  314,  310,  312,
+      298,  308,  309,  308,  288,  306,  298,  302,  293,  289,
+      277,  275,  281,  281,  260,  257,  149,  254,  263,  252,
+      259,    0,  256,  255,  244,  239,  210,  208,  219,  217,
+      202,  191,  191,  187,  190,    0,  168,  150,    0,  121,
+       99,    0,   99,   91,    0,   86,   73,   55,   52,    0,
+       33,    0,    0,    0,  462,  387,  394,  401,  407,  413,
+      420,  427,  434,  441,  447,  454,   56
+
     } ;
 
-static const flex_int16_t yy_def[72] =
+static const flex_int16_t yy_def[198] =
     {   0,
-       61,    1,   61,   61,   61,   61,   61,   62,   61,   61,
-       61,   63,   61,   61,   64,   61,   61,   65,   66,   66,
-       20,   20,   20,   61,   67,   61,   61,   61,   61,   61,
-       61,   61,   62,   61,   62,   61,   65,   63,   68,   64,
-       61,   64,   37,   61,   16,   16,   69,   37,   70,   20,
-       20,   71,   20,   20,   20,   20,   61,   61,   20,   20,
-        0,   61,   61,   61,   61,   61,   61,   61,   61,   61,
-       61
+      185,    1,  186,  186,  187,  187,  185,  188,  185,  185,
+      185,  185,  185,  185,  185,  189,  185,  185,  190,  188,
+      185,  185,  185,  185,  189,  185,  188,  188,  188,  188,
+      185,  191,  185,  185,  188,  185,  185,  185,  192,  185,
+      185,  185,  193,  192,  192,  185,  194,  185,  195,  194,
+      185,  185,  188,  189,  189,  188,  185,  185,  185,  189,
+      189,  190,  185,  190,  188,  188,  185,  185,  188,  188,
+      188,  188,  188,  188,  185,  185,  185,  192,  193,  193,
+      192,  185,  193,  193,  192,  192,  185,  185,  194,  185,
+      195,  196,  195,  194,  188,  188,  188,  197,  185,  192,
+
+      185,  194,  185,  196,  195,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  196,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,  197,  197,  197,  197,  197,  197,
+      197,  197,  197,  197,    0,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185
+
     } ;
 
-static const flex_int16_t yy_nxt[148] =
+static const flex_int16_t yy_nxt[522] =
     {   0,
-        4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
-       14,    4,   15,   16,   17,   18,   19,   20,   20,   21,
-       22,   20,   23,   24,   25,   26,   27,   28,   29,   30,
-       31,   32,   32,   32,   32,   34,   37,   41,   37,   32,
-       32,   58,   60,   37,   43,   37,   43,   59,   61,   42,
-       46,   37,   39,   37,   49,   35,   43,   51,   34,   44,
-       52,   45,   52,   37,   46,   46,   46,   46,   46,   46,
-       46,   41,   47,   37,   37,   58,   61,   61,   35,   57,
-       37,   37,   55,   42,   54,   53,   36,   61,   61,   49,
-       39,   33,   33,   33,   33,   38,   38,   40,   40,   40,
+        8,    9,   10,   11,   12,   13,   14,   15,   16,   17,
+       18,    8,   19,   20,   21,   22,   23,   24,   25,   26,
+       27,    8,    8,    8,    8,   28,   29,    8,   30,    8,
+       31,   32,   33,   34,    8,    8,    8,    8,   35,    8,
+        8,    8,    8,    8,    8,    8,    8,    8,    8,    8,
+        8,    8,    8,    8,    8,   36,   37,   33,   38,   40,
+       41,  106,   42,   57,   57,  124,   43,   40,   41,  184,
+       42,   44,   48,   48,   43,   49,   43,   48,   48,   44,
+       49,   63,   54,  125,   43,   57,   57,   58,   58,   45,
+       58,   58,   55,   58,   58,  183,   54,   45,  183,   50,
 
-       40,   48,   48,   50,   50,   56,   56,   38,   38,   46,
-       46,   48,   48,   50,   50,    3,   61,   61,   61,   61,
-       61,   61,   61,   61,   61,   61,   61,   61,   61,   61,
-       61,   61,   61,   61,   61,   61,   61,   61,   61,   61,
-       61,   61,   61,   61,   61,   61,   61
+       64,   82,   82,   51,   50,   56,   55,   54,   51,  182,
+       65,   54,   66,   69,   82,   82,   46,   55,   76,   56,
+       77,   55,   54,  181,   46,   54,   54,   79,   52,   70,
+       56,  180,   55,   52,   56,   55,   55,   80,   87,  180,
+       88,   71,   79,   72,   85,   56,  179,   86,   56,   56,
+       81,   78,   80,   54,   78,   90,   90,   92,   92,   63,
+       89,   78,   74,   55,   78,   81,   57,   57,  178,   54,
+       54,   54,   54,   65,   95,   66,   56,  159,   64,   55,
+       55,   55,   55,   82,   82,   96,   54,   93,   92,   54,
+       90,   90,   56,   56,   56,   56,   55,  177,  160,   55,
+
+       54,   54,   76,   87,   77,   88,   97,   98,   78,   56,
+       55,   55,   56,   92,   53,  176,   53,   53,   78,   53,
+       53,   79,  103,   56,   56,   53,  175,   53,   53,   53,
+       53,   80,   53,  115,   83,  103,  174,   83,   54,  172,
+      173,   54,   79,   53,   81,   53,   53,  100,   55,  104,
+      172,   55,   80,   79,  171,   85,  170,  169,   86,  169,
+      104,   56,  104,   80,   56,   81,   92,   92,   53,  102,
+       53,   53,   60,  168,   60,   60,   81,   60,   60,   92,
+       92,  167,  105,   60,   54,   60,   60,   60,   60,   95,
+       60,   83,  166,  165,   55,  164,   93,   92,  163,  162,
+
+      161,   60,  107,   60,   60,  158,  108,   56,  157,   93,
+       92,  109,  110,  111,  112,   79,  156,  155,  113,  114,
+      100,  136,   92,  154,  153,   80,   60,  137,   60,   60,
+       92,   92,  152,  102,  151,   92,  150,  138,   81,  149,
+      148,  147,  146,  145,  144,  143,  142,  141,  140,  139,
+      135,  134,  133,  132,  131,  130,  129,  128,  127,  126,
+       93,   92,  123,  122,  121,  120,  119,  118,  117,  116,
+      101,   99,  101,   84,   84,   84,   99,  185,   61,   61,
+       61,   94,   84,   75,   61,   68,   92,   39,   39,   39,
+       39,   39,   39,   39,   47,   47,   47,   47,   47,   47,
+
+       47,   53,   67,   61,   59,  185,   53,   60,  185,  185,
+      185,  185,   60,   62,   62,   62,   62,   62,   62,   62,
+       73,   73,  185,   73,   73,   73,   73,   78,  185,  185,
+       78,  185,   78,   78,   83,  185,  185,   83,  185,   83,
+       83,   89,  185,  185,   89,   89,   89,   91,   91,   91,
+       91,   91,   91,   91,   92,   92,   92,   92,   92,   92,
+       92,    7,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185
     } ;
 
-static const flex_int16_t yy_chk[148] =
+static const flex_int16_t yy_chk[522] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    5,    5,    6,    6,    8,   12,   15,   18,   32,
-       32,   58,   53,   12,   20,   18,   19,   51,   46,   15,
-       46,   20,   12,   19,   18,    8,   16,   19,   33,   16,
-       20,   16,   19,   16,   16,   16,   16,   16,   16,   16,
-       16,   40,   16,   37,   38,   44,   42,   35,   33,   29,
-       37,   38,   23,   40,   22,   21,    9,    3,    0,   37,
-       38,   62,   62,   62,   62,   63,   63,   64,   64,   64,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    3,
+        3,  197,    3,    9,    9,  116,    3,    4,    4,  181,
+        4,    3,    5,    5,    4,    5,    3,    6,    6,    4,
+        6,   19,    8,  116,    4,   10,   10,   11,   11,    3,
+       17,   17,    8,   18,   18,  179,   27,    4,  178,    5,
 
-       64,   65,   65,   66,   66,   67,   67,   68,   68,   69,
-       69,   70,   70,   71,   71,   61,   61,   61,   61,   61,
-       61,   61,   61,   61,   61,   61,   61,   61,   61,   61,
-       61,   61,   61,   61,   61,   61,   61,   61,   61,   61,
-       61,   61,   61,   61,   61,   61,   61
+       19,   40,   40,    5,    6,    8,   27,   20,    6,  177,
+       20,   28,   20,   27,   41,   41,    3,   20,   38,   27,
+       38,   28,   29,  176,    4,   30,   35,   39,    5,   28,
+       20,  174,   29,    6,   28,   30,   35,   39,   46,  173,
+       46,   29,   44,   30,   44,   29,  171,   44,   30,   35,
+       39,   45,   44,   53,   45,   48,   48,   49,   49,   62,
+       49,   81,   35,   53,   81,   44,   57,   57,  170,   65,
+       66,   69,   71,   66,   65,   66,   53,  147,   62,   65,
+       66,   69,   71,   82,   82,   69,   70,   49,   49,   72,
+       90,   90,   65,   66,   69,   71,   70,  168,  147,   72,
+
+       73,   74,   77,   88,   77,   88,   70,   74,   45,   70,
+       73,   74,   72,   49,   56,  167,   56,   56,   81,   56,
+       56,   78,   92,   73,   74,   56,  165,   56,   56,   56,
+       56,   78,   56,  104,   84,  115,  164,   84,   96,  163,
+      162,   97,   85,   56,   78,   56,   56,   85,   96,   92,
+      161,   97,   85,   86,  160,   86,  159,  158,   86,  157,
+      104,   96,  115,   86,   97,   85,   91,   91,   56,   91,
+       56,   56,   61,  156,   61,   61,   86,   61,   61,   93,
+       93,  155,   93,   61,   95,   61,   61,   61,   61,   95,
+       61,   84,  154,  153,   95,  151,   91,   91,  150,  149,
+
+      148,   61,   98,   61,   61,  146,   98,   95,  145,   93,
+       93,   98,   98,   98,   98,  100,  144,  143,   98,   98,
+      100,  127,   91,  142,  141,  100,   61,  127,   61,   61,
+      105,  105,  140,  105,  139,   93,  138,  127,  100,  137,
+      136,  135,  134,  133,  132,  131,  130,  129,  128,  127,
+      126,  125,  124,  123,  122,  121,  120,  119,  118,  117,
+      105,  105,  114,  113,  112,  111,  110,  109,  108,  107,
+      101,   99,   87,   83,   80,   79,   76,   64,   60,   55,
+       54,   50,   43,   37,   25,   24,  105,  186,  186,  186,
+      186,  186,  186,  186,  187,  187,  187,  187,  187,  187,
+
+      187,  188,   22,   16,   13,    7,  188,  189,    0,    0,
+        0,    0,  189,  190,  190,  190,  190,  190,  190,  190,
+      191,  191,    0,  191,  191,  191,  191,  192,    0,    0,
+      192,    0,  192,  192,  193,    0,    0,  193,    0,  193,
+      193,  194,    0,    0,  194,  194,  194,  195,  195,  195,
+      195,  195,  195,  195,  196,  196,  196,  196,  196,  196,
+      196,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185,  185,  185,  185,  185,  185,  185,  185,  185,  185,
+      185
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -523,15 +650,35 @@ char *yytext;
  Copyright holder is SereneDB GmbH, Berlin, Germany
 */
 
-#include <cstdlib>
+#include <fast_float/fast_float.h>
+
 #include <cstring>
 #include <string_view>
+
 #include "lucene_parser.hpp"
 
 static YY_BUFFER_STATE current_buffer = nullptr;
 #define YY_NO_INPUT 1
+/* Inside quotes the words are words: `and` is a term there rather than an
+   operator, and a phrase is a list of parts rather than one string to be
+   taken apart afterwards. */
+
+/* Between brackets a bound is almost anything, as Lucene reads it: a date or
+   a hyphenated word is a bound there, not an expression. */
+
+/* A backslash protects whatever follows it, as Lucene's `_ESCAPED_CHAR`
+   does: the set of characters worth escaping is not the parser's to guess. */
+/* Lucene's `_TERM_START_CHAR` and `_TERM_CHAR`, which say what a term is by
+   what it is not: everything the syntax has not claimed. That is how `café`,
+   `u.s.a` and `don't` are terms, and why the characters this parser reads as
+   operators -- `@` for a minimum match, `<`, `>` and `=` for a comparison --
+   are excluded where Lucene's classic parser keeps them. A `+` or a `-` is an
+   operator only where a term begins, and `&` and `|` only where they pair. */
+/* Inside quotes the space and the quote end a word, and nothing else does. */
 
 #define INITIAL 0
+#define PHRASE_BODY 1
+#define RANGE 2
 
 #ifndef YY_NO_UNISTD_H
 /* Special case for "unistd.h", since it is non-ANSI. We include it way
@@ -780,13 +927,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 62 )
+				if ( yy_current_state >= 186 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 116 );
+		while ( yy_base[yy_current_state] != 462 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -816,90 +963,296 @@ YY_RULE_SETUP
 { /* Skip whitespace */ }
 	YY_BREAK
 case 2:
+/* rule 2 can match eol */
+*yy_cp = (yy_hold_char); /* undo effects of setting up yytext */
+YY_LINENO_REWIND_TO(yy_bp + 1);
+(yy_c_buf_p) = yy_cp = yy_bp + 1;
+YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-{ return AND; }
+{
+                              /* A lone `+`, `-` or `!` is a term: what was
+                                 pasted in is searched for, rather than read
+                                 as an operator with nothing to apply to. */
+                              yylval->sv = {yytext, 1};
+                              return TERM;
+                            }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-{ return OR; }
+{ return AND; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-{ return NOT; }
+{ return OR; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-{ return TO; }
+{ return NOT; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-{ return LPAREN; }
+{ return TO; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-{ return RPAREN; }
+{ return FN_NGRAM; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-{ return LBRACKET; }
+{ return FN_PHRASE; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-{ return RBRACKET; }
+{ return FN_OR; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-{ return LBRACE; }
+{ return FN_UNORDERED; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-{ return RBRACE; }
+{ return FN_ATLEAST; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-{ return COLON; }
+{ return FN_ORDERED; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-{ return CARET; }
+{ return FN_MAXGAPS; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-{ return TILDE; }
+{ return FN_MAXWIDTH; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-{ return PLUS; }
+{ return FN_WILDCARD; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-{ return MINUS; }
+{ return FN_FUZZY; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
 {
-                              yylval->fnum = std::strtof(yytext, nullptr);
-                              return FLOAT;
+                              /* An interval function Lucene has and this
+                                 engine has no algebra for. It is read, and
+                                 refused where it would be executed. */
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return FN_OTHER;
                             }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
+{ return LPAREN; }
+	YY_BREAK
+case 19:
+YY_RULE_SETUP
+{ return RPAREN; }
+	YY_BREAK
+case 20:
+YY_RULE_SETUP
+{ BEGIN(RANGE); return LBRACKET; }
+	YY_BREAK
+case 21:
+YY_RULE_SETUP
+{ BEGIN(RANGE); return LBRACE; }
+	YY_BREAK
+case 22:
+/* rule 22 can match eol */
+YY_RULE_SETUP
+{ /* Skip whitespace */ }
+	YY_BREAK
+case 23:
+YY_RULE_SETUP
+{ BEGIN(INITIAL); return RBRACKET; }
+	YY_BREAK
+case 24:
+YY_RULE_SETUP
+{ BEGIN(INITIAL); return RBRACE; }
+	YY_BREAK
+case 25:
+YY_RULE_SETUP
+{ return TO; }
+	YY_BREAK
+case 26:
+/* rule 26 can match eol */
+YY_RULE_SETUP
 {
-                              yylval->num = std::atoi(yytext);
+                              /* A quoted bound holds what a bare one cannot:
+                                 spaces, brackets, the word TO. */
+                              yylval->sv = {yytext + 1, static_cast<size_t>(yyleng - 2)};
+                              return TERM;
+                            }
+	YY_BREAK
+case 27:
+YY_RULE_SETUP
+{
+                              /* Anything up to the delimiter, which is how
+                                 a date or a hyphenated bound gets through. */
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return TERM;
+                            }
+	YY_BREAK
+case 28:
+YY_RULE_SETUP
+{ return COLON; }
+	YY_BREAK
+case 29:
+YY_RULE_SETUP
+{ return CARET; }
+	YY_BREAK
+case 30:
+YY_RULE_SETUP
+{
+                              /* Lucene's `FUZZY_SLOP`: an edit distance after
+                                 a term, a slop after a phrase, and the two
+                                 are one token so that `the~2` cannot read as
+                                 a fuzzy `the` beside the term `2`. */
+                              yylval->fuzzy.has_value = yyleng > 1;
+                              if (yylval->fuzzy.has_value) {
+                                fast_float::from_chars(yytext + 1,
+                                                       yytext + yyleng,
+                                                       yylval->fuzzy.value);
+                              }
+                              return FUZZY;
+                            }
+	YY_BREAK
+case 31:
+YY_RULE_SETUP
+{ return AT; }
+	YY_BREAK
+case 32:
+YY_RULE_SETUP
+{ return LE; }
+	YY_BREAK
+case 33:
+YY_RULE_SETUP
+{ return GE; }
+	YY_BREAK
+case 34:
+YY_RULE_SETUP
+{ return LT; }
+	YY_BREAK
+case 35:
+YY_RULE_SETUP
+{ return GT; }
+	YY_BREAK
+case 36:
+YY_RULE_SETUP
+{ return EQ; }
+	YY_BREAK
+case 37:
+YY_RULE_SETUP
+{ return PLUS; }
+	YY_BREAK
+case 38:
+YY_RULE_SETUP
+{ return MINUS; }
+	YY_BREAK
+case 39:
+YY_RULE_SETUP
+{
+                              fast_float::from_chars(yytext, yytext + yyleng,
+                                                     yylval->flt.value);
+                              yylval->flt.text = {yytext,
+                                                  static_cast<size_t>(yyleng)};
+                              return FLOAT;
+                            }
+	YY_BREAK
+case 40:
+YY_RULE_SETUP
+{
+                              fast_float::from_chars(yytext, yytext + yyleng,
+                                                     yylval->num.value);
+                              yylval->num.text = {yytext,
+                                                  static_cast<size_t>(yyleng)};
                               return NUMBER;
                             }
 	YY_BREAK
-case 19:
-/* rule 19 can match eol */
+case 41:
+YY_RULE_SETUP
+{ BEGIN(PHRASE_BODY); return QUOTE; }
+	YY_BREAK
+case 42:
+YY_RULE_SETUP
+{ BEGIN(INITIAL); return QUOTE; }
+	YY_BREAK
+case 43:
+/* rule 43 can match eol */
+YY_RULE_SETUP
+{ /* Skip whitespace */ }
+	YY_BREAK
+case 44:
 YY_RULE_SETUP
 {
-                              /* Quoted phrase - point to content inside quotes */
-                              yylval->sv = {yytext + 1, static_cast<size_t>(yyleng - 2)};
-                              return PHRASE;
+                              /* A gap: how far the part after it may sit from
+                                 the part before it, rather than next to it.
+                                 The pattern already said both are digits, so
+                                 neither conversion can fail. */
+                              const char* dash = std::strchr(yytext, '-');
+                              const char* end = yytext + yyleng;
+                              fast_float::from_chars(yytext, dash,
+                                                     yylval->gap.min);
+                              fast_float::from_chars(dash + 1, end,
+                                                     yylval->gap.max);
+                              return GAP;
                             }
 	YY_BREAK
-case 20:
-/* rule 20 can match eol */
+case 45:
+YY_RULE_SETUP
+{
+                              /* Lucene's `FUZZY_SLOP`: an edit distance after
+                                 a term, a slop after a phrase, and the two
+                                 are one token so that `the~2` cannot read as
+                                 a fuzzy `the` beside the term `2`. */
+                              yylval->fuzzy.has_value = yyleng > 1;
+                              if (yylval->fuzzy.has_value) {
+                                fast_float::from_chars(yytext + 1,
+                                                       yytext + yyleng,
+                                                       yylval->fuzzy.value);
+                              }
+                              return FUZZY;
+                            }
+	YY_BREAK
+case 46:
+YY_RULE_SETUP
+{
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return PREFIX;
+                            }
+	YY_BREAK
+case 47:
+YY_RULE_SETUP
+{
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return WILDCARD;
+                            }
+	YY_BREAK
+case 48:
+YY_RULE_SETUP
+{
+                              /* A word of a phrase is anything that is not a
+                                 space, a quote, or one of the characters that
+                                 mean something here -- `war-torn` and `2` are
+                                 words, and what they become is the analyzer's
+                                 answer rather than the lexer's. */
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return TERM;
+                            }
+	YY_BREAK
+case 49:
+YY_RULE_SETUP
+{
+                              /* The parser turns this into a message on the
+                                 context, which is where every other failure
+                                 to read a query is reported. */
+                              return YYUNDEF;
+                            }
+	YY_BREAK
+case 50:
+/* rule 50 can match eol */
 YY_RULE_SETUP
 {
                               /* Regex pattern - point to content inside slashes */
@@ -907,39 +1260,17 @@ YY_RULE_SETUP
                               return REGEX;
                             }
 	YY_BREAK
-case 21:
+case 51:
 YY_RULE_SETUP
 {
-                              /* Check if it's a pure prefix (ends with single *, no other wildcards) */
-                              bool has_inner_wild = false;
-                              for (int i = 0; i < yyleng - 1; i++) {
-                                  if (yytext[i] == '\\') { i++; continue; }
-                                  if (yytext[i] == '*' || yytext[i] == '?') {
-                                      has_inner_wild = true;
-                                      break;
-                                  }
-                              }
+                              /* A word with a star at its end and none
+                                 within, which is what a term character class
+                                 that holds neither `*` nor `?` already says. */
                               yylval->sv = {yytext, static_cast<size_t>(yyleng)};
-                              return has_inner_wild ? WILDCARD : PREFIX;
+                              return PREFIX;
                             }
 	YY_BREAK
-case 22:
-YY_RULE_SETUP
-{
-                              /* Check if it's a pure suffix (starts with single *, no other wildcards) */
-                              bool has_inner_wild = false;
-                              for (int i = 1; i < yyleng; i++) {
-                                  if (yytext[i] == '\\') { i++; continue; }
-                                  if (yytext[i] == '*' || yytext[i] == '?') {
-                                      has_inner_wild = true;
-                                      break;
-                                  }
-                              }
-                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
-                              return has_inner_wild ? WILDCARD : SUFFIX;
-                            }
-	YY_BREAK
-case 23:
+case 52:
 YY_RULE_SETUP
 {
                               /* Standalone star (for range bounds) */
@@ -947,40 +1278,34 @@ YY_RULE_SETUP
                               return STAR;
                             }
 	YY_BREAK
-case 24:
+case 53:
 YY_RULE_SETUP
 {
-                              /* General wildcard pattern with * or ? */
+                              /* A pattern anywhere in the word, a leading one
+                                 included -- Lucene's classic parser refuses
+                                 that one, and nothing downstream needs it to. */
                               yylval->sv = {yytext, static_cast<size_t>(yyleng)};
                               return WILDCARD;
                             }
 	YY_BREAK
-case 25:
+case 54:
 YY_RULE_SETUP
 {
                               yylval->sv = {yytext, static_cast<size_t>(yyleng)};
                               return TERM;
                             }
 	YY_BREAK
-case 26:
+case 55:
 YY_RULE_SETUP
-{
-                              /* Terms starting with digits (like dates) */
-                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
-                              return TERM;
-                            }
+{ return YYUNDEF; }
 	YY_BREAK
-case 27:
-YY_RULE_SETUP
-{
-                              std::fprintf(stderr, "Unexpected character: %c\n", yytext[0]);
-                            }
-	YY_BREAK
-case 28:
+case 56:
 YY_RULE_SETUP
 ECHO;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
+case YY_STATE_EOF(PHRASE_BODY):
+case YY_STATE_EOF(RANGE):
 	yyterminate();
 
 	case YY_END_OF_BUFFER:
@@ -1276,7 +1601,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 62 )
+			if ( yy_current_state >= 186 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1304,11 +1629,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 62 )
+		if ( yy_current_state >= 186 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 61);
+	yy_is_jam = (yy_current_state == 185);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1951,6 +2276,10 @@ void LexerSetInput(std::string_view input) {
     if (current_buffer) {
         yy_delete_buffer(current_buffer);
     }
+    /* A query that failed to parse while inside quotes left the scanner
+       there, and the one after it would be read as the rest of a phrase --
+       silently, since a word is a word in both. Every query starts outside. */
+    BEGIN(INITIAL);
     current_buffer = yy_scan_bytes(input.data(), static_cast<int>(input.size()));
 }
 

--- a/libs/iresearch/include/iresearch/parser/lucene_lexer.l
+++ b/libs/iresearch/include/iresearch/parser/lucene_lexer.l
@@ -20,9 +20,11 @@
 
 %{
 
-#include <cstdlib>
+#include <fast_float/fast_float.h>
+
 #include <cstring>
 #include <string_view>
+
 #include "lucene_parser.hpp"
 
 static YY_BUFFER_STATE current_buffer = nullptr;
@@ -33,47 +35,188 @@ static YY_BUFFER_STATE current_buffer = nullptr;
 %option noinput
 %option bison-bridge
 
+/* Inside quotes the words are words: `and` is a term there rather than an
+   operator, and a phrase is a list of parts rather than one string to be
+   taken apart afterwards. */
+%x PHRASE_BODY
+
+/* Between brackets a bound is almost anything, as Lucene reads it: a date or
+   a hyphenated word is a bound there, not an expression. */
+%x RANGE
+
 DIGIT       [0-9]
-ALPHA       [a-zA-Z_]
 ALNUM       [a-zA-Z0-9_]
 WILDCHAR    [*?]
-ESCAPED     \\[+\-&|!(){}[\]^"~*?:\\/]
+/* A backslash protects whatever follows it, as Lucene's `_ESCAPED_CHAR`
+   does: the set of characters worth escaping is not the parser's to guess. */
+ESCAPED     \\.
+/* Lucene's `_TERM_START_CHAR` and `_TERM_CHAR`, which say what a term is by
+   what it is not: everything the syntax has not claimed. That is how `café`,
+   `u.s.a` and `don't` are terms, and why the characters this parser reads as
+   operators -- `@` for a minimum match, `<`, `>` and `=` for a comparison --
+   are excluded where Lucene's classic parser keeps them. A `+` or a `-` is an
+   operator only where a term begins, and `&` and `|` only where they pair. */
+TERMSTART   ([^ \t\r\n+\-!(){}\[\]:\^"~*?\\/@<>=&|]|{ESCAPED})
+TERMCHAR    ({TERMSTART}|[+\-&|])
+/* Inside quotes the space and the quote end a word, and nothing else does. */
+PWORD       ([^ \t\r\n"~*?\\]|{ESCAPED})
 
 %%
 
 [ \t\r\n]+                  { /* Skip whitespace */ }
 
+[+\-!]/[ \t\r\n]             {
+                              /* A lone `+`, `-` or `!` is a term: what was
+                                 pasted in is searched for, rather than read
+                                 as an operator with nothing to apply to. */
+                              yylval->sv = {yytext, 1};
+                              return TERM;
+                            }
+
 "AND"|"&&"                  { return AND; }
 "OR"|"||"                   { return OR; }
 "NOT"|"!"                   { return NOT; }
 "TO"                        { return TO; }
+"fn:ngram"                  { return FN_NGRAM; }
+"fn:phrase"                 { return FN_PHRASE; }
+"fn:or"                     { return FN_OR; }
+"fn:unordered"              { return FN_UNORDERED; }
+"fn:atLeast"|"fn:atleast"   { return FN_ATLEAST; }
+"fn:ordered"                { return FN_ORDERED; }
+"fn:maxgaps"|"fn:maxGaps"   { return FN_MAXGAPS; }
+"fn:maxwidth"|"fn:maxWidth" { return FN_MAXWIDTH; }
+"fn:wildcard"               { return FN_WILDCARD; }
+"fn:fuzzyTerm"|"fn:fuzzyterm"  { return FN_FUZZY; }
+"fn:"{ALNUM}+               {
+                              /* An interval function Lucene has and this
+                                 engine has no algebra for. It is read, and
+                                 refused where it would be executed. */
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return FN_OTHER;
+                            }
 
 "("                         { return LPAREN; }
 ")"                         { return RPAREN; }
-"["                         { return LBRACKET; }
-"]"                         { return RBRACKET; }
-"{"                         { return LBRACE; }
-"}"                         { return RBRACE; }
+"["                         { BEGIN(RANGE); return LBRACKET; }
+"{"                         { BEGIN(RANGE); return LBRACE; }
+
+<RANGE>[ \t\r\n]+          { /* Skip whitespace */ }
+<RANGE>"]"                   { BEGIN(INITIAL); return RBRACKET; }
+<RANGE>"}"                   { BEGIN(INITIAL); return RBRACE; }
+<RANGE>"TO"                  { return TO; }
+
+<RANGE>\"([^\"]|\\\")+\"      {
+                              /* A quoted bound holds what a bare one cannot:
+                                 spaces, brackets, the word TO. */
+                              yylval->sv = {yytext + 1, static_cast<size_t>(yyleng - 2)};
+                              return TERM;
+                            }
+
+<RANGE>[^ \t\r\n\]}]+       {
+                              /* Anything up to the delimiter, which is how
+                                 a date or a hyphenated bound gets through. */
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return TERM;
+                            }
 ":"                         { return COLON; }
 "^"                         { return CARET; }
-"~"                         { return TILDE; }
+"~"{DIGIT}*("."{DIGIT}+)?   {
+                              /* Lucene's `FUZZY_SLOP`: an edit distance after
+                                 a term, a slop after a phrase, and the two
+                                 are one token so that `the~2` cannot read as
+                                 a fuzzy `the` beside the term `2`. */
+                              yylval->fuzzy.has_value = yyleng > 1;
+                              if (yylval->fuzzy.has_value) {
+                                fast_float::from_chars(yytext + 1,
+                                                       yytext + yyleng,
+                                                       yylval->fuzzy.value);
+                              }
+                              return FUZZY;
+                            }
+"@"                         { return AT; }
+"<="                        { return LE; }
+">="                        { return GE; }
+"<"                         { return LT; }
+">"                         { return GT; }
+"="                         { return EQ; }
 "+"                         { return PLUS; }
 "-"                         { return MINUS; }
 
 {DIGIT}+"."{DIGIT}+         {
-                              yylval->fnum = std::strtof(yytext, nullptr);
+                              fast_float::from_chars(yytext, yytext + yyleng,
+                                                     yylval->flt.value);
+                              yylval->flt.text = {yytext,
+                                                  static_cast<size_t>(yyleng)};
                               return FLOAT;
                             }
 
 {DIGIT}+                    {
-                              yylval->num = std::atoi(yytext);
+                              fast_float::from_chars(yytext, yytext + yyleng,
+                                                     yylval->num.value);
+                              yylval->num.text = {yytext,
+                                                  static_cast<size_t>(yyleng)};
                               return NUMBER;
                             }
 
-\"([^\"\\]|\\.)*\"          {
-                              /* Quoted phrase - point to content inside quotes */
-                              yylval->sv = {yytext + 1, static_cast<size_t>(yyleng - 2)};
-                              return PHRASE;
+\"                          { BEGIN(PHRASE_BODY); return QUOTE; }
+
+<PHRASE_BODY>\"             { BEGIN(INITIAL); return QUOTE; }
+
+<PHRASE_BODY>[ \t\r\n]+    { /* Skip whitespace */ }
+
+<PHRASE_BODY>{DIGIT}+"-"{DIGIT}+  {
+                              /* A gap: how far the part after it may sit from
+                                 the part before it, rather than next to it.
+                                 The pattern already said both are digits, so
+                                 neither conversion can fail. */
+                              const char* dash = std::strchr(yytext, '-');
+                              const char* end = yytext + yyleng;
+                              fast_float::from_chars(yytext, dash,
+                                                     yylval->gap.min);
+                              fast_float::from_chars(dash + 1, end,
+                                                     yylval->gap.max);
+                              return GAP;
+                            }
+
+<PHRASE_BODY>"~"{DIGIT}*("."{DIGIT}+)?  {
+                              /* Lucene's `FUZZY_SLOP`: an edit distance after
+                                 a term, a slop after a phrase, and the two
+                                 are one token so that `the~2` cannot read as
+                                 a fuzzy `the` beside the term `2`. */
+                              yylval->fuzzy.has_value = yyleng > 1;
+                              if (yylval->fuzzy.has_value) {
+                                fast_float::from_chars(yytext + 1,
+                                                       yytext + yyleng,
+                                                       yylval->fuzzy.value);
+                              }
+                              return FUZZY;
+                            }
+
+<PHRASE_BODY>{PWORD}+\*     {
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return PREFIX;
+                            }
+
+<PHRASE_BODY>{PWORD}*{WILDCHAR}({PWORD}|{WILDCHAR})*  {
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return WILDCARD;
+                            }
+
+<PHRASE_BODY>{PWORD}+       {
+                              /* A word of a phrase is anything that is not a
+                                 space, a quote, or one of the characters that
+                                 mean something here -- `war-torn` and `2` are
+                                 words, and what they become is the analyzer's
+                                 answer rather than the lexer's. */
+                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
+                              return TERM;
+                            }
+
+<PHRASE_BODY>.               {
+                              /* The parser turns this into a message on the
+                                 context, which is where every other failure
+                                 to read a query is reported. */
+                              return YYUNDEF;
                             }
 
 \/([^\/\\]|\\.)*\/          {
@@ -82,32 +225,12 @@ ESCAPED     \\[+\-&|!(){}[\]^"~*?:\\/]
                               return REGEX;
                             }
 
-({ALNUM}|{ESCAPED})+\*      {
-                              /* Check if it's a pure prefix (ends with single *, no other wildcards) */
-                              bool has_inner_wild = false;
-                              for (int i = 0; i < yyleng - 1; i++) {
-                                  if (yytext[i] == '\\') { i++; continue; }
-                                  if (yytext[i] == '*' || yytext[i] == '?') {
-                                      has_inner_wild = true;
-                                      break;
-                                  }
-                              }
+{TERMSTART}{TERMCHAR}*\*    {
+                              /* A word with a star at its end and none
+                                 within, which is what a term character class
+                                 that holds neither `*` nor `?` already says. */
                               yylval->sv = {yytext, static_cast<size_t>(yyleng)};
-                              return has_inner_wild ? WILDCARD : PREFIX;
-                            }
-
-\*({ALNUM}|{ESCAPED})+      {
-                              /* Check if it's a pure suffix (starts with single *, no other wildcards) */
-                              bool has_inner_wild = false;
-                              for (int i = 1; i < yyleng; i++) {
-                                  if (yytext[i] == '\\') { i++; continue; }
-                                  if (yytext[i] == '*' || yytext[i] == '?') {
-                                      has_inner_wild = true;
-                                      break;
-                                  }
-                              }
-                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
-                              return has_inner_wild ? WILDCARD : SUFFIX;
+                              return PREFIX;
                             }
 
 "*"                         {
@@ -116,26 +239,20 @@ ESCAPED     \\[+\-&|!(){}[\]^"~*?:\\/]
                               return STAR;
                             }
 
-({ALNUM}|{ESCAPED})*({WILDCHAR}({ALNUM}|{ESCAPED})*)+  {
-                              /* General wildcard pattern with * or ? */
+({TERMSTART}{TERMCHAR}*)?{WILDCHAR}({TERMCHAR}|{WILDCHAR})*  {
+                              /* A pattern anywhere in the word, a leading one
+                                 included -- Lucene's classic parser refuses
+                                 that one, and nothing downstream needs it to. */
                               yylval->sv = {yytext, static_cast<size_t>(yyleng)};
                               return WILDCARD;
                             }
 
-({ALPHA}|{ESCAPED})({ALNUM}|{ESCAPED})*  {
+{TERMSTART}{TERMCHAR}*      {
                               yylval->sv = {yytext, static_cast<size_t>(yyleng)};
                               return TERM;
                             }
 
-{DIGIT}+({ALNUM}|{ESCAPED})*  {
-                              /* Terms starting with digits (like dates) */
-                              yylval->sv = {yytext, static_cast<size_t>(yyleng)};
-                              return TERM;
-                            }
-
-.                           {
-                              std::fprintf(stderr, "Unexpected character: %c\n", yytext[0]);
-                            }
+.                           { return YYUNDEF; }
 
 %%
 
@@ -143,6 +260,10 @@ void LexerSetInput(std::string_view input) {
     if (current_buffer) {
         yy_delete_buffer(current_buffer);
     }
+    /* A query that failed to parse while inside quotes left the scanner
+       there, and the one after it would be read as the rest of a phrase --
+       silently, since a word is a word in both. Every query starts outside. */
+    BEGIN(INITIAL);
     current_buffer = yy_scan_bytes(input.data(), static_cast<int>(input.size()));
 }
 

--- a/libs/iresearch/include/iresearch/parser/lucene_parser.cpp
+++ b/libs/iresearch/include/iresearch/parser/lucene_parser.cpp
@@ -106,41 +106,79 @@ enum yysymbol_kind_t
   YYSYMBOL_YYerror = 1,                    /* error  */
   YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
   YYSYMBOL_TERM = 3,                       /* TERM  */
-  YYSYMBOL_PHRASE = 4,                     /* PHRASE  */
-  YYSYMBOL_REGEX = 5,                      /* REGEX  */
-  YYSYMBOL_PREFIX = 6,                     /* PREFIX  */
-  YYSYMBOL_SUFFIX = 7,                     /* SUFFIX  */
-  YYSYMBOL_WILDCARD = 8,                   /* WILDCARD  */
-  YYSYMBOL_STAR = 9,                       /* STAR  */
-  YYSYMBOL_NUMBER = 10,                    /* NUMBER  */
-  YYSYMBOL_FLOAT = 11,                     /* FLOAT  */
-  YYSYMBOL_AND = 12,                       /* AND  */
-  YYSYMBOL_OR = 13,                        /* OR  */
-  YYSYMBOL_NOT = 14,                       /* NOT  */
-  YYSYMBOL_TO = 15,                        /* TO  */
-  YYSYMBOL_LPAREN = 16,                    /* LPAREN  */
-  YYSYMBOL_RPAREN = 17,                    /* RPAREN  */
-  YYSYMBOL_LBRACKET = 18,                  /* LBRACKET  */
-  YYSYMBOL_RBRACKET = 19,                  /* RBRACKET  */
-  YYSYMBOL_LBRACE = 20,                    /* LBRACE  */
-  YYSYMBOL_RBRACE = 21,                    /* RBRACE  */
-  YYSYMBOL_COLON = 22,                     /* COLON  */
-  YYSYMBOL_CARET = 23,                     /* CARET  */
-  YYSYMBOL_TILDE = 24,                     /* TILDE  */
-  YYSYMBOL_PLUS = 25,                      /* PLUS  */
-  YYSYMBOL_MINUS = 26,                     /* MINUS  */
-  YYSYMBOL_YYACCEPT = 27,                  /* $accept  */
-  YYSYMBOL_query = 28,                     /* query  */
-  YYSYMBOL_clause_list = 29,               /* clause_list  */
-  YYSYMBOL_mod_clause = 30,                /* mod_clause  */
-  YYSYMBOL_term_expr = 31,                 /* term_expr  */
-  YYSYMBOL_32_1 = 32,                      /* $@1  */
-  YYSYMBOL_boosted_expr = 33,              /* boosted_expr  */
-  YYSYMBOL_modified_term = 34,             /* modified_term  */
-  YYSYMBOL_base_term = 35,                 /* base_term  */
-  YYSYMBOL_36_2 = 36,                      /* @2  */
-  YYSYMBOL_range_expr = 37,                /* range_expr  */
-  YYSYMBOL_range_bound = 38                /* range_bound  */
+  YYSYMBOL_REGEX = 4,                      /* REGEX  */
+  YYSYMBOL_PREFIX = 5,                     /* PREFIX  */
+  YYSYMBOL_WILDCARD = 6,                   /* WILDCARD  */
+  YYSYMBOL_STAR = 7,                       /* STAR  */
+  YYSYMBOL_NUMBER = 8,                     /* NUMBER  */
+  YYSYMBOL_FLOAT = 9,                      /* FLOAT  */
+  YYSYMBOL_GAP = 10,                       /* GAP  */
+  YYSYMBOL_AND = 11,                       /* AND  */
+  YYSYMBOL_OR = 12,                        /* OR  */
+  YYSYMBOL_NOT = 13,                       /* NOT  */
+  YYSYMBOL_TO = 14,                        /* TO  */
+  YYSYMBOL_LPAREN = 15,                    /* LPAREN  */
+  YYSYMBOL_RPAREN = 16,                    /* RPAREN  */
+  YYSYMBOL_LBRACKET = 17,                  /* LBRACKET  */
+  YYSYMBOL_RBRACKET = 18,                  /* RBRACKET  */
+  YYSYMBOL_LBRACE = 19,                    /* LBRACE  */
+  YYSYMBOL_RBRACE = 20,                    /* RBRACE  */
+  YYSYMBOL_COLON = 21,                     /* COLON  */
+  YYSYMBOL_CARET = 22,                     /* CARET  */
+  YYSYMBOL_PLUS = 23,                      /* PLUS  */
+  YYSYMBOL_MINUS = 24,                     /* MINUS  */
+  YYSYMBOL_AT = 25,                        /* AT  */
+  YYSYMBOL_QUOTE = 26,                     /* QUOTE  */
+  YYSYMBOL_LT = 27,                        /* LT  */
+  YYSYMBOL_LE = 28,                        /* LE  */
+  YYSYMBOL_GT = 29,                        /* GT  */
+  YYSYMBOL_GE = 30,                        /* GE  */
+  YYSYMBOL_EQ = 31,                        /* EQ  */
+  YYSYMBOL_FUZZY = 32,                     /* FUZZY  */
+  YYSYMBOL_FN_NGRAM = 33,                  /* FN_NGRAM  */
+  YYSYMBOL_FN_PHRASE = 34,                 /* FN_PHRASE  */
+  YYSYMBOL_FN_WILDCARD = 35,               /* FN_WILDCARD  */
+  YYSYMBOL_FN_FUZZY = 36,                  /* FN_FUZZY  */
+  YYSYMBOL_FN_OR = 37,                     /* FN_OR  */
+  YYSYMBOL_FN_UNORDERED = 38,              /* FN_UNORDERED  */
+  YYSYMBOL_FN_ATLEAST = 39,                /* FN_ATLEAST  */
+  YYSYMBOL_FN_ORDERED = 40,                /* FN_ORDERED  */
+  YYSYMBOL_FN_MAXGAPS = 41,                /* FN_MAXGAPS  */
+  YYSYMBOL_FN_MAXWIDTH = 42,               /* FN_MAXWIDTH  */
+  YYSYMBOL_FN_OTHER = 43,                  /* FN_OTHER  */
+  YYSYMBOL_YYACCEPT = 44,                  /* $accept  */
+  YYSYMBOL_query = 45,                     /* query  */
+  YYSYMBOL_clause_list = 46,               /* clause_list  */
+  YYSYMBOL_mod_clause = 47,                /* mod_clause  */
+  YYSYMBOL_term_expr = 48,                 /* term_expr  */
+  YYSYMBOL_field_prefix = 49,              /* field_prefix  */
+  YYSYMBOL_field_name = 50,                /* field_name  */
+  YYSYMBOL_boosted_expr = 51,              /* boosted_expr  */
+  YYSYMBOL_modified_term = 52,             /* modified_term  */
+  YYSYMBOL_base_term = 53,                 /* base_term  */
+  YYSYMBOL_group = 54,                     /* group  */
+  YYSYMBOL_55_1 = 55,                      /* @1  */
+  YYSYMBOL_phrase = 56,                    /* phrase  */
+  YYSYMBOL_57_2 = 57,                      /* $@2  */
+  YYSYMBOL_phrase_body = 58,               /* phrase_body  */
+  YYSYMBOL_59_3 = 59,                      /* $@3  */
+  YYSYMBOL_phrase_part = 60,               /* phrase_part  */
+  YYSYMBOL_ngram_expr = 61,                /* ngram_expr  */
+  YYSYMBOL_62_4 = 62,                      /* $@4  */
+  YYSYMBOL_63_5 = 63,                      /* $@5  */
+  YYSYMBOL_64_6 = 64,                      /* $@6  */
+  YYSYMBOL_65_7 = 65,                      /* $@7  */
+  YYSYMBOL_66_8 = 66,                      /* $@8  */
+  YYSYMBOL_67_9 = 67,                      /* $@9  */
+  YYSYMBOL_68_10 = 68,                     /* $@10  */
+  YYSYMBOL_69_11 = 69,                     /* $@11  */
+  YYSYMBOL_fn_terms = 70,                  /* fn_terms  */
+  YYSYMBOL_fn_source = 71,                 /* fn_source  */
+  YYSYMBOL_fn_args = 72,                   /* fn_args  */
+  YYSYMBOL_threshold = 73,                 /* threshold  */
+  YYSYMBOL_ngram_terms = 74,               /* ngram_terms  */
+  YYSYMBOL_range_expr = 75,                /* range_expr  */
+  YYSYMBOL_range_bound = 76                /* range_bound  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -152,7 +190,7 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 int yylex(YYSTYPE* yylval);
 void yyerror(sdb::ParserContext& ctx, const char *s);
 
-#line 155 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 193 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
 
 #ifdef short
 # undef short
@@ -264,7 +302,7 @@ typedef int yytype_uint16;
 
 
 /* Stored state numbers (used for stacks). */
-typedef yytype_int8 yy_state_t;
+typedef yytype_uint8 yy_state_t;
 
 /* State numbers in computations.  */
 typedef int yy_state_fast_t;
@@ -473,21 +511,21 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  32
+#define YYFINAL  61
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   105
+#define YYLAST   555
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  27
+#define YYNTOKENS  44
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  12
+#define YYNNTS  33
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  36
+#define YYNRULES  94
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  55
+#define YYNSTATES  167
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   281
+#define YYMAXUTOK   298
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -529,17 +567,24 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
       15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26
+      25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
+      35,    36,    37,    38,    39,    40,    41,    42,    43
 };
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint8 yyrline[] =
+static const yytype_int16 yyrline[] =
 {
-       0,    80,    80,    84,    85,    86,    87,    91,    92,    93,
-      94,    98,    99,    99,   113,   114,   115,   119,   120,   121,
-     122,   123,   127,   128,   129,   130,   131,   132,   133,   134,
-     134,   145,   147,   149,   151,   156,   157
+       0,    95,    95,    99,   100,   101,   102,   106,   107,   108,
+     109,   113,   114,   115,   118,   119,   120,   121,   125,   126,
+     130,   138,   139,   142,   149,   153,   156,   163,   164,   165,
+     166,   167,   168,   169,   170,   171,   172,   173,   174,   178,
+     178,   191,   191,   196,   197,   198,   198,   203,   204,   205,
+     206,   216,   216,   218,   218,   220,   221,   222,   223,   224,
+     228,   228,   230,   230,   232,   232,   234,   234,   239,   239,
+     241,   241,   243,   253,   254,   258,   259,   260,   261,   262,
+     263,   266,   268,   269,   270,   274,   275,   279,   280,   284,
+     286,   288,   290,   295,   296
 };
 #endif
 
@@ -555,13 +600,18 @@ static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "\"end of file\"", "error", "\"invalid token\"", "TERM", "PHRASE",
-  "REGEX", "PREFIX", "SUFFIX", "WILDCARD", "STAR", "NUMBER", "FLOAT",
-  "AND", "OR", "NOT", "TO", "LPAREN", "RPAREN", "LBRACKET", "RBRACKET",
-  "LBRACE", "RBRACE", "COLON", "CARET", "TILDE", "PLUS", "MINUS",
-  "$accept", "query", "clause_list", "mod_clause", "term_expr", "$@1",
-  "boosted_expr", "modified_term", "base_term", "@2", "range_expr",
-  "range_bound", YY_NULLPTR
+  "\"end of file\"", "error", "\"invalid token\"", "TERM", "REGEX",
+  "PREFIX", "WILDCARD", "STAR", "NUMBER", "FLOAT", "GAP", "AND", "OR",
+  "NOT", "TO", "LPAREN", "RPAREN", "LBRACKET", "RBRACKET", "LBRACE",
+  "RBRACE", "COLON", "CARET", "PLUS", "MINUS", "AT", "QUOTE", "LT", "LE",
+  "GT", "GE", "EQ", "FUZZY", "FN_NGRAM", "FN_PHRASE", "FN_WILDCARD",
+  "FN_FUZZY", "FN_OR", "FN_UNORDERED", "FN_ATLEAST", "FN_ORDERED",
+  "FN_MAXGAPS", "FN_MAXWIDTH", "FN_OTHER", "$accept", "query",
+  "clause_list", "mod_clause", "term_expr", "field_prefix", "field_name",
+  "boosted_expr", "modified_term", "base_term", "group", "@1", "phrase",
+  "$@2", "phrase_body", "$@3", "phrase_part", "ngram_expr", "$@4", "$@5",
+  "$@6", "$@7", "$@8", "$@9", "$@10", "$@11", "fn_terms", "fn_source",
+  "fn_args", "threshold", "ngram_terms", "range_expr", "range_bound", YY_NULLPTR
 };
 
 static const char *
@@ -571,26 +621,37 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-21)
+#define YYPACT_NINF (-91)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-1)
+#define YYTABLE_NINF (-21)
 
 #define yytable_value_is_error(Yyn) \
   0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-static const yytype_int8 yypact[] =
+static const yytype_int16 yypact[] =
 {
-      79,   -20,    -9,   -21,   -21,   -21,   -21,     6,   -21,    14,
-      14,     6,     6,    19,    55,   -21,   -21,   -21,     2,   -21,
-     -21,   -21,    30,    32,   -21,    79,   -21,   -21,    26,    35,
-     -21,   -21,   -21,    79,    79,   -21,    -5,     6,   -21,   -21,
-      31,    14,    14,   -21,   -21,   -21,   -21,   -21,   -21,    -3,
-       9,   -21,   -21,   -21,   -21
+     166,   200,   -91,   -91,   -91,     7,   -91,   -91,   207,   -91,
+      72,    72,   207,   207,   -91,    26,    33,    38,    46,    51,
+      59,    62,    68,    69,    70,    79,    55,   125,   -91,   -91,
+     207,    85,   -91,    76,   -91,    86,    77,   -91,   -91,   -91,
+     128,   -91,   166,   -91,   -91,   127,   129,   -91,   -91,    20,
+      27,   -91,    99,   136,   -91,   -91,   137,   -91,   138,   139,
+     -91,   -91,   166,   166,   -91,   -91,   -91,    72,    72,    72,
+      72,   -91,    27,   142,   -91,   -91,    84,    72,    72,   120,
+     -91,   -91,    28,   -91,   -91,   -91,   -91,    20,   140,   141,
+     160,     8,   512,   512,   -91,   512,   113,   114,   248,   -91,
+     -91,   -91,   -91,   -91,   -91,   123,   -91,   -91,   -14,    -9,
+     -91,   -91,   -91,   -91,   174,    40,   -91,   -91,   -91,   162,
+     -91,   -91,   -91,   -91,   -91,   -91,   -91,   289,   -91,   330,
+     512,   371,   165,   167,   -91,   -91,   -91,   -91,   -91,   -91,
+     -91,   -91,   -91,    20,   -91,     4,   -91,   -91,   -91,   -91,
+     -91,   412,   -91,   -91,   -91,   -91,   -91,   -91,   -91,   512,
+     512,   453,   494,   168,   170,   -91,   -91
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -598,89 +659,217 @@ static const yytype_int8 yypact[] =
    means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       0,    22,    23,    24,    25,    26,    27,     0,    29,     0,
-       0,     0,     0,     0,     2,     3,     7,    11,    14,    17,
-      28,    12,    18,    20,    10,     0,    35,    36,     0,     0,
-       8,     9,     1,     0,     0,     4,     0,     0,    19,    21,
-       0,     0,     0,     5,     6,    15,    16,    13,    30,     0,
-       0,    31,    33,    34,    32
+       0,    27,    31,    32,    33,    38,    28,    29,     0,    39,
+       0,     0,     0,     0,    41,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     2,     3,     7,
+       0,     0,    11,    21,    24,    36,    30,    35,    34,    25,
+       0,    10,     0,    93,    94,     0,     0,     8,     9,     0,
+       0,    53,     0,     0,    60,    62,     0,    66,     0,     0,
+      81,     1,     0,     0,     4,    13,    18,     0,     0,     0,
+       0,    19,     0,     0,    26,    12,     0,     0,     0,    47,
+      48,    49,     0,    43,    85,    86,    51,     0,     0,     0,
+       0,     0,     0,     0,    64,     0,     0,     0,     0,     5,
+       6,    14,    15,    16,    17,    22,    37,    40,     0,     0,
+      50,    45,    42,    44,     0,     0,    57,    56,    55,     0,
+      58,    75,    78,    76,    77,    79,    80,     0,    73,     0,
+       0,     0,     0,     0,    83,    84,    72,    82,    23,    89,
+      91,    92,    90,     0,    87,     0,    54,    59,    61,    74,
+      63,     0,    67,    68,    70,    46,    88,    52,    65,     0,
+       0,     0,     0,     0,     0,    69,    71
 };
 
 /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] =
+static const yytype_int16 yypgoto[] =
 {
-     -21,   -21,     4,   -13,    -4,   -21,   -21,   -21,   -21,   -21,
-     -21,   -10
+     -91,   -91,   145,    10,     9,   -91,   -91,   -91,   -91,   -91,
+     -91,   -91,     0,   -91,   101,   -91,   -63,     2,   -91,   -91,
+     -91,   -91,   -91,   -91,   -91,   -91,   -90,   -80,   -91,   119,
+     -91,   -91,   -10
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] =
+static const yytype_uint8 yydefgoto[] =
 {
-       0,    13,    14,    15,    16,    37,    17,    18,    19,    25,
-      20,    28
+       0,    26,    27,    28,    29,    30,    31,    32,    33,    34,
+      35,    42,   125,    49,    82,   143,    83,   126,   114,    87,
+      92,    93,   130,    95,   159,   160,   127,   128,    98,    86,
+     145,    38,    45
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_int8 yytable[] =
+static const yytype_int16 yytable[] =
 {
-      29,    35,    21,    24,    22,    45,    46,    30,    31,     1,
-       2,     3,     4,     5,     6,    23,    51,    26,    52,    32,
-      43,    44,     8,    27,     9,    36,    10,    35,    53,    40,
-      54,    49,    50,    47,     1,     2,     3,     4,     5,     6,
-      38,    41,    39,    33,    34,     7,     0,     8,    48,     9,
-      42,    10,     0,     0,     0,     0,    11,    12,     1,     2,
-       3,     4,     5,     6,     0,     0,     0,    33,    34,     7,
-       0,     8,     0,     9,     0,    10,     0,     0,     0,     0,
-      11,    12,     1,     2,     3,     4,     5,     6,     0,     0,
-       0,     0,     0,     7,     0,     8,     0,     9,     0,    10,
-       0,     0,     0,     0,    11,    12
+      36,    46,    37,   129,   139,   131,   140,   156,    36,   141,
+      37,   142,    36,    36,    37,    37,   119,    41,   137,   113,
+     157,    47,    48,    79,   120,    80,    81,    36,    40,    37,
+      36,    79,    37,    80,    81,    84,    85,    64,   111,    65,
+     151,    50,    36,    79,    37,    80,    81,   149,    51,   149,
+     111,   149,   113,    52,   112,    61,   146,   101,   102,   103,
+     104,    53,    36,    36,    37,    37,    54,   108,   109,   161,
+     162,   149,    99,   100,    55,    43,    36,    56,    37,    44,
+     155,   149,   149,    57,    58,    59,    64,     1,     2,     3,
+       4,     5,     6,     7,    60,    62,    63,     8,    72,     9,
+     107,    10,    88,    11,    89,    90,    66,    12,    13,    74,
+      14,    73,    67,    68,    69,    70,    71,    15,    16,    17,
+      18,    19,    20,    21,    22,    23,    24,    25,     1,     2,
+       3,     4,     5,     6,     7,    75,    62,    63,     8,    91,
+       9,    77,    10,    78,    11,    94,    96,    97,    12,    13,
+     106,    14,   110,   132,   133,   138,   116,   117,    15,    16,
+      17,    18,    19,    20,    21,    22,    23,    24,    25,     1,
+       2,     3,     4,     5,     6,     7,   118,   144,   147,     8,
+     153,     9,   154,    10,   165,    11,   166,    76,   115,    12,
+      13,   105,    14,     0,     0,     0,     0,     0,     0,    15,
+      16,    17,    18,    19,    20,    21,    22,    23,    24,    25,
+       1,     2,     3,     4,     5,     6,     7,     0,     0,     0,
+       0,   -20,     9,     0,    10,     0,    11,   -20,   -20,   -20,
+     -20,   -20,    39,    14,     0,     0,     0,     0,     0,     0,
+      15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
+      25,   121,   122,   123,   124,     0,   134,   135,     0,     0,
+       0,     0,     0,     0,   136,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    14,     0,     0,     0,     0,     0,
+       0,    15,    16,    17,    18,    19,    20,    21,    22,    23,
+      24,    25,   121,   122,   123,   124,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   148,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    14,     0,     0,     0,     0,
+       0,     0,    15,    16,    17,    18,    19,    20,    21,    22,
+      23,    24,    25,   121,   122,   123,   124,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   150,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    14,     0,     0,     0,
+       0,     0,     0,    15,    16,    17,    18,    19,    20,    21,
+      22,    23,    24,    25,   121,   122,   123,   124,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   152,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    14,     0,     0,
+       0,     0,     0,     0,    15,    16,    17,    18,    19,    20,
+      21,    22,    23,    24,    25,   121,   122,   123,   124,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   158,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    14,     0,
+       0,     0,     0,     0,     0,    15,    16,    17,    18,    19,
+      20,    21,    22,    23,    24,    25,   121,   122,   123,   124,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   163,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    14,
+       0,     0,     0,     0,     0,     0,    15,    16,    17,    18,
+      19,    20,    21,    22,    23,    24,    25,   121,   122,   123,
+     124,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     164,     0,     0,     0,     0,   121,   122,   123,   124,     0,
+      14,     0,     0,     0,     0,     0,     0,    15,    16,    17,
+      18,    19,    20,    21,    22,    23,    24,    25,    14,     0,
+       0,     0,     0,     0,     0,    15,    16,    17,    18,    19,
+      20,    21,    22,    23,    24,    25
 };
 
-static const yytype_int8 yycheck[] =
+static const yytype_int16 yycheck[] =
 {
-      10,    14,    22,     7,    24,    10,    11,    11,    12,     3,
-       4,     5,     6,     7,     8,    24,    19,     3,    21,     0,
-      33,    34,    16,     9,    18,    23,    20,    40,    19,    25,
-      21,    41,    42,    37,     3,     4,     5,     6,     7,     8,
-      10,    15,    10,    12,    13,    14,    -1,    16,    17,    18,
-      15,    20,    -1,    -1,    -1,    -1,    25,    26,     3,     4,
-       5,     6,     7,     8,    -1,    -1,    -1,    12,    13,    14,
-      -1,    16,    -1,    18,    -1,    20,    -1,    -1,    -1,    -1,
-      25,    26,     3,     4,     5,     6,     7,     8,    -1,    -1,
-      -1,    -1,    -1,    14,    -1,    16,    -1,    18,    -1,    20,
-      -1,    -1,    -1,    -1,    25,    26
+       0,    11,     0,    93,    18,    95,    20,     3,     8,    18,
+       8,    20,    12,    13,    12,    13,     8,     8,    98,    82,
+      16,    12,    13,     3,    16,     5,     6,    27,    21,    27,
+      30,     3,    30,     5,     6,     8,     9,    27,    10,    30,
+     130,    15,    42,     3,    42,     5,     6,   127,    15,   129,
+      10,   131,   115,    15,    26,     0,    16,    67,    68,    69,
+      70,    15,    62,    63,    62,    63,    15,    77,    78,   159,
+     160,   151,    62,    63,    15,     3,    76,    15,    76,     7,
+     143,   161,   162,    15,    15,    15,    76,     3,     4,     5,
+       6,     7,     8,     9,    15,    11,    12,    13,    22,    15,
+      16,    17,     3,    19,     5,     6,    21,    23,    24,    32,
+      26,    25,    27,    28,    29,    30,    31,    33,    34,    35,
+      36,    37,    38,    39,    40,    41,    42,    43,     3,     4,
+       5,     6,     7,     8,     9,     7,    11,    12,    13,     3,
+      15,    14,    17,    14,    19,     8,     8,     8,    23,    24,
+       8,    26,    32,    40,    40,    32,    16,    16,    33,    34,
+      35,    36,    37,    38,    39,    40,    41,    42,    43,     3,
+       4,     5,     6,     7,     8,     9,    16,     3,    16,    13,
+      15,    15,    15,    17,    16,    19,    16,    42,    87,    23,
+      24,    72,    26,    -1,    -1,    -1,    -1,    -1,    -1,    33,
+      34,    35,    36,    37,    38,    39,    40,    41,    42,    43,
+       3,     4,     5,     6,     7,     8,     9,    -1,    -1,    -1,
+      -1,    21,    15,    -1,    17,    -1,    19,    27,    28,    29,
+      30,    31,    32,    26,    -1,    -1,    -1,    -1,    -1,    -1,
+      33,    34,    35,    36,    37,    38,    39,    40,    41,    42,
+      43,     3,     4,     5,     6,    -1,     8,     9,    -1,    -1,
+      -1,    -1,    -1,    -1,    16,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    26,    -1,    -1,    -1,    -1,    -1,
+      -1,    33,    34,    35,    36,    37,    38,    39,    40,    41,
+      42,    43,     3,     4,     5,     6,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    16,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    26,    -1,    -1,    -1,    -1,
+      -1,    -1,    33,    34,    35,    36,    37,    38,    39,    40,
+      41,    42,    43,     3,     4,     5,     6,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    16,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    26,    -1,    -1,    -1,
+      -1,    -1,    -1,    33,    34,    35,    36,    37,    38,    39,
+      40,    41,    42,    43,     3,     4,     5,     6,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    16,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    26,    -1,    -1,
+      -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    41,    42,    43,     3,     4,     5,     6,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    16,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    26,    -1,
+      -1,    -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,
+      38,    39,    40,    41,    42,    43,     3,     4,     5,     6,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    16,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    26,
+      -1,    -1,    -1,    -1,    -1,    -1,    33,    34,    35,    36,
+      37,    38,    39,    40,    41,    42,    43,     3,     4,     5,
+       6,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      16,    -1,    -1,    -1,    -1,     3,     4,     5,     6,    -1,
+      26,    -1,    -1,    -1,    -1,    -1,    -1,    33,    34,    35,
+      36,    37,    38,    39,    40,    41,    42,    43,    26,    -1,
+      -1,    -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,
+      38,    39,    40,    41,    42,    43
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,     3,     4,     5,     6,     7,     8,    14,    16,    18,
-      20,    25,    26,    28,    29,    30,    31,    33,    34,    35,
-      37,    22,    24,    24,    31,    36,     3,     9,    38,    38,
-      31,    31,     0,    12,    13,    30,    23,    32,    10,    10,
-      29,    15,    15,    30,    30,    10,    11,    31,    17,    38,
-      38,    19,    21,    19,    21
+       0,     3,     4,     5,     6,     7,     8,     9,    13,    15,
+      17,    19,    23,    24,    26,    33,    34,    35,    36,    37,
+      38,    39,    40,    41,    42,    43,    45,    46,    47,    48,
+      49,    50,    51,    52,    53,    54,    56,    61,    75,    32,
+      21,    48,    55,     3,     7,    76,    76,    48,    48,    57,
+      15,    15,    15,    15,    15,    15,    15,    15,    15,    15,
+      15,     0,    11,    12,    47,    48,    21,    27,    28,    29,
+      30,    31,    22,    25,    32,     7,    46,    14,    14,     3,
+       5,     6,    58,    60,     8,     9,    73,    63,     3,     5,
+       6,     3,    64,    65,     8,    67,     8,     8,    72,    47,
+      47,    76,    76,    76,    76,    73,     8,    16,    76,    76,
+      32,    10,    26,    60,    62,    58,    16,    16,    16,     8,
+      16,     3,     4,     5,     6,    56,    61,    70,    71,    70,
+      66,    70,    40,    40,     8,     9,    16,    71,    32,    18,
+      20,    18,    20,    59,     3,    74,    16,    16,    16,    71,
+      16,    70,    16,    15,    15,    60,     3,    16,    16,    68,
+      69,    70,    70,    16,    16,    16,    16
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    27,    28,    29,    29,    29,    29,    30,    30,    30,
-      30,    31,    32,    31,    33,    33,    33,    34,    34,    34,
-      34,    34,    35,    35,    35,    35,    35,    35,    35,    36,
-      35,    37,    37,    37,    37,    38,    38
+       0,    44,    45,    46,    46,    46,    46,    47,    47,    47,
+      47,    48,    48,    48,    48,    48,    48,    48,    49,    49,
+      50,    51,    51,    51,    52,    52,    52,    53,    53,    53,
+      53,    53,    53,    53,    53,    53,    53,    53,    53,    55,
+      54,    57,    56,    58,    58,    59,    58,    60,    60,    60,
+      60,    62,    61,    63,    61,    61,    61,    61,    61,    61,
+      64,    61,    65,    61,    66,    61,    67,    61,    68,    61,
+      69,    61,    61,    70,    70,    71,    71,    71,    71,    71,
+      71,    72,    72,    72,    72,    73,    73,    74,    74,    75,
+      75,    75,    75,    76,    76
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr2[] =
 {
        0,     2,     1,     1,     2,     3,     3,     1,     2,     2,
-       2,     1,     0,     4,     1,     3,     3,     1,     2,     3,
-       2,     3,     1,     1,     1,     1,     1,     1,     1,     0,
-       4,     5,     5,     5,     5,     1,     1
+       2,     1,     3,     2,     3,     3,     3,     3,     2,     2,
+       1,     1,     3,     4,     1,     2,     2,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     3,     1,     0,
+       4,     0,     4,     1,     2,     0,     4,     1,     1,     1,
+       2,     0,     6,     0,     5,     4,     4,     4,     4,     5,
+       0,     5,     0,     5,     0,     6,     0,     5,     0,     9,
+       0,     9,     4,     1,     2,     1,     1,     1,     1,     1,
+       1,     0,     2,     2,     2,     1,     1,     1,     2,     5,
+       5,     5,     5,     1,     1
 };
 
 
@@ -1152,208 +1341,513 @@ yyreduce:
   switch (yyn)
     {
   case 3: /* clause_list: mod_clause  */
-#line 84 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 99 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::Or); }
-#line 1157 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1346 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 4: /* clause_list: clause_list mod_clause  */
-#line 85 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 100 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::Or); }
-#line 1163 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1352 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 5: /* clause_list: clause_list AND mod_clause  */
-#line 86 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 101 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::And); }
-#line 1169 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1358 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 6: /* clause_list: clause_list OR mod_clause  */
-#line 87 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 102 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::Or); }
-#line 1175 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1364 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 7: /* mod_clause: term_expr  */
-#line 91 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 106 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::None; }
-#line 1181 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1370 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 8: /* mod_clause: PLUS term_expr  */
-#line 92 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 107 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::Required; }
-#line 1187 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1376 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 9: /* mod_clause: MINUS term_expr  */
-#line 93 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 108 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::Not; }
-#line 1193 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1382 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 10: /* mod_clause: NOT term_expr  */
-#line 94 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 109 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::Not; }
-#line 1199 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1388 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 12: /* $@1: %empty  */
-#line 99 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 11: /* term_expr: boosted_expr  */
+#line 113 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].filter); }
+#line 1394 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 12: /* term_expr: STAR COLON STAR  */
+#line 114 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddAll(); }
+#line 1400 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 13: /* term_expr: field_prefix term_expr  */
+#line 115 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].filter); }
+#line 1406 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 14: /* term_expr: field_name LT range_bound  */
+#line 118 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddRange("*", (yyvsp[0].sv), false, false); }
+#line 1412 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 15: /* term_expr: field_name LE range_bound  */
+#line 119 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddRange("*", (yyvsp[0].sv), false, true); }
+#line 1418 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 16: /* term_expr: field_name GT range_bound  */
+#line 120 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddRange((yyvsp[0].sv), "*", false, false); }
+#line 1424 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 17: /* term_expr: field_name GE range_bound  */
+#line 121 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddRange((yyvsp[0].sv), "*", true, false); }
+#line 1430 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 20: /* field_name: TERM  */
+#line 130 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     {
-                                      if (ctx.strict_field &&
-                                          std::string_view{(yyvsp[-1].sv)} !=
-                                              ctx.default_field_name) {
-                                        ctx.error_message =
-                                          "field-prefix in strict-field mode "
-                                          "must match the default field";
+                                      if (!ctx.CheckField((yyvsp[0].sv))) {
                                         YYABORT;
                                       }
                                     }
-#line 1214 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1440 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 15: /* boosted_expr: modified_term CARET NUMBER  */
-#line 114 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyvsp[-2].filter)->boost(static_cast<float>((yyvsp[0].num))); }
-#line 1220 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
-    break;
-
-  case 16: /* boosted_expr: modified_term CARET FLOAT  */
-#line 115 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyvsp[-2].filter)->boost((yyvsp[0].fnum)); }
-#line 1226 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
-    break;
-
-  case 17: /* modified_term: base_term  */
-#line 119 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 21: /* boosted_expr: modified_term  */
+#line 138 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1232 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1446 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 18: /* modified_term: TERM TILDE  */
-#line 120 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddFuzzy((yyvsp[-1].sv), 2); }
-#line 1238 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+  case 22: /* boosted_expr: modified_term CARET threshold  */
+#line 139 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyvsp[-2].filter)->boost((yyvsp[0].fnum)); (yyval.filter) = (yyvsp[-2].filter); }
+#line 1452 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 19: /* modified_term: TERM TILDE NUMBER  */
-#line 121 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddFuzzy((yyvsp[-2].sv), (yyvsp[0].num)); }
-#line 1244 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+  case 23: /* boosted_expr: modified_term CARET threshold FUZZY  */
+#line 143 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyvsp[-3].filter)->boost((yyvsp[-1].fnum));
+                                      (yyval.filter) = &ctx.ApplyFuzzy((yyvsp[-3].filter), (yyvsp[0].fuzzy).has_value,
+                                                           (yyvsp[0].fuzzy).value); }
+#line 1460 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 20: /* modified_term: PHRASE TILDE  */
-#line 122 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddPhrase((yyvsp[-1].sv), 0); }
-#line 1250 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+  case 24: /* modified_term: base_term  */
+#line 149 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].filter); }
+#line 1466 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 21: /* modified_term: PHRASE TILDE NUMBER  */
-#line 123 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddPhrase((yyvsp[-2].sv), (yyvsp[0].num)); }
-#line 1256 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+  case 25: /* modified_term: TERM FUZZY  */
+#line 153 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].fuzzy).has_value
+                                          ? &ctx.AddFuzzySimilarity((yyvsp[-1].sv), (yyvsp[0].fuzzy).value)
+                                          : &ctx.AddFuzzy((yyvsp[-1].sv), 2); }
+#line 1474 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 22: /* base_term: TERM  */
-#line 127 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 26: /* modified_term: phrase FUZZY  */
+#line 156 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { if ((yyvsp[0].fuzzy).has_value) {
+                                        ctx.SetSlop((yyvsp[-1].filter), static_cast<int>((yyvsp[0].fuzzy).value));
+                                      }
+                                      (yyval.filter) = (yyvsp[-1].filter); }
+#line 1483 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 27: /* base_term: TERM  */
+#line 163 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddTerm((yyvsp[0].sv)); }
-#line 1262 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1489 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 23: /* base_term: PHRASE  */
-#line 128 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddPhrase((yyvsp[0].sv), 0); }
-#line 1268 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+  case 28: /* base_term: NUMBER  */
+#line 164 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddTerm((yyvsp[0].num).text); }
+#line 1495 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 24: /* base_term: REGEX  */
-#line 129 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddWildcard((yyvsp[0].sv)); }
-#line 1274 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+  case 29: /* base_term: FLOAT  */
+#line 165 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddTerm((yyvsp[0].flt).text); }
+#line 1501 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 25: /* base_term: PREFIX  */
-#line 130 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddPrefix((yyvsp[0].sv)); }
-#line 1280 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
-    break;
-
-  case 26: /* base_term: SUFFIX  */
-#line 131 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddWildcard((yyvsp[0].sv)); }
-#line 1286 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
-    break;
-
-  case 27: /* base_term: WILDCARD  */
-#line 132 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
-                                    { (yyval.filter) = &ctx.AddWildcard((yyvsp[0].sv)); }
-#line 1292 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
-    break;
-
-  case 28: /* base_term: range_expr  */
-#line 133 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 30: /* base_term: phrase  */
+#line 166 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1298 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1507 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 29: /* @2: %empty  */
-#line 134 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 31: /* base_term: REGEX  */
+#line 167 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddRegex((yyvsp[0].sv)); }
+#line 1513 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 32: /* base_term: PREFIX  */
+#line 168 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddPrefix((yyvsp[0].sv)); }
+#line 1519 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 33: /* base_term: WILDCARD  */
+#line 169 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddWildcard((yyvsp[0].sv)); }
+#line 1525 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 34: /* base_term: range_expr  */
+#line 170 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].filter); }
+#line 1531 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 35: /* base_term: ngram_expr  */
+#line 171 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].filter); }
+#line 1537 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 36: /* base_term: group  */
+#line 172 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = (yyvsp[0].filter); }
+#line 1543 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 37: /* base_term: group AT NUMBER  */
+#line 173 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.SetMinMatch((yyvsp[-2].filter), (yyvsp[0].num).value); (yyval.filter) = (yyvsp[-2].filter); }
+#line 1549 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 38: /* base_term: STAR  */
+#line 174 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.AddFieldExists(); }
+#line 1555 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 39: /* @1: %empty  */
+#line 178 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     {
                                       (yyval.filter) = ctx.current_root;
                                       ctx.current_root = &ctx.current_root->GetOptional().add<irs::MixedBooleanFilter>();
                                     }
-#line 1307 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1564 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 30: /* base_term: LPAREN @2 clause_list RPAREN  */
-#line 138 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 40: /* group: LPAREN @1 clause_list RPAREN  */
+#line 182 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     {
                                       (yyval.filter) = ctx.current_root;
                                       ctx.current_root = sdb::basics::downCast<irs::MixedBooleanFilter>((yyvsp[-2].filter));
                                     }
-#line 1316 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1573 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 31: /* range_expr: LBRACKET range_bound TO range_bound RBRACKET  */
-#line 146 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 41: /* $@2: %empty  */
+#line 191 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginPhrase(); }
+#line 1579 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 42: /* phrase: QUOTE $@2 phrase_body QUOTE  */
+#line 192 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndPhrase(); }
+#line 1585 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 45: /* $@3: %empty  */
+#line 198 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.SetGap((yyvsp[0].gap).min, (yyvsp[0].gap).max); }
+#line 1591 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 47: /* phrase_part: TERM  */
+#line 203 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddPhraseTerm((yyvsp[0].sv)); }
+#line 1597 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 48: /* phrase_part: PREFIX  */
+#line 204 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddPhrasePrefix((yyvsp[0].sv)); }
+#line 1603 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 49: /* phrase_part: WILDCARD  */
+#line 205 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddPhraseWildcard((yyvsp[0].sv)); }
+#line 1609 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 50: /* phrase_part: TERM FUZZY  */
+#line 206 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddPhraseFuzzy(
+                                        (yyvsp[-1].sv), (yyvsp[0].fuzzy).has_value
+                                              ? static_cast<int>((yyvsp[0].fuzzy).value)
+                                              : 2); }
+#line 1618 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 51: /* $@4: %empty  */
+#line 216 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginNGram((yyvsp[0].fnum)); }
+#line 1624 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 52: /* ngram_expr: FN_NGRAM LPAREN threshold $@4 ngram_terms RPAREN  */
+#line 217 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndNGram(); }
+#line 1630 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 53: /* $@5: %empty  */
+#line 218 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginPhrase(); }
+#line 1636 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 54: /* ngram_expr: FN_PHRASE LPAREN $@5 phrase_body RPAREN  */
+#line 219 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndPhrase(); }
+#line 1642 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 55: /* ngram_expr: FN_WILDCARD LPAREN WILDCARD RPAREN  */
+#line 220 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                          { (yyval.filter) = &ctx.AddWildcard((yyvsp[-1].sv)); }
+#line 1648 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 56: /* ngram_expr: FN_WILDCARD LPAREN PREFIX RPAREN  */
+#line 221 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                          { (yyval.filter) = &ctx.AddWildcard((yyvsp[-1].sv)); }
+#line 1654 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 57: /* ngram_expr: FN_WILDCARD LPAREN TERM RPAREN  */
+#line 222 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                          { (yyval.filter) = &ctx.AddWildcard((yyvsp[-1].sv)); }
+#line 1660 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 58: /* ngram_expr: FN_FUZZY LPAREN TERM RPAREN  */
+#line 223 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                          { (yyval.filter) = &ctx.AddFuzzy((yyvsp[-1].sv), 2); }
+#line 1666 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 59: /* ngram_expr: FN_FUZZY LPAREN TERM NUMBER RPAREN  */
+#line 224 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                          { (yyval.filter) = &ctx.AddFuzzy((yyvsp[-2].sv), (yyvsp[-1].num).value); }
+#line 1672 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 60: /* $@6: %empty  */
+#line 228 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginFn(); }
+#line 1678 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 61: /* ngram_expr: FN_OR LPAREN $@6 fn_terms RPAREN  */
+#line 229 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndFnAny(); }
+#line 1684 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 62: /* $@7: %empty  */
+#line 230 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginFn(); }
+#line 1690 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 63: /* ngram_expr: FN_UNORDERED LPAREN $@7 fn_terms RPAREN  */
+#line 231 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndFnAll(); }
+#line 1696 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 64: /* $@8: %empty  */
+#line 232 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginFn(); }
+#line 1702 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 65: /* ngram_expr: FN_ATLEAST LPAREN NUMBER $@8 fn_terms RPAREN  */
+#line 233 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndFnAtLeast((yyvsp[-3].num).value); }
+#line 1708 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 66: /* $@9: %empty  */
+#line 234 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.BeginFn(); }
+#line 1714 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 67: /* ngram_expr: FN_ORDERED LPAREN $@9 fn_terms RPAREN  */
+#line 235 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndFnOrdered(); }
+#line 1720 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 68: /* $@10: %empty  */
+#line 239 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                                 { ctx.BeginFn(); }
+#line 1726 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 69: /* ngram_expr: FN_MAXGAPS LPAREN NUMBER FN_ORDERED LPAREN $@10 fn_terms RPAREN RPAREN  */
+#line 240 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndFnMaxGaps((yyvsp[-6].num).value); }
+#line 1732 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 70: /* $@11: %empty  */
+#line 241 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                                  { ctx.BeginFn(); }
+#line 1738 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 71: /* ngram_expr: FN_MAXWIDTH LPAREN NUMBER FN_ORDERED LPAREN $@11 fn_terms RPAREN RPAREN  */
+#line 242 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.filter) = &ctx.EndFnMaxWidth((yyvsp[-6].num).value); }
+#line 1744 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 72: /* ngram_expr: FN_OTHER LPAREN fn_args RPAREN  */
+#line 243 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                      { ctx.Unsupported((yyvsp[-3].sv)); (yyval.filter) = nullptr; }
+#line 1750 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 75: /* fn_source: TERM  */
+#line 258 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddFnTerm((yyvsp[0].sv)); }
+#line 1756 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 76: /* fn_source: PREFIX  */
+#line 259 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddFnOther("a prefix"); }
+#line 1762 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 77: /* fn_source: WILDCARD  */
+#line 260 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddFnOther("a wildcard"); }
+#line 1768 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 78: /* fn_source: REGEX  */
+#line 261 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddFnOther("a regular expression"); }
+#line 1774 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 79: /* fn_source: phrase  */
+#line 262 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddFnOther("a phrase"); }
+#line 1780 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 80: /* fn_source: ngram_expr  */
+#line 263 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddFnOther("a function"); }
+#line 1786 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 85: /* threshold: NUMBER  */
+#line 274 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.fnum) = static_cast<float>((yyvsp[0].num).value); }
+#line 1792 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 86: /* threshold: FLOAT  */
+#line 275 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { (yyval.fnum) = (yyvsp[0].flt).value; }
+#line 1798 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 87: /* ngram_terms: TERM  */
+#line 279 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddNGram((yyvsp[0].sv)); }
+#line 1804 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 88: /* ngram_terms: ngram_terms TERM  */
+#line 280 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+                                    { ctx.AddNGram((yyvsp[0].sv)); }
+#line 1810 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+    break;
+
+  case 89: /* range_expr: LBRACKET range_bound TO range_bound RBRACKET  */
+#line 285 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), true, true); }
-#line 1322 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1816 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 32: /* range_expr: LBRACE range_bound TO range_bound RBRACE  */
-#line 148 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 90: /* range_expr: LBRACE range_bound TO range_bound RBRACE  */
+#line 287 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), false, false); }
-#line 1328 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1822 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 33: /* range_expr: LBRACKET range_bound TO range_bound RBRACE  */
-#line 150 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 91: /* range_expr: LBRACKET range_bound TO range_bound RBRACE  */
+#line 289 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), true, false); }
-#line 1334 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1828 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 34: /* range_expr: LBRACE range_bound TO range_bound RBRACKET  */
-#line 152 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 92: /* range_expr: LBRACE range_bound TO range_bound RBRACKET  */
+#line 291 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), false, true); }
-#line 1340 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1834 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 35: /* range_bound: TERM  */
-#line 156 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 93: /* range_bound: TERM  */
+#line 295 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.sv) = (yyvsp[0].sv); }
-#line 1346 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1840 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
-  case 36: /* range_bound: STAR  */
-#line 157 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+  case 94: /* range_bound: STAR  */
+#line 296 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.sv) = (yyvsp[0].sv); }
-#line 1352 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1846 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
 
-#line 1356 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1850 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
 
       default: break;
     }
@@ -1546,7 +2040,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 160 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 299 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
 
 
 void yyerror(sdb::ParserContext& ctx, const char *s) {

--- a/libs/iresearch/include/iresearch/parser/lucene_parser.hpp
+++ b/libs/iresearch/include/iresearch/parser/lucene_parser.hpp
@@ -77,29 +77,46 @@ struct StringSpan {
     YYerror = 256,                 /* error  */
     YYUNDEF = 257,                 /* "invalid token"  */
     TERM = 258,                    /* TERM  */
-    PHRASE = 259,                  /* PHRASE  */
-    REGEX = 260,                   /* REGEX  */
-    PREFIX = 261,                  /* PREFIX  */
-    SUFFIX = 262,                  /* SUFFIX  */
-    WILDCARD = 263,                /* WILDCARD  */
-    STAR = 264,                    /* STAR  */
-    NUMBER = 265,                  /* NUMBER  */
-    FLOAT = 266,                   /* FLOAT  */
-    AND = 267,                     /* AND  */
-    OR = 268,                      /* OR  */
-    NOT = 269,                     /* NOT  */
-    TO = 270,                      /* TO  */
-    LPAREN = 271,                  /* LPAREN  */
-    RPAREN = 272,                  /* RPAREN  */
-    LBRACKET = 273,                /* LBRACKET  */
-    RBRACKET = 274,                /* RBRACKET  */
-    LBRACE = 275,                  /* LBRACE  */
-    RBRACE = 276,                  /* RBRACE  */
-    COLON = 277,                   /* COLON  */
-    CARET = 278,                   /* CARET  */
-    TILDE = 279,                   /* TILDE  */
-    PLUS = 280,                    /* PLUS  */
-    MINUS = 281                    /* MINUS  */
+    REGEX = 259,                   /* REGEX  */
+    PREFIX = 260,                  /* PREFIX  */
+    WILDCARD = 261,                /* WILDCARD  */
+    STAR = 262,                    /* STAR  */
+    NUMBER = 263,                  /* NUMBER  */
+    FLOAT = 264,                   /* FLOAT  */
+    GAP = 265,                     /* GAP  */
+    AND = 266,                     /* AND  */
+    OR = 267,                      /* OR  */
+    NOT = 268,                     /* NOT  */
+    TO = 269,                      /* TO  */
+    LPAREN = 270,                  /* LPAREN  */
+    RPAREN = 271,                  /* RPAREN  */
+    LBRACKET = 272,                /* LBRACKET  */
+    RBRACKET = 273,                /* RBRACKET  */
+    LBRACE = 274,                  /* LBRACE  */
+    RBRACE = 275,                  /* RBRACE  */
+    COLON = 276,                   /* COLON  */
+    CARET = 277,                   /* CARET  */
+    PLUS = 278,                    /* PLUS  */
+    MINUS = 279,                   /* MINUS  */
+    AT = 280,                      /* AT  */
+    QUOTE = 281,                   /* QUOTE  */
+    LT = 282,                      /* LT  */
+    LE = 283,                      /* LE  */
+    GT = 284,                      /* GT  */
+    GE = 285,                      /* GE  */
+    EQ = 286,                      /* EQ  */
+    FUZZY = 287,                   /* FUZZY  */
+    FN_NGRAM = 288,                /* FN_NGRAM  */
+    FN_PHRASE = 289,               /* FN_PHRASE  */
+    FN_WILDCARD = 290,             /* FN_WILDCARD  */
+    FN_FUZZY = 291,                /* FN_FUZZY  */
+    FN_OR = 292,                   /* FN_OR  */
+    FN_UNORDERED = 293,            /* FN_UNORDERED  */
+    FN_ATLEAST = 294,              /* FN_ATLEAST  */
+    FN_ORDERED = 295,              /* FN_ORDERED  */
+    FN_MAXGAPS = 296,              /* FN_MAXGAPS  */
+    FN_MAXWIDTH = 297,             /* FN_MAXWIDTH  */
+    FN_OTHER = 298                 /* FN_OTHER  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -111,11 +128,18 @@ union YYSTYPE
 #line 55 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
 
     StringSpan sv;
-    int num;
+    // A number is a count where one is asked for and a term everywhere else,
+    // so it carries both what it means and what it said.
+    struct { int value; StringSpan text; } num;
+    struct { bool has_value; float value; } fuzzy;
+    // A float is a threshold where one is asked for and a term everywhere
+    // else, the same way a number is.
+    struct { float value; StringSpan text; } flt;
     float fnum;
+    struct { int min; int max; } gap;
     irs::FilterWithBoost* filter;
 
-#line 118 "libs/iresearch/include/iresearch/parser/lucene_parser.hpp"
+#line 142 "libs/iresearch/include/iresearch/parser/lucene_parser.hpp"
 
 };
 typedef union YYSTYPE YYSTYPE;

--- a/libs/iresearch/include/iresearch/parser/lucene_parser.y
+++ b/libs/iresearch/include/iresearch/parser/lucene_parser.y
@@ -54,19 +54,34 @@ void yyerror(sdb::ParserContext& ctx, const char *s);
 
 %union {
     StringSpan sv;
-    int num;
+    // A number is a count where one is asked for and a term everywhere else,
+    // so it carries both what it means and what it said.
+    struct { int value; StringSpan text; } num;
+    struct { bool has_value; float value; } fuzzy;
+    // A float is a threshold where one is asked for and a term everywhere
+    // else, the same way a number is.
+    struct { float value; StringSpan text; } flt;
     float fnum;
+    struct { int min; int max; } gap;
     irs::FilterWithBoost* filter;
 }
 
-%token <sv> TERM PHRASE REGEX PREFIX SUFFIX WILDCARD STAR
+%token <sv> TERM REGEX PREFIX WILDCARD STAR
 %token <num> NUMBER
-%token <fnum> FLOAT
+%token <flt> FLOAT
+%token <gap> GAP
 %token AND OR NOT TO
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
-%token COLON CARET TILDE PLUS MINUS
+%token COLON CARET PLUS MINUS AT QUOTE LT LE GT GE EQ
+%token <fuzzy> FUZZY
+%token FN_NGRAM FN_PHRASE FN_WILDCARD FN_FUZZY
+%token FN_OR FN_UNORDERED FN_ATLEAST FN_ORDERED FN_MAXGAPS FN_MAXWIDTH
+%token <sv> FN_OTHER
 
-%type <filter> modified_term base_term range_expr
+%type <filter> term_expr boosted_expr modified_term base_term range_expr
+%type <filter> group phrase
+%type <filter> ngram_expr
+%type <fnum> threshold
 %type <sv> range_bound
 
 %left OR
@@ -95,43 +110,72 @@ mod_clause:
     ;
 
 term_expr:
-    boosted_expr
-    | TERM COLON                    {
-                                      if (ctx.strict_field &&
-                                          std::string_view{$1} !=
-                                              ctx.default_field_name) {
-                                        ctx.error_message =
-                                          "field-prefix in strict-field mode "
-                                          "must match the default field";
+    boosted_expr                    { $$ = $1; }
+    | STAR COLON STAR               { $$ = &ctx.AddAll(); }
+    | field_prefix term_expr        { $$ = $2; }
+    // What Lucene's flexible parser spells `field<5`: a range with one end
+    // left open.
+    | field_name LT range_bound     { $$ = &ctx.AddRange("*", $3, false, false); }
+    | field_name LE range_bound     { $$ = &ctx.AddRange("*", $3, false, true); }
+    | field_name GT range_bound     { $$ = &ctx.AddRange($3, "*", false, false); }
+    | field_name GE range_bound     { $$ = &ctx.AddRange($3, "*", true, false); }
+    ;
+
+field_prefix:
+    field_name COLON
+    | field_name EQ
+    ;
+
+field_name:
+    TERM                            {
+                                      if (!ctx.CheckField($1)) {
                                         YYABORT;
                                       }
                                     }
-      term_expr
     ;
 
 boosted_expr:
-    modified_term
-    | modified_term CARET NUMBER    { $1->boost(static_cast<float>($3)); }
-    | modified_term CARET FLOAT     { $1->boost($3); }
+    modified_term                   { $$ = $1; }
+    | modified_term CARET threshold { $1->boost($3); $$ = $1; }
+    // Lucene takes the two suffixes in either order, and a fuzziness read
+    // after a boost has to reach a term that is already built.
+    | modified_term CARET threshold FUZZY
+                                    { $1->boost($3);
+                                      $$ = &ctx.ApplyFuzzy($1, $4.has_value,
+                                                           $4.value); }
     ;
 
 modified_term:
     base_term                       { $$ = $1; }
-    | TERM TILDE                    { $$ = &ctx.AddFuzzy($1, 2); }
-    | TERM TILDE NUMBER             { $$ = &ctx.AddFuzzy($1, $3); }
-    | PHRASE TILDE                  { $$ = &ctx.AddPhrase($1, 0); }
-    | PHRASE TILDE NUMBER           { $$ = &ctx.AddPhrase($1, $3); }
+    // A distance of two is what a bare `~` means, and a value of one or more
+    // is that many edits where a value below one is Lucene's older
+    // similarity -- `AddFuzzySimilarity` tells them apart the way Lucene does.
+    | TERM FUZZY                    { $$ = $2.has_value
+                                          ? &ctx.AddFuzzySimilarity($1, $2.value)
+                                          : &ctx.AddFuzzy($1, 2); }
+    | phrase FUZZY                  { if ($2.has_value) {
+                                        ctx.SetSlop($1, static_cast<int>($2.value));
+                                      }
+                                      $$ = $1; }
     ;
 
 base_term:
     TERM                            { $$ = &ctx.AddTerm($1); }
-    | PHRASE                        { $$ = &ctx.AddPhrase($1, 0); }
-    | REGEX                         { $$ = &ctx.AddWildcard($1); }
+    | NUMBER                        { $$ = &ctx.AddTerm($1.text); }
+    | FLOAT                         { $$ = &ctx.AddTerm($1.text); }
+    | phrase                        { $$ = $1; }
+    | REGEX                         { $$ = &ctx.AddRegex($1); }
     | PREFIX                        { $$ = &ctx.AddPrefix($1); }
-    | SUFFIX                        { $$ = &ctx.AddWildcard($1); }
     | WILDCARD                      { $$ = &ctx.AddWildcard($1); }
     | range_expr                    { $$ = $1; }
-    | LPAREN                        {
+    | ngram_expr                    { $$ = $1; }
+    | group                         { $$ = $1; }
+    | group AT NUMBER               { ctx.SetMinMatch($1, $3.value); $$ = $1; }
+    | STAR                          { $$ = &ctx.AddFieldExists(); }
+    ;
+
+group:
+    LPAREN                          {
                                       $<filter>$ = ctx.current_root;
                                       ctx.current_root = &ctx.current_root->GetOptional().add<irs::MixedBooleanFilter>();
                                     }
@@ -139,6 +183,101 @@ base_term:
                                       $$ = ctx.current_root;
                                       ctx.current_root = sdb::basics::downCast<irs::MixedBooleanFilter>($<filter>2);
                                     }
+    ;
+
+// A phrase is a list of parts, each of them the same thing a clause outside
+// quotes may be, and a gap says how far apart two of them sit.
+phrase:
+    QUOTE                           { ctx.BeginPhrase(); }
+        phrase_body QUOTE           { $$ = &ctx.EndPhrase(); }
+    ;
+
+phrase_body:
+    phrase_part
+    | phrase_body phrase_part
+    | phrase_body GAP               { ctx.SetGap($2.min, $2.max); }
+        phrase_part
+    ;
+
+phrase_part:
+    TERM                            { ctx.AddPhraseTerm($1); }
+    | PREFIX                        { ctx.AddPhrasePrefix($1); }
+    | WILDCARD                      { ctx.AddPhraseWildcard($1); }
+    | TERM FUZZY                    { ctx.AddPhraseFuzzy(
+                                        $1, $2.has_value
+                                              ? static_cast<int>($2.value)
+                                              : 2); }
+    ;
+
+// An n-gram similarity: how much of a sequence of terms a document has to
+// carry. Lucene has no such filter, so this follows the shape its own
+// extensions take -- a named function over a parenthesized argument list.
+ngram_expr:
+    FN_NGRAM LPAREN threshold       { ctx.BeginNGram($3); }
+        ngram_terms RPAREN          { $$ = &ctx.EndNGram(); }
+    | FN_PHRASE LPAREN              { ctx.BeginPhrase(); }
+        phrase_body RPAREN          { $$ = &ctx.EndPhrase(); }
+    | FN_WILDCARD LPAREN WILDCARD RPAREN  { $$ = &ctx.AddWildcard($3); }
+    | FN_WILDCARD LPAREN PREFIX RPAREN    { $$ = &ctx.AddWildcard($3); }
+    | FN_WILDCARD LPAREN TERM RPAREN      { $$ = &ctx.AddWildcard($3); }
+    | FN_FUZZY LPAREN TERM RPAREN         { $$ = &ctx.AddFuzzy($3, 2); }
+    | FN_FUZZY LPAREN TERM NUMBER RPAREN  { $$ = &ctx.AddFuzzy($3, $4.value); }
+    // Which documents these hold is a question this engine can answer, even
+    // though it has no intervals to compose: a set of terms, joined by how
+    // many of them a document needs and in what order they must lie.
+    | FN_OR LPAREN                  { ctx.BeginFn(); }
+        fn_terms RPAREN             { $$ = &ctx.EndFnAny(); }
+    | FN_UNORDERED LPAREN           { ctx.BeginFn(); }
+        fn_terms RPAREN             { $$ = &ctx.EndFnAll(); }
+    | FN_ATLEAST LPAREN NUMBER      { ctx.BeginFn(); }
+        fn_terms RPAREN             { $$ = &ctx.EndFnAtLeast($3.value); }
+    | FN_ORDERED LPAREN             { ctx.BeginFn(); }
+        fn_terms RPAREN             { $$ = &ctx.EndFnOrdered(); }
+    // A bound on the gaps is a bound on the distance only where there is one
+    // pair to measure; over more of them it bounds their total, which a
+    // phrase cannot say.
+    | FN_MAXGAPS LPAREN NUMBER FN_ORDERED LPAREN { ctx.BeginFn(); }
+        fn_terms RPAREN RPAREN      { $$ = &ctx.EndFnMaxGaps($3.value); }
+    | FN_MAXWIDTH LPAREN NUMBER FN_ORDERED LPAREN { ctx.BeginFn(); }
+        fn_terms RPAREN RPAREN      { $$ = &ctx.EndFnMaxWidth($3.value); }
+    | FN_OTHER LPAREN fn_args RPAREN  { ctx.Unsupported($1); $$ = nullptr; }
+    ;
+
+// What an interval function is applied to, read but not acted on: the
+// argument list is consumed so the message names the function rather than
+// whatever came after it.
+// What an interval function is applied to. Lucene composes these freely;
+// here a term is a source this engine can answer for, and anything else is
+// read so that the refusal can say what it was rather than where it stopped.
+fn_terms:
+    fn_source
+    | fn_terms fn_source
+    ;
+
+fn_source:
+    TERM                            { ctx.AddFnTerm($1); }
+    | PREFIX                        { ctx.AddFnOther("a prefix"); }
+    | WILDCARD                      { ctx.AddFnOther("a wildcard"); }
+    | REGEX                         { ctx.AddFnOther("a regular expression"); }
+    | phrase                        { ctx.AddFnOther("a phrase"); }
+    | ngram_expr                    { ctx.AddFnOther("a function"); }
+    ;
+
+fn_args:
+    /* empty */
+    | fn_args fn_source
+    | fn_args NUMBER
+    | fn_args FLOAT
+    ;
+
+threshold:
+    NUMBER                          { $$ = static_cast<float>($1.value); }
+    | FLOAT                         { $$ = $1.value; }
+    ;
+
+ngram_terms:
+    TERM                            { ctx.AddNGram($1); }
+    | ngram_terms TERM              { ctx.AddNGram($2); }
     ;
 
 range_expr:

--- a/libs/iresearch/include/iresearch/parser/parser.hpp
+++ b/libs/iresearch/include/iresearch/parser/parser.hpp
@@ -133,7 +133,9 @@ struct ParserContext {
     }
     auto& f = current_root->GetOptional().add<irs::ByTerm>();
     *f.mutable_field_id() = default_field_id;
-    f.mutable_options()->term = std::move(first);
+    // A word the analyzer makes nothing of -- a lone `+` -- is searched for
+    // as it was written rather than as the empty term.
+    f.mutable_options()->term = count != 0 ? std::move(first) : text;
     return f;
   }
 
@@ -262,7 +264,7 @@ struct ParserContext {
     *f.mutable_field_id() = default_field_id;
     SDB_ASSERT(!value.empty() && value.back() == '*');
     value.remove_suffix(1);
-    f.mutable_options()->term = Analyze(value);
+    f.mutable_options()->term = Normalize(value);
     return f;
   }
 
@@ -272,7 +274,7 @@ struct ParserContext {
     // Only the literal head goes through the analyzer -- it would eat the
     // pattern characters.
     const auto wildcard = FindPattern(value);
-    auto pattern = Analyze(value.substr(0, wildcard));
+    auto pattern = Normalize(value.substr(0, wildcard));
     pattern.append(Pattern(value.substr(wildcard)));
     *f.mutable_options() = irs::ByWildcardOptions{std::move(pattern)};
     return f;
@@ -286,14 +288,14 @@ struct ParserContext {
     if (min_val == "*") {
       range.min_type = irs::BoundType::Unbounded;
     } else {
-      range.min = Analyze(min_val);
+      range.min = Normalize(min_val);
       range.min_type =
         inc_min ? irs::BoundType::Inclusive : irs::BoundType::Exclusive;
     }
     if (max_val == "*") {
       range.max_type = irs::BoundType::Unbounded;
     } else {
-      range.max = Analyze(max_val);
+      range.max = Normalize(max_val);
       range.max_type =
         inc_max ? irs::BoundType::Inclusive : irs::BoundType::Exclusive;
     }
@@ -438,6 +440,23 @@ struct ParserContext {
     return {};
   }
 
+  // What a pattern, a distance or a bound is measured against: Lucene
+  // normalizes that text rather than tokenizing it -- `Analyzer#normalize`.
+  // The analyzer here has no such mode, so its answer is taken where it is
+  // the whole of what it was given, and the text as written where it is not:
+  // a quoted bound holds spaces, and tokenizing would keep only the first
+  // word of it.
+  irs::bstring Normalize(std::string_view word) {
+    auto text = Unescape(word);
+    tokenizer->reset(irs::ViewCast<char>(irs::bytes_view{text}));
+    auto token = irs::get<irs::TermAttr>(*tokenizer);
+    if (!tokenizer->next()) {
+      return text;
+    }
+    irs::bstring first{token->value};
+    return tokenizer->next() ? text : first;
+  }
+
   // Where a part goes: next to the one before it, or as far off as a gap
   // asked. Zero is no gap rather than a gap of zero, which is what the
   // one-argument `push_back` means.
@@ -488,7 +507,7 @@ struct ParserContext {
 
   irs::ByEditDistance& AddFuzzySimilarity(std::string_view value,
                                           float similarity) {
-    return FuzzyFromSimilarity(Analyze(value), similarity);
+    return FuzzyFromSimilarity(Normalize(value), similarity);
   }
 
   irs::ByEditDistance& FuzzyFromSimilarity(irs::bstring value,
@@ -615,7 +634,7 @@ struct ParserContext {
   }
 
   irs::ByEditDistance& AddFuzzy(std::string_view value, int distance) {
-    return AddFuzzyTerm(Analyze(value), distance);
+    return AddFuzzyTerm(Normalize(value), distance);
   }
 };
 

--- a/libs/iresearch/include/iresearch/parser/parser.hpp
+++ b/libs/iresearch/include/iresearch/parser/parser.hpp
@@ -22,19 +22,25 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "iresearch/analysis/analyzer.hpp"
 #include "iresearch/analysis/token_attributes.hpp"
 #include "iresearch/analysis/tokenizer.hpp"
+#include "iresearch/search/all_filter.hpp"
 #include "iresearch/search/boolean_filter.hpp"
 #include "iresearch/search/levenshtein_filter.hpp"
 #include "iresearch/search/mixed_boolean_filter.hpp"
+#include "iresearch/search/ngram_similarity_filter.hpp"
 #include "iresearch/search/phrase_filter.hpp"
 #include "iresearch/search/prefix_filter.hpp"
 #include "iresearch/search/range_filter.hpp"
+#include "iresearch/search/regexp_filter.hpp"
 #include "iresearch/search/term_filter.hpp"
 #include "iresearch/search/wildcard_filter.hpp"
 #include "iresearch/utils/type_id.hpp"
+#include "iresearch/utils/utf8_utils.hpp"
+#include "iresearch/utils/wildcard_utils.hpp"
 #include "pg/sql_exception_macro.h"
 
 namespace sdb {
@@ -57,6 +63,14 @@ struct ParserContext {
   std::string error_message;
   Modifier last_mod{Modifier::None};
   bool strict_field = false;
+
+  // What is being built while the grammar reads its parts.
+  irs::ByPhrase* phrase{nullptr};
+  irs::ByNGramSimilarity* ngram{nullptr};
+  std::vector<std::string_view> fn_terms;
+  std::string_view fn_other;
+  size_t offs_min{0};
+  size_t offs_max{0};
 
   ParserContext(irs::MixedBooleanFilter& root, irs::field_id field_id,
                 irs::analysis::Analyzer& tokenizer)
@@ -91,42 +105,176 @@ struct ParserContext {
     }
   }
 
-  irs::ByTerm& AddTerm(std::string_view value) {
+  // What the query spells is not what the index holds: the analyzer stands
+  // between them, here as everywhere else. A word it splits is asked for the
+  // way Lucene asks -- any of its parts, under the default operator.
+  irs::FilterWithBoost& AddTerm(std::string_view value) {
+    const auto text = Unescape(value);
+    tokenizer->reset(irs::ViewCast<char>(irs::bytes_view{text}));
+    auto token = irs::get<irs::TermAttr>(*tokenizer);
+
+    irs::bstring first;
+    size_t count = 0;
+    irs::MixedBooleanFilter* several = nullptr;
+    while (tokenizer->next()) {
+      if (count == 0) {
+        first = token->value;
+      } else {
+        if (count == 1) {
+          several = &current_root->GetOptional().add<irs::MixedBooleanFilter>();
+          AddTermTo(several->GetOptional(), first);
+        }
+        AddTermTo(several->GetOptional(), token->value);
+      }
+      ++count;
+    }
+    if (several != nullptr) {
+      return *several;
+    }
     auto& f = current_root->GetOptional().add<irs::ByTerm>();
     *f.mutable_field_id() = default_field_id;
-    f.mutable_options()->term = irs::ViewCast<irs::byte_type>(value);
+    f.mutable_options()->term = std::move(first);
     return f;
   }
 
-  irs::ByPhrase& AddPhrase(std::string_view value, int slop = 0) {
+  // A pattern of its own rather than a wildcard: `.` and `*` mean what a
+  // regular expression means by them, which is not what `%` and `_` mean.
+  irs::ByRegexp& AddRegex(std::string_view value) {
+    auto& f = current_root->GetOptional().add<irs::ByRegexp>();
+    *f.mutable_field_id() = default_field_id;
+    f.mutable_options()->pattern = irs::ViewCast<irs::byte_type>(value);
+    return f;
+  }
+
+  // A named field is read where the default field is: there is nothing here
+  // that maps a name to a field of the index, so the name is only checked.
+  bool CheckField(std::string_view name) {
+    if (strict_field && name != default_field_name) {
+      error_message =
+        "field-prefix in strict-field mode must match the default field";
+      return false;
+    }
+    return true;
+  }
+
+  // A phrase is built part by part as the grammar reads them, so nothing
+  // takes a string apart here: what a part is, and where it sits, are
+  // answers the parser already has.
+  void BeginPhrase() {
     auto& f = current_root->GetOptional().add<irs::ByPhrase>();
     *f.mutable_field_id() = default_field_id;
-    tokenizer->reset(value);
+    phrase = &f;
+    offs_min = 0;
+    offs_max = 0;
+  }
+
+  irs::ByPhrase& EndPhrase() {
+    SDB_ASSERT(phrase != nullptr);
+    auto& f = *phrase;
+    phrase = nullptr;
+    return f;
+  }
+
+  // How far the part after it may sit from the part before, which the parts
+  // of a phrase that says nothing leave at one.
+  void SetGap(int min, int max) {
+    offs_min = static_cast<size_t>(min);
+    offs_max = static_cast<size_t>(max);
+  }
+
+  void SetSlop(irs::FilterWithBoost* f, int slop) {
+    sdb::basics::downCast<irs::ByPhrase>(*f).mutable_options()->set_slop(
+      static_cast<irs::PosAttr::value_t>(slop));
+  }
+
+  void SetMinMatch(irs::FilterWithBoost* f, int count) {
+    sdb::basics::downCast<irs::MixedBooleanFilter>(*f)
+      .GetOptional()
+      .min_match_count(static_cast<size_t>(count));
+  }
+
+  // A word of a phrase is whatever the analyzer makes of it: one term, or
+  // several, and several of them sit one after another.
+  void AddPhraseTerm(std::string_view word) {
+    const auto text = Unescape(word);
+    tokenizer->reset(irs::ViewCast<char>(irs::bytes_view{text}));
     auto token = irs::get<irs::TermAttr>(*tokenizer);
-    for (; tokenizer->next();) {
-      f.mutable_options()->push_back<irs::ByTermOptions>().term = token->value;
+    while (tokenizer->next()) {
+      Emplace<irs::ByTermOptions>().term = token->value;
     }
-    if (slop > 0) {
-      f.mutable_options()->set_slop(static_cast<irs::PosAttr::value_t>(slop));
+  }
+
+  void AddPhrasePrefix(std::string_view word) {
+    word.remove_suffix(1);
+    Emplace<irs::ByPrefixOptions>().term = Analyze(word);
+  }
+
+  void AddPhraseWildcard(std::string_view word) {
+    // Only the literal head goes through the analyzer -- it would eat the
+    // pattern characters.
+    const auto wildcard = FindPattern(word);
+    auto pattern = Analyze(word.substr(0, wildcard));
+    pattern.append(Pattern(word.substr(wildcard)));
+    Emplace<irs::ByWildcardOptions>().term = std::move(pattern);
+  }
+
+  // Where a pattern begins: the first `*` or `?` a backslash did not protect.
+  static size_t FindPattern(std::string_view word) noexcept {
+    for (size_t i = 0; i != word.size(); ++i) {
+      if (word[i] == '\\') {
+        ++i;
+      } else if (word[i] == '*' || word[i] == '?') {
+        return i;
+      }
     }
+    return word.size();
+  }
+
+  void AddPhraseFuzzy(std::string_view word, int distance) {
+    auto& part = Emplace<irs::ByEditDistanceOptions>();
+    part.term = Analyze(word);
+    part.max_distance = static_cast<uint8_t>(distance);
+  }
+
+  // An n-gram similarity, built the same way: the grammar hands over the
+  // threshold, then the terms.
+  void BeginNGram(float threshold) {
+    auto& f = current_root->GetOptional().add<irs::ByNGramSimilarity>();
+    *f.mutable_field_id() = default_field_id;
+    f.mutable_options()->threshold = threshold;
+    ngram = &f;
+  }
+
+  void AddNGram(std::string_view word) {
+    SDB_ASSERT(ngram != nullptr);
+    ngram->mutable_options()->ngrams.emplace_back(Analyze(word));
+  }
+
+  irs::ByNGramSimilarity& EndNGram() {
+    SDB_ASSERT(ngram != nullptr);
+    auto& f = *ngram;
+    ngram = nullptr;
     return f;
   }
 
   irs::ByPrefix& AddPrefix(std::string_view value) {
     auto& f = current_root->GetOptional().add<irs::ByPrefix>();
     *f.mutable_field_id() = default_field_id;
-    if (!value.empty() && value.back() == '*') {
-      value.remove_suffix(1);
-    }
-    f.mutable_options()->term = irs::ViewCast<irs::byte_type>(value);
+    SDB_ASSERT(!value.empty() && value.back() == '*');
+    value.remove_suffix(1);
+    f.mutable_options()->term = Analyze(value);
     return f;
   }
 
   irs::ByWildcard& AddWildcard(std::string_view value) {
     auto& f = current_root->GetOptional().add<irs::ByWildcard>();
     *f.mutable_field_id() = default_field_id;
-    *f.mutable_options() =
-      irs::ByWildcardOptions{irs::ViewCast<irs::byte_type>(value)};
+    // Only the literal head goes through the analyzer -- it would eat the
+    // pattern characters.
+    const auto wildcard = FindPattern(value);
+    auto pattern = Analyze(value.substr(0, wildcard));
+    pattern.append(Pattern(value.substr(wildcard)));
+    *f.mutable_options() = irs::ByWildcardOptions{std::move(pattern)};
     return f;
   }
 
@@ -138,26 +286,336 @@ struct ParserContext {
     if (min_val == "*") {
       range.min_type = irs::BoundType::Unbounded;
     } else {
-      range.min = irs::ViewCast<irs::byte_type>(min_val);
+      range.min = Analyze(min_val);
       range.min_type =
         inc_min ? irs::BoundType::Inclusive : irs::BoundType::Exclusive;
     }
     if (max_val == "*") {
       range.max_type = irs::BoundType::Unbounded;
     } else {
-      range.max = irs::ViewCast<irs::byte_type>(max_val);
+      range.max = Analyze(max_val);
       range.max_type =
         inc_max ? irs::BoundType::Inclusive : irs::BoundType::Exclusive;
     }
     return f;
   }
 
-  irs::ByEditDistance& AddFuzzy(std::string_view value, int distance) {
+  // Lucene spells a wildcard `*` and `?`; the filters spell it `%` and `_`,
+  // with a backslash making either literal. That is the same boundary the
+  // field name and the analyzer are resolved at, so it is crossed here --
+  // otherwise a pattern reads as a term that happens to contain a star, and
+  // matches nothing.
+  static irs::bstring Pattern(std::string_view word) {
+    irs::bstring out;
+    out.reserve(word.size());
+    for (size_t i = 0; i != word.size(); ++i) {
+      const auto c = word[i];
+      switch (c) {
+        case '\\':
+          // What the query escaped stays literal, and `*` and `?` need no
+          // escaping once they are no longer the pattern characters.
+          if (i + 1 != word.size()) {
+            const auto next = word[++i];
+            if (next != '*' && next != '?') {
+              out += static_cast<irs::byte_type>('\\');
+            }
+            out += static_cast<irs::byte_type>(next);
+          }
+          break;
+        case '*':
+          out += static_cast<irs::byte_type>(irs::WildcardMatch::kAnyStr);
+          break;
+        case '?':
+          out += static_cast<irs::byte_type>(irs::WildcardMatch::kAnyChr);
+          break;
+        case irs::WildcardMatch::kAnyStr:
+        case irs::WildcardMatch::kAnyChr:
+          // Literal here, a pattern character there.
+          out += static_cast<irs::byte_type>(irs::WildcardMatch::kEscape);
+          out += static_cast<irs::byte_type>(c);
+          break;
+        default:
+          out += static_cast<irs::byte_type>(c);
+      }
+    }
+    return out;
+  }
+
+  // How far apart two parts of an ordered match may sit when nothing bounds
+  // them. Large rather than unbounded: the matcher compares against it, so
+  // it only has to be past any position a document can hold.
+  static constexpr size_t kAnyGap = 1U << 24U;
+
+  template<typename Boolean>
+  void AddTermTo(Boolean& root, std::string_view word) {
+    AddTermTo(root, Analyze(word));
+  }
+
+  template<typename Boolean>
+  void AddTermTo(Boolean& root, irs::bytes_view word) {
+    auto& f = root.template add<irs::ByTerm>();
+    *f.mutable_field_id() = default_field_id;
+    f.mutable_options()->term = word;
+  }
+
+  void RequirePair(std::string_view name) {
+    if (fn_terms.size() != 2) {
+      THROW_SQL_ERROR(ERR_MSG("`", name,
+                              "` is supported over two terms, where what it "
+                              "bounds is a distance rather than a total"));
+    }
+  }
+
+  irs::ByPhrase& FnPhrase(size_t offs_min, size_t offs_max) {
+    BeginPhrase();
+    bool first = true;
+    for (const auto term : fn_terms) {
+      if (!first) {
+        SetGap(static_cast<int>(offs_min), static_cast<int>(offs_max));
+      }
+      first = false;
+      AddPhraseTerm(term);
+    }
+    return EndPhrase();
+  }
+
+  // What a backslash protected is the character itself, and `\uXXXX` is the
+  // character it names. Lucene's `discardEscapeChar`: the query says how to
+  // spell a term, the index holds the term itself.
+  static uint32_t Hex(char c) noexcept {
+    if (c >= '0' && c <= '9') {
+      return static_cast<uint32_t>(c - '0');
+    }
+    if (c >= 'a' && c <= 'f') {
+      return static_cast<uint32_t>(c - 'a') + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+      return static_cast<uint32_t>(c - 'A') + 10;
+    }
+    return 16;  // not a digit
+  }
+
+  static irs::bstring Unescape(std::string_view word) {
+    irs::bstring out;
+    out.reserve(word.size());
+    for (size_t i = 0; i != word.size(); ++i) {
+      if (word[i] != '\\' || i + 1 == word.size()) {
+        out += static_cast<irs::byte_type>(word[i]);
+        continue;
+      }
+      const auto next = word[++i];
+      if (next != 'u' || i + 4 >= word.size()) {
+        out += static_cast<irs::byte_type>(next);
+        continue;
+      }
+      uint32_t code = 0;
+      size_t digits = 0;
+      for (; digits != 4; ++digits) {
+        const auto digit = Hex(word[i + 1 + digits]);
+        if (digit > 15) {
+          break;
+        }
+        code = code * 16 + digit;
+      }
+      if (digits != 4) {
+        out += static_cast<irs::byte_type>(next);
+        continue;
+      }
+      i += 4;
+      irs::byte_type utf8[irs::utf8_utils::kMaxCharSize];
+      out.append(utf8, irs::utf8_utils::FromChar32(code, utf8));
+    }
+    return out;
+  }
+
+  irs::bstring Analyze(std::string_view word) {
+    const auto text = Unescape(word);
+    tokenizer->reset(irs::ViewCast<char>(irs::bytes_view{text}));
+    auto token = irs::get<irs::TermAttr>(*tokenizer);
+    if (tokenizer->next()) {
+      return irs::bstring{token->value};
+    }
+    return {};
+  }
+
+  // Where a part goes: next to the one before it, or as far off as a gap
+  // asked. Zero is no gap rather than a gap of zero, which is what the
+  // one-argument `push_back` means.
+  template<typename Part>
+  Part& Emplace() {
+    SDB_ASSERT(phrase != nullptr);
+    auto* options = phrase->mutable_options();
+    auto& part = offs_min == 0 && offs_max == 0
+                   ? options->push_back<Part>()
+                   : options->push_back<Part>(offs_min, offs_max);
+    offs_min = 0;
+    offs_max = 0;
+    return part;
+  }
+
+  // Lucene's older spelling of an edit distance: a similarity between zero
+  // and one, which it turns into edits by the length of the term.
+  // `FuzzyQuery.floatToEdits`.
+  // A term or a phrase may give a boost and a fuzziness in either order, and
+  // both orders mean the same thing. Reading the boost first leaves a plain
+  // term already built, and a fuzzy term is a different filter -- so the term
+  // is taken back out and asked for again as the one it should have been. A
+  // phrase only needs its slop set.
+  irs::FilterWithBoost& ApplyFuzzy(irs::FilterWithBoost* built, bool has_value,
+                                   float value) {
+    if (built->type() == irs::Type<irs::ByPhrase>::id()) {
+      if (has_value) {
+        SetSlop(built, static_cast<int>(value));
+      }
+      return *built;
+    }
+    if (built->type() != irs::Type<irs::ByTerm>::id()) {
+      THROW_SQL_ERROR(
+        ERR_MSG("a fuzziness applies to a term or a phrase, not to this"));
+    }
+    auto& term = sdb::basics::downCast<irs::ByTerm>(*built);
+    auto text = term.options().term;
+    const auto boost = term.Boost();
+
+    auto& optional = current_root->GetOptional();
+    optional.PopBack();
+
+    auto& f = has_value ? FuzzyFromSimilarity(std::move(text), value)
+                        : AddFuzzyTerm(std::move(text), 2);
+    f.boost(boost);
+    return f;
+  }
+
+  irs::ByEditDistance& AddFuzzySimilarity(std::string_view value,
+                                          float similarity) {
+    return FuzzyFromSimilarity(Analyze(value), similarity);
+  }
+
+  irs::ByEditDistance& FuzzyFromSimilarity(irs::bstring value,
+                                           float similarity) {
+    constexpr int kMaxEdits = 2;
+    int distance = 0;
+    if (similarity >= 1.F) {
+      distance = std::min(static_cast<int>(similarity), kMaxEdits);
+    } else if (similarity > 0.F) {
+      const auto length = static_cast<int>(irs::utf8_utils::Length(value));
+      distance = std::min(
+        static_cast<int>((1.F - similarity) * static_cast<float>(length)),
+        kMaxEdits);
+    }
+    return AddFuzzyTerm(std::move(value), distance);
+  }
+
+  irs::ByEditDistance& AddFuzzyTerm(irs::bstring value, int distance) {
     auto& f = current_root->GetOptional().add<irs::ByEditDistance>();
     *f.mutable_field_id() = default_field_id;
-    f.mutable_options()->term = irs::ViewCast<irs::byte_type>(value);
+    f.mutable_options()->term = std::move(value);
     f.mutable_options()->max_distance = static_cast<uint8_t>(distance);
     return f;
+  }
+
+  // Every document, which is what a query that names no term at all means.
+  irs::All& AddAll() {
+    auto& f = current_root->GetOptional().add<irs::All>();
+    return f;
+  }
+
+  // A field with any value: Lucene's `field:*`. Nothing here answers it, so
+  // it is read and refused rather than quietly meaning something else.
+  irs::FilterWithBoost& AddFieldExists() {
+    THROW_SQL_ERROR(
+      ERR_MSG("field existence queries (`field:*`) are not supported"));
+  }
+
+  // The terms an interval function is applied to. What such a function means
+  // for a document -- which documents hold a match at all -- is a question
+  // this engine can answer even without intervals to compose; where the
+  // answer depends on where the matches lie relative to each other, it
+  // cannot, and that function is refused instead.
+  void BeginFn() {
+    fn_terms.clear();
+    fn_other = {};
+  }
+
+  void AddFnTerm(std::string_view word) { fn_terms.emplace_back(word); }
+
+  // A source that is not a term. What such a function means for a document
+  // depends on where its matches lie, and this engine composes documents
+  // rather than positions -- so the refusal says what it was given.
+  void AddFnOther(std::string_view kind) { fn_other = kind; }
+
+  void RequireTerms(std::string_view name) const {
+    if (!fn_other.empty()) {
+      THROW_SQL_ERROR(ERR_MSG("`", name, "` over ", fn_other,
+                              " is not supported: it would ask where the "
+                              "matches lie, and only terms can be answered "
+                              "for here"));
+    }
+  }
+
+  // One of them is enough.
+  irs::FilterWithBoost& EndFnAny() {
+    RequireTerms("fn:or");
+    auto& f = current_root->GetOptional().add<irs::MixedBooleanFilter>();
+    for (const auto term : fn_terms) {
+      AddTermTo(f.GetOptional(), term);
+    }
+    return f;
+  }
+
+  // All of them, wherever they lie.
+  irs::FilterWithBoost& EndFnAll() {
+    RequireTerms("fn:unordered");
+    auto& f = current_root->GetOptional().add<irs::MixedBooleanFilter>();
+    for (const auto term : fn_terms) {
+      AddTermTo(f.GetRequired(), term);
+    }
+    return f;
+  }
+
+  irs::FilterWithBoost& EndFnAtLeast(int count) {
+    RequireTerms("fn:atLeast");
+    auto& f = current_root->GetOptional().add<irs::MixedBooleanFilter>();
+    for (const auto term : fn_terms) {
+      AddTermTo(f.GetOptional(), term);
+    }
+    f.GetOptional().min_match_count(static_cast<size_t>(count));
+    return f;
+  }
+
+  // In this order, however far apart: a phrase whose parts may sit anywhere
+  // after the one before them.
+  irs::FilterWithBoost& EndFnOrdered() {
+    RequireTerms("fn:ordered");
+    return FnPhrase(1, kAnyGap);
+  }
+
+  // `maxgaps` bounds the words between, `maxwidth` the span end to end. Over
+  // one pair either is a distance; over more they bound a total across the
+  // whole match, and a phrase says only how far each part sits from the last.
+  irs::FilterWithBoost& EndFnMaxGaps(int gaps) {
+    RequireTerms("fn:maxgaps");
+    RequirePair("fn:maxgaps");
+    return FnPhrase(1, static_cast<size_t>(gaps) + 1);
+  }
+
+  irs::FilterWithBoost& EndFnMaxWidth(int width) {
+    RequireTerms("fn:maxwidth");
+    RequirePair("fn:maxwidth");
+    if (width < 2) {
+      THROW_SQL_ERROR(ERR_MSG("`fn:maxwidth` needs a width of at least two"));
+    }
+    return FnPhrase(1, static_cast<size_t>(width) - 1);
+  }
+
+  // An interval function whose answer depends on where matches lie relative
+  // to one another, which needs intervals this engine does not have.
+  void Unsupported(std::string_view name) {
+    THROW_SQL_ERROR(ERR_MSG("`", name, "` is not supported"));
+  }
+
+  irs::ByEditDistance& AddFuzzy(std::string_view value, int distance) {
+    return AddFuzzyTerm(Analyze(value), distance);
   }
 };
 

--- a/libs/iresearch/include/iresearch/search/block_disjunction.hpp
+++ b/libs/iresearch/include/iresearch/search/block_disjunction.hpp
@@ -233,7 +233,7 @@ class BlockDisjunction : public DocIterator {
           _match_count = 1;
         }
       } else if constexpr (Traits::kMinMatch) {
-        if (target == value) {
+        if (value == _doc) {
           ++_match_count;
         }
       }

--- a/libs/iresearch/include/iresearch/utils/automaton_utils.cpp
+++ b/libs/iresearch/include/iresearch/utils/automaton_utils.cpp
@@ -67,6 +67,29 @@ void Utf8EmplaceArc(automaton& a, automaton::StateId from, bytes_view label,
   }
 }
 
+void EmplaceSinkArcs(automaton& a) {
+  // States are visited by index and only arcs are added to them, so the one
+  // state this may append is past `count` and needs no visit of its own.
+  const auto count = a.NumStates();
+
+  auto sink = fst::kNoStateId;
+  for (automaton::StateId state = 0; state < count; ++state) {
+    if (a.NumArcs(state)) {
+      continue;
+    }
+    if (!a.Final(state)) {
+      if (fst::kNoStateId == sink) {
+        sink = state;  // a state that reads nothing and accepts nothing is one
+      }
+      continue;
+    }
+    if (fst::kNoStateId == sink) {
+      sink = a.AddState();
+    }
+    a.EmplaceArc(state, RangeLabel::From(0, 255), sink);
+  }
+}
+
 void Utf8EmplaceRhoArc(automaton& a, automaton::StateId from,
                        automaton::StateId to) {
   const auto id = a.NumStates();  // stated ids are sequential

--- a/libs/iresearch/include/iresearch/utils/automaton_utils.hpp
+++ b/libs/iresearch/include/iresearch/utils/automaton_utils.hpp
@@ -420,6 +420,14 @@ void Utf8EmplaceArc(automaton& a, automaton::StateId from, bytes_view label,
 void Utf8EmplaceRhoArc(automaton& a, automaton::StateId from,
                        automaton::StateId to);
 
+// Gives a state that accepts and reads nothing something to read: what
+// matches nothing goes to a sink, which is then the only state left without
+// arcs, and is not final. `TableMatcher` finds the sink that way, and the
+// term dictionary walk expects a live state to have arcs. Levenshtein
+// automatons are built like this already; ones assembled from parts and
+// determinized are not.
+void EmplaceSinkArcs(automaton& a);
+
 inline automaton MakeChar(bytes_view c) {
   automaton a;
   a.AddStates(2);

--- a/libs/iresearch/include/iresearch/utils/regexp_utils.cpp
+++ b/libs/iresearch/include/iresearch/utils/regexp_utils.cpp
@@ -646,6 +646,8 @@ automaton FromRegexp(bytes_view pattern, int64_t max_dfa_states,
     return {};
   }
 
+  EmplaceSinkArcs(dfa);
+
   return dfa;
 }
 

--- a/libs/iresearch/include/iresearch/utils/wildcard_utils.cpp
+++ b/libs/iresearch/include/iresearch/utils/wildcard_utils.cpp
@@ -149,6 +149,8 @@ automaton FromWildcard(bytes_view expr) {
              dfa.Properties(kExpectedDfaProperties, true));
 #endif
 
+  EmplaceSinkArcs(dfa);
+
   return dfa;
 }
 

--- a/resources/tests/iresearch/iresearch-load/wiki_small/queries.json
+++ b/resources/tests/iresearch/iresearch-load/wiki_small/queries.json
@@ -1015,45 +1015,6 @@
 {"query": "\"to be or not to be\"", "tags": ["phrase", "phrase:num_tokens_>3"]}
 {"query": "to be or not to be", "tags": ["union", "union:num_tokens_>3"]}
 {"query": "a search engine is an information retrieval software system designed to help find information stored on one or more computer systems", "tags": ["union", "union:num_tokens_>3"]}
-{"query": "+python -snake -monty", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+python -snake", "tags": ["negated", "global", "negated:num_tokens_2"]}
-{"query": "+jaguar -car -football", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+jaguar -car", "tags": ["negated", "global", "negated:num_tokens_2"]}
-{"query": "+mercury -planet -element", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+mercury -planet", "tags": ["negated", "global", "negated:num_tokens_2"]}
-{"query": "+java -coffee -island", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+java -coffee", "tags": ["negated", "global", "negated:num_tokens_2"]}
-{"query": "+saturn -planet -car", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+mustang -car -horse", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+amazon -river -rainforest", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+apple -fruit -tree", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+delta -airlines -river", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+jordan -country -basketball", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+orion -constellation -spacecraft", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+bass -fish -guitar", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+eclipse -lunar -solar", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+springfield -illinois -missouri", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+puma -cat -shoes", "tags": ["negated", "global", "negated:num_tokens_3"]}
-{"query": "+climate +policy", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
-{"query": "+data +privacy", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
-{"query": "+global +markets", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
-{"query": "+public +transit", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
-{"query": "+consumer +rights", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
-{"query": "+financial +reporting +standards", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+mental +health +resources", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+water +quality +report", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+housing +market +trends", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+electric +grid +stability", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+disaster +relief +funds", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+insurance +claim +process", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+credit +card +rewards", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+data +center +cooling", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+remote +learning +tools", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
-{"query": "+open +source +software +licenses", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
-{"query": "+health +care +cost +trends", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
-{"query": "+renewable +energy +policy +goals", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
-{"query": "+airport +security +screening +rules", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
-{"query": "+climate +change +impact +report", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
 {"query": "+climate policy", "tags": ["intersection_union", "global", "intersection_union:num_tokens_2"]}
 {"query": "remote +work", "tags": ["intersection_union", "global", "intersection_union:num_tokens_2"]}
 {"query": "+data privacy", "tags": ["intersection_union", "global", "intersection_union:num_tokens_2"]}
@@ -1094,3 +1055,403 @@
 {"query": "local +election ballot measures", "tags": ["intersection_union", "global", "intersection_union:num_tokens_>3"]}
 {"query": "+climate change impact report", "tags": ["intersection_union", "global", "intersection_union:num_tokens_>3"]}
 {"query": "customer +service phone number", "tags": ["intersection_union", "global", "intersection_union:num_tokens_>3"]}
+{"query": "+python -snake -monty", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+python -snake", "tags": ["negated", "global", "negated:num_tokens_2"]}
+{"query": "+jaguar -car -football", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+jaguar -car", "tags": ["negated", "global", "negated:num_tokens_2"]}
+{"query": "+mercury -planet -element", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+mercury -planet", "tags": ["negated", "global", "negated:num_tokens_2"]}
+{"query": "+java -coffee -island", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+java -coffee", "tags": ["negated", "global", "negated:num_tokens_2"]}
+{"query": "+saturn -planet -car", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+mustang -car -horse", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+amazon -river -rainforest", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+apple -fruit -tree", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+delta -airlines -river", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+jordan -country -basketball", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+orion -constellation -spacecraft", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+bass -fish -guitar", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+eclipse -lunar -solar", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+springfield -illinois -missouri", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "+puma -cat -shoes", "tags": ["negated", "global", "negated:num_tokens_3"]}
+{"query": "(the world state)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(the world state history)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(world state history)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(world state history president)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(state history president)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(state history president river)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(history president river)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(history president river population)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(president river population)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(president river population university)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(river population university)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(river population university germany)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(population university germany)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(population university germany album)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(university germany album)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(university germany album military)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(germany album military)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(germany album military railway)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(album military railway)@2", "tags": ["minmatch", "minmatch:num_tokens_3"]}
+{"query": "(album military railway football)@3", "tags": ["minmatch", "minmatch:num_tokens_>3"]}
+{"query": "(the world \"griffith observatory\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"griffith observatory\" \"bowel obstruction\" the)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(world state \"bowel obstruction\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"bowel obstruction\" \"vicenza italy\" world)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(state history \"vicenza italy\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"vicenza italy\" \"digital scanning\" state)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(history president \"digital scanning\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"digital scanning\" \"borders books\" history)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(president river \"borders books\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"borders books\" \"american funds\" president)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(river population \"american funds\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"american funds\" \"scottsdale az\" river)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(population university \"scottsdale az\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"scottsdale az\" \"freelance work\" population)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(university germany \"freelance work\")@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "(\"freelance work\" \"color combinations\" university)@2", "tags": ["minmatch", "minmatch:mixed"]}
+{"query": "\"griffith 1-1 observatory\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"griffith 1-3 observatory\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"griffith observatory\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"griffith observatory\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"bowel 1-1 obstruction\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"bowel 1-3 obstruction\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"bowel obstruction\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"bowel obstruction\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"vicenza 1-1 italy\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"vicenza 1-3 italy\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"vicenza italy\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"vicenza italy\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"digital 1-1 scanning\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"digital 1-3 scanning\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"digital scanning\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"digital scanning\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"borders 1-1 books\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"borders 1-3 books\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"borders books\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"borders books\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"american 1-1 funds\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"american 1-3 funds\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"american funds\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"american funds\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"scottsdale 1-1 az\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"scottsdale 1-3 az\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"scottsdale az\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"scottsdale az\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"freelance 1-1 work\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"freelance 1-3 work\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"freelance work\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"freelance work\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"color 1-1 combinations\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"color 1-3 combinations\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"color combinations\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"color combinations\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"italian 1-1 translation\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"italian 1-3 translation\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"italian translation\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"italian translation\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"milwaukee 1-1 newspaper\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"milwaukee 1-3 newspaper\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"milwaukee newspaper\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"milwaukee newspaper\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"omaha 1-1 symphony\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"omaha 1-3 symphony\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"omaha symphony\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"omaha symphony\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"body 1-1 painting\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"body 1-3 painting\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"body painting\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"body painting\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"stone 1-1 mountain\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"stone 1-3 mountain\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_2"]}
+{"query": "\"stone mountain\"~1", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"stone mountain\"~3", "tags": ["slop_phrase", "slop_phrase:num_tokens_2"]}
+{"query": "\"plus 1-2 size 1-3 clothing\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"plus size clothing\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"wisconsin 1-2 attorney 1-3 general\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"wisconsin attorney general\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"the 1-2 english 1-3 restoration\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"the english restoration\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"french 1-2 culinary 1-3 institute\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"french culinary institute\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"robert 1-2 green 1-3 ingersoll\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"robert green ingersoll\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"who 1-2 dares 1-3 wins\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"who dares wins\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"ford 1-2 modeling 1-3 agency\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"ford modeling agency\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"texas 1-2 state 1-3 legislature\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"texas state legislature\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"georgia 1-2 public 1-3 broadcasting\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"georgia public broadcasting\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"texas 1-2 death 1-3 row\"", "tags": ["interval_phrase", "interval_phrase:num_tokens_3"]}
+{"query": "\"texas death row\"~2", "tags": ["slop_phrase", "slop_phrase:num_tokens_3"]}
+{"query": "\"griffith observatory\" the", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"griffith observatory\" \"bowel obstruction\" the", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"griffith observatory\" +the", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"griffith observatory\" +the +world", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+the -\"griffith observatory\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"griffith observatory\" -california", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "the^2 world", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"griffith observatory\" the^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "the~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+the~1 +\"griffith observatory\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"bowel obstruction\" world", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"bowel obstruction\" \"vicenza italy\" world", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"bowel obstruction\" +world", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"bowel obstruction\" +world +state", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+world -\"bowel obstruction\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"bowel obstruction\" -world", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "world^2 state", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"bowel obstruction\" world^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "world~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+world~1 +\"bowel obstruction\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"vicenza italy\" state", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"vicenza italy\" \"digital scanning\" state", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"vicenza italy\" +state", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"vicenza italy\" +state +history", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+state -\"vicenza italy\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"vicenza italy\" -state", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "state^2 history", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"vicenza italy\" state^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "state~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+state~1 +\"vicenza italy\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"digital scanning\" history", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"digital scanning\" \"borders books\" history", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"digital scanning\" +history", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"digital scanning\" +history +album", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+history -\"digital scanning\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"digital scanning\" -history", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "history^2 president", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"digital scanning\" history^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "history~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+history~1 +\"digital scanning\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"borders books\" president", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"borders books\" \"american funds\" president", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"borders books\" +president", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"borders books\" +president +australia", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+president -\"borders books\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"borders books\" -president", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "president^2 river", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"borders books\" president^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "president~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+president~1 +\"borders books\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"american funds\" river", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"american funds\" \"scottsdale az\" river", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"american funds\" +river", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"american funds\" +river +population", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+river -\"american funds\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"american funds\" -river", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "river^2 population", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"american funds\" river^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "river~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+river~1 +\"american funds\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"scottsdale az\" population", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"scottsdale az\" \"freelance work\" population", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"scottsdale az\" +population", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"scottsdale az\" +population +district", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+population -\"scottsdale az\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"scottsdale az\" -population", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "population^2 university", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"scottsdale az\" population^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "population~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+population~1 +\"scottsdale az\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"freelance work\" university", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"freelance work\" \"color combinations\" university", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"freelance work\" +university", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"freelance work\" +university +germany", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+university -\"freelance work\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"freelance work\" -university", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "university^2 germany", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"freelance work\" university^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "university~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+university~1 +\"freelance work\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"color combinations\" germany", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"color combinations\" \"italian translation\" germany", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"color combinations\" +germany", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"color combinations\" +germany +album", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+germany -\"color combinations\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"color combinations\" -germany", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "germany^2 album", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"color combinations\" germany^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "germany~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+germany~1 +\"color combinations\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "\"italian translation\" album", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "\"italian translation\" \"milwaukee newspaper\" album", "tags": ["bool_or", "bool_or:mixed"]}
+{"query": "+\"italian translation\" +album", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+\"italian translation\" +album +military", "tags": ["bool_and", "bool_and:mixed"]}
+{"query": "+album -\"italian translation\"", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "+\"italian translation\" -album", "tags": ["bool_not", "bool_not:mixed"]}
+{"query": "album^2 military", "tags": ["bool_boost", "bool_boost:terms"]}
+{"query": "+\"italian translation\" album^3", "tags": ["bool_boost", "bool_boost:mixed"]}
+{"query": "album~1", "tags": ["fuzzy", "fuzzy:num_tokens_1"]}
+{"query": "+album~1 +\"italian translation\"", "tags": ["fuzzy", "fuzzy:mixed"]}
+{"query": "fn:ngram(1.0 milwaukee newspaper)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 new york population)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 ford modeling agency population)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 griffith bowel obstruction vicenza)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 griffith bowel obstruction)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 italy digital)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 robert green ingersoll)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 who dares wins river)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 italy digital scanning plus)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 italy digital scanning)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 size clothing)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 people having sex)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 texas death row album)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 size clothing borders books)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 size clothing borders)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 american funds)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 texas death row)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 robert green ingersoll president)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 american funds scottsdale wisconsin)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 american funds scottsdale)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 attorney general)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 ford modeling agency)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 georgia public broadcasting germany)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 attorney general english restoration)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 attorney general english)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 freelance work)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 cured of cancer)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 hempstead new york bridge)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 freelance work french culinary)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 freelance work french)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 omaha symphony)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 georgia public broadcasting)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 cured of cancer television)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 institute color combinations italian)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 institute color combinations)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 catholic answers)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 the globe newspaper)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 helen of troy aircraft)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 translation milwaukee newspaper robert)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 translation milwaukee newspaper)", "tags": ["ngram", "ngram:any"]}
+{"query": "fn:ngram(1.0 green ingersoll)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(1.0 world bank president)", "tags": ["ngram", "ngram:all"]}
+{"query": "fn:ngram(0.7 trans siberian orchestra stadium)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.5 green ingersoll omaha body)", "tags": ["ngram", "ngram:partial"]}
+{"query": "fn:ngram(0.34 green ingersoll omaha)", "tags": ["ngram", "ngram:any"]}
+{"query": "\"griffith obse*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"griffith obse*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"griffith 1-2 obse*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"griffith observator*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"bowel obst*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"bowel obst*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"bowel 1-2 obst*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"bowel obstructio*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"vicenza ital*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"digital scan*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"digital scan*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"digital 1-2 scan*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"digital scannin*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"plus size clot*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"plus size clot*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"plus 1-2 clot*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"plus size clothin*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"borders book*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"american fund*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"wisconsin attorney gene*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"wisconsin attorney gene*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"wisconsin 1-2 gene*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"wisconsin attorney genera*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"the english rest*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"the english rest*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"the 1-2 rest*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"the english restoratio*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"freelance wor*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"french culinary inst*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"french culinary inst*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"french 1-2 inst*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"french culinary institut*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"color comb*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"color comb*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"color 1-2 comb*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"color combination*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"italian tran*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"italian tran*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"italian 1-2 tran*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"italian translatio*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"milwaukee news*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"milwaukee news*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"milwaukee 1-2 news*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"milwaukee newspape*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"robert green inge*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"robert green inge*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"robert 1-2 inge*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"robert green ingersol*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"omaha symp*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"omaha symp*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"omaha 1-2 symp*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"omaha symphon*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"body pain*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"body pain*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"body 1-2 pain*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"body paintin*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"who dares win*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"west palm beach flor*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"west palm beach flor*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"west 1-2 flor*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"west palm beach florid*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"stone moun*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"stone moun*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"stone 1-2 moun*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"stone mountai*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"san fran*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"san fran*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"san 1-2 fran*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"san francisc*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"ford modeling agenc*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"glass work*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"personal loa*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"texas state legi*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"texas state legi*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"texas 1-2 legi*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"texas state legislatur*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"spiritual warf*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"spiritual warf*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"spiritual 1-2 warf*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"spiritual warfar*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"georgia public broa*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"georgia public broa*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"georgia 1-2 broa*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"georgia public broadcastin*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"catholic answ*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"catholic answ*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"catholic 1-2 answ*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"catholic answer*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"interest onl*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"army rese*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"army rese*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"army 1-2 rese*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"army reserv*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"chicken coo*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"new york popu*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"new york popu*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"new 1-2 popu*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"new york populatio*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"most improved playe*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"ear ach*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "\"mercury insu*\"", "tags": ["variadic_phrase", "variadic_phrase:wide"]}
+{"query": "\"mercury insu*\"~2", "tags": ["variadic_phrase", "variadic_phrase:slop"]}
+{"query": "\"mercury 1-2 insu*\"", "tags": ["variadic_phrase", "variadic_phrase:gaps"]}
+{"query": "\"mercury insuranc*\"", "tags": ["variadic_phrase", "variadic_phrase:narrow"]}
+{"query": "+climate +policy", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
+{"query": "+data +privacy", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
+{"query": "+global +markets", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
+{"query": "+public +transit", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
+{"query": "+consumer +rights", "tags": ["intersection", "global", "intersection:num_tokens_2"]}
+{"query": "+financial +reporting +standards", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+mental +health +resources", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+water +quality +report", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+housing +market +trends", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+electric +grid +stability", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+disaster +relief +funds", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+insurance +claim +process", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+credit +card +rewards", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+data +center +cooling", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+remote +learning +tools", "tags": ["intersection", "global", "intersection:num_tokens_3"]}
+{"query": "+open +source +software +licenses", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
+{"query": "+health +care +cost +trends", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
+{"query": "+renewable +energy +policy +goals", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
+{"query": "+airport +security +screening +rules", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}
+{"query": "+climate +change +impact +report", "tags": ["intersection", "global", "intersection:num_tokens_>3"]}

--- a/resources/tests/iresearch/iresearch-load/wiki_small/reference.json
+++ b/resources/tests/iresearch/iresearch-load/wiki_small/reference.json
@@ -12204,474 +12204,6 @@
     ]
   },
   {
-    "query": "+python -snake -monty",
-    "count": 2281,
-    "top_100": 2281,
-    "result_type": "Hash",
-    "top_100_result": [
-      "351ec72a2bc0725674ffe14e69cc143e33796385fb9686e17feb7c0f49a0220c"
-    ],
-    "top_100_count_result": [
-      "351ec72a2bc0725674ffe14e69cc143e33796385fb9686e17feb7c0f49a0220c"
-    ]
-  },
-  {
-    "query": "+python -snake",
-    "count": 3151,
-    "top_100": 3151,
-    "result_type": "Hash",
-    "top_100_result": [
-      "0923316124cccc0a2bf105e5769b0e4bda672b4ea9312c6f5a2fd7695c2c0465"
-    ],
-    "top_100_count_result": [
-      "0923316124cccc0a2bf105e5769b0e4bda672b4ea9312c6f5a2fd7695c2c0465"
-    ]
-  },
-  {
-    "query": "+jaguar -car -football",
-    "count": 1672,
-    "top_100": 1672,
-    "result_type": "Hash",
-    "top_100_result": [
-      "7858faf8278314f497d0062b3ba7da629cd4f0f1c40a8ebb45ebd800985bac10"
-    ],
-    "top_100_count_result": [
-      "7858faf8278314f497d0062b3ba7da629cd4f0f1c40a8ebb45ebd800985bac10"
-    ]
-  },
-  {
-    "query": "+jaguar -car",
-    "count": 1791,
-    "top_100": 1791,
-    "result_type": "Hash",
-    "top_100_result": [
-      "3ee6f9f6c7a8d9e79184d47ec8a038905e02f0610a370a1d2023dd9cac4778a4"
-    ],
-    "top_100_count_result": [
-      "3ee6f9f6c7a8d9e79184d47ec8a038905e02f0610a370a1d2023dd9cac4778a4"
-    ]
-  },
-  {
-    "query": "+mercury -planet -element",
-    "count": 9895,
-    "top_100": 8970,
-    "result_type": "Hash",
-    "top_100_result": [
-      "0e7f84475af3fe6c0267d5b8b6fc8d5f970111a16d48502cbca08426cce2f362"
-    ],
-    "top_100_count_result": [
-      "0e7f84475af3fe6c0267d5b8b6fc8d5f970111a16d48502cbca08426cce2f362"
-    ]
-  },
-  {
-    "query": "+mercury -planet",
-    "count": 10327,
-    "top_100": 9369,
-    "result_type": "Hash",
-    "top_100_result": [
-      "740230b40e3b85b67cc2c7016a226c285cf64442b334d42cae6c4fc09b1ed6ea"
-    ],
-    "top_100_count_result": [
-      "740230b40e3b85b67cc2c7016a226c285cf64442b334d42cae6c4fc09b1ed6ea"
-    ]
-  },
-  {
-    "query": "+java -coffee -island",
-    "count": 9756,
-    "top_100": 8533,
-    "result_type": "Hash",
-    "top_100_result": [
-      "958097c90dcab2b6d61390ad1803e6f148a7030c6b84ea0f9f32109cfd71753b"
-    ],
-    "top_100_count_result": [
-      "958097c90dcab2b6d61390ad1803e6f148a7030c6b84ea0f9f32109cfd71753b"
-    ]
-  },
-  {
-    "query": "+java -coffee",
-    "count": 11530,
-    "top_100": 10010,
-    "result_type": "Hash",
-    "top_100_result": [
-      "f4faa9b0d10699fba2715be3d998e8f95ba513b00493768cc9ba9890a6e27391"
-    ],
-    "top_100_count_result": [
-      "f4faa9b0d10699fba2715be3d998e8f95ba513b00493768cc9ba9890a6e27391"
-    ]
-  },
-  {
-    "query": "+saturn -planet -car",
-    "count": 3045,
-    "top_100": 3045,
-    "result_type": "Hash",
-    "top_100_result": [
-      "e67a70ce3420df90b18a4ec291cbccb7118fde7914badf81a8b74844641d1313"
-    ],
-    "top_100_count_result": [
-      "e67a70ce3420df90b18a4ec291cbccb7118fde7914badf81a8b74844641d1313"
-    ]
-  },
-  {
-    "query": "+mustang -car -horse",
-    "count": 1492,
-    "top_100": 1492,
-    "result_type": "Hash",
-    "top_100_result": [
-      "0f2a6a6f92a0a218252b2322294a1e802d311980741a6e633fd5f475501b6c89"
-    ],
-    "top_100_count_result": [
-      "0f2a6a6f92a0a218252b2322294a1e802d311980741a6e633fd5f475501b6c89"
-    ]
-  },
-  {
-    "query": "+amazon -river -rainforest",
-    "count": 7740,
-    "top_100": 7358,
-    "result_type": "Hash",
-    "top_100_result": [
-      "d90e2acb4c67c3109acf1d2e6a5089d548c965cc5ddf153ffba326dc381359f8"
-    ],
-    "top_100_count_result": [
-      "d90e2acb4c67c3109acf1d2e6a5089d548c965cc5ddf153ffba326dc381359f8"
-    ]
-  },
-  {
-    "query": "+apple -fruit -tree",
-    "count": 12832,
-    "top_100": 11338,
-    "result_type": "Hash",
-    "top_100_result": [
-      "8ed6cc4fd10b3b1f0e97e9180bfad7940322f472f1bfa2c582e6647d068d7855"
-    ],
-    "top_100_count_result": [
-      "8ed6cc4fd10b3b1f0e97e9180bfad7940322f472f1bfa2c582e6647d068d7855"
-    ]
-  },
-  {
-    "query": "+delta -airlines -river",
-    "count": 11876,
-    "top_100": 9864,
-    "result_type": "Hash",
-    "top_100_result": [
-      "435dd9fbce603064c6f5f9b8d22757e85ed6e6427978b823b4af8d9a1c4ae899"
-    ],
-    "top_100_count_result": [
-      "435dd9fbce603064c6f5f9b8d22757e85ed6e6427978b823b4af8d9a1c4ae899"
-    ]
-  },
-  {
-    "query": "+jordan -country -basketball",
-    "count": 16503,
-    "top_100": 12814,
-    "result_type": "Hash",
-    "top_100_result": [
-      "556a08301a7ca8453491e391adad0e0673fb7e23737eb53d74c68a0e23c8e23a"
-    ],
-    "top_100_count_result": [
-      "556a08301a7ca8453491e391adad0e0673fb7e23737eb53d74c68a0e23c8e23a"
-    ]
-  },
-  {
-    "query": "+orion -constellation -spacecraft",
-    "count": 2357,
-    "top_100": 2357,
-    "result_type": "Hash",
-    "top_100_result": [
-      "dc8d6730cb64dafefcae53bd4ec79e2ba7f7d6679410fedef388108824f9c1e8"
-    ],
-    "top_100_count_result": [
-      "dc8d6730cb64dafefcae53bd4ec79e2ba7f7d6679410fedef388108824f9c1e8"
-    ]
-  },
-  {
-    "query": "+bass -fish -guitar",
-    "count": 17780,
-    "top_100": 12485,
-    "result_type": "Hash",
-    "top_100_result": [
-      "e388dac4ee054df8105bbd4a9d7666f441764f2239aab8e501489c41afe51aca"
-    ],
-    "top_100_count_result": [
-      "e388dac4ee054df8105bbd4a9d7666f441764f2239aab8e501489c41afe51aca"
-    ]
-  },
-  {
-    "query": "+eclipse -lunar -solar",
-    "count": 3733,
-    "top_100": 3733,
-    "result_type": "Hash",
-    "top_100_result": [
-      "b08f3cb11449a2ab3d968db661539cee9ee6941ca7de8be78da466ad86fe34fc"
-    ],
-    "top_100_count_result": [
-      "b08f3cb11449a2ab3d968db661539cee9ee6941ca7de8be78da466ad86fe34fc"
-    ]
-  },
-  {
-    "query": "+springfield -illinois -missouri",
-    "count": 6315,
-    "top_100": 6315,
-    "result_type": "Hash",
-    "top_100_result": [
-      "54a84efc24470ea8e9e890ae37ba79ecda5c160a1ebf55c02fe8ee2778b65c1d"
-    ],
-    "top_100_count_result": [
-      "54a84efc24470ea8e9e890ae37ba79ecda5c160a1ebf55c02fe8ee2778b65c1d"
-    ]
-  },
-  {
-    "query": "+puma -cat -shoes",
-    "count": 1339,
-    "top_100": 1339,
-    "result_type": "Hash",
-    "top_100_result": [
-      "d60b88ce4dd1008b2a9b968aad743450ba5e7d3f19dc50a539770c23bdc50b65"
-    ],
-    "top_100_count_result": [
-      "d60b88ce4dd1008b2a9b968aad743450ba5e7d3f19dc50a539770c23bdc50b65"
-    ]
-  },
-  {
-    "query": "+climate +policy",
-    "count": 4509,
-    "top_100": 4509,
-    "result_type": "Hash",
-    "top_100_result": [
-      "cf70de227d79ea127dfe511112bd74fc7ae1457172afe8b86af0b1520a14f86f"
-    ],
-    "top_100_count_result": [
-      "cf70de227d79ea127dfe511112bd74fc7ae1457172afe8b86af0b1520a14f86f"
-    ]
-  },
-  {
-    "query": "+data +privacy",
-    "count": 1783,
-    "top_100": 1783,
-    "result_type": "Hash",
-    "top_100_result": [
-      "c43db4051e6c1f29cb3f487fa078e30e4ea609640caa4919552fc60d54fa5f56"
-    ],
-    "top_100_count_result": [
-      "c43db4051e6c1f29cb3f487fa078e30e4ea609640caa4919552fc60d54fa5f56"
-    ]
-  },
-  {
-    "query": "+global +markets",
-    "count": 4718,
-    "top_100": 4718,
-    "result_type": "Hash",
-    "top_100_result": [
-      "8c2176c8004108723bd04d11a1bca17ddb983a1cb172c3888b89dd8426acee74"
-    ],
-    "top_100_count_result": [
-      "8c2176c8004108723bd04d11a1bca17ddb983a1cb172c3888b89dd8426acee74"
-    ]
-  },
-  {
-    "query": "+public +transit",
-    "count": 7598,
-    "top_100": 7598,
-    "result_type": "Hash",
-    "top_100_result": [
-      "6599d4ec925e28586c5ebc2df82f3b815d0c21ff99aabcc6adba10776b432586"
-    ],
-    "top_100_count_result": [
-      "6599d4ec925e28586c5ebc2df82f3b815d0c21ff99aabcc6adba10776b432586"
-    ]
-  },
-  {
-    "query": "+consumer +rights",
-    "count": 2605,
-    "top_100": 2605,
-    "result_type": "Hash",
-    "top_100_result": [
-      "40dd84abb15a75a6ac01628d1b6451428546349d7b2c5f13f788ced5979a6104"
-    ],
-    "top_100_count_result": [
-      "40dd84abb15a75a6ac01628d1b6451428546349d7b2c5f13f788ced5979a6104"
-    ]
-  },
-  {
-    "query": "+financial +reporting +standards",
-    "count": 933,
-    "top_100": 933,
-    "result_type": "Hash",
-    "top_100_result": [
-      "4baf7dd751c7d36aea5c8b05f2fe75115852155cc8ff39d4e38093cf19a12e57"
-    ],
-    "top_100_count_result": [
-      "4baf7dd751c7d36aea5c8b05f2fe75115852155cc8ff39d4e38093cf19a12e57"
-    ]
-  },
-  {
-    "query": "+mental +health +resources",
-    "count": 1204,
-    "top_100": 1204,
-    "result_type": "Hash",
-    "top_100_result": [
-      "c06b179bce122c69934c1b46444f5b0edcce6e49d2ed4961485bbd08a7f74c21"
-    ],
-    "top_100_count_result": [
-      "c06b179bce122c69934c1b46444f5b0edcce6e49d2ed4961485bbd08a7f74c21"
-    ]
-  },
-  {
-    "query": "+water +quality +report",
-    "count": 2340,
-    "top_100": 2340,
-    "result_type": "Hash",
-    "top_100_result": [
-      "6455ad889116ea70a780492230aa375d62957cb3e7749b4f29e04947a0d64748"
-    ],
-    "top_100_count_result": [
-      "6455ad889116ea70a780492230aa375d62957cb3e7749b4f29e04947a0d64748"
-    ]
-  },
-  {
-    "query": "+housing +market +trends",
-    "count": 275,
-    "top_100": 275,
-    "result_type": "Hash",
-    "top_100_result": [
-      "a77747ab6c8cbfdd1ba7b4f6997d2f51a6aa0a73976fb7210b997c0bdd69ad12"
-    ],
-    "top_100_count_result": [
-      "a77747ab6c8cbfdd1ba7b4f6997d2f51a6aa0a73976fb7210b997c0bdd69ad12"
-    ]
-  },
-  {
-    "query": "+electric +grid +stability",
-    "count": 118,
-    "top_100": 118,
-    "result_type": "Hash",
-    "top_100_result": [
-      "22aa8e4a5a646722f85765f56d8a735921690fd265205fc92bc04c7b51ab6d9c"
-    ],
-    "top_100_count_result": [
-      "22aa8e4a5a646722f85765f56d8a735921690fd265205fc92bc04c7b51ab6d9c"
-    ]
-  },
-  {
-    "query": "+disaster +relief +funds",
-    "count": 566,
-    "top_100": 566,
-    "result_type": "Hash",
-    "top_100_result": [
-      "c86aa06617a2e75f76ffa0162cb6ac10f3dff9f8a2a77f3caf95b90e214a3f8e"
-    ],
-    "top_100_count_result": [
-      "c86aa06617a2e75f76ffa0162cb6ac10f3dff9f8a2a77f3caf95b90e214a3f8e"
-    ]
-  },
-  {
-    "query": "+insurance +claim +process",
-    "count": 647,
-    "top_100": 647,
-    "result_type": "Hash",
-    "top_100_result": [
-      "38657e8024eb8054d632e42458ab92ea4247802bc46c602fd6d76d514f9c9981"
-    ],
-    "top_100_count_result": [
-      "38657e8024eb8054d632e42458ab92ea4247802bc46c602fd6d76d514f9c9981"
-    ]
-  },
-  {
-    "query": "+credit +card +rewards",
-    "count": 99,
-    "top_100": 99,
-    "result_type": "Hash",
-    "top_100_result": [
-      "d7ed79b670ce798b67a7aa0f6f7c48da6d950f2d3a6fb7ea1c36d5fbb56ad82c"
-    ],
-    "top_100_count_result": [
-      "d7ed79b670ce798b67a7aa0f6f7c48da6d950f2d3a6fb7ea1c36d5fbb56ad82c"
-    ]
-  },
-  {
-    "query": "+data +center +cooling",
-    "count": 416,
-    "top_100": 416,
-    "result_type": "Hash",
-    "top_100_result": [
-      "98c174588c2e9313c44a678256e4261ccf4f771cb32eb39ac987a18e620069e1"
-    ],
-    "top_100_count_result": [
-      "98c174588c2e9313c44a678256e4261ccf4f771cb32eb39ac987a18e620069e1"
-    ]
-  },
-  {
-    "query": "+remote +learning +tools",
-    "count": 187,
-    "top_100": 187,
-    "result_type": "Hash",
-    "top_100_result": [
-      "5b05dd81504c687710b730b9be69c6419f4fb4c0e447bc81a99a6f26547ee956"
-    ],
-    "top_100_count_result": [
-      "5b05dd81504c687710b730b9be69c6419f4fb4c0e447bc81a99a6f26547ee956"
-    ]
-  },
-  {
-    "query": "+open +source +software +licenses",
-    "count": 424,
-    "top_100": 424,
-    "result_type": "Hash",
-    "top_100_result": [
-      "252d593717f40848479b403bf365f0a4dd0cb1d54094fb0c534649e73f9042f4"
-    ],
-    "top_100_count_result": [
-      "252d593717f40848479b403bf365f0a4dd0cb1d54094fb0c534649e73f9042f4"
-    ]
-  },
-  {
-    "query": "+health +care +cost +trends",
-    "count": 240,
-    "top_100": 240,
-    "result_type": "Hash",
-    "top_100_result": [
-      "daee59f1d2b1cbf5faf51df45d30d168bacc01bb6bb02888503d2b53a1674b4b"
-    ],
-    "top_100_count_result": [
-      "daee59f1d2b1cbf5faf51df45d30d168bacc01bb6bb02888503d2b53a1674b4b"
-    ]
-  },
-  {
-    "query": "+renewable +energy +policy +goals",
-    "count": 183,
-    "top_100": 183,
-    "result_type": "Hash",
-    "top_100_result": [
-      "99420e5b7b0e455ffa9b97248ede414d10d6f9197a7511caa976769bd32d21fc"
-    ],
-    "top_100_count_result": [
-      "99420e5b7b0e455ffa9b97248ede414d10d6f9197a7511caa976769bd32d21fc"
-    ]
-  },
-  {
-    "query": "+airport +security +screening +rules",
-    "count": 33,
-    "top_100": 33,
-    "result_type": "Hash",
-    "top_100_result": [
-      "7cb7110ab964b0af5b458d0a29f6da4b598bde574c332ca25df74447f66c97b2"
-    ],
-    "top_100_count_result": [
-      "7cb7110ab964b0af5b458d0a29f6da4b598bde574c332ca25df74447f66c97b2"
-    ]
-  },
-  {
-    "query": "+climate +change +impact +report",
-    "count": 807,
-    "top_100": 807,
-    "result_type": "Hash",
-    "top_100_result": [
-      "f28d1d01a91d7c0599ce1867cee88d81ab73bb3c32b47c7e6c4a45d260462b91"
-    ],
-    "top_100_count_result": [
-      "f28d1d01a91d7c0599ce1867cee88d81ab73bb3c32b47c7e6c4a45d260462b91"
-    ]
-  },
-  {
     "query": "+climate policy",
     "count": 42009,
     "top_100": 42009,
@@ -13149,6 +12681,4806 @@
     ],
     "top_100_count_result": [
       "336362aef34474b0ec293e5c1d6c55a3d7944d7bb469bf0795e38e9390950f09"
+    ]
+  },
+  {
+    "query": "+python -snake -monty",
+    "count": 2281,
+    "top_100": 2281,
+    "result_type": "Hash",
+    "top_100_result": [
+      "351ec72a2bc0725674ffe14e69cc143e33796385fb9686e17feb7c0f49a0220c"
+    ],
+    "top_100_count_result": [
+      "351ec72a2bc0725674ffe14e69cc143e33796385fb9686e17feb7c0f49a0220c"
+    ]
+  },
+  {
+    "query": "+python -snake",
+    "count": 3151,
+    "top_100": 3151,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0923316124cccc0a2bf105e5769b0e4bda672b4ea9312c6f5a2fd7695c2c0465"
+    ],
+    "top_100_count_result": [
+      "0923316124cccc0a2bf105e5769b0e4bda672b4ea9312c6f5a2fd7695c2c0465"
+    ]
+  },
+  {
+    "query": "+jaguar -car -football",
+    "count": 1672,
+    "top_100": 1672,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7858faf8278314f497d0062b3ba7da629cd4f0f1c40a8ebb45ebd800985bac10"
+    ],
+    "top_100_count_result": [
+      "7858faf8278314f497d0062b3ba7da629cd4f0f1c40a8ebb45ebd800985bac10"
+    ]
+  },
+  {
+    "query": "+jaguar -car",
+    "count": 1791,
+    "top_100": 1791,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3ee6f9f6c7a8d9e79184d47ec8a038905e02f0610a370a1d2023dd9cac4778a4"
+    ],
+    "top_100_count_result": [
+      "3ee6f9f6c7a8d9e79184d47ec8a038905e02f0610a370a1d2023dd9cac4778a4"
+    ]
+  },
+  {
+    "query": "+mercury -planet -element",
+    "count": 9895,
+    "top_100": 8970,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0e7f84475af3fe6c0267d5b8b6fc8d5f970111a16d48502cbca08426cce2f362"
+    ],
+    "top_100_count_result": [
+      "0e7f84475af3fe6c0267d5b8b6fc8d5f970111a16d48502cbca08426cce2f362"
+    ]
+  },
+  {
+    "query": "+mercury -planet",
+    "count": 10327,
+    "top_100": 9369,
+    "result_type": "Hash",
+    "top_100_result": [
+      "740230b40e3b85b67cc2c7016a226c285cf64442b334d42cae6c4fc09b1ed6ea"
+    ],
+    "top_100_count_result": [
+      "740230b40e3b85b67cc2c7016a226c285cf64442b334d42cae6c4fc09b1ed6ea"
+    ]
+  },
+  {
+    "query": "+java -coffee -island",
+    "count": 9756,
+    "top_100": 8533,
+    "result_type": "Hash",
+    "top_100_result": [
+      "958097c90dcab2b6d61390ad1803e6f148a7030c6b84ea0f9f32109cfd71753b"
+    ],
+    "top_100_count_result": [
+      "958097c90dcab2b6d61390ad1803e6f148a7030c6b84ea0f9f32109cfd71753b"
+    ]
+  },
+  {
+    "query": "+java -coffee",
+    "count": 11530,
+    "top_100": 10010,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f4faa9b0d10699fba2715be3d998e8f95ba513b00493768cc9ba9890a6e27391"
+    ],
+    "top_100_count_result": [
+      "f4faa9b0d10699fba2715be3d998e8f95ba513b00493768cc9ba9890a6e27391"
+    ]
+  },
+  {
+    "query": "+saturn -planet -car",
+    "count": 3045,
+    "top_100": 3045,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e67a70ce3420df90b18a4ec291cbccb7118fde7914badf81a8b74844641d1313"
+    ],
+    "top_100_count_result": [
+      "e67a70ce3420df90b18a4ec291cbccb7118fde7914badf81a8b74844641d1313"
+    ]
+  },
+  {
+    "query": "+mustang -car -horse",
+    "count": 1492,
+    "top_100": 1492,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0f2a6a6f92a0a218252b2322294a1e802d311980741a6e633fd5f475501b6c89"
+    ],
+    "top_100_count_result": [
+      "0f2a6a6f92a0a218252b2322294a1e802d311980741a6e633fd5f475501b6c89"
+    ]
+  },
+  {
+    "query": "+amazon -river -rainforest",
+    "count": 7740,
+    "top_100": 7358,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d90e2acb4c67c3109acf1d2e6a5089d548c965cc5ddf153ffba326dc381359f8"
+    ],
+    "top_100_count_result": [
+      "d90e2acb4c67c3109acf1d2e6a5089d548c965cc5ddf153ffba326dc381359f8"
+    ]
+  },
+  {
+    "query": "+apple -fruit -tree",
+    "count": 12832,
+    "top_100": 11338,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8ed6cc4fd10b3b1f0e97e9180bfad7940322f472f1bfa2c582e6647d068d7855"
+    ],
+    "top_100_count_result": [
+      "8ed6cc4fd10b3b1f0e97e9180bfad7940322f472f1bfa2c582e6647d068d7855"
+    ]
+  },
+  {
+    "query": "+delta -airlines -river",
+    "count": 11876,
+    "top_100": 9864,
+    "result_type": "Hash",
+    "top_100_result": [
+      "435dd9fbce603064c6f5f9b8d22757e85ed6e6427978b823b4af8d9a1c4ae899"
+    ],
+    "top_100_count_result": [
+      "435dd9fbce603064c6f5f9b8d22757e85ed6e6427978b823b4af8d9a1c4ae899"
+    ]
+  },
+  {
+    "query": "+jordan -country -basketball",
+    "count": 16503,
+    "top_100": 12814,
+    "result_type": "Hash",
+    "top_100_result": [
+      "556a08301a7ca8453491e391adad0e0673fb7e23737eb53d74c68a0e23c8e23a"
+    ],
+    "top_100_count_result": [
+      "556a08301a7ca8453491e391adad0e0673fb7e23737eb53d74c68a0e23c8e23a"
+    ]
+  },
+  {
+    "query": "+orion -constellation -spacecraft",
+    "count": 2357,
+    "top_100": 2357,
+    "result_type": "Hash",
+    "top_100_result": [
+      "dc8d6730cb64dafefcae53bd4ec79e2ba7f7d6679410fedef388108824f9c1e8"
+    ],
+    "top_100_count_result": [
+      "dc8d6730cb64dafefcae53bd4ec79e2ba7f7d6679410fedef388108824f9c1e8"
+    ]
+  },
+  {
+    "query": "+bass -fish -guitar",
+    "count": 17780,
+    "top_100": 12485,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e388dac4ee054df8105bbd4a9d7666f441764f2239aab8e501489c41afe51aca"
+    ],
+    "top_100_count_result": [
+      "e388dac4ee054df8105bbd4a9d7666f441764f2239aab8e501489c41afe51aca"
+    ]
+  },
+  {
+    "query": "+eclipse -lunar -solar",
+    "count": 3733,
+    "top_100": 3733,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b08f3cb11449a2ab3d968db661539cee9ee6941ca7de8be78da466ad86fe34fc"
+    ],
+    "top_100_count_result": [
+      "b08f3cb11449a2ab3d968db661539cee9ee6941ca7de8be78da466ad86fe34fc"
+    ]
+  },
+  {
+    "query": "+springfield -illinois -missouri",
+    "count": 6315,
+    "top_100": 6315,
+    "result_type": "Hash",
+    "top_100_result": [
+      "54a84efc24470ea8e9e890ae37ba79ecda5c160a1ebf55c02fe8ee2778b65c1d"
+    ],
+    "top_100_count_result": [
+      "54a84efc24470ea8e9e890ae37ba79ecda5c160a1ebf55c02fe8ee2778b65c1d"
+    ]
+  },
+  {
+    "query": "+puma -cat -shoes",
+    "count": 1339,
+    "top_100": 1339,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d60b88ce4dd1008b2a9b968aad743450ba5e7d3f19dc50a539770c23bdc50b65"
+    ],
+    "top_100_count_result": [
+      "d60b88ce4dd1008b2a9b968aad743450ba5e7d3f19dc50a539770c23bdc50b65"
+    ]
+  },
+  {
+    "query": "(the world state)@2",
+    "count": 1027681,
+    "top_100": 1027681,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3e374e4991c856f337b9e05cc0d438a0c604a6f8ae12ee7603f6bf0c1355dfc0"
+    ],
+    "top_100_count_result": [
+      "3e374e4991c856f337b9e05cc0d438a0c604a6f8ae12ee7603f6bf0c1355dfc0"
+    ]
+  },
+  {
+    "query": "(the world state history)@3",
+    "count": 368422,
+    "top_100": 368422,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a3835f66c3bae1b24eb0ff760436df94c65158e12e9c236aeba7fffd34643364"
+    ],
+    "top_100_count_result": [
+      "a3835f66c3bae1b24eb0ff760436df94c65158e12e9c236aeba7fffd34643364"
+    ]
+  },
+  {
+    "query": "(world state history)@2",
+    "count": 368515,
+    "top_100": 368515,
+    "result_type": "Hash",
+    "top_100_result": [
+      "36c99f3958833b01ac613159500426eaf847d4ec04c43dafd17288b76aa47879"
+    ],
+    "top_100_count_result": [
+      "36c99f3958833b01ac613159500426eaf847d4ec04c43dafd17288b76aa47879"
+    ]
+  },
+  {
+    "query": "(world state history president)@3",
+    "count": 110309,
+    "top_100": 110309,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d361ebeb89c7f5007a7152f6bf7451c46c832f9f8b4891db99d8b9e5a9ea3e50"
+    ],
+    "top_100_count_result": [
+      "d361ebeb89c7f5007a7152f6bf7451c46c832f9f8b4891db99d8b9e5a9ea3e50"
+    ]
+  },
+  {
+    "query": "(state history president)@2",
+    "count": 268897,
+    "top_100": 268897,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5161b578bdebb421113f9822065eb4514fd53b8bc966c4b84141a87e5ca2073c"
+    ],
+    "top_100_count_result": [
+      "5161b578bdebb421113f9822065eb4514fd53b8bc966c4b84141a87e5ca2073c"
+    ]
+  },
+  {
+    "query": "(state history president river)@3",
+    "count": 73165,
+    "top_100": 73165,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fda9b237d8509955c0a7e0e981559e7781a3dff9f64da68b2909b785468d3483"
+    ],
+    "top_100_count_result": [
+      "fda9b237d8509955c0a7e0e981559e7781a3dff9f64da68b2909b785468d3483"
+    ]
+  },
+  {
+    "query": "(history president river)@2",
+    "count": 164261,
+    "top_100": 164261,
+    "result_type": "Hash",
+    "top_100_result": [
+      "91e8ecaf00d763ff58eab4874cb90476992ccc2504294e1fb707644483dfbe54"
+    ],
+    "top_100_count_result": [
+      "91e8ecaf00d763ff58eab4874cb90476992ccc2504294e1fb707644483dfbe54"
+    ]
+  },
+  {
+    "query": "(history president river population)@3",
+    "count": 49741,
+    "top_100": 49741,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c9295e0c95d6c9139fb935416567488bb147af9123ff56cef46b6fa773d793ea"
+    ],
+    "top_100_count_result": [
+      "c9295e0c95d6c9139fb935416567488bb147af9123ff56cef46b6fa773d793ea"
+    ]
+  },
+  {
+    "query": "(president river population)@2",
+    "count": 82487,
+    "top_100": 82487,
+    "result_type": "Hash",
+    "top_100_result": [
+      "634c6a760c2407d8302ce2129e54577e79fc182081fce32f21d0269ee6794ef1"
+    ],
+    "top_100_count_result": [
+      "634c6a760c2407d8302ce2129e54577e79fc182081fce32f21d0269ee6794ef1"
+    ]
+  },
+  {
+    "query": "(president river population university)@3",
+    "count": 20387,
+    "top_100": 20387,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c78444d0325812694a696dd77e365f6fb7e0691bc3ba31b71f2d7896b397fa0a"
+    ],
+    "top_100_count_result": [
+      "c78444d0325812694a696dd77e365f6fb7e0691bc3ba31b71f2d7896b397fa0a"
+    ]
+  },
+  {
+    "query": "(river population university)@2",
+    "count": 89970,
+    "top_100": 89970,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0d0a6b6c850fc2f15b97e00b41e69d367665a16ffb4ade288efcf10193c96646"
+    ],
+    "top_100_count_result": [
+      "0d0a6b6c850fc2f15b97e00b41e69d367665a16ffb4ade288efcf10193c96646"
+    ]
+  },
+  {
+    "query": "(river population university germany)@3",
+    "count": 14182,
+    "top_100": 14182,
+    "result_type": "Hash",
+    "top_100_result": [
+      "adafc02c59a4e6dd9cd1201572fdfcc4d6dee1c7fdf8aefdbc2257118ccbd90e"
+    ],
+    "top_100_count_result": [
+      "adafc02c59a4e6dd9cd1201572fdfcc4d6dee1c7fdf8aefdbc2257118ccbd90e"
+    ]
+  },
+  {
+    "query": "(population university germany)@2",
+    "count": 69322,
+    "top_100": 69322,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f4c3f856eb1ad7f343ad0cbb40a8ec78e13f71710c2846ed16d89f0d97a52603"
+    ],
+    "top_100_count_result": [
+      "f4c3f856eb1ad7f343ad0cbb40a8ec78e13f71710c2846ed16d89f0d97a52603"
+    ]
+  },
+  {
+    "query": "(population university germany album)@3",
+    "count": 4781,
+    "top_100": 4781,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a72ca45bff62a394ca1a938d134efaad787f683f7a060ad6c37e35197f138c4b"
+    ],
+    "top_100_count_result": [
+      "a72ca45bff62a394ca1a938d134efaad787f683f7a060ad6c37e35197f138c4b"
+    ]
+  },
+  {
+    "query": "(university germany album)@2",
+    "count": 48557,
+    "top_100": 48557,
+    "result_type": "Hash",
+    "top_100_result": [
+      "64eb41ab3fb61735828b5a9a67133833df1fbe9a2fcf53f7e73a3569a7cdd7e1"
+    ],
+    "top_100_count_result": [
+      "64eb41ab3fb61735828b5a9a67133833df1fbe9a2fcf53f7e73a3569a7cdd7e1"
+    ]
+  },
+  {
+    "query": "(university germany album military)@3",
+    "count": 7934,
+    "top_100": 7934,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0d6c63b6fee7dfda7561721b55aabc7eae1ab58c2f815c89e3e09b3fd6510b6a"
+    ],
+    "top_100_count_result": [
+      "0d6c63b6fee7dfda7561721b55aabc7eae1ab58c2f815c89e3e09b3fd6510b6a"
+    ]
+  },
+  {
+    "query": "(germany album military)@2",
+    "count": 34334,
+    "top_100": 34334,
+    "result_type": "Hash",
+    "top_100_result": [
+      "603738b943469191db3efa00239c6926d3f0297a1e8cb6878a855c46efec0437"
+    ],
+    "top_100_count_result": [
+      "603738b943469191db3efa00239c6926d3f0297a1e8cb6878a855c46efec0437"
+    ]
+  },
+  {
+    "query": "(germany album military railway)@3",
+    "count": 2677,
+    "top_100": 2677,
+    "result_type": "Hash",
+    "top_100_result": [
+      "40e3a89fa4f8f64ed53c8419b5f16a68ee2cbb8333df9fc6d2f8156309144629"
+    ],
+    "top_100_count_result": [
+      "40e3a89fa4f8f64ed53c8419b5f16a68ee2cbb8333df9fc6d2f8156309144629"
+    ]
+  },
+  {
+    "query": "(album military railway)@2",
+    "count": 10976,
+    "top_100": 10976,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ed67e6a909a05ff7b9e8a7fc4e8c7ac5bbc61f645cc68007f28b5bfd021e9a4a"
+    ],
+    "top_100_count_result": [
+      "ed67e6a909a05ff7b9e8a7fc4e8c7ac5bbc61f645cc68007f28b5bfd021e9a4a"
+    ]
+  },
+  {
+    "query": "(album military railway football)@3",
+    "count": 985,
+    "top_100": 985,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a71d3f3530b32fb81d4afe2f8045710b2561a6549910a76ab1d35a22012166c7"
+    ],
+    "top_100_count_result": [
+      "a71d3f3530b32fb81d4afe2f8045710b2561a6549910a76ab1d35a22012166c7"
+    ]
+  },
+  {
+    "query": "(the world \"griffith observatory\")@2",
+    "count": 631199,
+    "top_100": 631199,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a7d61753fbc0b7f07c50c97592cdc6a03e0ec561fed4180ccb31d1d956f353ea"
+    ],
+    "top_100_count_result": [
+      "a7d61753fbc0b7f07c50c97592cdc6a03e0ec561fed4180ccb31d1d956f353ea"
+    ]
+  },
+  {
+    "query": "(\"griffith observatory\" \"bowel obstruction\" the)@2",
+    "count": 167,
+    "top_100": 167,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6ba542209bc4147e56098922b4b036d864d6119276a09dfd70757693b0ba3bfc"
+    ],
+    "top_100_count_result": [
+      "6ba542209bc4147e56098922b4b036d864d6119276a09dfd70757693b0ba3bfc"
+    ]
+  },
+  {
+    "query": "(world state \"bowel obstruction\")@2",
+    "count": 120792,
+    "top_100": 120792,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d07996080bedafefc5f2500ec889cb9476fa199d7f34b840429b1458604b5924"
+    ],
+    "top_100_count_result": [
+      "d07996080bedafefc5f2500ec889cb9476fa199d7f34b840429b1458604b5924"
+    ]
+  },
+  {
+    "query": "(\"bowel obstruction\" \"vicenza italy\" world)@2",
+    "count": 74,
+    "top_100": 74,
+    "result_type": "Hash",
+    "top_100_result": [
+      "99ad84464f29e34df0697ce78bd5fca155443fa5c85542084dc5a2170ddec0fc"
+    ],
+    "top_100_count_result": [
+      "99ad84464f29e34df0697ce78bd5fca155443fa5c85542084dc5a2170ddec0fc"
+    ]
+  },
+  {
+    "query": "(state history \"vicenza italy\")@2",
+    "count": 173725,
+    "top_100": 173725,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b63b582db4ceae025d3e2ece99a94e94bb6167c60153155ae4fc6f5c833c0168"
+    ],
+    "top_100_count_result": [
+      "b63b582db4ceae025d3e2ece99a94e94bb6167c60153155ae4fc6f5c833c0168"
+    ]
+  },
+  {
+    "query": "(\"vicenza italy\" \"digital scanning\" state)@2",
+    "count": 18,
+    "top_100": 18,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b08c4918402d70a2ed16afc843264ec6c91a4eecfbe2f06a6de0ff9edcffcebe"
+    ],
+    "top_100_count_result": [
+      "b08c4918402d70a2ed16afc843264ec6c91a4eecfbe2f06a6de0ff9edcffcebe"
+    ]
+  },
+  {
+    "query": "(history president \"digital scanning\")@2",
+    "count": 77787,
+    "top_100": 77787,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bd52e97a29059f2254c97f30a29ec2e26445f07e6dde9b43ad451a669725021f"
+    ],
+    "top_100_count_result": [
+      "bd52e97a29059f2254c97f30a29ec2e26445f07e6dde9b43ad451a669725021f"
+    ]
+  },
+  {
+    "query": "(\"digital scanning\" \"borders books\" history)@2",
+    "count": 10,
+    "top_100": 10,
+    "result_type": "Hash",
+    "top_100_result": [
+      "84984ff6d92e6ceb012911854eb427cefec6bda755d9678e3bfb53140a74cf3f"
+    ],
+    "top_100_count_result": [
+      "84984ff6d92e6ceb012911854eb427cefec6bda755d9678e3bfb53140a74cf3f"
+    ]
+  },
+  {
+    "query": "(president river \"borders books\")@2",
+    "count": 18514,
+    "top_100": 18514,
+    "result_type": "Hash",
+    "top_100_result": [
+      "449d0d4d37bf012682ed80b621c68f13f58590dcd817ae62d87d17f24ce6ffc1"
+    ],
+    "top_100_count_result": [
+      "449d0d4d37bf012682ed80b621c68f13f58590dcd817ae62d87d17f24ce6ffc1"
+    ]
+  },
+  {
+    "query": "(\"borders books\" \"american funds\" president)@2",
+    "count": 15,
+    "top_100": 15,
+    "result_type": "Hash",
+    "top_100_result": [
+      "028b4f3563d78e29597fab50660532df1fbe275768785b2fbe6241483ca7eebb"
+    ],
+    "top_100_count_result": [
+      "028b4f3563d78e29597fab50660532df1fbe275768785b2fbe6241483ca7eebb"
+    ]
+  },
+  {
+    "query": "(river population \"american funds\")@2",
+    "count": 53989,
+    "top_100": 53989,
+    "result_type": "Hash",
+    "top_100_result": [
+      "31f1e01cb3d36f19adc0d8a0b0ecd70f1c74c72f16292851ba76df56493de093"
+    ],
+    "top_100_count_result": [
+      "31f1e01cb3d36f19adc0d8a0b0ecd70f1c74c72f16292851ba76df56493de093"
+    ]
+  },
+  {
+    "query": "(\"american funds\" \"scottsdale az\" river)@2",
+    "count": 7,
+    "top_100": 7,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1c33a32deb15f012752ce8c276986bb0664761199fe06c431a90cd3c31503440"
+    ],
+    "top_100_count_result": [
+      "1c33a32deb15f012752ce8c276986bb0664761199fe06c431a90cd3c31503440"
+    ]
+  },
+  {
+    "query": "(population university \"scottsdale az\")@2",
+    "count": 26631,
+    "top_100": 26631,
+    "result_type": "Hash",
+    "top_100_result": [
+      "25fe3b990f04f46c28b7c0e925d629f2b1a04ff482ebe2126f5f9f07509d76ea"
+    ],
+    "top_100_count_result": [
+      "25fe3b990f04f46c28b7c0e925d629f2b1a04ff482ebe2126f5f9f07509d76ea"
+    ]
+  },
+  {
+    "query": "(\"scottsdale az\" \"freelance work\" population)@2",
+    "count": 6,
+    "top_100": 6,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6a0184616fad0bcf4a66d68565392d02e34fba1ccf4922e315411e47689f1632"
+    ],
+    "top_100_count_result": [
+      "6a0184616fad0bcf4a66d68565392d02e34fba1ccf4922e315411e47689f1632"
+    ]
+  },
+  {
+    "query": "(university germany \"freelance work\")@2",
+    "count": 31745,
+    "top_100": 31745,
+    "result_type": "Hash",
+    "top_100_result": [
+      "44cf56f80301e2418adfc5873c9968691c0a9e5bf070c75e3a9328cf4e8aa126"
+    ],
+    "top_100_count_result": [
+      "44cf56f80301e2418adfc5873c9968691c0a9e5bf070c75e3a9328cf4e8aa126"
+    ]
+  },
+  {
+    "query": "(\"freelance work\" \"color combinations\" university)@2",
+    "count": 160,
+    "top_100": 160,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8f60f098f6a6fa11e35ab59faf989c4506b7f1ac55ed19cb72d3d3d8ca72c1a1"
+    ],
+    "top_100_count_result": [
+      "8f60f098f6a6fa11e35ab59faf989c4506b7f1ac55ed19cb72d3d3d8ca72c1a1"
+    ]
+  },
+  {
+    "query": "\"griffith 1-1 observatory\"",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7e4884c3c11d91a7f71d792596d90b6a2efca9de9d517dc82583c6f55c5eab9e"
+    ],
+    "top_100_count_result": [
+      "7e4884c3c11d91a7f71d792596d90b6a2efca9de9d517dc82583c6f55c5eab9e"
+    ]
+  },
+  {
+    "query": "\"griffith 1-3 observatory\"",
+    "count": 63,
+    "top_100": 63,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e6be646a7c6a0f3f9aeb40fde48f850fcb8e43b451f8961753d4bb226ca650ae"
+    ],
+    "top_100_count_result": [
+      "e6be646a7c6a0f3f9aeb40fde48f850fcb8e43b451f8961753d4bb226ca650ae"
+    ]
+  },
+  {
+    "query": "\"griffith observatory\"~1",
+    "count": 63,
+    "top_100": 63,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ea0cdeb6518dae26ca00a4346f1c8aff5e285512f0b49738e81d80e76cf4ca4b"
+    ],
+    "top_100_count_result": [
+      "ea0cdeb6518dae26ca00a4346f1c8aff5e285512f0b49738e81d80e76cf4ca4b"
+    ]
+  },
+  {
+    "query": "\"griffith observatory\"~3",
+    "count": 64,
+    "top_100": 64,
+    "result_type": "Hash",
+    "top_100_result": [
+      "eef43e0b70d227a5bdfb510eeae7f55086c4f597ad505c30886f65b4d503eda1"
+    ],
+    "top_100_count_result": [
+      "eef43e0b70d227a5bdfb510eeae7f55086c4f597ad505c30886f65b4d503eda1"
+    ]
+  },
+  {
+    "query": "\"bowel 1-1 obstruction\"",
+    "count": 110,
+    "top_100": 110,
+    "result_type": "Hash",
+    "top_100_result": [
+      "350a4d52c6c674487e843c8ea6445b62b8399f474d4217a6e2d6ee7fbcaf81a8"
+    ],
+    "top_100_count_result": [
+      "350a4d52c6c674487e843c8ea6445b62b8399f474d4217a6e2d6ee7fbcaf81a8"
+    ]
+  },
+  {
+    "query": "\"bowel 1-3 obstruction\"",
+    "count": 112,
+    "top_100": 112,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c82acaf16fb3914e3d23336cfc7dc5b92026b29d10e9fe1949870e2b3953506e"
+    ],
+    "top_100_count_result": [
+      "c82acaf16fb3914e3d23336cfc7dc5b92026b29d10e9fe1949870e2b3953506e"
+    ]
+  },
+  {
+    "query": "\"bowel obstruction\"~1",
+    "count": 110,
+    "top_100": 110,
+    "result_type": "Hash",
+    "top_100_result": [
+      "350a4d52c6c674487e843c8ea6445b62b8399f474d4217a6e2d6ee7fbcaf81a8"
+    ],
+    "top_100_count_result": [
+      "350a4d52c6c674487e843c8ea6445b62b8399f474d4217a6e2d6ee7fbcaf81a8"
+    ]
+  },
+  {
+    "query": "\"bowel obstruction\"~3",
+    "count": 117,
+    "top_100": 117,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4c6dc8484e91bd5428d1258c7883d7ab3ab974c76c6803cccad5d2ba42e28847"
+    ],
+    "top_100_count_result": [
+      "4c6dc8484e91bd5428d1258c7883d7ab3ab974c76c6803cccad5d2ba42e28847"
+    ]
+  },
+  {
+    "query": "\"vicenza 1-1 italy\"",
+    "count": 112,
+    "top_100": 111,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9b07b23dff9e343929419b85b5c1accc47657e73482332d249d69e849e12d495"
+    ],
+    "top_100_count_result": [
+      "9b07b23dff9e343929419b85b5c1accc47657e73482332d249d69e849e12d495"
+    ]
+  },
+  {
+    "query": "\"vicenza 1-3 italy\"",
+    "count": 271,
+    "top_100": 227,
+    "result_type": "Hash",
+    "top_100_result": [
+      "817570beb396b0ead6ba0101ede139a7f8a98309b250a746d7dd606ec8f5e11b"
+    ],
+    "top_100_count_result": [
+      "817570beb396b0ead6ba0101ede139a7f8a98309b250a746d7dd606ec8f5e11b"
+    ]
+  },
+  {
+    "query": "\"vicenza italy\"~1",
+    "count": 241,
+    "top_100": 241,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4e109b00f71185cdfa92d3db87626571dea8f820ff114f54af17fba77604c567"
+    ],
+    "top_100_count_result": [
+      "4e109b00f71185cdfa92d3db87626571dea8f820ff114f54af17fba77604c567"
+    ]
+  },
+  {
+    "query": "\"vicenza italy\"~3",
+    "count": 287,
+    "top_100": 287,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3f002240786bc5efca617f6e3a3dfe3512e7e7cc880ff2d70569fb24841de536"
+    ],
+    "top_100_count_result": [
+      "3f002240786bc5efca617f6e3a3dfe3512e7e7cc880ff2d70569fb24841de536"
+    ]
+  },
+  {
+    "query": "\"digital 1-1 scanning\"",
+    "count": 17,
+    "top_100": 17,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b38c7ab0c5978b9e06f6609029b8cfe6db3bddce1ac7d4ef2c21ee1691012fe8"
+    ],
+    "top_100_count_result": [
+      "b38c7ab0c5978b9e06f6609029b8cfe6db3bddce1ac7d4ef2c21ee1691012fe8"
+    ]
+  },
+  {
+    "query": "\"digital 1-3 scanning\"",
+    "count": 26,
+    "top_100": 26,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d378b83ad2c5393e0611134197545a0faeb7a63dd00e5f790384e3fe21bada8e"
+    ],
+    "top_100_count_result": [
+      "d378b83ad2c5393e0611134197545a0faeb7a63dd00e5f790384e3fe21bada8e"
+    ]
+  },
+  {
+    "query": "\"digital scanning\"~1",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9b9c79e0c32ba6ee202529feb898e6459deb8a065b0cd0a18f6e943e4fd45cca"
+    ],
+    "top_100_count_result": [
+      "9b9c79e0c32ba6ee202529feb898e6459deb8a065b0cd0a18f6e943e4fd45cca"
+    ]
+  },
+  {
+    "query": "\"digital scanning\"~3",
+    "count": 47,
+    "top_100": 47,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f2fdde1a2da7a58c99396ae65f7956c96a1d18e0ebb5c353c0fd631492b4fbc2"
+    ],
+    "top_100_count_result": [
+      "f2fdde1a2da7a58c99396ae65f7956c96a1d18e0ebb5c353c0fd631492b4fbc2"
+    ]
+  },
+  {
+    "query": "\"borders 1-1 books\"",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1766ac6f7247df82418bb59ac6497672a89f23148df88de26e8b48bda8c185f8"
+    ],
+    "top_100_count_result": [
+      "1766ac6f7247df82418bb59ac6497672a89f23148df88de26e8b48bda8c185f8"
+    ]
+  },
+  {
+    "query": "\"borders 1-3 books\"",
+    "count": 36,
+    "top_100": 36,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ab3d03a86f83707f9a6e1c042f225809d667f22487ca8f9659813db6ecfc358a"
+    ],
+    "top_100_count_result": [
+      "ab3d03a86f83707f9a6e1c042f225809d667f22487ca8f9659813db6ecfc358a"
+    ]
+  },
+  {
+    "query": "\"borders books\"~1",
+    "count": 33,
+    "top_100": 33,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9daf1ca3d502123f94be6a075229a7712ec18366df44b028ff895cb5b7606581"
+    ],
+    "top_100_count_result": [
+      "9daf1ca3d502123f94be6a075229a7712ec18366df44b028ff895cb5b7606581"
+    ]
+  },
+  {
+    "query": "\"borders books\"~3",
+    "count": 42,
+    "top_100": 42,
+    "result_type": "Hash",
+    "top_100_result": [
+      "eed28a42890426cdc3d8c09950c8e1f289c4b998aa28298c8158292a24cddcda"
+    ],
+    "top_100_count_result": [
+      "eed28a42890426cdc3d8c09950c8e1f289c4b998aa28298c8158292a24cddcda"
+    ]
+  },
+  {
+    "query": "\"american 1-1 funds\"",
+    "count": 23,
+    "top_100": 23,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e44b46023950861b00a91b4e12cef7e35f61be4203c4b8954ce2506027d64320"
+    ],
+    "top_100_count_result": [
+      "e44b46023950861b00a91b4e12cef7e35f61be4203c4b8954ce2506027d64320"
+    ]
+  },
+  {
+    "query": "\"american 1-3 funds\"",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "af82f4d1bd4d8cb4370bd749b550631761d1e60aaa23ea0a82195479be142c95"
+    ],
+    "top_100_count_result": [
+      "af82f4d1bd4d8cb4370bd749b550631761d1e60aaa23ea0a82195479be142c95"
+    ]
+  },
+  {
+    "query": "\"american funds\"~1",
+    "count": 39,
+    "top_100": 39,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1af6d8b7feda31c545edf2ae82877e5a919a858d2f098ac65eaa8c9d73328c23"
+    ],
+    "top_100_count_result": [
+      "1af6d8b7feda31c545edf2ae82877e5a919a858d2f098ac65eaa8c9d73328c23"
+    ]
+  },
+  {
+    "query": "\"american funds\"~3",
+    "count": 119,
+    "top_100": 119,
+    "result_type": "Hash",
+    "top_100_result": [
+      "600b438973042ceb4fc808fa8dd157b47514d87f251347c06f3e6703fa53aa6c"
+    ],
+    "top_100_count_result": [
+      "600b438973042ceb4fc808fa8dd157b47514d87f251347c06f3e6703fa53aa6c"
+    ]
+  },
+  {
+    "query": "\"scottsdale 1-1 az\"",
+    "count": 56,
+    "top_100": 56,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1d02facb3b006bd47f6f742394b4a2d750e37675c2b8d2bc19db77004c12c8ed"
+    ],
+    "top_100_count_result": [
+      "1d02facb3b006bd47f6f742394b4a2d750e37675c2b8d2bc19db77004c12c8ed"
+    ]
+  },
+  {
+    "query": "\"scottsdale 1-3 az\"",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5e489ec551c629347e636e4fdbf31302e5524dd09002c6917e8fc65f1fd1e9e6"
+    ],
+    "top_100_count_result": [
+      "5e489ec551c629347e636e4fdbf31302e5524dd09002c6917e8fc65f1fd1e9e6"
+    ]
+  },
+  {
+    "query": "\"scottsdale az\"~1",
+    "count": 56,
+    "top_100": 56,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1d02facb3b006bd47f6f742394b4a2d750e37675c2b8d2bc19db77004c12c8ed"
+    ],
+    "top_100_count_result": [
+      "1d02facb3b006bd47f6f742394b4a2d750e37675c2b8d2bc19db77004c12c8ed"
+    ]
+  },
+  {
+    "query": "\"scottsdale az\"~3",
+    "count": 58,
+    "top_100": 58,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8c1bcaf5d785a93e73dc11e85e24b4d5c6ed4942ed2a9eb405a0ec550db7eecd"
+    ],
+    "top_100_count_result": [
+      "8c1bcaf5d785a93e73dc11e85e24b4d5c6ed4942ed2a9eb405a0ec550db7eecd"
+    ]
+  },
+  {
+    "query": "\"freelance 1-1 work\"",
+    "count": 307,
+    "top_100": 228,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4da8acade67f8fbb3ac6f91dbd91e6e6298333b6022ce5861e3d2f2fcba76aca"
+    ],
+    "top_100_count_result": [
+      "4da8acade67f8fbb3ac6f91dbd91e6e6298333b6022ce5861e3d2f2fcba76aca"
+    ]
+  },
+  {
+    "query": "\"freelance 1-3 work\"",
+    "count": 409,
+    "top_100": 336,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a6da96dc7d9430a108e92b770f5d5d6df399479ac914899bfaa32f89e3f94383"
+    ],
+    "top_100_count_result": [
+      "a6da96dc7d9430a108e92b770f5d5d6df399479ac914899bfaa32f89e3f94383"
+    ]
+  },
+  {
+    "query": "\"freelance work\"~1",
+    "count": 354,
+    "top_100": 354,
+    "result_type": "Hash",
+    "top_100_result": [
+      "32a235d6e1f0464434e1607fab7515a2acb0b96c5d5b2f8bb80aff0883294d78"
+    ],
+    "top_100_count_result": [
+      "32a235d6e1f0464434e1607fab7515a2acb0b96c5d5b2f8bb80aff0883294d78"
+    ]
+  },
+  {
+    "query": "\"freelance work\"~3",
+    "count": 495,
+    "top_100": 495,
+    "result_type": "Hash",
+    "top_100_result": [
+      "df62f1a4cb8636d3fb1812f4469fe709c8037fa7fcdf2785d3300de70886a93c"
+    ],
+    "top_100_count_result": [
+      "df62f1a4cb8636d3fb1812f4469fe709c8037fa7fcdf2785d3300de70886a93c"
+    ]
+  },
+  {
+    "query": "\"color 1-1 combinations\"",
+    "count": 177,
+    "top_100": 160,
+    "result_type": "Hash",
+    "top_100_result": [
+      "49b9380d98fcf635ab6379c2f507b936fb909a1de5573be487d2c2547426b06e"
+    ],
+    "top_100_count_result": [
+      "49b9380d98fcf635ab6379c2f507b936fb909a1de5573be487d2c2547426b06e"
+    ]
+  },
+  {
+    "query": "\"color 1-3 combinations\"",
+    "count": 193,
+    "top_100": 183,
+    "result_type": "Hash",
+    "top_100_result": [
+      "162b44a3bb744f3cc0595eb7df8b3d9d1d5edee1d624a1f9b886d0fd9c522ad4"
+    ],
+    "top_100_count_result": [
+      "162b44a3bb744f3cc0595eb7df8b3d9d1d5edee1d624a1f9b886d0fd9c522ad4"
+    ]
+  },
+  {
+    "query": "\"color combinations\"~1",
+    "count": 183,
+    "top_100": 183,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4eed3aa79a49283b13baa2732127d0d700484d5b9280167f63cc96bb81f224eb"
+    ],
+    "top_100_count_result": [
+      "4eed3aa79a49283b13baa2732127d0d700484d5b9280167f63cc96bb81f224eb"
+    ]
+  },
+  {
+    "query": "\"color combinations\"~3",
+    "count": 203,
+    "top_100": 203,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3713e1157b0dcbf158a17e94eecbbc6875c38cd7d172931650643e7fc0dd68a2"
+    ],
+    "top_100_count_result": [
+      "3713e1157b0dcbf158a17e94eecbbc6875c38cd7d172931650643e7fc0dd68a2"
+    ]
+  },
+  {
+    "query": "\"italian 1-1 translation\"",
+    "count": 252,
+    "top_100": 208,
+    "result_type": "Hash",
+    "top_100_result": [
+      "617f683debe59a9e59f6364156af31ec4f3e4364e87316760e40714a5221ee72"
+    ],
+    "top_100_count_result": [
+      "617f683debe59a9e59f6364156af31ec4f3e4364e87316760e40714a5221ee72"
+    ]
+  },
+  {
+    "query": "\"italian 1-3 translation\"",
+    "count": 284,
+    "top_100": 264,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6c275e9db2859a29b6d0479fe43c5e0e42234dfaa02e728c613d94626b1cd732"
+    ],
+    "top_100_count_result": [
+      "6c275e9db2859a29b6d0479fe43c5e0e42234dfaa02e728c613d94626b1cd732"
+    ]
+  },
+  {
+    "query": "\"italian translation\"~1",
+    "count": 265,
+    "top_100": 265,
+    "result_type": "Hash",
+    "top_100_result": [
+      "617f683debe59a9e59f6364156af31ec4f3e4364e87316760e40714a5221ee72"
+    ],
+    "top_100_count_result": [
+      "617f683debe59a9e59f6364156af31ec4f3e4364e87316760e40714a5221ee72"
+    ]
+  },
+  {
+    "query": "\"italian translation\"~3",
+    "count": 362,
+    "top_100": 362,
+    "result_type": "Hash",
+    "top_100_result": [
+      "23ec7de81a56d8761d41a96fe7a9b2530a78be3442e521c72dd354afd917eb0d"
+    ],
+    "top_100_count_result": [
+      "23ec7de81a56d8761d41a96fe7a9b2530a78be3442e521c72dd354afd917eb0d"
+    ]
+  },
+  {
+    "query": "\"milwaukee 1-1 newspaper\"",
+    "count": 10,
+    "top_100": 10,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ae6ed0faea751efe17ef0336f0746e921e50f45676024d1d36ba578d5d0e84bf"
+    ],
+    "top_100_count_result": [
+      "ae6ed0faea751efe17ef0336f0746e921e50f45676024d1d36ba578d5d0e84bf"
+    ]
+  },
+  {
+    "query": "\"milwaukee 1-3 newspaper\"",
+    "count": 26,
+    "top_100": 26,
+    "result_type": "Hash",
+    "top_100_result": [
+      "282eca6bad12126763271ccade38e7ec66eb21a9e435d4ad4074c1b5f1f7fac9"
+    ],
+    "top_100_count_result": [
+      "282eca6bad12126763271ccade38e7ec66eb21a9e435d4ad4074c1b5f1f7fac9"
+    ]
+  },
+  {
+    "query": "\"milwaukee newspaper\"~1",
+    "count": 15,
+    "top_100": 15,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d191389fa479a9aaadf115ee4aaf0762cc16d0ee9805f630af6491442167ba8d"
+    ],
+    "top_100_count_result": [
+      "d191389fa479a9aaadf115ee4aaf0762cc16d0ee9805f630af6491442167ba8d"
+    ]
+  },
+  {
+    "query": "\"milwaukee newspaper\"~3",
+    "count": 38,
+    "top_100": 38,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d8dcdbaab0917577020d9072882f01cfc31fe7588ed67f8236b850d719282176"
+    ],
+    "top_100_count_result": [
+      "d8dcdbaab0917577020d9072882f01cfc31fe7588ed67f8236b850d719282176"
+    ]
+  },
+  {
+    "query": "\"omaha 1-1 symphony\"",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ],
+    "top_100_count_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ]
+  },
+  {
+    "query": "\"omaha 1-3 symphony\"",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4541ebc711bd353f8abeb1f474a0fa2e5fce255ee75e48d52205524666900fc1"
+    ],
+    "top_100_count_result": [
+      "4541ebc711bd353f8abeb1f474a0fa2e5fce255ee75e48d52205524666900fc1"
+    ]
+  },
+  {
+    "query": "\"omaha symphony\"~1",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ],
+    "top_100_count_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ]
+  },
+  {
+    "query": "\"omaha symphony\"~3",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "087207b8f4c21473390f2718275b6a9ae391612f3cee92b7e9013874ffd142e5"
+    ],
+    "top_100_count_result": [
+      "087207b8f4c21473390f2718275b6a9ae391612f3cee92b7e9013874ffd142e5"
+    ]
+  },
+  {
+    "query": "\"body 1-1 painting\"",
+    "count": 141,
+    "top_100": 139,
+    "result_type": "Hash",
+    "top_100_result": [
+      "84498db6b2ae912b1ddecc0e7d7e9cb2a992a9e7cff4c40531edb9d862f3d681"
+    ],
+    "top_100_count_result": [
+      "84498db6b2ae912b1ddecc0e7d7e9cb2a992a9e7cff4c40531edb9d862f3d681"
+    ]
+  },
+  {
+    "query": "\"body 1-3 painting\"",
+    "count": 175,
+    "top_100": 172,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b046b3c4dd19cf193fe06262cd0ea311807ee3a4c0bda6b06b4bd8409b0585bf"
+    ],
+    "top_100_count_result": [
+      "b046b3c4dd19cf193fe06262cd0ea311807ee3a4c0bda6b06b4bd8409b0585bf"
+    ]
+  },
+  {
+    "query": "\"body painting\"~1",
+    "count": 154,
+    "top_100": 154,
+    "result_type": "Hash",
+    "top_100_result": [
+      "35587444eec605c6b571a9ee8dce3917009ec7dbe837530bcce8f72f343e974f"
+    ],
+    "top_100_count_result": [
+      "35587444eec605c6b571a9ee8dce3917009ec7dbe837530bcce8f72f343e974f"
+    ]
+  },
+  {
+    "query": "\"body painting\"~3",
+    "count": 206,
+    "top_100": 206,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e0f3ee10837cb84a8276fc29bf69c73100d81fa13183cf3d89958e38863d269b"
+    ],
+    "top_100_count_result": [
+      "e0f3ee10837cb84a8276fc29bf69c73100d81fa13183cf3d89958e38863d269b"
+    ]
+  },
+  {
+    "query": "\"stone 1-1 mountain\"",
+    "count": 329,
+    "top_100": 231,
+    "result_type": "Hash",
+    "top_100_result": [
+      "87a7bcdbb987dd4955868112581a68bb23ca3dd63d94d735111e6b6658005038"
+    ],
+    "top_100_count_result": [
+      "87a7bcdbb987dd4955868112581a68bb23ca3dd63d94d735111e6b6658005038"
+    ]
+  },
+  {
+    "query": "\"stone 1-3 mountain\"",
+    "count": 385,
+    "top_100": 293,
+    "result_type": "Hash",
+    "top_100_result": [
+      "43758e8c7b0926857840bca59af28a37e03fe6187915e55b64ffc133f7008759"
+    ],
+    "top_100_count_result": [
+      "43758e8c7b0926857840bca59af28a37e03fe6187915e55b64ffc133f7008759"
+    ]
+  },
+  {
+    "query": "\"stone mountain\"~1",
+    "count": 348,
+    "top_100": 348,
+    "result_type": "Hash",
+    "top_100_result": [
+      "396f1af02885f7e8a3017ea7dfc1e7d5dfd6c7d0ee041e6a4060fd5465c8b690"
+    ],
+    "top_100_count_result": [
+      "396f1af02885f7e8a3017ea7dfc1e7d5dfd6c7d0ee041e6a4060fd5465c8b690"
+    ]
+  },
+  {
+    "query": "\"stone mountain\"~3",
+    "count": 479,
+    "top_100": 479,
+    "result_type": "Hash",
+    "top_100_result": [
+      "426a20f7b94beecb457c529d44a359b2fb85c32f8b22c6468fdf7232b70b8bc7"
+    ],
+    "top_100_count_result": [
+      "426a20f7b94beecb457c529d44a359b2fb85c32f8b22c6468fdf7232b70b8bc7"
+    ]
+  },
+  {
+    "query": "\"plus 1-2 size 1-3 clothing\"",
+    "count": 20,
+    "top_100": 20,
+    "result_type": "Hash",
+    "top_100_result": [
+      "79caa21b751dcd6b2add59608a1192631c73e35e693d0a6e5f1a95a8d4423376"
+    ],
+    "top_100_count_result": [
+      "79caa21b751dcd6b2add59608a1192631c73e35e693d0a6e5f1a95a8d4423376"
+    ]
+  },
+  {
+    "query": "\"plus size clothing\"~2",
+    "count": 20,
+    "top_100": 20,
+    "result_type": "Hash",
+    "top_100_result": [
+      "221f638a87e030065c62cea7d3b5853fd00f9e74825477c4b4b105bcca42fc9d"
+    ],
+    "top_100_count_result": [
+      "221f638a87e030065c62cea7d3b5853fd00f9e74825477c4b4b105bcca42fc9d"
+    ]
+  },
+  {
+    "query": "\"wisconsin 1-2 attorney 1-3 general\"",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a057d944021152b96714272b696de57797592556fded91e963f63eaa46c6113d"
+    ],
+    "top_100_count_result": [
+      "a057d944021152b96714272b696de57797592556fded91e963f63eaa46c6113d"
+    ]
+  },
+  {
+    "query": "\"wisconsin attorney general\"~2",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a92b431001abafb24da468f6f931e7c6ec49499dab002661ee7c4966376aa2c8"
+    ],
+    "top_100_count_result": [
+      "a92b431001abafb24da468f6f931e7c6ec49499dab002661ee7c4966376aa2c8"
+    ]
+  },
+  {
+    "query": "\"the 1-2 english 1-3 restoration\"",
+    "count": 212,
+    "top_100": 212,
+    "result_type": "Hash",
+    "top_100_result": [
+      "56a6b74c5ca4919a2e2398e2941c679a11bbbb8359335a331e068edf1b9c5cd7"
+    ],
+    "top_100_count_result": [
+      "56a6b74c5ca4919a2e2398e2941c679a11bbbb8359335a331e068edf1b9c5cd7"
+    ]
+  },
+  {
+    "query": "\"the english restoration\"~2",
+    "count": 214,
+    "top_100": 214,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c186e449ab1156b3f75e2b8eb98fec2ade1b7163c9bf2500b97e4814a437053b"
+    ],
+    "top_100_count_result": [
+      "c186e449ab1156b3f75e2b8eb98fec2ade1b7163c9bf2500b97e4814a437053b"
+    ]
+  },
+  {
+    "query": "\"french 1-2 culinary 1-3 institute\"",
+    "count": 31,
+    "top_100": 31,
+    "result_type": "Hash",
+    "top_100_result": [
+      "adf2a419032fe4466cb141109a4592f869e6fc0a0dd1adc3ec5ce94a0bb642b5"
+    ],
+    "top_100_count_result": [
+      "adf2a419032fe4466cb141109a4592f869e6fc0a0dd1adc3ec5ce94a0bb642b5"
+    ]
+  },
+  {
+    "query": "\"french culinary institute\"~2",
+    "count": 31,
+    "top_100": 31,
+    "result_type": "Hash",
+    "top_100_result": [
+      "adf2a419032fe4466cb141109a4592f869e6fc0a0dd1adc3ec5ce94a0bb642b5"
+    ],
+    "top_100_count_result": [
+      "adf2a419032fe4466cb141109a4592f869e6fc0a0dd1adc3ec5ce94a0bb642b5"
+    ]
+  },
+  {
+    "query": "\"robert 1-2 green 1-3 ingersoll\"",
+    "count": 12,
+    "top_100": 12,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ac2ec5ba3e53451dfd8f5b9a42bb62e6035a132840f93b54397a38009d1b7689"
+    ],
+    "top_100_count_result": [
+      "ac2ec5ba3e53451dfd8f5b9a42bb62e6035a132840f93b54397a38009d1b7689"
+    ]
+  },
+  {
+    "query": "\"robert green ingersoll\"~2",
+    "count": 12,
+    "top_100": 12,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ac2ec5ba3e53451dfd8f5b9a42bb62e6035a132840f93b54397a38009d1b7689"
+    ],
+    "top_100_count_result": [
+      "ac2ec5ba3e53451dfd8f5b9a42bb62e6035a132840f93b54397a38009d1b7689"
+    ]
+  },
+  {
+    "query": "\"who 1-2 dares 1-3 wins\"",
+    "count": 65,
+    "top_100": 65,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7ae0b6d782e2a001c71f68075ae84076d2f2d46683581e443fd0f37b949f0550"
+    ],
+    "top_100_count_result": [
+      "7ae0b6d782e2a001c71f68075ae84076d2f2d46683581e443fd0f37b949f0550"
+    ]
+  },
+  {
+    "query": "\"who dares wins\"~2",
+    "count": 65,
+    "top_100": 65,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7ae0b6d782e2a001c71f68075ae84076d2f2d46683581e443fd0f37b949f0550"
+    ],
+    "top_100_count_result": [
+      "7ae0b6d782e2a001c71f68075ae84076d2f2d46683581e443fd0f37b949f0550"
+    ]
+  },
+  {
+    "query": "\"ford 1-2 modeling 1-3 agency\"",
+    "count": 55,
+    "top_100": 55,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f79e8219bfa6159879f42ae9356175a993933532210ab8aed574cb5fd2b3ac02"
+    ],
+    "top_100_count_result": [
+      "f79e8219bfa6159879f42ae9356175a993933532210ab8aed574cb5fd2b3ac02"
+    ]
+  },
+  {
+    "query": "\"ford modeling agency\"~2",
+    "count": 55,
+    "top_100": 55,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d926be8661041a811671021c546f426e60a97d79db2308123cd460d0503e0358"
+    ],
+    "top_100_count_result": [
+      "d926be8661041a811671021c546f426e60a97d79db2308123cd460d0503e0358"
+    ]
+  },
+  {
+    "query": "\"texas 1-2 state 1-3 legislature\"",
+    "count": 94,
+    "top_100": 94,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c0bbb33a000a3fdd809f4aecd3abd7e7c8f187a0249f5677c4b0c8094571053e"
+    ],
+    "top_100_count_result": [
+      "c0bbb33a000a3fdd809f4aecd3abd7e7c8f187a0249f5677c4b0c8094571053e"
+    ]
+  },
+  {
+    "query": "\"texas state legislature\"~2",
+    "count": 96,
+    "top_100": 96,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c185eb1a5975871aec643a9e2f2b10e29d35173484c7f7deb33fef5cc478063d"
+    ],
+    "top_100_count_result": [
+      "c185eb1a5975871aec643a9e2f2b10e29d35173484c7f7deb33fef5cc478063d"
+    ]
+  },
+  {
+    "query": "\"georgia 1-2 public 1-3 broadcasting\"",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "222ed6cee27b2fa7d27351a9b8fca16aebf97c8854e623c2ef0ae29617914d2f"
+    ],
+    "top_100_count_result": [
+      "222ed6cee27b2fa7d27351a9b8fca16aebf97c8854e623c2ef0ae29617914d2f"
+    ]
+  },
+  {
+    "query": "\"georgia public broadcasting\"~2",
+    "count": 62,
+    "top_100": 62,
+    "result_type": "Hash",
+    "top_100_result": [
+      "00acda8586bed4f981b0e805d0fbeb84fdf3247d2bd9ea8f058b534f9f272985"
+    ],
+    "top_100_count_result": [
+      "00acda8586bed4f981b0e805d0fbeb84fdf3247d2bd9ea8f058b534f9f272985"
+    ]
+  },
+  {
+    "query": "\"texas 1-2 death 1-3 row\"",
+    "count": 28,
+    "top_100": 28,
+    "result_type": "Hash",
+    "top_100_result": [
+      "227f57b22895a04677e36770b9e535c61fbe9adb9aa40b5f802b3c78f7d903d8"
+    ],
+    "top_100_count_result": [
+      "227f57b22895a04677e36770b9e535c61fbe9adb9aa40b5f802b3c78f7d903d8"
+    ]
+  },
+  {
+    "query": "\"texas death row\"~2",
+    "count": 35,
+    "top_100": 35,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d315698ec13beec40829bfb6fe080a67706eb827b029874c87b80fca13d1da3e"
+    ],
+    "top_100_count_result": [
+      "d315698ec13beec40829bfb6fe080a67706eb827b029874c87b80fca13d1da3e"
+    ]
+  },
+  {
+    "query": "\"griffith observatory\" the",
+    "count": 4168066,
+    "top_100": 4168066,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8b461a8b2d3063db50ec587df757e93d83d9bc83b0950e7dc6d1757becfe6dbb"
+    ],
+    "top_100_count_result": [
+      "8b461a8b2d3063db50ec587df757e93d83d9bc83b0950e7dc6d1757becfe6dbb"
+    ]
+  },
+  {
+    "query": "\"griffith observatory\" \"bowel obstruction\" the",
+    "count": 4168066,
+    "top_100": 4168066,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6ba542209bc4147e56098922b4b036d864d6119276a09dfd70757693b0ba3bfc"
+    ],
+    "top_100_count_result": [
+      "6ba542209bc4147e56098922b4b036d864d6119276a09dfd70757693b0ba3bfc"
+    ]
+  },
+  {
+    "query": "+\"griffith observatory\" +the",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f408c013b3bf3912b54e782b618b333ea37736662bf3f71989a03dd2ecffe80b"
+    ],
+    "top_100_count_result": [
+      "f408c013b3bf3912b54e782b618b333ea37736662bf3f71989a03dd2ecffe80b"
+    ]
+  },
+  {
+    "query": "+\"griffith observatory\" +the +world",
+    "count": 19,
+    "top_100": 19,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f764a1db063d70e9364c8562ab2a930772c768763f8ee81b611c76d04ac160be"
+    ],
+    "top_100_count_result": [
+      "f764a1db063d70e9364c8562ab2a930772c768763f8ee81b611c76d04ac160be"
+    ]
+  },
+  {
+    "query": "+the -\"griffith observatory\"",
+    "count": 4168009,
+    "top_100": 78209,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f3ba46b2bcb4e2a8c3dc450d2fdbb86c8576e50277d958ad1cdf10d48e4ce19a"
+    ],
+    "top_100_count_result": [
+      "f3ba46b2bcb4e2a8c3dc450d2fdbb86c8576e50277d958ad1cdf10d48e4ce19a"
+    ]
+  },
+  {
+    "query": "+\"griffith observatory\" -california",
+    "count": 26,
+    "top_100": 26,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1406c8d91d16057412fae9e91cbfe998393dbe1205f07936099076c654ad5ef9"
+    ],
+    "top_100_count_result": [
+      "1406c8d91d16057412fae9e91cbfe998393dbe1205f07936099076c654ad5ef9"
+    ]
+  },
+  {
+    "query": "the^2 world",
+    "count": 4170957,
+    "top_100": 1576,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d2613368071656753909f8b6386d17fc79194c057cad1ed67c561ed66e41df2d"
+    ],
+    "top_100_count_result": [
+      "d2613368071656753909f8b6386d17fc79194c057cad1ed67c561ed66e41df2d"
+    ]
+  },
+  {
+    "query": "+\"griffith observatory\" the^3",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f408c013b3bf3912b54e782b618b333ea37736662bf3f71989a03dd2ecffe80b"
+    ],
+    "top_100_count_result": [
+      "f408c013b3bf3912b54e782b618b333ea37736662bf3f71989a03dd2ecffe80b"
+    ]
+  },
+  {
+    "query": "the~1",
+    "count": 4203952,
+    "top_100": 4203952,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f3ba46b2bcb4e2a8c3dc450d2fdbb86c8576e50277d958ad1cdf10d48e4ce19a"
+    ],
+    "top_100_count_result": [
+      "f3ba46b2bcb4e2a8c3dc450d2fdbb86c8576e50277d958ad1cdf10d48e4ce19a"
+    ]
+  },
+  {
+    "query": "+the~1 +\"griffith observatory\"",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "00335192ac593287495566a815c75064ad75c90b19abcf9887051b7d06b2b4cf"
+    ],
+    "top_100_count_result": [
+      "00335192ac593287495566a815c75064ad75c90b19abcf9887051b7d06b2b4cf"
+    ]
+  },
+  {
+    "query": "\"bowel obstruction\" world",
+    "count": 634131,
+    "top_100": 634131,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6fa1fc7ee1ab996b3c8901d31a430bd0ba71adb6f8de2283d098803a0cacc630"
+    ],
+    "top_100_count_result": [
+      "6fa1fc7ee1ab996b3c8901d31a430bd0ba71adb6f8de2283d098803a0cacc630"
+    ]
+  },
+  {
+    "query": "\"bowel obstruction\" \"vicenza italy\" world",
+    "count": 634200,
+    "top_100": 634200,
+    "result_type": "Hash",
+    "top_100_result": [
+      "54a22d07d4bddb7d44c19383c856e3422f1c04ce38ece6c73e2a2ee806349624"
+    ],
+    "top_100_count_result": [
+      "54a22d07d4bddb7d44c19383c856e3422f1c04ce38ece6c73e2a2ee806349624"
+    ]
+  },
+  {
+    "query": "+\"bowel obstruction\" +world",
+    "count": 31,
+    "top_100": 31,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1035cb8f1baf18cc2a701efd061aa876710df062fb1507b93239eb8577f8011a"
+    ],
+    "top_100_count_result": [
+      "1035cb8f1baf18cc2a701efd061aa876710df062fb1507b93239eb8577f8011a"
+    ]
+  },
+  {
+    "query": "+\"bowel obstruction\" +world +state",
+    "count": 11,
+    "top_100": 11,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2f6521864e6881e2b2cad985c4448e9ef21c6c033705a0ff7a2a4b37aa3e272e"
+    ],
+    "top_100_count_result": [
+      "2f6521864e6881e2b2cad985c4448e9ef21c6c033705a0ff7a2a4b37aa3e272e"
+    ]
+  },
+  {
+    "query": "+world -\"bowel obstruction\"",
+    "count": 634021,
+    "top_100": 40257,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d8d9d42715b2fcedebdfe9077aed4354860b2e9a66ceba80f2603d9183b6389a"
+    ],
+    "top_100_count_result": [
+      "d8d9d42715b2fcedebdfe9077aed4354860b2e9a66ceba80f2603d9183b6389a"
+    ]
+  },
+  {
+    "query": "+\"bowel obstruction\" -world",
+    "count": 79,
+    "top_100": 79,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1607a0a91cf8a88bf9a183270b4350960529e23492bb75baae3414b0a4e6f0f7"
+    ],
+    "top_100_count_result": [
+      "1607a0a91cf8a88bf9a183270b4350960529e23492bb75baae3414b0a4e6f0f7"
+    ]
+  },
+  {
+    "query": "world^2 state",
+    "count": 1036349,
+    "top_100": 11345,
+    "result_type": "Hash",
+    "top_100_result": [
+      "83f8e3bb314af70142ee3ad4b66dd7691f93ce3a946647caf323ddba29cf9c42"
+    ],
+    "top_100_count_result": [
+      "83f8e3bb314af70142ee3ad4b66dd7691f93ce3a946647caf323ddba29cf9c42"
+    ]
+  },
+  {
+    "query": "+\"bowel obstruction\" world^3",
+    "count": 110,
+    "top_100": 110,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8dc752c501eeef185966c397ece1a1f33f9c682775a1bdb62364b9c7c3936da6"
+    ],
+    "top_100_count_result": [
+      "8dc752c501eeef185966c397ece1a1f33f9c682775a1bdb62364b9c7c3936da6"
+    ]
+  },
+  {
+    "query": "world~1",
+    "count": 1017625,
+    "top_100": 1017625,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d8d9d42715b2fcedebdfe9077aed4354860b2e9a66ceba80f2603d9183b6389a"
+    ],
+    "top_100_count_result": [
+      "d8d9d42715b2fcedebdfe9077aed4354860b2e9a66ceba80f2603d9183b6389a"
+    ]
+  },
+  {
+    "query": "+world~1 +\"bowel obstruction\"",
+    "count": 47,
+    "top_100": 47,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0f3989f227006d6969e66adb54cd8ad3061091dafb9cfcbfd71b98b9eb5c3310"
+    ],
+    "top_100_count_result": [
+      "0f3989f227006d6969e66adb54cd8ad3061091dafb9cfcbfd71b98b9eb5c3310"
+    ]
+  },
+  {
+    "query": "\"vicenza italy\" state",
+    "count": 523159,
+    "top_100": 523159,
+    "result_type": "Hash",
+    "top_100_result": [
+      "70803fd592b900e8f34884228d54ae38690ad7046e7c2f2dd000f967d7ab87ce"
+    ],
+    "top_100_count_result": [
+      "70803fd592b900e8f34884228d54ae38690ad7046e7c2f2dd000f967d7ab87ce"
+    ]
+  },
+  {
+    "query": "\"vicenza italy\" \"digital scanning\" state",
+    "count": 523173,
+    "top_100": 523173,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9e70b98cf4f4f5ab2f13d8d7defff8d4634127157ddd3438cf11dc7128fe4e1f"
+    ],
+    "top_100_count_result": [
+      "9e70b98cf4f4f5ab2f13d8d7defff8d4634127157ddd3438cf11dc7128fe4e1f"
+    ]
+  },
+  {
+    "query": "+\"vicenza italy\" +state",
+    "count": 15,
+    "top_100": 15,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0fb84dcc8e231266995e761f8858940d36832bf3e6a2f55691ffc74075ac2990"
+    ],
+    "top_100_count_result": [
+      "0fb84dcc8e231266995e761f8858940d36832bf3e6a2f55691ffc74075ac2990"
+    ]
+  },
+  {
+    "query": "+\"vicenza italy\" +state +history",
+    "count": 8,
+    "top_100": 8,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f2f0c808937a335f634105a19ddaefad1a3136699e8f930f66f3eda5137af0e8"
+    ],
+    "top_100_count_result": [
+      "f2f0c808937a335f634105a19ddaefad1a3136699e8f930f66f3eda5137af0e8"
+    ]
+  },
+  {
+    "query": "+state -\"vicenza italy\"",
+    "count": 523047,
+    "top_100": 48053,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ddf882df6167f7336d6bec5bf44e59227c13f0c100f8e1d7ea08a849904733d5"
+    ],
+    "top_100_count_result": [
+      "ddf882df6167f7336d6bec5bf44e59227c13f0c100f8e1d7ea08a849904733d5"
+    ]
+  },
+  {
+    "query": "+\"vicenza italy\" -state",
+    "count": 97,
+    "top_100": 97,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8a2a2b06f1afc130841140e0a8526f7998ef5bd937afbc8bacc5bf3e6033ac74"
+    ],
+    "top_100_count_result": [
+      "8a2a2b06f1afc130841140e0a8526f7998ef5bd937afbc8bacc5bf3e6033ac74"
+    ]
+  },
+  {
+    "query": "state^2 history",
+    "count": 1030384,
+    "top_100": 12354,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ba0f7841a01a77cc9d4657eac0687314d82548c6be82ef04ae4be4906c1f5980"
+    ],
+    "top_100_count_result": [
+      "ba0f7841a01a77cc9d4657eac0687314d82548c6be82ef04ae4be4906c1f5980"
+    ]
+  },
+  {
+    "query": "+\"vicenza italy\" state^3",
+    "count": 112,
+    "top_100": 112,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e6d75df2e652926a7e020348cef0c69988155ccb150b149fc6924bc6aa2a0567"
+    ],
+    "top_100_count_result": [
+      "e6d75df2e652926a7e020348cef0c69988155ccb150b149fc6924bc6aa2a0567"
+    ]
+  },
+  {
+    "query": "state~1",
+    "count": 1105658,
+    "top_100": 1105658,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ddf882df6167f7336d6bec5bf44e59227c13f0c100f8e1d7ea08a849904733d5"
+    ],
+    "top_100_count_result": [
+      "ddf882df6167f7336d6bec5bf44e59227c13f0c100f8e1d7ea08a849904733d5"
+    ]
+  },
+  {
+    "query": "+state~1 +\"vicenza italy\"",
+    "count": 54,
+    "top_100": 54,
+    "result_type": "Hash",
+    "top_100_result": [
+      "759758e00649d912ae67d4c2fbbc4c90aeee426fdfaaf322f37efdcc3a28ecfb"
+    ],
+    "top_100_count_result": [
+      "759758e00649d912ae67d4c2fbbc4c90aeee426fdfaaf322f37efdcc3a28ecfb"
+    ]
+  },
+  {
+    "query": "\"digital scanning\" history",
+    "count": 681025,
+    "top_100": 681025,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3f6104db14c744f907b0cc596959e6bb0217f6e5daa447fae36dcb5aa0d9a5d7"
+    ],
+    "top_100_count_result": [
+      "3f6104db14c744f907b0cc596959e6bb0217f6e5daa447fae36dcb5aa0d9a5d7"
+    ]
+  },
+  {
+    "query": "\"digital scanning\" \"borders books\" history",
+    "count": 681042,
+    "top_100": 681042,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1ce585f9d57914d21e27baa0b20ae53bb89e725f3a9df6b2d8f9ba9369f2f375"
+    ],
+    "top_100_count_result": [
+      "1ce585f9d57914d21e27baa0b20ae53bb89e725f3a9df6b2d8f9ba9369f2f375"
+    ]
+  },
+  {
+    "query": "+\"digital scanning\" +history",
+    "count": 2,
+    "top_100": 2,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5936492c4c468715dc5a914b5cea2a052143f408ff7b8ed95a3b0378fd13439b"
+    ],
+    "top_100_count_result": [
+      "5936492c4c468715dc5a914b5cea2a052143f408ff7b8ed95a3b0378fd13439b"
+    ]
+  },
+  {
+    "query": "+\"digital scanning\" +history +album",
+    "count": 1,
+    "top_100": 1,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c9509982311a2685bf365864f0e1edb5d1c6ca63369f2ef54ad8cdd13cf29670"
+    ],
+    "top_100_count_result": [
+      "c9509982311a2685bf365864f0e1edb5d1c6ca63369f2ef54ad8cdd13cf29670"
+    ]
+  },
+  {
+    "query": "+history -\"digital scanning\"",
+    "count": 681008,
+    "top_100": 48306,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5c4d7d9ca791e80316c84e7b3f93b61e20fc0168bd2a6387dcdf40454766617a"
+    ],
+    "top_100_count_result": [
+      "5c4d7d9ca791e80316c84e7b3f93b61e20fc0168bd2a6387dcdf40454766617a"
+    ]
+  },
+  {
+    "query": "+\"digital scanning\" -history",
+    "count": 15,
+    "top_100": 15,
+    "result_type": "Hash",
+    "top_100_result": [
+      "be7058cd5a9dcf5ac13799a096b0dbb5e1408367dd6027c3fa46886fa12e5046"
+    ],
+    "top_100_count_result": [
+      "be7058cd5a9dcf5ac13799a096b0dbb5e1408367dd6027c3fa46886fa12e5046"
+    ]
+  },
+  {
+    "query": "history^2 president",
+    "count": 847081,
+    "top_100": 22463,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4fa9dd5c21020367a88988b17d08617e524a22ca569ad6d49ca2893cc8f37e95"
+    ],
+    "top_100_count_result": [
+      "4fa9dd5c21020367a88988b17d08617e524a22ca569ad6d49ca2893cc8f37e95"
+    ]
+  },
+  {
+    "query": "+\"digital scanning\" history^3",
+    "count": 17,
+    "top_100": 17,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3de6bf34602f67b3d14d4d4ba44e58d5f7f194e69ecd5f32c342459a1b1e6171"
+    ],
+    "top_100_count_result": [
+      "3de6bf34602f67b3d14d4d4ba44e58d5f7f194e69ecd5f32c342459a1b1e6171"
+    ]
+  },
+  {
+    "query": "history~1",
+    "count": 681097,
+    "top_100": 681097,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5c4d7d9ca791e80316c84e7b3f93b61e20fc0168bd2a6387dcdf40454766617a"
+    ],
+    "top_100_count_result": [
+      "5c4d7d9ca791e80316c84e7b3f93b61e20fc0168bd2a6387dcdf40454766617a"
+    ]
+  },
+  {
+    "query": "+history~1 +\"digital scanning\"",
+    "count": 2,
+    "top_100": 2,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5936492c4c468715dc5a914b5cea2a052143f408ff7b8ed95a3b0378fd13439b"
+    ],
+    "top_100_count_result": [
+      "5936492c4c468715dc5a914b5cea2a052143f408ff7b8ed95a3b0378fd13439b"
+    ]
+  },
+  {
+    "query": "\"borders books\" president",
+    "count": 243875,
+    "top_100": 243875,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bdc86d5b527870d2b320a539bced4d319bb3fe50f5f41eb81835ba5b20ef364a"
+    ],
+    "top_100_count_result": [
+      "bdc86d5b527870d2b320a539bced4d319bb3fe50f5f41eb81835ba5b20ef364a"
+    ]
+  },
+  {
+    "query": "\"borders books\" \"american funds\" president",
+    "count": 243887,
+    "top_100": 243887,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a6420a1f7b73b8cf28cc39c6fbf3c36cd7b73b4e023ec5100ab97fc37457877e"
+    ],
+    "top_100_count_result": [
+      "a6420a1f7b73b8cf28cc39c6fbf3c36cd7b73b4e023ec5100ab97fc37457877e"
+    ]
+  },
+  {
+    "query": "+\"borders books\" +president",
+    "count": 4,
+    "top_100": 4,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e5b448a8562a7abc3fb9ea95186127becc11955bf26a2a6807205ec4ac73e485"
+    ],
+    "top_100_count_result": [
+      "e5b448a8562a7abc3fb9ea95186127becc11955bf26a2a6807205ec4ac73e485"
+    ]
+  },
+  {
+    "query": "+\"borders books\" +president +australia",
+    "count": 1,
+    "top_100": 1,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e4ed21166dbd4d8b9ae32fc009d950d91776c795da5af79ade5e5a0d4ec76d7a"
+    ],
+    "top_100_count_result": [
+      "e4ed21166dbd4d8b9ae32fc009d950d91776c795da5af79ade5e5a0d4ec76d7a"
+    ]
+  },
+  {
+    "query": "+president -\"borders books\"",
+    "count": 243850,
+    "top_100": 44046,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fb0c4340983c1cf42d7a0c4d0227261d43b5bb715ebd9e459d210b0deddf9267"
+    ],
+    "top_100_count_result": [
+      "fb0c4340983c1cf42d7a0c4d0227261d43b5bb715ebd9e459d210b0deddf9267"
+    ]
+  },
+  {
+    "query": "+\"borders books\" -president",
+    "count": 21,
+    "top_100": 21,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7f47755fa89894fa3fc846575076fd58001926f51891292bc7b89a8e2c13ce35"
+    ],
+    "top_100_count_result": [
+      "7f47755fa89894fa3fc846575076fd58001926f51891292bc7b89a8e2c13ce35"
+    ]
+  },
+  {
+    "query": "president^2 river",
+    "count": 477628,
+    "top_100": 11369,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1aff47a483892845cdf5cac53f1d2f263e8c9877bd4295e5f3eb8313c4bab420"
+    ],
+    "top_100_count_result": [
+      "1aff47a483892845cdf5cac53f1d2f263e8c9877bd4295e5f3eb8313c4bab420"
+    ]
+  },
+  {
+    "query": "+\"borders books\" president^3",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6617dec3c74e7fc3476af98349d4a3d384d01cf413b9dbe5aaf04804c2d03b1e"
+    ],
+    "top_100_count_result": [
+      "6617dec3c74e7fc3476af98349d4a3d384d01cf413b9dbe5aaf04804c2d03b1e"
+    ]
+  },
+  {
+    "query": "president~1",
+    "count": 279000,
+    "top_100": 279000,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fb0c4340983c1cf42d7a0c4d0227261d43b5bb715ebd9e459d210b0deddf9267"
+    ],
+    "top_100_count_result": [
+      "fb0c4340983c1cf42d7a0c4d0227261d43b5bb715ebd9e459d210b0deddf9267"
+    ]
+  },
+  {
+    "query": "+president~1 +\"borders books\"",
+    "count": 4,
+    "top_100": 4,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e5b448a8562a7abc3fb9ea95186127becc11955bf26a2a6807205ec4ac73e485"
+    ],
+    "top_100_count_result": [
+      "e5b448a8562a7abc3fb9ea95186127becc11955bf26a2a6807205ec4ac73e485"
+    ]
+  },
+  {
+    "query": "\"american funds\" river",
+    "count": 252300,
+    "top_100": 252300,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f216ab7017873a8114cfdd41f8402e3745e57fb484b034a10002b6571a5668d9"
+    ],
+    "top_100_count_result": [
+      "f216ab7017873a8114cfdd41f8402e3745e57fb484b034a10002b6571a5668d9"
+    ]
+  },
+  {
+    "query": "\"american funds\" \"scottsdale az\" river",
+    "count": 252354,
+    "top_100": 252354,
+    "result_type": "Hash",
+    "top_100_result": [
+      "cd317127776128e326d328a88eaaf2746349ddfb7ad241643adb01cf5e46e1a8"
+    ],
+    "top_100_count_result": [
+      "cd317127776128e326d328a88eaaf2746349ddfb7ad241643adb01cf5e46e1a8"
+    ]
+  },
+  {
+    "query": "+\"american funds\" +river",
+    "count": 5,
+    "top_100": 5,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0ac2005f1ca0f8a4bd2d23c1b93ea6c0e2298e45f0946d607b2f2af7e8b7d476"
+    ],
+    "top_100_count_result": [
+      "0ac2005f1ca0f8a4bd2d23c1b93ea6c0e2298e45f0946d607b2f2af7e8b7d476"
+    ]
+  },
+  {
+    "query": "+\"american funds\" +river +population",
+    "count": 3,
+    "top_100": 3,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0744cc92cbe5d3cc160211d43667262a7d5e40234cb90944a472ad14918becdc"
+    ],
+    "top_100_count_result": [
+      "0744cc92cbe5d3cc160211d43667262a7d5e40234cb90944a472ad14918becdc"
+    ]
+  },
+  {
+    "query": "+river -\"american funds\"",
+    "count": 252277,
+    "top_100": 44666,
+    "result_type": "Hash",
+    "top_100_result": [
+      "917d58d81f5a45ee502028f36c31d4bf324101831c65bbb0c013ab2a03b5f142"
+    ],
+    "top_100_count_result": [
+      "917d58d81f5a45ee502028f36c31d4bf324101831c65bbb0c013ab2a03b5f142"
+    ]
+  },
+  {
+    "query": "+\"american funds\" -river",
+    "count": 18,
+    "top_100": 18,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f08baa5304662d87936fe23a8e0e38b09eadb1b8c49cfc9789348dad8d30239b"
+    ],
+    "top_100_count_result": [
+      "f08baa5304662d87936fe23a8e0e38b09eadb1b8c49cfc9789348dad8d30239b"
+    ]
+  },
+  {
+    "query": "river^2 population",
+    "count": 564004,
+    "top_100": 6889,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a0b0a984c56f43e9ccc2eb668eac13e90efdf05825691ab950c6e77a28b11ff8"
+    ],
+    "top_100_count_result": [
+      "a0b0a984c56f43e9ccc2eb668eac13e90efdf05825691ab950c6e77a28b11ff8"
+    ]
+  },
+  {
+    "query": "+\"american funds\" river^3",
+    "count": 23,
+    "top_100": 23,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4022b9774521f2f94143cbab72b2a1ca66065b45348053acabfa26c3d5cc8582"
+    ],
+    "top_100_count_result": [
+      "4022b9774521f2f94143cbab72b2a1ca66065b45348053acabfa26c3d5cc8582"
+    ]
+  },
+  {
+    "query": "river~1",
+    "count": 337408,
+    "top_100": 337408,
+    "result_type": "Hash",
+    "top_100_result": [
+      "917d58d81f5a45ee502028f36c31d4bf324101831c65bbb0c013ab2a03b5f142"
+    ],
+    "top_100_count_result": [
+      "917d58d81f5a45ee502028f36c31d4bf324101831c65bbb0c013ab2a03b5f142"
+    ]
+  },
+  {
+    "query": "+river~1 +\"american funds\"",
+    "count": 7,
+    "top_100": 7,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c02c30ac104ea5207a755279bbab20c94b51460b930ddcd78ea863febe9fb2b2"
+    ],
+    "top_100_count_result": [
+      "c02c30ac104ea5207a755279bbab20c94b51460b930ddcd78ea863febe9fb2b2"
+    ]
+  },
+  {
+    "query": "\"scottsdale az\" population",
+    "count": 365759,
+    "top_100": 365759,
+    "result_type": "Hash",
+    "top_100_result": [
+      "64d2d10c97d63b0ac9f7e99c87a89b5f9822780ba28ce33912fb685d20f6abe0"
+    ],
+    "top_100_count_result": [
+      "64d2d10c97d63b0ac9f7e99c87a89b5f9822780ba28ce33912fb685d20f6abe0"
+    ]
+  },
+  {
+    "query": "\"scottsdale az\" \"freelance work\" population",
+    "count": 366062,
+    "top_100": 366062,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4d6dc4a22bd0c5456bc105922f1d4918ad3f0294288be7d5e850588fa3e60c33"
+    ],
+    "top_100_count_result": [
+      "4d6dc4a22bd0c5456bc105922f1d4918ad3f0294288be7d5e850588fa3e60c33"
+    ]
+  },
+  {
+    "query": "+\"scottsdale az\" +population",
+    "count": 2,
+    "top_100": 2,
+    "result_type": "Hash",
+    "top_100_result": [
+      "726bb55ef1403cbdcc62960508267ebf8dacc6450bbf3261eff00fd7675a7c62"
+    ],
+    "top_100_count_result": [
+      "726bb55ef1403cbdcc62960508267ebf8dacc6450bbf3261eff00fd7675a7c62"
+    ]
+  },
+  {
+    "query": "+\"scottsdale az\" +population +district",
+    "count": 1,
+    "top_100": 1,
+    "result_type": "Hash",
+    "top_100_result": [
+      "462dab448ecc0571a58af3f8deac5bfa7bb96acf14a30badbf32e7ced82beb86"
+    ],
+    "top_100_count_result": [
+      "462dab448ecc0571a58af3f8deac5bfa7bb96acf14a30badbf32e7ced82beb86"
+    ]
+  },
+  {
+    "query": "+population -\"scottsdale az\"",
+    "count": 365703,
+    "top_100": 34824,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5d57ec32f58395a6de2a58a98b3f85437d037a17cdb318dbca582d4abef358cc"
+    ],
+    "top_100_count_result": [
+      "5d57ec32f58395a6de2a58a98b3f85437d037a17cdb318dbca582d4abef358cc"
+    ]
+  },
+  {
+    "query": "+\"scottsdale az\" -population",
+    "count": 54,
+    "top_100": 54,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bd4c5e59000a35d7f0a7c8c611a532443f87c07c2f4abc9dc02f6091da268038"
+    ],
+    "top_100_count_result": [
+      "bd4c5e59000a35d7f0a7c8c611a532443f87c07c2f4abc9dc02f6091da268038"
+    ]
+  },
+  {
+    "query": "population^2 university",
+    "count": 805142,
+    "top_100": 9849,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4486afb3cc2ca6ce187f3e3705aedaee3b2b47760ecc5c1bb75e74bb778fb69c"
+    ],
+    "top_100_count_result": [
+      "4486afb3cc2ca6ce187f3e3705aedaee3b2b47760ecc5c1bb75e74bb778fb69c"
+    ]
+  },
+  {
+    "query": "+\"scottsdale az\" population^3",
+    "count": 56,
+    "top_100": 56,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e9b1d08cf293fc51a74cd1a1ce5455654113b2c6d04739a220293bf6a5240a83"
+    ],
+    "top_100_count_result": [
+      "e9b1d08cf293fc51a74cd1a1ce5455654113b2c6d04739a220293bf6a5240a83"
+    ]
+  },
+  {
+    "query": "population~1",
+    "count": 378747,
+    "top_100": 378747,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5d57ec32f58395a6de2a58a98b3f85437d037a17cdb318dbca582d4abef358cc"
+    ],
+    "top_100_count_result": [
+      "5d57ec32f58395a6de2a58a98b3f85437d037a17cdb318dbca582d4abef358cc"
+    ]
+  },
+  {
+    "query": "+population~1 +\"scottsdale az\"",
+    "count": 3,
+    "top_100": 3,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f5afba174fd1a2565a4ddf0caf89dbdd1b15a6905ad0729bb48cbde43506aa65"
+    ],
+    "top_100_count_result": [
+      "f5afba174fd1a2565a4ddf0caf89dbdd1b15a6905ad0729bb48cbde43506aa65"
+    ]
+  },
+  {
+    "query": "\"freelance work\" university",
+    "count": 466222,
+    "top_100": 466222,
+    "result_type": "Hash",
+    "top_100_result": [
+      "063a24cd0d473eea1acd0677d7a9b82d8b93b305ef51a42c94c38cd92ce5e683"
+    ],
+    "top_100_count_result": [
+      "063a24cd0d473eea1acd0677d7a9b82d8b93b305ef51a42c94c38cd92ce5e683"
+    ]
+  },
+  {
+    "query": "\"freelance work\" \"color combinations\" university",
+    "count": 466370,
+    "top_100": 466370,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1dcc0c8f5c42fea9ee49c1b8a4a943d073664874411b2474e6c6da85b1517202"
+    ],
+    "top_100_count_result": [
+      "1dcc0c8f5c42fea9ee49c1b8a4a943d073664874411b2474e6c6da85b1517202"
+    ]
+  },
+  {
+    "query": "+\"freelance work\" +university",
+    "count": 131,
+    "top_100": 131,
+    "result_type": "Hash",
+    "top_100_result": [
+      "05f01c4f9e79b29ea638640a2f3348c47f14d7c6911395b24e4662b87ad302a1"
+    ],
+    "top_100_count_result": [
+      "05f01c4f9e79b29ea638640a2f3348c47f14d7c6911395b24e4662b87ad302a1"
+    ]
+  },
+  {
+    "query": "+\"freelance work\" +university +germany",
+    "count": 8,
+    "top_100": 8,
+    "result_type": "Hash",
+    "top_100_result": [
+      "efbe56ca9dd3b76097e04c8df56be7ac1b2233cd55617dc6a4578b7d93c09159"
+    ],
+    "top_100_count_result": [
+      "efbe56ca9dd3b76097e04c8df56be7ac1b2233cd55617dc6a4578b7d93c09159"
+    ]
+  },
+  {
+    "query": "+university -\"freelance work\"",
+    "count": 465915,
+    "top_100": 48881,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3f0e8fc44d7da76215ad43da6949522b285636dcaf86750600b5b4c801884623"
+    ],
+    "top_100_count_result": [
+      "3f0e8fc44d7da76215ad43da6949522b285636dcaf86750600b5b4c801884623"
+    ]
+  },
+  {
+    "query": "+\"freelance work\" -university",
+    "count": 176,
+    "top_100": 162,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1793516895f6db1e367546d0793aaf3e3714900510282b42a07c7b1232ce0052"
+    ],
+    "top_100_count_result": [
+      "1793516895f6db1e367546d0793aaf3e3714900510282b42a07c7b1232ce0052"
+    ]
+  },
+  {
+    "query": "university^2 germany",
+    "count": 609769,
+    "top_100": 11120,
+    "result_type": "Hash",
+    "top_100_result": [
+      "56087b9659ba7537fae846892c85cc4c3e6c0abcd2bf279f0b94fe6d881c6c8c"
+    ],
+    "top_100_count_result": [
+      "56087b9659ba7537fae846892c85cc4c3e6c0abcd2bf279f0b94fe6d881c6c8c"
+    ]
+  },
+  {
+    "query": "+\"freelance work\" university^3",
+    "count": 307,
+    "top_100": 307,
+    "result_type": "Hash",
+    "top_100_result": [
+      "317174d6c1b2d1146bf3ef9ba8e3621195ba4f3620f654922c0f64c8878a766b"
+    ],
+    "top_100_count_result": [
+      "317174d6c1b2d1146bf3ef9ba8e3621195ba4f3620f654922c0f64c8878a766b"
+    ]
+  },
+  {
+    "query": "university~1",
+    "count": 468726,
+    "top_100": 468726,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3f0e8fc44d7da76215ad43da6949522b285636dcaf86750600b5b4c801884623"
+    ],
+    "top_100_count_result": [
+      "3f0e8fc44d7da76215ad43da6949522b285636dcaf86750600b5b4c801884623"
+    ]
+  },
+  {
+    "query": "+university~1 +\"freelance work\"",
+    "count": 131,
+    "top_100": 131,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d909c5ca4e4b8a6155ecf1a51cb00e2f33b15010840beec3f3a7eb8f08568234"
+    ],
+    "top_100_count_result": [
+      "d909c5ca4e4b8a6155ecf1a51cb00e2f33b15010840beec3f3a7eb8f08568234"
+    ]
+  },
+  {
+    "query": "\"color combinations\" germany",
+    "count": 175494,
+    "top_100": 175494,
+    "result_type": "Hash",
+    "top_100_result": [
+      "07d8989dad7b633f9d0d135ba948e15123e1baab09dc1b304d481b2c6c41292e"
+    ],
+    "top_100_count_result": [
+      "07d8989dad7b633f9d0d135ba948e15123e1baab09dc1b304d481b2c6c41292e"
+    ]
+  },
+  {
+    "query": "\"color combinations\" \"italian translation\" germany",
+    "count": 175711,
+    "top_100": 175711,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5524775866f5692be7cfb91a5516d6b28fc7f0e6219699bdbfb61a0e2101d038"
+    ],
+    "top_100_count_result": [
+      "5524775866f5692be7cfb91a5516d6b28fc7f0e6219699bdbfb61a0e2101d038"
+    ]
+  },
+  {
+    "query": "+\"color combinations\" +germany",
+    "count": 14,
+    "top_100": 14,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9174dc100de8eb469056847bf953957ada9d50fb361580bae9b098a993fa86d6"
+    ],
+    "top_100_count_result": [
+      "9174dc100de8eb469056847bf953957ada9d50fb361580bae9b098a993fa86d6"
+    ]
+  },
+  {
+    "query": "+\"color combinations\" +germany +album",
+    "count": 1,
+    "top_100": 1,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2d1f6cc74a8f72a788d96774a9c47f84741e16c84e44a671715bec488b2d0aed"
+    ],
+    "top_100_count_result": [
+      "2d1f6cc74a8f72a788d96774a9c47f84741e16c84e44a671715bec488b2d0aed"
+    ]
+  },
+  {
+    "query": "+germany -\"color combinations\"",
+    "count": 175317,
+    "top_100": 34913,
+    "result_type": "Hash",
+    "top_100_result": [
+      "37f8fad789f42bff29cf48ae0184a87f92b6688d0905b4e272d953eba12bcc88"
+    ],
+    "top_100_count_result": [
+      "37f8fad789f42bff29cf48ae0184a87f92b6688d0905b4e272d953eba12bcc88"
+    ]
+  },
+  {
+    "query": "+\"color combinations\" -germany",
+    "count": 163,
+    "top_100": 149,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4d34b0124302669ddec2d6c051203cdc22fafe0bbf6818c53c5597f791d57f4f"
+    ],
+    "top_100_count_result": [
+      "4d34b0124302669ddec2d6c051203cdc22fafe0bbf6818c53c5597f791d57f4f"
+    ]
+  },
+  {
+    "query": "germany^2 album",
+    "count": 364656,
+    "top_100": 4918,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c7497e988ca28c73aa53ef56255109d08dd2bb28ce8f52ccc6f130024922c68d"
+    ],
+    "top_100_count_result": [
+      "c7497e988ca28c73aa53ef56255109d08dd2bb28ce8f52ccc6f130024922c68d"
+    ]
+  },
+  {
+    "query": "+\"color combinations\" germany^3",
+    "count": 177,
+    "top_100": 177,
+    "result_type": "Hash",
+    "top_100_result": [
+      "aa5e4101d1dcad64be31b43e2a287701382fecea5f5c4de5d0385e9f8c927100"
+    ],
+    "top_100_count_result": [
+      "aa5e4101d1dcad64be31b43e2a287701382fecea5f5c4de5d0385e9f8c927100"
+    ]
+  },
+  {
+    "query": "germany~1",
+    "count": 318207,
+    "top_100": 318207,
+    "result_type": "Hash",
+    "top_100_result": [
+      "37f8fad789f42bff29cf48ae0184a87f92b6688d0905b4e272d953eba12bcc88"
+    ],
+    "top_100_count_result": [
+      "37f8fad789f42bff29cf48ae0184a87f92b6688d0905b4e272d953eba12bcc88"
+    ]
+  },
+  {
+    "query": "+germany~1 +\"color combinations\"",
+    "count": 27,
+    "top_100": 27,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f3bc1050550a9173d6667ccc06d7a768b86b3ee114429c73372907731c7d9f94"
+    ],
+    "top_100_count_result": [
+      "f3bc1050550a9173d6667ccc06d7a768b86b3ee114429c73372907731c7d9f94"
+    ]
+  },
+  {
+    "query": "\"italian translation\" album",
+    "count": 198452,
+    "top_100": 198452,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c52645f9274613b149db160f60723cf36da3964256b582c587e88107b354f0e9"
+    ],
+    "top_100_count_result": [
+      "c52645f9274613b149db160f60723cf36da3964256b582c587e88107b354f0e9"
+    ]
+  },
+  {
+    "query": "\"italian translation\" \"milwaukee newspaper\" album",
+    "count": 198462,
+    "top_100": 198462,
+    "result_type": "Hash",
+    "top_100_result": [
+      "be5f691f3f875f24c177cdca73792872df64a4c487be6ed0519a8b0772b0b633"
+    ],
+    "top_100_count_result": [
+      "be5f691f3f875f24c177cdca73792872df64a4c487be6ed0519a8b0772b0b633"
+    ]
+  },
+  {
+    "query": "+\"italian translation\" +album",
+    "count": 10,
+    "top_100": 10,
+    "result_type": "Hash",
+    "top_100_result": [
+      "305cac079531c0eceffeddd3e4dc377a4e600e56d92e6a98d13c9884ced1938d"
+    ],
+    "top_100_count_result": [
+      "305cac079531c0eceffeddd3e4dc377a4e600e56d92e6a98d13c9884ced1938d"
+    ]
+  },
+  {
+    "query": "+\"italian translation\" +album +military",
+    "count": 1,
+    "top_100": 1,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5e8e230749b946193669464235549718b4d241c2779f25ee4c099ab58bfd23a0"
+    ],
+    "top_100_count_result": [
+      "5e8e230749b946193669464235549718b4d241c2779f25ee4c099ab58bfd23a0"
+    ]
+  },
+  {
+    "query": "+album -\"italian translation\"",
+    "count": 198200,
+    "top_100": 38849,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f4f4486654c11cb4752647f3199a94c723002f31ab8cfa3e2a52349500dfd2bd"
+    ],
+    "top_100_count_result": [
+      "f4f4486654c11cb4752647f3199a94c723002f31ab8cfa3e2a52349500dfd2bd"
+    ]
+  },
+  {
+    "query": "+\"italian translation\" -album",
+    "count": 242,
+    "top_100": 201,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ab43265306f4f660a02d49b3911a2f10e29d7aa2ae0ba6c902f48d91e48872e1"
+    ],
+    "top_100_count_result": [
+      "ab43265306f4f660a02d49b3911a2f10e29d7aa2ae0ba6c902f48d91e48872e1"
+    ]
+  },
+  {
+    "query": "album^2 military",
+    "count": 377480,
+    "top_100": 16506,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e17f0472a8cdb6e7fb948cd5365b0f7220f710e0dd0be4e9d296b2d2d2d30ae8"
+    ],
+    "top_100_count_result": [
+      "e17f0472a8cdb6e7fb948cd5365b0f7220f710e0dd0be4e9d296b2d2d2d30ae8"
+    ]
+  },
+  {
+    "query": "+\"italian translation\" album^3",
+    "count": 252,
+    "top_100": 252,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d3d656defa874bdbd86f9a98e4e63a097d857eb3d30d31e6e71948687107b458"
+    ],
+    "top_100_count_result": [
+      "d3d656defa874bdbd86f9a98e4e63a097d857eb3d30d31e6e71948687107b458"
+    ]
+  },
+  {
+    "query": "album~1",
+    "count": 211758,
+    "top_100": 211758,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f4f4486654c11cb4752647f3199a94c723002f31ab8cfa3e2a52349500dfd2bd"
+    ],
+    "top_100_count_result": [
+      "f4f4486654c11cb4752647f3199a94c723002f31ab8cfa3e2a52349500dfd2bd"
+    ]
+  },
+  {
+    "query": "+album~1 +\"italian translation\"",
+    "count": 12,
+    "top_100": 12,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ad0b646704491ed51b3860af70289d1dddb850dce23133d9c70c09bfbaec6cd2"
+    ],
+    "top_100_count_result": [
+      "ad0b646704491ed51b3860af70289d1dddb850dce23133d9c70c09bfbaec6cd2"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 milwaukee newspaper)",
+    "count": 10,
+    "top_100": 10,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ae6ed0faea751efe17ef0336f0746e921e50f45676024d1d36ba578d5d0e84bf"
+    ],
+    "top_100_count_result": [
+      "ae6ed0faea751efe17ef0336f0746e921e50f45676024d1d36ba578d5d0e84bf"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 new york population)",
+    "count": 11,
+    "top_100": 11,
+    "result_type": "Hash",
+    "top_100_result": [
+      "61b6b1356372d96e9e0a25f85459386ecb7d55e8a6231eff4d29572ef8b23f99"
+    ],
+    "top_100_count_result": [
+      "61b6b1356372d96e9e0a25f85459386ecb7d55e8a6231eff4d29572ef8b23f99"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 ford modeling agency population)",
+    "count": 199,
+    "top_100": 199,
+    "result_type": "Hash",
+    "top_100_result": [
+      "49565018504132a1fbfd697c195318c4eaa8fdc84445049d5ede3102485e0f01"
+    ],
+    "top_100_count_result": [
+      "49565018504132a1fbfd697c195318c4eaa8fdc84445049d5ede3102485e0f01"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 griffith bowel obstruction vicenza)",
+    "count": 178,
+    "top_100": 178,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e402339ad268353274d5b82ddd86e4ae28d6ff3d4d4ec3316a03225aaa0a87ef"
+    ],
+    "top_100_count_result": [
+      "e402339ad268353274d5b82ddd86e4ae28d6ff3d4d4ec3316a03225aaa0a87ef"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 griffith bowel obstruction)",
+    "count": 178,
+    "top_100": 178,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e402339ad268353274d5b82ddd86e4ae28d6ff3d4d4ec3316a03225aaa0a87ef"
+    ],
+    "top_100_count_result": [
+      "e402339ad268353274d5b82ddd86e4ae28d6ff3d4d4ec3316a03225aaa0a87ef"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 italy digital)",
+    "count": 2,
+    "top_100": 2,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2806a6af9e57ea1576fb7e824cfc4687dbfab5ed318c857fe0f3e6fc2242d2a1"
+    ],
+    "top_100_count_result": [
+      "2806a6af9e57ea1576fb7e824cfc4687dbfab5ed318c857fe0f3e6fc2242d2a1"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 robert green ingersoll)",
+    "count": 11,
+    "top_100": 11,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ],
+    "top_100_count_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 who dares wins river)",
+    "count": 552,
+    "top_100": 552,
+    "result_type": "Hash",
+    "top_100_result": [
+      "57e64634c939b3703df587637043502fa7ded30c410915f4f98d17d4ce7bc30a"
+    ],
+    "top_100_count_result": [
+      "57e64634c939b3703df587637043502fa7ded30c410915f4f98d17d4ce7bc30a"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 italy digital scanning plus)",
+    "count": 5039,
+    "top_100": 5039,
+    "result_type": "Hash",
+    "top_100_result": [
+      "28d38f80de2872c8cabd6db6ff2b5ec3192f7588c1404b394307ae93bce08cd0"
+    ],
+    "top_100_count_result": [
+      "28d38f80de2872c8cabd6db6ff2b5ec3192f7588c1404b394307ae93bce08cd0"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 italy digital scanning)",
+    "count": 1687,
+    "top_100": 1687,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0eb5532425de03d8f0d32ab70d64bb5adc14d98b6060333c653fdaddc9fd6149"
+    ],
+    "top_100_count_result": [
+      "0eb5532425de03d8f0d32ab70d64bb5adc14d98b6060333c653fdaddc9fd6149"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 size clothing)",
+    "count": 20,
+    "top_100": 20,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bff295118edb5ec054228693d0e802e9abe58ead0b6ad76f6d19e0e6523dfc3e"
+    ],
+    "top_100_count_result": [
+      "bff295118edb5ec054228693d0e802e9abe58ead0b6ad76f6d19e0e6523dfc3e"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 people having sex)",
+    "count": 15,
+    "top_100": 15,
+    "result_type": "Hash",
+    "top_100_result": [
+      "67ed251c6b3253a2d86c7175dc6cf2685711988bad13df16e0670c780bf94f97"
+    ],
+    "top_100_count_result": [
+      "67ed251c6b3253a2d86c7175dc6cf2685711988bad13df16e0670c780bf94f97"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 texas death row album)",
+    "count": 799,
+    "top_100": 799,
+    "result_type": "Hash",
+    "top_100_result": [
+      "791e1106f0affdbee6fadb993e9fc2871c341b6a1b78a85b0be7a6464990a23f"
+    ],
+    "top_100_count_result": [
+      "791e1106f0affdbee6fadb993e9fc2871c341b6a1b78a85b0be7a6464990a23f"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 size clothing borders books)",
+    "count": 9723,
+    "top_100": 9723,
+    "result_type": "Hash",
+    "top_100_result": [
+      "87a455e614efb8793b4500c137ee8d700cde2480feb3450022f2c6c8d6b8e0f3"
+    ],
+    "top_100_count_result": [
+      "87a455e614efb8793b4500c137ee8d700cde2480feb3450022f2c6c8d6b8e0f3"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 size clothing borders)",
+    "count": 3845,
+    "top_100": 3845,
+    "result_type": "Hash",
+    "top_100_result": [
+      "dbb2058a70c5ef6b6d9685255400c2f679550285a8a48cb61f542ea24791df92"
+    ],
+    "top_100_count_result": [
+      "dbb2058a70c5ef6b6d9685255400c2f679550285a8a48cb61f542ea24791df92"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 american funds)",
+    "count": 23,
+    "top_100": 23,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e44b46023950861b00a91b4e12cef7e35f61be4203c4b8954ce2506027d64320"
+    ],
+    "top_100_count_result": [
+      "e44b46023950861b00a91b4e12cef7e35f61be4203c4b8954ce2506027d64320"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 texas death row)",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "34e676bc234cbe0c36527f463d77c5fe1153d13e5a21382435a4cd9348822402"
+    ],
+    "top_100_count_result": [
+      "34e676bc234cbe0c36527f463d77c5fe1153d13e5a21382435a4cd9348822402"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 robert green ingersoll president)",
+    "count": 807,
+    "top_100": 807,
+    "result_type": "Hash",
+    "top_100_result": [
+      "eabb3229605f376a2c19833d8d30d5bfe70c1e792704a9d568e1b5260a42d355"
+    ],
+    "top_100_count_result": [
+      "eabb3229605f376a2c19833d8d30d5bfe70c1e792704a9d568e1b5260a42d355"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 american funds scottsdale wisconsin)",
+    "count": 23420,
+    "top_100": 23420,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fc2af5e47d8a62d8708a45cdc371de69b9ab12e06d8c7a825d6b890e919d0cf8"
+    ],
+    "top_100_count_result": [
+      "fc2af5e47d8a62d8708a45cdc371de69b9ab12e06d8c7a825d6b890e919d0cf8"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 american funds scottsdale)",
+    "count": 11623,
+    "top_100": 11623,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ede900c683df85ad842b8f44c7c7ab2162a2146b9cd7b0dfea7254d089a66bb9"
+    ],
+    "top_100_count_result": [
+      "ede900c683df85ad842b8f44c7c7ab2162a2146b9cd7b0dfea7254d089a66bb9"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 attorney general)",
+    "count": 13386,
+    "top_100": 613,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6463f708edab982d8a541647da13915af5991c9cbb1ca0b7598d4b4701384a69"
+    ],
+    "top_100_count_result": [
+      "6463f708edab982d8a541647da13915af5991c9cbb1ca0b7598d4b4701384a69"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 ford modeling agency)",
+    "count": 53,
+    "top_100": 53,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7f0b8285cdaa1020050c71593e96f2203794c4e3ce755a68280bbebc296f3e33"
+    ],
+    "top_100_count_result": [
+      "7f0b8285cdaa1020050c71593e96f2203794c4e3ce755a68280bbebc296f3e33"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 georgia public broadcasting germany)",
+    "count": 933,
+    "top_100": 933,
+    "result_type": "Hash",
+    "top_100_result": [
+      "93b18010ca51ed47a5bc4eea31dade00973c0c70cc262e3d4870240d5f3130d1"
+    ],
+    "top_100_count_result": [
+      "93b18010ca51ed47a5bc4eea31dade00973c0c70cc262e3d4870240d5f3130d1"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 attorney general english restoration)",
+    "count": 52762,
+    "top_100": 52762,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8749fc5be92298352ef50be2257f4fbeb7fb1efcc6b796f74b6a897eb7e8542f"
+    ],
+    "top_100_count_result": [
+      "8749fc5be92298352ef50be2257f4fbeb7fb1efcc6b796f74b6a897eb7e8542f"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 attorney general english)",
+    "count": 43652,
+    "top_100": 43652,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e84a6a862f0464b83b2ba641dff8cb38aed2f65eb028b7f54d0200fde4e71b5d"
+    ],
+    "top_100_count_result": [
+      "e84a6a862f0464b83b2ba641dff8cb38aed2f65eb028b7f54d0200fde4e71b5d"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 freelance work)",
+    "count": 307,
+    "top_100": 228,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4da8acade67f8fbb3ac6f91dbd91e6e6298333b6022ce5861e3d2f2fcba76aca"
+    ],
+    "top_100_count_result": [
+      "4da8acade67f8fbb3ac6f91dbd91e6e6298333b6022ce5861e3d2f2fcba76aca"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 cured of cancer)",
+    "count": 13,
+    "top_100": 13,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8d0ebe7075f5d277c5135673aa8bae7b5dc5ff12e3edc07d4939ebd80a954abb"
+    ],
+    "top_100_count_result": [
+      "8d0ebe7075f5d277c5135673aa8bae7b5dc5ff12e3edc07d4939ebd80a954abb"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 hempstead new york bridge)",
+    "count": 6699,
+    "top_100": 6699,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9e2b50afddab28b1e53cabad256ff3295f533ee52c2a0b378f0f327a4de40355"
+    ],
+    "top_100_count_result": [
+      "9e2b50afddab28b1e53cabad256ff3295f533ee52c2a0b378f0f327a4de40355"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 freelance work french culinary)",
+    "count": 37467,
+    "top_100": 37467,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3670a9525535dbccf3cc588019a95c7a40fe94dd697bd23d989f0fcb1e752c7a"
+    ],
+    "top_100_count_result": [
+      "3670a9525535dbccf3cc588019a95c7a40fe94dd697bd23d989f0fcb1e752c7a"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 freelance work french)",
+    "count": 36611,
+    "top_100": 36611,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fa84041341bfb46662263e7d5d3765496242e47792d6416b499a25bb4bbede98"
+    ],
+    "top_100_count_result": [
+      "fa84041341bfb46662263e7d5d3765496242e47792d6416b499a25bb4bbede98"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 omaha symphony)",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ],
+    "top_100_count_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 georgia public broadcasting)",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3362b5c274c9b2680118e301726316182cf83c28cfe332b4e4941af821a72d2b"
+    ],
+    "top_100_count_result": [
+      "3362b5c274c9b2680118e301726316182cf83c28cfe332b4e4941af821a72d2b"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 cured of cancer television)",
+    "count": 2856,
+    "top_100": 2856,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6b1e652bbd0b07bad4eeddd71111144b83736237ce194e326f9bdb30e0f5ab39"
+    ],
+    "top_100_count_result": [
+      "6b1e652bbd0b07bad4eeddd71111144b83736237ce194e326f9bdb30e0f5ab39"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 institute color combinations italian)",
+    "count": 7537,
+    "top_100": 7537,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9d976b05013325fc8e31167270d1a0d33c6d006b99d1aa60e29b290bd3edf80e"
+    ],
+    "top_100_count_result": [
+      "9d976b05013325fc8e31167270d1a0d33c6d006b99d1aa60e29b290bd3edf80e"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 institute color combinations)",
+    "count": 3152,
+    "top_100": 3152,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bc64b68f9c18ec5bcab4b117e3baa066e7926660e78162857d5ac66129703354"
+    ],
+    "top_100_count_result": [
+      "bc64b68f9c18ec5bcab4b117e3baa066e7926660e78162857d5ac66129703354"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 catholic answers)",
+    "count": 23,
+    "top_100": 23,
+    "result_type": "Hash",
+    "top_100_result": [
+      "28456271d550dfb57ad28840cd85e5f99e027fe87afb4359330ea52a036c0ded"
+    ],
+    "top_100_count_result": [
+      "28456271d550dfb57ad28840cd85e5f99e027fe87afb4359330ea52a036c0ded"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 the globe newspaper)",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f97f848f80de72114fa0e180968cd96a37fe787ad50507de3fd31213f781d758"
+    ],
+    "top_100_count_result": [
+      "f97f848f80de72114fa0e180968cd96a37fe787ad50507de3fd31213f781d758"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 helen of troy aircraft)",
+    "count": 641,
+    "top_100": 641,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bcf098f8d36e0a419de94333752c4115d2b568f4da6315cc7ac2b6f8a9afecb3"
+    ],
+    "top_100_count_result": [
+      "bcf098f8d36e0a419de94333752c4115d2b568f4da6315cc7ac2b6f8a9afecb3"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 translation milwaukee newspaper robert)",
+    "count": 8522,
+    "top_100": 8522,
+    "result_type": "Hash",
+    "top_100_result": [
+      "33d770f829a77b200a03068f3e606aa318bffa76b8d64cd91145e07142360915"
+    ],
+    "top_100_count_result": [
+      "33d770f829a77b200a03068f3e606aa318bffa76b8d64cd91145e07142360915"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 translation milwaukee newspaper)",
+    "count": 1437,
+    "top_100": 1437,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2010de502000d38a1b9adc343059d3765eaf186497d5f8c39871b77da9448970"
+    ],
+    "top_100_count_result": [
+      "2010de502000d38a1b9adc343059d3765eaf186497d5f8c39871b77da9448970"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 green ingersoll)",
+    "count": 11,
+    "top_100": 11,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ],
+    "top_100_count_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ]
+  },
+  {
+    "query": "fn:ngram(1.0 world bank president)",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d453e18c36e5ca242f20348bc46769ecabafa4cd83465cf0618f58543811b26e"
+    ],
+    "top_100_count_result": [
+      "d453e18c36e5ca242f20348bc46769ecabafa4cd83465cf0618f58543811b26e"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.7 trans siberian orchestra stadium)",
+    "count": 122,
+    "top_100": 122,
+    "result_type": "Hash",
+    "top_100_result": [
+      "aed5db1b3f91dba822ce71d334ebe768fe47b658a370505fb5415cfcf490ebb9"
+    ],
+    "top_100_count_result": [
+      "aed5db1b3f91dba822ce71d334ebe768fe47b658a370505fb5415cfcf490ebb9"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.5 green ingersoll omaha body)",
+    "count": 8357,
+    "top_100": 8357,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fefc0e63482ab5753b07798b14f71c7a364215f9e6731889a5308b7eb8059658"
+    ],
+    "top_100_count_result": [
+      "fefc0e63482ab5753b07798b14f71c7a364215f9e6731889a5308b7eb8059658"
+    ]
+  },
+  {
+    "query": "fn:ngram(0.34 green ingersoll omaha)",
+    "count": 237,
+    "top_100": 237,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ecba8eb867afb14fee76317ee3b33b75cce65b26d699aa3c00ebc0d9d7bd7452"
+    ],
+    "top_100_count_result": [
+      "ecba8eb867afb14fee76317ee3b33b75cce65b26d699aa3c00ebc0d9d7bd7452"
+    ]
+  },
+  {
+    "query": "\"griffith obse*\"",
+    "count": 60,
+    "top_100": 60,
+    "result_type": "Hash",
+    "top_100_result": [
+      "dae80cf4110d77d0acc036d91e2d5a379be178c7e5bb3c57d84d88e9757ed8e9"
+    ],
+    "top_100_count_result": [
+      "dae80cf4110d77d0acc036d91e2d5a379be178c7e5bb3c57d84d88e9757ed8e9"
+    ]
+  },
+  {
+    "query": "\"griffith obse*\"~2",
+    "count": 68,
+    "top_100": 68,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d11cc24960f9a9a820d5468570517266e4bf538ab60675028328a79929f4e366"
+    ],
+    "top_100_count_result": [
+      "d11cc24960f9a9a820d5468570517266e4bf538ab60675028328a79929f4e366"
+    ]
+  },
+  {
+    "query": "\"griffith 1-2 obse*\"",
+    "count": 68,
+    "top_100": 68,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f7517b2c85fbc7c58305470148d142836d9c9283542ec626344d0e060824b299"
+    ],
+    "top_100_count_result": [
+      "f7517b2c85fbc7c58305470148d142836d9c9283542ec626344d0e060824b299"
+    ]
+  },
+  {
+    "query": "\"griffith observator*\"",
+    "count": 57,
+    "top_100": 57,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7e4884c3c11d91a7f71d792596d90b6a2efca9de9d517dc82583c6f55c5eab9e"
+    ],
+    "top_100_count_result": [
+      "7e4884c3c11d91a7f71d792596d90b6a2efca9de9d517dc82583c6f55c5eab9e"
+    ]
+  },
+  {
+    "query": "\"bowel obst*\"",
+    "count": 118,
+    "top_100": 118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c6d0767ad324166e1b3ed3fa1b9e52c0c7fa6a9be9283acd3e4800b5a5a2f8bb"
+    ],
+    "top_100_count_result": [
+      "c6d0767ad324166e1b3ed3fa1b9e52c0c7fa6a9be9283acd3e4800b5a5a2f8bb"
+    ]
+  },
+  {
+    "query": "\"bowel obst*\"~2",
+    "count": 122,
+    "top_100": 122,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7f3cdd3bbd7b19f4a3681814b9a0470f980b36257ef00a5070854172a83e26d6"
+    ],
+    "top_100_count_result": [
+      "7f3cdd3bbd7b19f4a3681814b9a0470f980b36257ef00a5070854172a83e26d6"
+    ]
+  },
+  {
+    "query": "\"bowel 1-2 obst*\"",
+    "count": 118,
+    "top_100": 118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "65c395a0cc89c1bbe2ab9f9ff03aaf4f86eeefc5be42952afef6bd3be49ab405"
+    ],
+    "top_100_count_result": [
+      "65c395a0cc89c1bbe2ab9f9ff03aaf4f86eeefc5be42952afef6bd3be49ab405"
+    ]
+  },
+  {
+    "query": "\"bowel obstructio*\"",
+    "count": 118,
+    "top_100": 118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0810021de80d8983c4931dbb1e9a3771bcc1a744c3e18f11759234d10e89f5f6"
+    ],
+    "top_100_count_result": [
+      "0810021de80d8983c4931dbb1e9a3771bcc1a744c3e18f11759234d10e89f5f6"
+    ]
+  },
+  {
+    "query": "\"vicenza ital*\"",
+    "count": 114,
+    "top_100": 114,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fc52870c058156bcc9281f05cab33c29311136e00d907bc608df5a6d6f23040a"
+    ],
+    "top_100_count_result": [
+      "fc52870c058156bcc9281f05cab33c29311136e00d907bc608df5a6d6f23040a"
+    ]
+  },
+  {
+    "query": "\"digital scan*\"",
+    "count": 55,
+    "top_100": 55,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2e8dcf60372fd0e75e533ba1433f91082fbcb66efa3b2c74e041db264f43605c"
+    ],
+    "top_100_count_result": [
+      "2e8dcf60372fd0e75e533ba1433f91082fbcb66efa3b2c74e041db264f43605c"
+    ]
+  },
+  {
+    "query": "\"digital scan*\"~2",
+    "count": 157,
+    "top_100": 157,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a436f917490b6cc3c8f0964df41a5126c3da6fd9df9e479e7ef80ded153d07aa"
+    ],
+    "top_100_count_result": [
+      "a436f917490b6cc3c8f0964df41a5126c3da6fd9df9e479e7ef80ded153d07aa"
+    ]
+  },
+  {
+    "query": "\"digital 1-2 scan*\"",
+    "count": 91,
+    "top_100": 91,
+    "result_type": "Hash",
+    "top_100_result": [
+      "22f6255cb7eda025ca97f446aecaa9d403139fbd071d2b2f0d92ba8814f28e1a"
+    ],
+    "top_100_count_result": [
+      "22f6255cb7eda025ca97f446aecaa9d403139fbd071d2b2f0d92ba8814f28e1a"
+    ]
+  },
+  {
+    "query": "\"digital scannin*\"",
+    "count": 17,
+    "top_100": 17,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b38c7ab0c5978b9e06f6609029b8cfe6db3bddce1ac7d4ef2c21ee1691012fe8"
+    ],
+    "top_100_count_result": [
+      "b38c7ab0c5978b9e06f6609029b8cfe6db3bddce1ac7d4ef2c21ee1691012fe8"
+    ]
+  },
+  {
+    "query": "\"plus size clot*\"",
+    "count": 18,
+    "top_100": 18,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4585d8ce11873744208921228371a08c56b0ebad89af4399f97ddd4274914d88"
+    ],
+    "top_100_count_result": [
+      "4585d8ce11873744208921228371a08c56b0ebad89af4399f97ddd4274914d88"
+    ]
+  },
+  {
+    "query": "\"plus size clot*\"~2",
+    "count": 20,
+    "top_100": 20,
+    "result_type": "Hash",
+    "top_100_result": [
+      "221f638a87e030065c62cea7d3b5853fd00f9e74825477c4b4b105bcca42fc9d"
+    ],
+    "top_100_count_result": [
+      "221f638a87e030065c62cea7d3b5853fd00f9e74825477c4b4b105bcca42fc9d"
+    ]
+  },
+  {
+    "query": "\"plus 1-2 clot*\"",
+    "count": 26,
+    "top_100": 26,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d1670eab23f6fc390ffb2093fcbceb9e35d9bb24111ff4bbf86f9946c8ae3de8"
+    ],
+    "top_100_count_result": [
+      "d1670eab23f6fc390ffb2093fcbceb9e35d9bb24111ff4bbf86f9946c8ae3de8"
+    ]
+  },
+  {
+    "query": "\"plus size clothin*\"",
+    "count": 18,
+    "top_100": 18,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4585d8ce11873744208921228371a08c56b0ebad89af4399f97ddd4274914d88"
+    ],
+    "top_100_count_result": [
+      "4585d8ce11873744208921228371a08c56b0ebad89af4399f97ddd4274914d88"
+    ]
+  },
+  {
+    "query": "\"borders book*\"",
+    "count": 68,
+    "top_100": 68,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ae9d3cc76740b3be9e390b85bd7f6f77cd53a7eebf76cb375ee3108b1f2a0c97"
+    ],
+    "top_100_count_result": [
+      "ae9d3cc76740b3be9e390b85bd7f6f77cd53a7eebf76cb375ee3108b1f2a0c97"
+    ]
+  },
+  {
+    "query": "\"american fund*\"",
+    "count": 118,
+    "top_100": 118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "589288ea30371d24cdd9c1a8686615bd148e832bf13752ac52ff23c87b4843ad"
+    ],
+    "top_100_count_result": [
+      "589288ea30371d24cdd9c1a8686615bd148e832bf13752ac52ff23c87b4843ad"
+    ]
+  },
+  {
+    "query": "\"wisconsin attorney gene*\"",
+    "count": 47,
+    "top_100": 47,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ef8f45bc8e8f51b6f4969ea0994e7a1ffa19e6356fc5ade7a993f1c14a273fc0"
+    ],
+    "top_100_count_result": [
+      "ef8f45bc8e8f51b6f4969ea0994e7a1ffa19e6356fc5ade7a993f1c14a273fc0"
+    ]
+  },
+  {
+    "query": "\"wisconsin attorney gene*\"~2",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a92b431001abafb24da468f6f931e7c6ec49499dab002661ee7c4966376aa2c8"
+    ],
+    "top_100_count_result": [
+      "a92b431001abafb24da468f6f931e7c6ec49499dab002661ee7c4966376aa2c8"
+    ]
+  },
+  {
+    "query": "\"wisconsin 1-2 gene*\"",
+    "count": 98,
+    "top_100": 98,
+    "result_type": "Hash",
+    "top_100_result": [
+      "0f45005461d3d92e667aef511829700035ed8de15c1590b8359d3ed4082b93a0"
+    ],
+    "top_100_count_result": [
+      "0f45005461d3d92e667aef511829700035ed8de15c1590b8359d3ed4082b93a0"
+    ]
+  },
+  {
+    "query": "\"wisconsin attorney genera*\"",
+    "count": 47,
+    "top_100": 47,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ef8f45bc8e8f51b6f4969ea0994e7a1ffa19e6356fc5ade7a993f1c14a273fc0"
+    ],
+    "top_100_count_result": [
+      "ef8f45bc8e8f51b6f4969ea0994e7a1ffa19e6356fc5ade7a993f1c14a273fc0"
+    ]
+  },
+  {
+    "query": "\"the english rest*\"",
+    "count": 204,
+    "top_100": 204,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a09b0db121cc96cfcd7b5750144f08849f4944136e139740e098f173563fc0a5"
+    ],
+    "top_100_count_result": [
+      "a09b0db121cc96cfcd7b5750144f08849f4944136e139740e098f173563fc0a5"
+    ]
+  },
+  {
+    "query": "\"the english rest*\"~2",
+    "count": 254,
+    "top_100": 254,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c186e449ab1156b3f75e2b8eb98fec2ade1b7163c9bf2500b97e4814a437053b"
+    ],
+    "top_100_count_result": [
+      "c186e449ab1156b3f75e2b8eb98fec2ade1b7163c9bf2500b97e4814a437053b"
+    ]
+  },
+  {
+    "query": "\"the 1-2 rest*\"",
+    "count": 150321,
+    "top_100": 150321,
+    "result_type": "Hash",
+    "top_100_result": [
+      "9ac448223e68fa86b54b8e51f61f138a275931345fe6358b55dfb726c34f79f6"
+    ],
+    "top_100_count_result": [
+      "9ac448223e68fa86b54b8e51f61f138a275931345fe6358b55dfb726c34f79f6"
+    ]
+  },
+  {
+    "query": "\"the english restoratio*\"",
+    "count": 201,
+    "top_100": 201,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a09b0db121cc96cfcd7b5750144f08849f4944136e139740e098f173563fc0a5"
+    ],
+    "top_100_count_result": [
+      "a09b0db121cc96cfcd7b5750144f08849f4944136e139740e098f173563fc0a5"
+    ]
+  },
+  {
+    "query": "\"freelance wor*\"",
+    "count": 340,
+    "top_100": 340,
+    "result_type": "Hash",
+    "top_100_result": [
+      "1d82c1abebf7d5bcf1169022b6ee4dddd1d5247ecc5a7fb49c416c7c7d1042fa"
+    ],
+    "top_100_count_result": [
+      "1d82c1abebf7d5bcf1169022b6ee4dddd1d5247ecc5a7fb49c416c7c7d1042fa"
+    ]
+  },
+  {
+    "query": "\"french culinary inst*\"",
+    "count": 32,
+    "top_100": 32,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e2a40df2890639cd651c5915c8700732622b476121c6fa7e22c48b3363f190f9"
+    ],
+    "top_100_count_result": [
+      "e2a40df2890639cd651c5915c8700732622b476121c6fa7e22c48b3363f190f9"
+    ]
+  },
+  {
+    "query": "\"french culinary inst*\"~2",
+    "count": 32,
+    "top_100": 32,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e2a40df2890639cd651c5915c8700732622b476121c6fa7e22c48b3363f190f9"
+    ],
+    "top_100_count_result": [
+      "e2a40df2890639cd651c5915c8700732622b476121c6fa7e22c48b3363f190f9"
+    ]
+  },
+  {
+    "query": "\"french 1-2 inst*\"",
+    "count": 1118,
+    "top_100": 1118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "57dfc2448c0c207d8658e987663beab6bf042ed6608f49986fd9827ebb01a94e"
+    ],
+    "top_100_count_result": [
+      "57dfc2448c0c207d8658e987663beab6bf042ed6608f49986fd9827ebb01a94e"
+    ]
+  },
+  {
+    "query": "\"french culinary institut*\"",
+    "count": 32,
+    "top_100": 32,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e2a40df2890639cd651c5915c8700732622b476121c6fa7e22c48b3363f190f9"
+    ],
+    "top_100_count_result": [
+      "e2a40df2890639cd651c5915c8700732622b476121c6fa7e22c48b3363f190f9"
+    ]
+  },
+  {
+    "query": "\"color comb*\"",
+    "count": 259,
+    "top_100": 259,
+    "result_type": "Hash",
+    "top_100_result": [
+      "cd6dbd6fe2f066639b2a3fb9a363e56ef5e0cfbb89f8186b1792782904b81ae8"
+    ],
+    "top_100_count_result": [
+      "cd6dbd6fe2f066639b2a3fb9a363e56ef5e0cfbb89f8186b1792782904b81ae8"
+    ]
+  },
+  {
+    "query": "\"color comb*\"~2",
+    "count": 366,
+    "top_100": 366,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b6f81b6d9547c9ec616cabd69e388abd8b3a3047bc75e0a3c020bfb1472025f8"
+    ],
+    "top_100_count_result": [
+      "b6f81b6d9547c9ec616cabd69e388abd8b3a3047bc75e0a3c020bfb1472025f8"
+    ]
+  },
+  {
+    "query": "\"color 1-2 comb*\"",
+    "count": 298,
+    "top_100": 298,
+    "result_type": "Hash",
+    "top_100_result": [
+      "442d76da0338b14a256484f7e5669c8000cc798c42419f4771c2e420720afad3"
+    ],
+    "top_100_count_result": [
+      "442d76da0338b14a256484f7e5669c8000cc798c42419f4771c2e420720afad3"
+    ]
+  },
+  {
+    "query": "\"color combination*\"",
+    "count": 239,
+    "top_100": 239,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5f263ca0a5ccae3fe6a4bece94b5d8906f78a8831c5c1de1b3b0f767f1f9d912"
+    ],
+    "top_100_count_result": [
+      "5f263ca0a5ccae3fe6a4bece94b5d8906f78a8831c5c1de1b3b0f767f1f9d912"
+    ]
+  },
+  {
+    "query": "\"italian tran*\"",
+    "count": 406,
+    "top_100": 406,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c53177c7447514f65e910ef71b88d9d9a9881060d53f15b5e806371d095ac7dd"
+    ],
+    "top_100_count_result": [
+      "c53177c7447514f65e910ef71b88d9d9a9881060d53f15b5e806371d095ac7dd"
+    ]
+  },
+  {
+    "query": "\"italian tran*\"~2",
+    "count": 861,
+    "top_100": 861,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5768d52a8d34c7f11366bf14919990a825f80f5094e7981ac17a41eff75b2902"
+    ],
+    "top_100_count_result": [
+      "5768d52a8d34c7f11366bf14919990a825f80f5094e7981ac17a41eff75b2902"
+    ]
+  },
+  {
+    "query": "\"italian 1-2 tran*\"",
+    "count": 587,
+    "top_100": 587,
+    "result_type": "Hash",
+    "top_100_result": [
+      "70d1a0fc3d2e090e3cf5b3499678c2e1fccc453ffc9c38c02007873b51ffc031"
+    ],
+    "top_100_count_result": [
+      "70d1a0fc3d2e090e3cf5b3499678c2e1fccc453ffc9c38c02007873b51ffc031"
+    ]
+  },
+  {
+    "query": "\"italian translatio*\"",
+    "count": 300,
+    "top_100": 300,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b9cec090c360bc3e943912744f2df64413a54d9614f1f5077fbf4fe3e5f06a18"
+    ],
+    "top_100_count_result": [
+      "b9cec090c360bc3e943912744f2df64413a54d9614f1f5077fbf4fe3e5f06a18"
+    ]
+  },
+  {
+    "query": "\"milwaukee news*\"",
+    "count": 18,
+    "top_100": 18,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2419d1e3afeba57fdf82213a676252da89eb2a2b148549309f9823429b846b8f"
+    ],
+    "top_100_count_result": [
+      "2419d1e3afeba57fdf82213a676252da89eb2a2b148549309f9823429b846b8f"
+    ]
+  },
+  {
+    "query": "\"milwaukee news*\"~2",
+    "count": 45,
+    "top_100": 45,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4db874dce94f51c1f0316ed5437fc6d8a7c6d4e74a74d82d9d31565ad60c1f7e"
+    ],
+    "top_100_count_result": [
+      "4db874dce94f51c1f0316ed5437fc6d8a7c6d4e74a74d82d9d31565ad60c1f7e"
+    ]
+  },
+  {
+    "query": "\"milwaukee 1-2 news*\"",
+    "count": 28,
+    "top_100": 28,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ef507ac16265cbd9d932cce4264532476e60a1127107a76738b009f770411080"
+    ],
+    "top_100_count_result": [
+      "ef507ac16265cbd9d932cce4264532476e60a1127107a76738b009f770411080"
+    ]
+  },
+  {
+    "query": "\"milwaukee newspape*\"",
+    "count": 13,
+    "top_100": 13,
+    "result_type": "Hash",
+    "top_100_result": [
+      "486ee51f9af3db1281e271c4e4588b9f659baa2bf7f24d9001b9627fd9a334cf"
+    ],
+    "top_100_count_result": [
+      "486ee51f9af3db1281e271c4e4588b9f659baa2bf7f24d9001b9627fd9a334cf"
+    ]
+  },
+  {
+    "query": "\"robert green inge*\"",
+    "count": 11,
+    "top_100": 11,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ],
+    "top_100_count_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ]
+  },
+  {
+    "query": "\"robert green inge*\"~2",
+    "count": 12,
+    "top_100": 12,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ac2ec5ba3e53451dfd8f5b9a42bb62e6035a132840f93b54397a38009d1b7689"
+    ],
+    "top_100_count_result": [
+      "ac2ec5ba3e53451dfd8f5b9a42bb62e6035a132840f93b54397a38009d1b7689"
+    ]
+  },
+  {
+    "query": "\"robert 1-2 inge*\"",
+    "count": 111,
+    "top_100": 111,
+    "result_type": "Hash",
+    "top_100_result": [
+      "48180c4b145ce6211af8dbd2799392cdb03e18431af26b90b46db54c4c047fdc"
+    ],
+    "top_100_count_result": [
+      "48180c4b145ce6211af8dbd2799392cdb03e18431af26b90b46db54c4c047fdc"
+    ]
+  },
+  {
+    "query": "\"robert green ingersol*\"",
+    "count": 11,
+    "top_100": 11,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ],
+    "top_100_count_result": [
+      "e534aa5c1915425e4c597cc409695be94f94380aaf9b1c8afdda1ae66045e110"
+    ]
+  },
+  {
+    "query": "\"omaha symp*\"",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ],
+    "top_100_count_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ]
+  },
+  {
+    "query": "\"omaha symp*\"~2",
+    "count": 26,
+    "top_100": 26,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8eda70cbe241914a69de3c8a066863800bc3375f9253e88fdfbc9680af399fe9"
+    ],
+    "top_100_count_result": [
+      "8eda70cbe241914a69de3c8a066863800bc3375f9253e88fdfbc9680af399fe9"
+    ]
+  },
+  {
+    "query": "\"omaha 1-2 symp*\"",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ],
+    "top_100_count_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ]
+  },
+  {
+    "query": "\"omaha symphon*\"",
+    "count": 25,
+    "top_100": 25,
+    "result_type": "Hash",
+    "top_100_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ],
+    "top_100_count_result": [
+      "805decbb30b6594519b8ac284ce1453d1793d21856b8ba6f1fda717b8cfe4a17"
+    ]
+  },
+  {
+    "query": "\"body pain*\"",
+    "count": 352,
+    "top_100": 352,
+    "result_type": "Hash",
+    "top_100_result": [
+      "374c6a9887f1a6279b4dd97df6e6a50c5c535db64b7b6e9c757fc2a10ba5072d"
+    ],
+    "top_100_count_result": [
+      "374c6a9887f1a6279b4dd97df6e6a50c5c535db64b7b6e9c757fc2a10ba5072d"
+    ]
+  },
+  {
+    "query": "\"body pain*\"~2",
+    "count": 597,
+    "top_100": 597,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b780aed7ad966f9614bc744ee006cf21f5b4f1d3606f243e684e6cd985cd2768"
+    ],
+    "top_100_count_result": [
+      "b780aed7ad966f9614bc744ee006cf21f5b4f1d3606f243e684e6cd985cd2768"
+    ]
+  },
+  {
+    "query": "\"body 1-2 pain*\"",
+    "count": 466,
+    "top_100": 466,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b15140a49655eae5ce664bf30e1330aded4eb761436bbb2a62dff674dffdcf30"
+    ],
+    "top_100_count_result": [
+      "b15140a49655eae5ce664bf30e1330aded4eb761436bbb2a62dff674dffdcf30"
+    ]
+  },
+  {
+    "query": "\"body paintin*\"",
+    "count": 144,
+    "top_100": 144,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a3708d20c64076afc60173a4325635b76f6e25db93496f07580d96492fba434b"
+    ],
+    "top_100_count_result": [
+      "a3708d20c64076afc60173a4325635b76f6e25db93496f07580d96492fba434b"
+    ]
+  },
+  {
+    "query": "\"who dares win*\"",
+    "count": 64,
+    "top_100": 64,
+    "result_type": "Hash",
+    "top_100_result": [
+      "bc18794ac9a30806265668d948c56024673592ea65173a369f40d943ef2325e7"
+    ],
+    "top_100_count_result": [
+      "bc18794ac9a30806265668d948c56024673592ea65173a369f40d943ef2325e7"
+    ]
+  },
+  {
+    "query": "\"west palm beach flor*\"",
+    "count": 566,
+    "top_100": 566,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e57ff544c2bc90aa6b86631980d7a74b58b943cb97cda6d2609b6bb4dd0951a8"
+    ],
+    "top_100_count_result": [
+      "e57ff544c2bc90aa6b86631980d7a74b58b943cb97cda6d2609b6bb4dd0951a8"
+    ]
+  },
+  {
+    "query": "\"west palm beach flor*\"~2",
+    "count": 582,
+    "top_100": 582,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f75e1b4461de3f8c20d977153461b6a2ab5dce52d4ffab6326ff4918c3e59e86"
+    ],
+    "top_100_count_result": [
+      "f75e1b4461de3f8c20d977153461b6a2ab5dce52d4ffab6326ff4918c3e59e86"
+    ]
+  },
+  {
+    "query": "\"west 1-2 flor*\"",
+    "count": 1667,
+    "top_100": 1667,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5cdc978accc536d8cc05dddc3d3117685027a0fcd3e28b3416a2e9bcbf6782c7"
+    ],
+    "top_100_count_result": [
+      "5cdc978accc536d8cc05dddc3d3117685027a0fcd3e28b3416a2e9bcbf6782c7"
+    ]
+  },
+  {
+    "query": "\"west palm beach florid*\"",
+    "count": 566,
+    "top_100": 566,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e57ff544c2bc90aa6b86631980d7a74b58b943cb97cda6d2609b6bb4dd0951a8"
+    ],
+    "top_100_count_result": [
+      "e57ff544c2bc90aa6b86631980d7a74b58b943cb97cda6d2609b6bb4dd0951a8"
+    ]
+  },
+  {
+    "query": "\"stone moun*\"",
+    "count": 398,
+    "top_100": 398,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2e17b4d50a7ee5e446f7e8180ef739cb2e00741bc815cf6d84741484e5d5f835"
+    ],
+    "top_100_count_result": [
+      "2e17b4d50a7ee5e446f7e8180ef739cb2e00741bc815cf6d84741484e5d5f835"
+    ]
+  },
+  {
+    "query": "\"stone moun*\"~2",
+    "count": 598,
+    "top_100": 598,
+    "result_type": "Hash",
+    "top_100_result": [
+      "cb470a7646e070188f3c2d08a784e0bd0008ed25ca3121ec8e8414bf2aa6197d"
+    ],
+    "top_100_count_result": [
+      "cb470a7646e070188f3c2d08a784e0bd0008ed25ca3121ec8e8414bf2aa6197d"
+    ]
+  },
+  {
+    "query": "\"stone 1-2 moun*\"",
+    "count": 465,
+    "top_100": 465,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8aee7970fb2cbe302596854cf897310f536fc2821f9fe19cb6ac99d6b54c10b1"
+    ],
+    "top_100_count_result": [
+      "8aee7970fb2cbe302596854cf897310f536fc2821f9fe19cb6ac99d6b54c10b1"
+    ]
+  },
+  {
+    "query": "\"stone mountai*\"",
+    "count": 343,
+    "top_100": 343,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4dd99b9ce47d3423e2b48310651dee5fb4ae73d8e7448aeef73e82fb0b22350f"
+    ],
+    "top_100_count_result": [
+      "4dd99b9ce47d3423e2b48310651dee5fb4ae73d8e7448aeef73e82fb0b22350f"
+    ]
+  },
+  {
+    "query": "\"san fran*\"",
+    "count": 45521,
+    "top_100": 45521,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7947ee45d4761f8335aa6f5998be512bac0a5d579ba833370f67307e4b0d2e59"
+    ],
+    "top_100_count_result": [
+      "7947ee45d4761f8335aa6f5998be512bac0a5d579ba833370f67307e4b0d2e59"
+    ]
+  },
+  {
+    "query": "\"san fran*\"~2",
+    "count": 45786,
+    "top_100": 45786,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3ea68fd2817c6ec6a5bcc9aa9a311951391cbba6fe9c1f7eaa1416572d6a9b62"
+    ],
+    "top_100_count_result": [
+      "3ea68fd2817c6ec6a5bcc9aa9a311951391cbba6fe9c1f7eaa1416572d6a9b62"
+    ]
+  },
+  {
+    "query": "\"san 1-2 fran*\"",
+    "count": 45584,
+    "top_100": 45584,
+    "result_type": "Hash",
+    "top_100_result": [
+      "68b516fcc56b6e037e6f5f618cce90ce110e1250e2b06ef29c812fd4d527765f"
+    ],
+    "top_100_count_result": [
+      "68b516fcc56b6e037e6f5f618cce90ce110e1250e2b06ef29c812fd4d527765f"
+    ]
+  },
+  {
+    "query": "\"san francisc*\"",
+    "count": 44914,
+    "top_100": 44914,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6074f178cb96418527bc3ffd0b79a5cbcbaeb4bc66d6c93b4ef29318c3cfd890"
+    ],
+    "top_100_count_result": [
+      "6074f178cb96418527bc3ffd0b79a5cbcbaeb4bc66d6c93b4ef29318c3cfd890"
+    ]
+  },
+  {
+    "query": "\"ford modeling agenc*\"",
+    "count": 53,
+    "top_100": 53,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7f0b8285cdaa1020050c71593e96f2203794c4e3ce755a68280bbebc296f3e33"
+    ],
+    "top_100_count_result": [
+      "7f0b8285cdaa1020050c71593e96f2203794c4e3ce755a68280bbebc296f3e33"
+    ]
+  },
+  {
+    "query": "\"glass work*\"",
+    "count": 546,
+    "top_100": 546,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d36c82ba41a668efb2d26bf581939d8c427ad5182be9d2f0f85ed442fc35e9e7"
+    ],
+    "top_100_count_result": [
+      "d36c82ba41a668efb2d26bf581939d8c427ad5182be9d2f0f85ed442fc35e9e7"
+    ]
+  },
+  {
+    "query": "\"personal loa*\"",
+    "count": 201,
+    "top_100": 201,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f9a9e2a7bf9687aee49eb0ee0d9479ef3b674fa41571f4f04e78cfe408cf5e5b"
+    ],
+    "top_100_count_result": [
+      "f9a9e2a7bf9687aee49eb0ee0d9479ef3b674fa41571f4f04e78cfe408cf5e5b"
+    ]
+  },
+  {
+    "query": "\"texas state legi*\"",
+    "count": 114,
+    "top_100": 114,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6a189eb93265817e7615a3399cc6c6077624f9df364342511d5edd49141d504b"
+    ],
+    "top_100_count_result": [
+      "6a189eb93265817e7615a3399cc6c6077624f9df364342511d5edd49141d504b"
+    ]
+  },
+  {
+    "query": "\"texas state legi*\"~2",
+    "count": 118,
+    "top_100": 118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4c482130f3c1d2b94484fea6d3d14a90dafc624e9a80197a2cf5df007b66bc6b"
+    ],
+    "top_100_count_result": [
+      "4c482130f3c1d2b94484fea6d3d14a90dafc624e9a80197a2cf5df007b66bc6b"
+    ]
+  },
+  {
+    "query": "\"texas 1-2 legi*\"",
+    "count": 757,
+    "top_100": 757,
+    "result_type": "Hash",
+    "top_100_result": [
+      "dcc8fafde7a21bd85d0194acb46345cdfb398938b6d3d31136d56dd321219c58"
+    ],
+    "top_100_count_result": [
+      "dcc8fafde7a21bd85d0194acb46345cdfb398938b6d3d31136d56dd321219c58"
+    ]
+  },
+  {
+    "query": "\"texas state legislatur*\"",
+    "count": 95,
+    "top_100": 95,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3b086400d40131a30fa88cfcc9de47ba1641dad9ca396b0720ae24adf1cc23a3"
+    ],
+    "top_100_count_result": [
+      "3b086400d40131a30fa88cfcc9de47ba1641dad9ca396b0720ae24adf1cc23a3"
+    ]
+  },
+  {
+    "query": "\"spiritual warf*\"",
+    "count": 76,
+    "top_100": 76,
+    "result_type": "Hash",
+    "top_100_result": [
+      "773a1e5f1c71b330e2cadf09efc4e29465a988ff28c4635b3997fce7869b43de"
+    ],
+    "top_100_count_result": [
+      "773a1e5f1c71b330e2cadf09efc4e29465a988ff28c4635b3997fce7869b43de"
+    ]
+  },
+  {
+    "query": "\"spiritual warf*\"~2",
+    "count": 77,
+    "top_100": 77,
+    "result_type": "Hash",
+    "top_100_result": [
+      "73c04d054eb2250608ad838d7392c3c4461f4bf343750bde5ad02283d9599126"
+    ],
+    "top_100_count_result": [
+      "73c04d054eb2250608ad838d7392c3c4461f4bf343750bde5ad02283d9599126"
+    ]
+  },
+  {
+    "query": "\"spiritual 1-2 warf*\"",
+    "count": 76,
+    "top_100": 76,
+    "result_type": "Hash",
+    "top_100_result": [
+      "703bd947b87b64ce6a89d2e9b5b47333e5a469b4b13faf88a1ec1d2593cacde3"
+    ],
+    "top_100_count_result": [
+      "703bd947b87b64ce6a89d2e9b5b47333e5a469b4b13faf88a1ec1d2593cacde3"
+    ]
+  },
+  {
+    "query": "\"spiritual warfar*\"",
+    "count": 76,
+    "top_100": 76,
+    "result_type": "Hash",
+    "top_100_result": [
+      "773a1e5f1c71b330e2cadf09efc4e29465a988ff28c4635b3997fce7869b43de"
+    ],
+    "top_100_count_result": [
+      "773a1e5f1c71b330e2cadf09efc4e29465a988ff28c4635b3997fce7869b43de"
+    ]
+  },
+  {
+    "query": "\"georgia public broa*\"",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3362b5c274c9b2680118e301726316182cf83c28cfe332b4e4941af821a72d2b"
+    ],
+    "top_100_count_result": [
+      "3362b5c274c9b2680118e301726316182cf83c28cfe332b4e4941af821a72d2b"
+    ]
+  },
+  {
+    "query": "\"georgia public broa*\"~2",
+    "count": 64,
+    "top_100": 64,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ce5493074fc5fb2d693067cc8891c4daead47012796734a5e9f69f4d6bd59a60"
+    ],
+    "top_100_count_result": [
+      "ce5493074fc5fb2d693067cc8891c4daead47012796734a5e9f69f4d6bd59a60"
+    ]
+  },
+  {
+    "query": "\"georgia 1-2 broa*\"",
+    "count": 127,
+    "top_100": 127,
+    "result_type": "Hash",
+    "top_100_result": [
+      "03f32a9654790d8f9023d6cb0a961a3abd0bc395fa3600b537e686b70cf88b4c"
+    ],
+    "top_100_count_result": [
+      "03f32a9654790d8f9023d6cb0a961a3abd0bc395fa3600b537e686b70cf88b4c"
+    ]
+  },
+  {
+    "query": "\"georgia public broadcastin*\"",
+    "count": 61,
+    "top_100": 61,
+    "result_type": "Hash",
+    "top_100_result": [
+      "3362b5c274c9b2680118e301726316182cf83c28cfe332b4e4941af821a72d2b"
+    ],
+    "top_100_count_result": [
+      "3362b5c274c9b2680118e301726316182cf83c28cfe332b4e4941af821a72d2b"
+    ]
+  },
+  {
+    "query": "\"catholic answ*\"",
+    "count": 29,
+    "top_100": 29,
+    "result_type": "Hash",
+    "top_100_result": [
+      "73aa5ef6814c2294a494da7f21ebf52ce1aa5c631e554d91c8b396b48692bb33"
+    ],
+    "top_100_count_result": [
+      "73aa5ef6814c2294a494da7f21ebf52ce1aa5c631e554d91c8b396b48692bb33"
+    ]
+  },
+  {
+    "query": "\"catholic answ*\"~2",
+    "count": 44,
+    "top_100": 44,
+    "result_type": "Hash",
+    "top_100_result": [
+      "b78dbbaea7c0c0dd5f08dad873e1bee3efabce4a4e91330e05c68cd1dd5c345d"
+    ],
+    "top_100_count_result": [
+      "b78dbbaea7c0c0dd5f08dad873e1bee3efabce4a4e91330e05c68cd1dd5c345d"
+    ]
+  },
+  {
+    "query": "\"catholic 1-2 answ*\"",
+    "count": 38,
+    "top_100": 38,
+    "result_type": "Hash",
+    "top_100_result": [
+      "099b9b9b7edc9d78a50769b01746e67a6711750a7be20c1567f2286d842b8ef9"
+    ],
+    "top_100_count_result": [
+      "099b9b9b7edc9d78a50769b01746e67a6711750a7be20c1567f2286d842b8ef9"
+    ]
+  },
+  {
+    "query": "\"catholic answer*\"",
+    "count": 29,
+    "top_100": 29,
+    "result_type": "Hash",
+    "top_100_result": [
+      "73aa5ef6814c2294a494da7f21ebf52ce1aa5c631e554d91c8b396b48692bb33"
+    ],
+    "top_100_count_result": [
+      "73aa5ef6814c2294a494da7f21ebf52ce1aa5c631e554d91c8b396b48692bb33"
+    ]
+  },
+  {
+    "query": "\"interest onl*\"",
+    "count": 198,
+    "top_100": 198,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f11849fcc2e9d41ee720edb52cd7a4e9edb621f1bb112464701b956a616f357c"
+    ],
+    "top_100_count_result": [
+      "f11849fcc2e9d41ee720edb52cd7a4e9edb621f1bb112464701b956a616f357c"
+    ]
+  },
+  {
+    "query": "\"army rese*\"",
+    "count": 2398,
+    "top_100": 2398,
+    "result_type": "Hash",
+    "top_100_result": [
+      "041f677c9d8fee4187562d477f958aecf0921ca61664d87a0695446f4768f0c8"
+    ],
+    "top_100_count_result": [
+      "041f677c9d8fee4187562d477f958aecf0921ca61664d87a0695446f4768f0c8"
+    ]
+  },
+  {
+    "query": "\"army rese*\"~2",
+    "count": 3451,
+    "top_100": 3451,
+    "result_type": "Hash",
+    "top_100_result": [
+      "98e3445ca5280a2574dbfeb5030c252234c971f42c071ad914b2ec7e78416604"
+    ],
+    "top_100_count_result": [
+      "98e3445ca5280a2574dbfeb5030c252234c971f42c071ad914b2ec7e78416604"
+    ]
+  },
+  {
+    "query": "\"army 1-2 rese*\"",
+    "count": 2832,
+    "top_100": 2832,
+    "result_type": "Hash",
+    "top_100_result": [
+      "ae1f82ab98962e718c23d6dfd80b1a2e21dd563308c1f26579b689a8096b7b87"
+    ],
+    "top_100_count_result": [
+      "ae1f82ab98962e718c23d6dfd80b1a2e21dd563308c1f26579b689a8096b7b87"
+    ]
+  },
+  {
+    "query": "\"army reserv*\"",
+    "count": 2214,
+    "top_100": 2214,
+    "result_type": "Hash",
+    "top_100_result": [
+      "385f59da5b557c594e40e82ab6c9d2bc1ec021391fb2af7d1f1e68e799468911"
+    ],
+    "top_100_count_result": [
+      "385f59da5b557c594e40e82ab6c9d2bc1ec021391fb2af7d1f1e68e799468911"
+    ]
+  },
+  {
+    "query": "\"chicken coo*\"",
+    "count": 406,
+    "top_100": 406,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e04b9c6e8ac299d477e8c5a189729dac81ed185e8662ec2983565f2977616eb9"
+    ],
+    "top_100_count_result": [
+      "e04b9c6e8ac299d477e8c5a189729dac81ed185e8662ec2983565f2977616eb9"
+    ]
+  },
+  {
+    "query": "\"new york popu*\"",
+    "count": 26,
+    "top_100": 26,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d3c09d6586e8d05efbf8c6df0142fea65510e1daf097f54c93d6717641858f0f"
+    ],
+    "top_100_count_result": [
+      "d3c09d6586e8d05efbf8c6df0142fea65510e1daf097f54c93d6717641858f0f"
+    ]
+  },
+  {
+    "query": "\"new york popu*\"~2",
+    "count": 498,
+    "top_100": 498,
+    "result_type": "Hash",
+    "top_100_result": [
+      "fa97585afb9c0e2933834a92936080557eec4fb42f7cc00cefac5e3d58634723"
+    ],
+    "top_100_count_result": [
+      "fa97585afb9c0e2933834a92936080557eec4fb42f7cc00cefac5e3d58634723"
+    ]
+  },
+  {
+    "query": "\"new 1-2 popu*\"",
+    "count": 951,
+    "top_100": 951,
+    "result_type": "Hash",
+    "top_100_result": [
+      "db99693ef52f1e5d95af510616d6dbf6e024b9ce195d8a56e1423da082925eec"
+    ],
+    "top_100_count_result": [
+      "db99693ef52f1e5d95af510616d6dbf6e024b9ce195d8a56e1423da082925eec"
+    ]
+  },
+  {
+    "query": "\"new york populatio*\"",
+    "count": 13,
+    "top_100": 13,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e8c338167a54e452e8b04827c19ed86ef6d9dceac6e4735d3c4f25f5ec2a6b7a"
+    ],
+    "top_100_count_result": [
+      "e8c338167a54e452e8b04827c19ed86ef6d9dceac6e4735d3c4f25f5ec2a6b7a"
+    ]
+  },
+  {
+    "query": "\"most improved playe*\"",
+    "count": 458,
+    "top_100": 458,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e9abf7e1fdbbda02fc1f44c482b0fb440f72ca02378311890756bee648f72851"
+    ],
+    "top_100_count_result": [
+      "e9abf7e1fdbbda02fc1f44c482b0fb440f72ca02378311890756bee648f72851"
+    ]
+  },
+  {
+    "query": "\"ear ach*\"",
+    "count": 15,
+    "top_100": 15,
+    "result_type": "Hash",
+    "top_100_result": [
+      "e4c09ed6c84b48b69511b4047798877b5683b667d64a7600c4c24fe09a2d2c7a"
+    ],
+    "top_100_count_result": [
+      "e4c09ed6c84b48b69511b4047798877b5683b667d64a7600c4c24fe09a2d2c7a"
+    ]
+  },
+  {
+    "query": "\"mercury insu*\"",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "00165fadaa3a87df9be084dd8c5e2d75827672929054c0e026beb60db8b58069"
+    ],
+    "top_100_count_result": [
+      "00165fadaa3a87df9be084dd8c5e2d75827672929054c0e026beb60db8b58069"
+    ]
+  },
+  {
+    "query": "\"mercury insu*\"~2",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "2938bdd260849423622cee1b488cfb86a547a51c7ae330ff6b7d5b83b2b6da6d"
+    ],
+    "top_100_count_result": [
+      "2938bdd260849423622cee1b488cfb86a547a51c7ae330ff6b7d5b83b2b6da6d"
+    ]
+  },
+  {
+    "query": "\"mercury 1-2 insu*\"",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "00165fadaa3a87df9be084dd8c5e2d75827672929054c0e026beb60db8b58069"
+    ],
+    "top_100_count_result": [
+      "00165fadaa3a87df9be084dd8c5e2d75827672929054c0e026beb60db8b58069"
+    ]
+  },
+  {
+    "query": "\"mercury insuranc*\"",
+    "count": 22,
+    "top_100": 22,
+    "result_type": "Hash",
+    "top_100_result": [
+      "00165fadaa3a87df9be084dd8c5e2d75827672929054c0e026beb60db8b58069"
+    ],
+    "top_100_count_result": [
+      "00165fadaa3a87df9be084dd8c5e2d75827672929054c0e026beb60db8b58069"
+    ]
+  },
+  {
+    "query": "+climate +policy",
+    "count": 4509,
+    "top_100": 4509,
+    "result_type": "Hash",
+    "top_100_result": [
+      "cf70de227d79ea127dfe511112bd74fc7ae1457172afe8b86af0b1520a14f86f"
+    ],
+    "top_100_count_result": [
+      "cf70de227d79ea127dfe511112bd74fc7ae1457172afe8b86af0b1520a14f86f"
+    ]
+  },
+  {
+    "query": "+data +privacy",
+    "count": 1783,
+    "top_100": 1783,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c43db4051e6c1f29cb3f487fa078e30e4ea609640caa4919552fc60d54fa5f56"
+    ],
+    "top_100_count_result": [
+      "c43db4051e6c1f29cb3f487fa078e30e4ea609640caa4919552fc60d54fa5f56"
+    ]
+  },
+  {
+    "query": "+global +markets",
+    "count": 4718,
+    "top_100": 4718,
+    "result_type": "Hash",
+    "top_100_result": [
+      "8c2176c8004108723bd04d11a1bca17ddb983a1cb172c3888b89dd8426acee74"
+    ],
+    "top_100_count_result": [
+      "8c2176c8004108723bd04d11a1bca17ddb983a1cb172c3888b89dd8426acee74"
+    ]
+  },
+  {
+    "query": "+public +transit",
+    "count": 7598,
+    "top_100": 7598,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6599d4ec925e28586c5ebc2df82f3b815d0c21ff99aabcc6adba10776b432586"
+    ],
+    "top_100_count_result": [
+      "6599d4ec925e28586c5ebc2df82f3b815d0c21ff99aabcc6adba10776b432586"
+    ]
+  },
+  {
+    "query": "+consumer +rights",
+    "count": 2605,
+    "top_100": 2605,
+    "result_type": "Hash",
+    "top_100_result": [
+      "40dd84abb15a75a6ac01628d1b6451428546349d7b2c5f13f788ced5979a6104"
+    ],
+    "top_100_count_result": [
+      "40dd84abb15a75a6ac01628d1b6451428546349d7b2c5f13f788ced5979a6104"
+    ]
+  },
+  {
+    "query": "+financial +reporting +standards",
+    "count": 933,
+    "top_100": 933,
+    "result_type": "Hash",
+    "top_100_result": [
+      "4baf7dd751c7d36aea5c8b05f2fe75115852155cc8ff39d4e38093cf19a12e57"
+    ],
+    "top_100_count_result": [
+      "4baf7dd751c7d36aea5c8b05f2fe75115852155cc8ff39d4e38093cf19a12e57"
+    ]
+  },
+  {
+    "query": "+mental +health +resources",
+    "count": 1204,
+    "top_100": 1204,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c06b179bce122c69934c1b46444f5b0edcce6e49d2ed4961485bbd08a7f74c21"
+    ],
+    "top_100_count_result": [
+      "c06b179bce122c69934c1b46444f5b0edcce6e49d2ed4961485bbd08a7f74c21"
+    ]
+  },
+  {
+    "query": "+water +quality +report",
+    "count": 2340,
+    "top_100": 2340,
+    "result_type": "Hash",
+    "top_100_result": [
+      "6455ad889116ea70a780492230aa375d62957cb3e7749b4f29e04947a0d64748"
+    ],
+    "top_100_count_result": [
+      "6455ad889116ea70a780492230aa375d62957cb3e7749b4f29e04947a0d64748"
+    ]
+  },
+  {
+    "query": "+housing +market +trends",
+    "count": 275,
+    "top_100": 275,
+    "result_type": "Hash",
+    "top_100_result": [
+      "a77747ab6c8cbfdd1ba7b4f6997d2f51a6aa0a73976fb7210b997c0bdd69ad12"
+    ],
+    "top_100_count_result": [
+      "a77747ab6c8cbfdd1ba7b4f6997d2f51a6aa0a73976fb7210b997c0bdd69ad12"
+    ]
+  },
+  {
+    "query": "+electric +grid +stability",
+    "count": 118,
+    "top_100": 118,
+    "result_type": "Hash",
+    "top_100_result": [
+      "22aa8e4a5a646722f85765f56d8a735921690fd265205fc92bc04c7b51ab6d9c"
+    ],
+    "top_100_count_result": [
+      "22aa8e4a5a646722f85765f56d8a735921690fd265205fc92bc04c7b51ab6d9c"
+    ]
+  },
+  {
+    "query": "+disaster +relief +funds",
+    "count": 566,
+    "top_100": 566,
+    "result_type": "Hash",
+    "top_100_result": [
+      "c86aa06617a2e75f76ffa0162cb6ac10f3dff9f8a2a77f3caf95b90e214a3f8e"
+    ],
+    "top_100_count_result": [
+      "c86aa06617a2e75f76ffa0162cb6ac10f3dff9f8a2a77f3caf95b90e214a3f8e"
+    ]
+  },
+  {
+    "query": "+insurance +claim +process",
+    "count": 647,
+    "top_100": 647,
+    "result_type": "Hash",
+    "top_100_result": [
+      "38657e8024eb8054d632e42458ab92ea4247802bc46c602fd6d76d514f9c9981"
+    ],
+    "top_100_count_result": [
+      "38657e8024eb8054d632e42458ab92ea4247802bc46c602fd6d76d514f9c9981"
+    ]
+  },
+  {
+    "query": "+credit +card +rewards",
+    "count": 99,
+    "top_100": 99,
+    "result_type": "Hash",
+    "top_100_result": [
+      "d7ed79b670ce798b67a7aa0f6f7c48da6d950f2d3a6fb7ea1c36d5fbb56ad82c"
+    ],
+    "top_100_count_result": [
+      "d7ed79b670ce798b67a7aa0f6f7c48da6d950f2d3a6fb7ea1c36d5fbb56ad82c"
+    ]
+  },
+  {
+    "query": "+data +center +cooling",
+    "count": 416,
+    "top_100": 416,
+    "result_type": "Hash",
+    "top_100_result": [
+      "98c174588c2e9313c44a678256e4261ccf4f771cb32eb39ac987a18e620069e1"
+    ],
+    "top_100_count_result": [
+      "98c174588c2e9313c44a678256e4261ccf4f771cb32eb39ac987a18e620069e1"
+    ]
+  },
+  {
+    "query": "+remote +learning +tools",
+    "count": 187,
+    "top_100": 187,
+    "result_type": "Hash",
+    "top_100_result": [
+      "5b05dd81504c687710b730b9be69c6419f4fb4c0e447bc81a99a6f26547ee956"
+    ],
+    "top_100_count_result": [
+      "5b05dd81504c687710b730b9be69c6419f4fb4c0e447bc81a99a6f26547ee956"
+    ]
+  },
+  {
+    "query": "+open +source +software +licenses",
+    "count": 424,
+    "top_100": 424,
+    "result_type": "Hash",
+    "top_100_result": [
+      "252d593717f40848479b403bf365f0a4dd0cb1d54094fb0c534649e73f9042f4"
+    ],
+    "top_100_count_result": [
+      "252d593717f40848479b403bf365f0a4dd0cb1d54094fb0c534649e73f9042f4"
+    ]
+  },
+  {
+    "query": "+health +care +cost +trends",
+    "count": 240,
+    "top_100": 240,
+    "result_type": "Hash",
+    "top_100_result": [
+      "daee59f1d2b1cbf5faf51df45d30d168bacc01bb6bb02888503d2b53a1674b4b"
+    ],
+    "top_100_count_result": [
+      "daee59f1d2b1cbf5faf51df45d30d168bacc01bb6bb02888503d2b53a1674b4b"
+    ]
+  },
+  {
+    "query": "+renewable +energy +policy +goals",
+    "count": 183,
+    "top_100": 183,
+    "result_type": "Hash",
+    "top_100_result": [
+      "99420e5b7b0e455ffa9b97248ede414d10d6f9197a7511caa976769bd32d21fc"
+    ],
+    "top_100_count_result": [
+      "99420e5b7b0e455ffa9b97248ede414d10d6f9197a7511caa976769bd32d21fc"
+    ]
+  },
+  {
+    "query": "+airport +security +screening +rules",
+    "count": 33,
+    "top_100": 33,
+    "result_type": "Hash",
+    "top_100_result": [
+      "7cb7110ab964b0af5b458d0a29f6da4b598bde574c332ca25df74447f66c97b2"
+    ],
+    "top_100_count_result": [
+      "7cb7110ab964b0af5b458d0a29f6da4b598bde574c332ca25df74447f66c97b2"
+    ]
+  },
+  {
+    "query": "+climate +change +impact +report",
+    "count": 807,
+    "top_100": 807,
+    "result_type": "Hash",
+    "top_100_result": [
+      "f28d1d01a91d7c0599ce1867cee88d81ab73bb3c32b47c7e6c4a45d260462b91"
+    ],
+    "top_100_count_result": [
+      "f28d1d01a91d7c0599ce1867cee88d81ab73bb3c32b47c7e6c4a45d260462b91"
     ]
   }
 ]

--- a/tests/bench/search-benchmark-game/build_index.cpp
+++ b/tests/bench/search-benchmark-game/build_index.cpp
@@ -18,7 +18,10 @@
 /// Copyright holder is SereneDB GmbH, Berlin, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <iostream>
+#include <absl/strings/str_format.h>
+
+#include <cstdio>
+#include <iostream>  // std::cin
 #include <iresearch/index/index_reader.hpp>
 #include <iresearch/utils/timer_utils.hpp>
 
@@ -49,10 +52,9 @@ int main(int argc, const char* argv[]) {
         });
       std::sort(output.begin(), output.end());
       for (auto& [key, count, time_us] : output) {
-        std::cout << key << " calls:" << count << ", time: " << time_us
-                  << " us, avg call: "
-                  << static_cast<double>(time_us) / static_cast<double>(count)
-                  << " us" << std::endl;
+        absl::PrintF("%s calls:%d, time: %d us, avg call: %g us\n", key, count,
+                     time_us,
+                     static_cast<double>(time_us) / static_cast<double>(count));
       }
     };
 
@@ -89,10 +91,9 @@ int main(int argc, const char* argv[]) {
                               return std::make_unique<IndexAllFields>();
                             });
 
-    std::cout << "Number of documents: " << builder.GetReader().docs_count()
-              << std::endl;
+    absl::PrintF("Number of documents: %d\n", builder.GetReader().docs_count());
   } catch (const std::exception& ex) {
-    std::cerr << "fatal: " << ex.what() << std::endl;
+    absl::FPrintF(stderr, "fatal: %s\n", ex.what());
     exit_code = 1;
   }
   // MUST run before main() returns -- see comment at top of main().

--- a/tests/bench/search-benchmark-game/do_query.cpp
+++ b/tests/bench/search-benchmark-game/do_query.cpp
@@ -20,111 +20,37 @@
 
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_format.h>
-#include <fast_float/fast_float.h>
 
 #include <cstdio>
-#include <iostream>
+#include <iostream>  // std::cin
 #include <iresearch/search/filter_optimizer.hpp>
 #include <iresearch/utils/levenshtein_default_pdp.hpp>
-#include <optional>
 #include <string>
-#include <system_error>
 
 #include "basics/duckdb_engine.h"
 #include "executor.h"
 
 namespace {
 
-// What a line asks of its query, spelled as `count`, `docs`, `scored` or
-// `top_<N>`. A top-k reads `_count` as "do not prune, take the exact total",
-// and anything that is not a bare count may end in `_hash` for a checksum
-// over what it found and `_print` for all of it -- either, both, in either
-// order.
-enum class Kind : uint8_t {
-  Count,
-  Docs,
-  Scored,
-  TopK,
-};
-
-struct Command {
-  Kind kind;
-  bench::Report report;
-  size_t k = 0;        // top-k only
-  bool exact = false;  // top-k only: `_count`
-};
-
-constexpr std::string_view kUnsupported = "UNSUPPORTED";
-
-bool StripSuffix(std::string_view& name, std::string_view suffix) {
-  if (!name.ends_with(suffix)) {
-    return false;
-  }
-  name.remove_suffix(suffix.size());
-  return true;
-}
-
-std::optional<Command> ParseCommand(std::string_view name) {
-  Command cmd{.kind = Kind::Count};
-
-  for (;;) {
-    if (!cmd.report.print && StripSuffix(name, "_print")) {
-      cmd.report.print = true;
-      continue;
-    }
-    if (!cmd.report.hash && StripSuffix(name, "_hash")) {
-      cmd.report.hash = true;
-      continue;
-    }
-    break;
-  }
-
-  if (name == "count") {
-    // A count is a number and nothing else: there are no documents in hand to
-    // checksum or to print.
-    return cmd.report.hash || cmd.report.print ? std::nullopt
-                                               : std::optional{cmd};
-  }
-  if (name == "docs") {
-    cmd.kind = Kind::Docs;
-    return cmd;
-  }
-  if (name == "scored") {
-    cmd.kind = Kind::Scored;
-    return cmd;
-  }
-
-  cmd.exact = StripSuffix(name, "_count");
-  if (!name.starts_with("top_")) {
-    return std::nullopt;
-  }
-  name.remove_prefix(4);
-
-  const auto* const end = name.data() + name.size();
-  const auto [stop, ec] = fast_float::from_chars(name.data(), end, cmd.k);
-  if (ec != std::errc{} || stop != end || cmd.k == 0) {
-    return std::nullopt;
-  }
-  cmd.kind = Kind::TopK;
-  return cmd;
-}
-
-size_t ExecuteCommand(bench::Executor& executor, const Command& cmd,
+size_t ExecuteCommand(bench::Executor& executor, const bench::Command& cmd,
                       std::string_view query) {
   switch (cmd.kind) {
-    case Kind::Count:
+    case bench::Kind::Unsupported:
+      break;
+    case bench::Kind::Count:
       return executor.ExecuteCount(query);
-    case Kind::Docs: {
+    case bench::Kind::Docs: {
       const auto result = executor.ExecuteEmitDocs(query, cmd.report);
       return cmd.report.hash ? result.hash : result.count;
     }
-    case Kind::Scored: {
+    case bench::Kind::Scored: {
       const auto result = executor.ExecuteEmitScoredDocs(query, cmd.report);
       return cmd.report.hash ? result.hash : result.count;
     }
-    case Kind::TopK: {
-      const auto count = cmd.exact ? executor.ExecuteTopKWithCount(cmd.k, query)
-                                   : executor.ExecuteTopK(cmd.k, query);
+    case bench::Kind::TopK: {
+      const auto count = cmd.prune
+                           ? executor.ExecuteTopK(cmd.k, query)
+                           : executor.ExecuteTopKWithCount(cmd.k, query);
       if (cmd.report.print) {
         executor.PrintResults();
       }
@@ -160,19 +86,19 @@ int main(int argc, const char* argv[]) {
       const auto tab = line.find('\t');
       const auto cmd =
         tab == std::string_view::npos
-          ? std::nullopt
-          : ParseCommand(absl::AsciiStrToLower(line.substr(0, tab)));
-      if (!cmd) {
+          ? bench::Command{}
+          : bench::ParseCommand(absl::AsciiStrToLower(line.substr(0, tab)));
+      if (cmd.kind == bench::Kind::Unsupported) {
         absl::FPrintF(stderr, "unknown command: %s\n", line);
       } else {
         try {
-          count = ExecuteCommand(executor, *cmd, line.substr(tab + 1));
+          count = ExecuteCommand(executor, cmd, line.substr(tab + 1));
         } catch (const std::exception& ex) {
           absl::FPrintF(stderr, "unsupported: %s\n", ex.what());
         }
       }
       if (!count) {
-        absl::PrintF("%s\n", kUnsupported);
+        absl::PrintF("UNSUPPORTED\n");
       } else {
         absl::PrintF("%d\n", count);
       }

--- a/tests/bench/search-benchmark-game/do_query.cpp
+++ b/tests/bench/search-benchmark-game/do_query.cpp
@@ -18,129 +18,120 @@
 /// Copyright holder is SereneDB GmbH, Berlin, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <absl/strings/str_split.h>
+#include <absl/strings/ascii.h>
+#include <absl/strings/str_format.h>
+#include <fast_float/fast_float.h>
 
+#include <cstdio>
 #include <iostream>
 #include <iresearch/search/filter_optimizer.hpp>
 #include <iresearch/utils/levenshtein_default_pdp.hpp>
-#include <magic_enum/magic_enum.hpp>
+#include <optional>
 #include <string>
+#include <system_error>
 
 #include "basics/duckdb_engine.h"
 #include "executor.h"
 
-enum class QueryType {
-  Count,
-  UnoptimizedCount,
-  Top10,
-  Top100,
-  Top1000,
-  Top10Count,
-  Top100Count,
-  Top1000Count,
-  Top100Debug,
-  Top100CountDebug,
-  EmitDocs,
-  EmitDocsDebug,
-  EmitScoredDocs,
-  EmitScoredDocsDebug,
-  Unsupported,
-};
-
-namespace magic_enum {
-
-template<>
-constexpr customize::customize_t customize::enum_name<QueryType>(
-  QueryType value) noexcept {
-  switch (value) {
-    case QueryType::Count:
-    case QueryType::UnoptimizedCount:
-      return "COUNT";
-    case QueryType::Top10:
-      return "TOP_10";
-    case QueryType::Top100:
-      return "TOP_100";
-    case QueryType::Top1000:
-      return "TOP_1000";
-    case QueryType::Top10Count:
-      return "TOP_10_COUNT";
-    case QueryType::Top100Count:
-      return "TOP_100_COUNT";
-    case QueryType::Top1000Count:
-      return "TOP_1000_COUNT";
-    case QueryType::Top100Debug:
-      return "TOP_100_DEBUG";
-    case QueryType::Top100CountDebug:
-      return "TOP_100_COUNT_DEBUG";
-    case QueryType::EmitDocs:
-      return "EMIT_DOCS";
-    case QueryType::EmitDocsDebug:
-      return "EMIT_DOCS_DEBUG";
-    case QueryType::EmitScoredDocs:
-      return "EMIT_SCORED_DOCS";
-    case QueryType::EmitScoredDocsDebug:
-      return "EMIT_SCORED_DOCS_DEBUG";
-    default:
-      return "UNSUPPORTED";
-  }
-}
-
-}  // namespace magic_enum
 namespace {
 
-struct Query {
-  QueryType type = QueryType::Unsupported;
-  std::string_view query;
+// What a line asks of its query, spelled as `count`, `docs`, `scored` or
+// `top_<N>`. A top-k reads `_count` as "do not prune, take the exact total",
+// and anything that is not a bare count may end in `_hash` for a checksum
+// over what it found and `_print` for all of it -- either, both, in either
+// order.
+enum class Kind : uint8_t {
+  Count,
+  Docs,
+  Scored,
+  TopK,
 };
 
-Query ParseQuery(std::string_view str) {
-  auto parts = absl::StrSplit(str, '\t');
-  auto begin = parts.begin();
+struct Command {
+  Kind kind;
+  bench::Report report;
+  size_t k = 0;        // top-k only
+  bool exact = false;  // top-k only: `_count`
+};
 
-  auto type = magic_enum::enum_cast<QueryType>(*begin);
-  if (!type) {
-    return {};
+constexpr std::string_view kUnsupported = "UNSUPPORTED";
+
+bool StripSuffix(std::string_view& name, std::string_view suffix) {
+  if (!name.ends_with(suffix)) {
+    return false;
   }
-
-  ++begin;
-  return {*type, *begin};
+  name.remove_suffix(suffix.size());
+  return true;
 }
 
-size_t ExecuteQuery(bench::Executor& executor, Query q) {
-  auto [type, query] = q;
-  switch (type) {
-    case QueryType::UnoptimizedCount:
-    case QueryType::Count:
-      return executor.ExecuteCount(query);
-    case QueryType::Top10:
-      return executor.ExecuteTopK(10, query);
-    case QueryType::Top100:
-      return executor.ExecuteTopK(100, query);
-    case QueryType::Top1000:
-      return executor.ExecuteTopK(1000, query);
-    case QueryType::Top10Count:
-      return executor.ExecuteTopKWithCount(10, query);
-    case QueryType::Top100Count:
-      return executor.ExecuteTopKWithCount(100, query);
-    case QueryType::Top1000Count:
-      return executor.ExecuteTopKWithCount(1000, query);
-    case QueryType::Top100Debug:
-      executor.ExecuteTopK(100, query);
-      return executor.HashResults();
-    case QueryType::Top100CountDebug:
-      executor.ExecuteTopKWithCount(100, query);
-      return executor.HashResults();
-    case QueryType::EmitDocs:
-      return executor.ExecuteEmitDocs(query).count;
-    case QueryType::EmitDocsDebug:
-      return executor.ExecuteEmitDocs(query, true).hash;
-    case QueryType::EmitScoredDocs:
-      return executor.ExecuteEmitScoredDocs(query).count;
-    case QueryType::EmitScoredDocsDebug:
-      return executor.ExecuteEmitScoredDocs(query, true).hash;
-    default:
-      return 0;
+std::optional<Command> ParseCommand(std::string_view name) {
+  Command cmd{.kind = Kind::Count};
+
+  for (;;) {
+    if (!cmd.report.print && StripSuffix(name, "_print")) {
+      cmd.report.print = true;
+      continue;
+    }
+    if (!cmd.report.hash && StripSuffix(name, "_hash")) {
+      cmd.report.hash = true;
+      continue;
+    }
+    break;
   }
+
+  if (name == "count") {
+    // A count is a number and nothing else: there are no documents in hand to
+    // checksum or to print.
+    return cmd.report.hash || cmd.report.print ? std::nullopt
+                                               : std::optional{cmd};
+  }
+  if (name == "docs") {
+    cmd.kind = Kind::Docs;
+    return cmd;
+  }
+  if (name == "scored") {
+    cmd.kind = Kind::Scored;
+    return cmd;
+  }
+
+  cmd.exact = StripSuffix(name, "_count");
+  if (!name.starts_with("top_")) {
+    return std::nullopt;
+  }
+  name.remove_prefix(4);
+
+  const auto* const end = name.data() + name.size();
+  const auto [stop, ec] = fast_float::from_chars(name.data(), end, cmd.k);
+  if (ec != std::errc{} || stop != end || cmd.k == 0) {
+    return std::nullopt;
+  }
+  cmd.kind = Kind::TopK;
+  return cmd;
+}
+
+size_t ExecuteCommand(bench::Executor& executor, const Command& cmd,
+                      std::string_view query) {
+  switch (cmd.kind) {
+    case Kind::Count:
+      return executor.ExecuteCount(query);
+    case Kind::Docs: {
+      const auto result = executor.ExecuteEmitDocs(query, cmd.report);
+      return cmd.report.hash ? result.hash : result.count;
+    }
+    case Kind::Scored: {
+      const auto result = executor.ExecuteEmitScoredDocs(query, cmd.report);
+      return cmd.report.hash ? result.hash : result.count;
+    }
+    case Kind::TopK: {
+      const auto count = cmd.exact ? executor.ExecuteTopKWithCount(cmd.k, query)
+                                   : executor.ExecuteTopK(cmd.k, query);
+      if (cmd.report.print) {
+        executor.PrintResults();
+      }
+      return cmd.report.hash ? executor.HashResults() : count;
+    }
+  }
+  return 0;
 }
 
 }  // namespace
@@ -164,15 +155,33 @@ int main(int argc, const char* argv[]) {
 
     std::string data;
     while (std::getline(std::cin, data)) {
-      const auto count = ExecuteQuery(executor, ParseQuery(data));
-      if (!count) {
-        std::cout << magic_enum::enum_name(QueryType::Unsupported) << "\n";
+      size_t count = 0;
+      const std::string_view line{data};
+      const auto tab = line.find('\t');
+      const auto cmd =
+        tab == std::string_view::npos
+          ? std::nullopt
+          : ParseCommand(absl::AsciiStrToLower(line.substr(0, tab)));
+      if (!cmd) {
+        absl::FPrintF(stderr, "unknown command: %s\n", line);
       } else {
-        std::cout << count << "\n";
+        try {
+          count = ExecuteCommand(executor, *cmd, line.substr(tab + 1));
+        } catch (const std::exception& ex) {
+          absl::FPrintF(stderr, "unsupported: %s\n", ex.what());
+        }
       }
+      if (!count) {
+        absl::PrintF("%s\n", kUnsupported);
+      } else {
+        absl::PrintF("%d\n", count);
+      }
+      // The driver writes one query and waits for its line, and nothing ties
+      // this output to the input any more.
+      std::fflush(stdout);
     }
   } catch (const std::exception& ex) {
-    std::cerr << "fatal: " << ex.what() << std::endl;
+    absl::FPrintF(stderr, "fatal: %s\n", ex.what());
     exit_code = 1;
   }
   sdb::DuckDBEngine::Instance().Shutdown();

--- a/tests/bench/search-benchmark-game/executor.cpp
+++ b/tests/bench/search-benchmark-game/executor.cpp
@@ -20,17 +20,20 @@
 
 #include "executor.h"
 
+#include <absl/strings/str_format.h>
+
 #include <algorithm>
-#include <charconv>
 #include <cmath>
-#include <cstring>
+#include <cstdio>
 #include <iresearch/analysis/segmentation_tokenizer.hpp>
 #include <iresearch/index/norm.hpp>
 #include <iresearch/parser/parser.hpp>
 #include <iresearch/search/bm25.hpp>
 #include <iresearch/search/boolean_filter.hpp>
 #include <iresearch/search/filter_optimizer.hpp>
+#include <iresearch/search/ngram_similarity_filter.hpp>
 #include <iresearch/search/phrase_filter.hpp>
+#include <iresearch/search/term_filter.hpp>
 #include <iresearch/store/store_utils.hpp>
 #include <tuple>
 #include <vector>
@@ -44,7 +47,19 @@ namespace {
 
 template<typename T>
 size_t HashBatch(size_t hash, const T* data, size_t size) {
-  return sdb::basics::WyHash(data, size * sizeof(T), hash);
+  for (size_t i = 0; i != size; ++i) {
+    hash = sdb::basics::WyHash(data + i, sizeof(T), hash);
+  }
+  return hash;
+}
+
+template<typename T, typename U>
+size_t HashPairs(size_t hash, const T* docs, const U* scores, size_t size) {
+  for (size_t i = 0; i != size; ++i) {
+    hash = sdb::basics::WyHash(docs + i, sizeof(T), hash);
+    hash = sdb::basics::WyHash(scores + i, sizeof(U), hash);
+  }
+  return hash;
 }
 
 }  // namespace
@@ -111,7 +126,7 @@ size_t Executor::ExecuteCount(std::string_view query) {
   return count;
 }
 
-EmitResult Executor::ExecuteEmitDocs(std::string_view query, bool checksum) {
+EmitResult Executor::ExecuteEmitDocs(std::string_view query, Report report) {
   auto filter = ParseFilter(query);
   if (!filter) {
     return {};
@@ -135,8 +150,13 @@ EmitResult Executor::ExecuteEmitDocs(std::string_view query, bool checksum) {
     while (!irs::doc_limits::eof(min)) {
       const auto n = docs->EmitDocs(_emit_docs.data(), min, min + kEmitWindow);
       result.count += n;
-      if (checksum) {
+      if (report.hash) {
         result.hash = HashBatch(result.hash, _emit_docs.data(), n);
+      }
+      if (report.print) {
+        for (uint32_t i = 0; i != n; ++i) {
+          absl::FPrintF(stderr, "doc=%u\n", _emit_docs[i]);
+        }
       }
       min = docs->value();
     }
@@ -145,7 +165,7 @@ EmitResult Executor::ExecuteEmitDocs(std::string_view query, bool checksum) {
 }
 
 EmitResult Executor::ExecuteEmitScoredDocs(std::string_view query,
-                                           bool checksum) {
+                                           Report report) {
   auto filter = ParseFilter(query);
   if (!filter) {
     return {};
@@ -180,9 +200,19 @@ EmitResult Executor::ExecuteEmitScoredDocs(std::string_view query,
         docs->EmitScoredDocs(_emit_docs.data(), _emit_scores.data(),
                              min + kEmitWindow, score_func, &fetcher, min);
       result.count += n;
-      if (checksum) {
-        result.hash = HashBatch(result.hash, _emit_docs.data(), n);
-        result.hash = HashBatch(result.hash, _emit_scores.data(), n);
+      if (report.hash) {
+        // Pairwise, so the checksum does not depend on where the batch
+        // boundaries happen to fall: docs-then-scores per batch interleaves
+        // differently for a path that emits per window of ids and one that
+        // emits per window of results.
+        result.hash =
+          HashPairs(result.hash, _emit_docs.data(), _emit_scores.data(), n);
+      }
+      if (report.print) {
+        for (uint32_t i = 0; i != n; ++i) {
+          absl::FPrintF(stderr, "doc=%u score=%.6f\n", _emit_docs[i],
+                        _emit_scores[i]);
+        }
       }
       min = docs->value();
     }
@@ -210,63 +240,21 @@ size_t Executor::HashResults() const {
   return hash;
 }
 
-// "~term MIN-MAX term MIN-MAX term" builds a phrase whose gaps are ranges,
-// one range per adjacent pair. The Lucene syntax cannot express this (it only
-// carries a whole-phrase slop), and it is the only way to reach the interval
-// phrase iterator from a query string.
-irs::Filter::ptr Executor::ParseIntervalPhrase(std::string_view str) {
-  auto root = std::make_unique<irs::MixedBooleanFilter>();
-  auto& phrase = root->GetOptional().add<irs::ByPhrase>();
-  *phrase.mutable_field_id() = kTextFieldId;
-  auto* options = phrase.mutable_options();
-
-  size_t offs_min = 0;
-  size_t offs_max = 0;
-  bool want_term = true;
-  for (size_t pos = 0; pos <= str.size();) {
-    const auto next = std::min(str.find(' ', pos), str.size());
-    const auto word = str.substr(pos, next - pos);
-    pos = next + 1;
-    if (word.empty()) {
-      continue;
+void Executor::PrintResults() const {
+  for (size_t i = 0; i != _result_count; ++i) {
+    const auto& hit = _results[i];
+    if (irs::doc_limits::valid(hit.doc)) {
+      absl::FPrintF(stderr, "doc=%u segment=%u score=%.6f\n", hit.doc,
+                    hit.segment_idx, hit.score);
     }
-    if (want_term) {
-      _tokenizer->reset(word);
-      const auto* token = irs::get<irs::TermAttr>(*_tokenizer);
-      if (!_tokenizer->next()) {
-        return {};
-      }
-      options->push_back<irs::ByTermOptions>(offs_min, offs_max).term =
-        token->value;
-    } else {
-      const auto dash = word.find('-');
-      if (dash == std::string_view::npos) {
-        return {};
-      }
-      std::from_chars(word.data(), word.data() + dash, offs_min);
-      std::from_chars(word.data() + dash + 1, word.data() + word.size(),
-                      offs_max);
-      if (offs_min == 0 || offs_min > offs_max) {
-        return {};
-      }
-    }
-    want_term = !want_term;
   }
-  if (options->size() < 2 || want_term) {
-    return {};
-  }
-  irs::Filter::ptr filter = std::move(root);
-  irs::Optimize(filter, {.scored = _scorer_ptr != nullptr});
-  return filter;
 }
 
 irs::Filter::ptr Executor::ParseFilter(std::string_view str) {
-  if (str.starts_with('~')) {
-    return ParseIntervalPhrase(str.substr(1));
-  }
   auto root = std::make_unique<irs::MixedBooleanFilter>();
   sdb::ParserContext context{*root, kTextFieldId, *_tokenizer};
   if (!sdb::ParseQuery(context, str)) {
+    absl::FPrintF(stderr, "parse error: %s: %s\n", context.error_message, str);
     return {};
   }
   if (root->empty()) {

--- a/tests/bench/search-benchmark-game/executor.cpp
+++ b/tests/bench/search-benchmark-game/executor.cpp
@@ -21,8 +21,10 @@
 #include "executor.h"
 
 #include <absl/strings/str_format.h>
+#include <fast_float/fast_float.h>
 
 #include <algorithm>
+#include <charconv>
 #include <cmath>
 #include <cstdio>
 #include <iresearch/analysis/segmentation_tokenizer.hpp>
@@ -62,7 +64,62 @@ size_t HashPairs(size_t hash, const T* docs, const U* scores, size_t size) {
   return hash;
 }
 
+bool StripSuffix(std::string_view& name, std::string_view suffix) {
+  if (!name.ends_with(suffix)) {
+    return false;
+  }
+  name.remove_suffix(suffix.size());
+  return true;
+}
+
 }  // namespace
+
+Command ParseCommand(std::string_view name) {
+  Command cmd{.kind = Kind::Count};
+
+  for (;;) {
+    if (!cmd.report.print && StripSuffix(name, "_print")) {
+      cmd.report.print = true;
+      continue;
+    }
+    if (!cmd.report.hash && StripSuffix(name, "_hash")) {
+      cmd.report.hash = true;
+      continue;
+    }
+    break;
+  }
+
+  if (name == "count") {
+    // A count is a number and nothing else: there are no documents in hand to
+    // checksum or to print.
+    if (cmd.report.hash || cmd.report.print) {
+      return {};
+    }
+    return cmd;
+  }
+  if (name == "docs") {
+    cmd.kind = Kind::Docs;
+    return cmd;
+  }
+  if (name == "scored") {
+    cmd.kind = Kind::Scored;
+    return cmd;
+  }
+
+  cmd.prune = !StripSuffix(name, "_count");
+  if (!name.starts_with("top_")) {
+    return {};
+  }
+  name.remove_prefix(4);
+
+  const auto* const end = name.data() + name.size();
+  const auto [stop, ec] = fast_float::from_chars(name.data(), end, cmd.k);
+  if (ec != std::errc{} || stop != end || cmd.k == 0) {
+    return {};
+  }
+  cmd.kind = Kind::TopK;
+  return cmd;
+}
 
 Executor::Executor(std::string_view path, const BenchConfig& config)
   : _scorer{irs::BM25::Make(irs::BM25::Options{})},

--- a/tests/bench/search-benchmark-game/executor.h
+++ b/tests/bench/search-benchmark-game/executor.h
@@ -43,6 +43,14 @@ struct BenchConfig {
   size_t segment_mem_max = 1 << 28;
 };
 
+// What a query line asks for besides the documents themselves: a checksum
+// over them, every one of them printed, or both -- and by default neither,
+// which leaves only how many there were.
+struct Report {
+  bool hash = false;
+  bool print = false;
+};
+
 struct EmitResult {
   size_t count = 0;
   size_t hash = 0;
@@ -56,9 +64,9 @@ class Executor {
   size_t ExecuteTopKWithCount(size_t k, std::string_view query);
   size_t ExecuteCount(std::string_view query);
   size_t HashResults() const;
-  EmitResult ExecuteEmitDocs(std::string_view query, bool checksum = false);
-  EmitResult ExecuteEmitScoredDocs(std::string_view query,
-                                   bool checksum = false);
+  void PrintResults() const;
+  EmitResult ExecuteEmitDocs(std::string_view query, Report report = {});
+  EmitResult ExecuteEmitScoredDocs(std::string_view query, Report report = {});
 
   const irs::DirectoryReader& GetReader() const { return _reader; }
   auto GetResults(this auto& self) {
@@ -66,7 +74,6 @@ class Executor {
   }
 
   irs::Filter::ptr ParseFilter(std::string_view str);
-  irs::Filter::ptr ParseIntervalPhrase(std::string_view str);
 
  private:
   void ResetResults(size_t k) noexcept {

--- a/tests/bench/search-benchmark-game/executor.h
+++ b/tests/bench/search-benchmark-game/executor.h
@@ -28,6 +28,7 @@
 #include <iresearch/search/filter.hpp>
 #include <iresearch/search/scorer.hpp>
 #include <iresearch/store/mmap_directory.hpp>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
@@ -50,6 +51,30 @@ struct Report {
   bool hash = false;
   bool print = false;
 };
+
+// What a line asks of its query, spelled as `count`, `docs`, `scored` or
+// `top_<N>`. A top-k reads `_count` as "do not prune, take the exact total",
+// and anything that is not a bare count may end in `_hash` for a checksum
+// over what it found and `_print` for all of it -- either, both, in either
+// order. Anything else is `Unsupported`.
+enum class Kind : uint8_t {
+  Unsupported,
+  Count,
+  Docs,
+  Scored,
+  TopK,
+};
+
+struct Command {
+  Kind kind = Kind::Unsupported;
+  Report report;
+  bool prune = true;  // top-k only: `_count` takes the exact total instead
+  uint32_t k = 0;     // top-k only
+};
+
+static_assert(sizeof(Command) == 8);
+
+Command ParseCommand(std::string_view name);
 
 struct EmitResult {
   size_t count = 0;

--- a/tests/bench/search-benchmark-game/index_builder.cpp
+++ b/tests/bench/search-benchmark-game/index_builder.cpp
@@ -20,12 +20,15 @@
 
 #include "index_builder.h"
 
+#include <absl/strings/str_format.h>
+
 #include <atomic>
+#include <cstdio>
 #include <duckdb/main/database.hpp>
-#include <iostream>
 #include <iresearch/search/bm25.hpp>
 #include <iresearch/store/store_utils.hpp>
 #include <iresearch/utils/index_utils.hpp>
+#include <istream>
 #include <memory>
 
 #include "basics/duckdb_engine.h"
@@ -130,7 +133,8 @@ void IndexBuilder::IndexFromStream(std::istream& input,
     thread_pool.run([&compaction_cv, &compaction_mutex, &batch_provider, this] {
       while (!batch_provider.done.load()) {
         {
-          std::cout << "[COMMIT]" << std::endl;
+          absl::PrintF("[COMMIT]\n");
+          std::fflush(stdout);
           _writer->RefreshCommit();
         }
 
@@ -163,7 +167,8 @@ void IndexBuilder::IndexFromStream(std::istream& input,
         }
 
         {
-          std::cout << "[COMPACT]" << std::flush;
+          absl::PrintF("[COMPACT]");
+          std::fflush(stdout);
           _writer->Compact(policy);
         }
 
@@ -183,18 +188,21 @@ void IndexBuilder::IndexFromStream(std::istream& input,
         auto ctx = _writer->GetBatch();
         (*handler)(buf, ctx);
         ctx.Commit();
-        std::cout << "." << std::flush;
+        absl::PrintF(".");
+        std::fflush(stdout);
       }
     });
   }
 
   thread_pool.stop();
 
-  std::cout << "[COMMIT]" << std::endl;
+  absl::PrintF("[COMMIT]\n");
+  std::fflush(stdout);
   _writer->RefreshCommit();
 
   if (_opts.compact_all) {
-    std::cout << "Compacting all segments:" << std::endl;
+    absl::PrintF("Compacting all segments:\n");
+    std::fflush(stdout);
     CompactAll();
   } else if (_opts.compaction_threads) {
     irs::directory_utils::RemoveAllUnreferenced(_dir);

--- a/tests/libs/iresearch/parser/lucene_parser_test.cpp
+++ b/tests/libs/iresearch/parser/lucene_parser_test.cpp
@@ -1969,3 +1969,94 @@ TEST_F(LuceneParserTest, MaxGapsOverMoreThanAPairIsRefused) {
 TEST_F(LuceneParserTest, FieldExistenceIsRefused) {
   EXPECT_ANY_THROW(sdb::ParseQuery(ctx, "title:*"));
 }
+
+// Rules the grammar has that nothing else here reaches.
+
+TEST_F(LuceneParserTest, UnicodeEscape) {
+  // `\uXXXX` is the character it names -- Lucene's `discardEscapeChar`
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "caf\\u00e9"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "caf\xc3\xa9");
+}
+
+TEST_F(LuceneParserTest, EscapeKeepsWhatItProtected) {
+  // the `+` is part of the term rather than an operator, and the analyzer
+  // makes two words of what it protected
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "a\\+b"));
+  ASSERT_TRUE(RequiredRoot().empty());
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& parts =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0])
+      .GetOptional();
+  ASSERT_EQ(2, parts.size());
+  AssertTerm(parts[0], kFieldId, "a");
+  AssertTerm(parts[1], kFieldId, "b");
+}
+
+TEST_F(LuceneParserTest, LoneOperatorIsATerm) {
+  // what was pasted in is searched for, rather than read as an operator with
+  // nothing to apply to
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "alpha + beta"));
+  ASSERT_EQ(3, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "alpha");
+  AssertTerm(OptionalRoot()[1], kFieldId, "+");
+  AssertTerm(OptionalRoot()[2], kFieldId, "beta");
+}
+
+TEST_F(LuceneParserTest, MatchAll) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "*:*"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  EXPECT_EQ(irs::Type<irs::All>::id(), OptionalRoot()[0].type());
+}
+
+TEST_F(LuceneParserTest, RangeWithQuotedBound) {
+  // a quoted bound holds what a bare one cannot: spaces, and the word TO
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "[\"alpha beta\" TO gamma]"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertRange(OptionalRoot()[0], kFieldId, "alpha beta",
+              irs::BoundType::Inclusive, "gamma", irs::BoundType::Inclusive);
+}
+
+TEST_F(LuceneParserTest, FnPhrase) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:phrase(alpha beta)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, FnWildcard) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:wildcard(al*ha)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertWildcard(OptionalRoot()[0], kFieldId, "al%ha");
+}
+
+TEST_F(LuceneParserTest, FnFuzzyTerm) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:fuzzyTerm(alpha)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertFuzzy(OptionalRoot()[0], kFieldId, "alpha", 2);
+}
+
+TEST_F(LuceneParserTest, FnFuzzyTermWithDistance) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:fuzzyTerm(alpha 1)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertFuzzy(OptionalRoot()[0], kFieldId, "alpha", 1);
+}
+
+TEST_F(LuceneParserTest, FnMaxGapsOverAPair) {
+  // over one pair a gap bound is a distance, which a phrase can say
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:maxgaps(2 fn:ordered(alpha beta))"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, FnMaxWidthOverAPair) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:maxwidth(3 fn:ordered(alpha beta))"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, FnMaxWidthTooNarrowIsRefused) {
+  EXPECT_ANY_THROW(sdb::ParseQuery(ctx, "fn:maxwidth(1 fn:ordered(a b))"));
+}

--- a/tests/libs/iresearch/parser/lucene_parser_test.cpp
+++ b/tests/libs/iresearch/parser/lucene_parser_test.cpp
@@ -161,7 +161,7 @@ TEST_F(LuceneParserTest, PrefixQuery) {
 TEST_F(LuceneParserTest, WildcardQuery) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "h*llo"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "h*llo");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "h%llo");
 }
 
 // strict_field=true: a field-prefix is rejected unless it exactly
@@ -1231,7 +1231,7 @@ TEST_F(LuceneParserTest, FieldWithWildcard) {
   // title:h*llo -> Optional[title:wildcard(h*llo)]
   ASSERT_TRUE(sdb::ParseQuery(ctx, "title:h*llo"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "h*llo");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "h%llo");
 }
 
 TEST_F(LuceneParserTest, RangeWithUnboundedMax) {
@@ -1348,49 +1348,62 @@ TEST_F(LuceneParserTest, ParseError_AndOr) {
 TEST_F(LuceneParserTest, QuestionMarkWildcard) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "Te?m"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "Te?m");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "te_m");
 }
 
 TEST_F(LuceneParserTest, MultipleQuestionMarkWildcard) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "T??m"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "T??m");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "t__m");
 }
 
 TEST_F(LuceneParserTest, FieldQuestionMarkWildcard) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "title:Te?m"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "Te?m");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "te_m");
 }
 
 TEST_F(LuceneParserTest, SuffixQuery) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "*suffix"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "*suffix");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "%suffix");
 }
 
 TEST_F(LuceneParserTest, FieldSuffixQuery) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "title:*suffix"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "*suffix");
+  AssertWildcard(OptionalRoot()[0], kFieldId, "%suffix");
 }
 
 TEST_F(LuceneParserTest, EscapedMinus) {
+  // `a-b` is one term to the query and two words to the analyzer, which is
+  // what Lucene asks for under the default operator
   ASSERT_TRUE(sdb::ParseQuery(ctx, "a\\-b"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertTerm(OptionalRoot()[0], kFieldId, "a\\-b");
+  const auto& parts =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0])
+      .GetOptional();
+  ASSERT_EQ(2, parts.size());
+  AssertTerm(parts[0], kFieldId, "a");
+  AssertTerm(parts[1], kFieldId, "b");
 }
 
 TEST_F(LuceneParserTest, EscapedColon) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "a\\:b"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertTerm(OptionalRoot()[0], kFieldId, "a\\:b");
+  AssertTerm(OptionalRoot()[0], kFieldId, "a:b");
 }
 
 TEST_F(LuceneParserTest, EscapedStar) {
+  // an escaped star is a star, not the place a pattern begins
   ASSERT_TRUE(sdb::ParseQuery(ctx, "a\\*b"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertTerm(OptionalRoot()[0], kFieldId, "a\\*b");
+  const auto& parts =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0])
+      .GetOptional();
+  ASSERT_EQ(2, parts.size());
+  AssertTerm(parts[0], kFieldId, "a");
+  AssertTerm(parts[1], kFieldId, "b");
 }
 
 TEST_F(LuceneParserTest, DoubleAmpersandAnd) {
@@ -1438,13 +1451,13 @@ TEST_F(LuceneParserTest, BoostedRangeFloat) {
 TEST_F(LuceneParserTest, BoostedWildcard) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "h*llo^2"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "h*llo", 2.0f);
+  AssertWildcard(OptionalRoot()[0], kFieldId, "h%llo", 2.0f);
 }
 
 TEST_F(LuceneParserTest, BoostedWildcardFloat) {
   ASSERT_TRUE(sdb::ParseQuery(ctx, "h*llo^1.7"));
   ASSERT_EQ(1, OptionalRoot().size());
-  AssertWildcard(OptionalRoot()[0], kFieldId, "h*llo", 1.7f);
+  AssertWildcard(OptionalRoot()[0], kFieldId, "h%llo", 1.7f);
 }
 
 TEST_F(LuceneParserTest, TabSeparator) {
@@ -1491,8 +1504,10 @@ TEST_F(LuceneParserTest, SingleCharTerm) {
   AssertTerm(OptionalRoot()[0], kFieldId, "a");
 }
 
-TEST_F(LuceneParserTest, ParseError_StandaloneNumber) {
-  ASSERT_FALSE(sdb::ParseQuery(ctx, "123"));
+TEST_F(LuceneParserTest, StandaloneNumber) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "123"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "123");
 }
 
 TEST_F(LuceneParserTest, ParseError_EmptyQuery) {
@@ -1772,3 +1787,185 @@ TEST_F(LuceneParserTest, OptionalOnly) {
 }
 
 }  // namespace
+
+// What a term is: everything the syntax has not claimed, run through the
+// analyzer -- Lucene's `_TERM_START_CHAR` and `getFieldQuery`.
+
+TEST_F(LuceneParserTest, TermIsAnalyzed) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "Hello"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "hello");
+}
+
+TEST_F(LuceneParserTest, TermNotAscii) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "Z\xc3\xbcrich"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "z\xc3\xbcrich");
+}
+
+TEST_F(LuceneParserTest, TermWithDots) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "u.s.a"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "u.s.a");
+}
+
+TEST_F(LuceneParserTest, TermWithApostrophe) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "don't"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertTerm(OptionalRoot()[0], kFieldId, "don't");
+}
+
+TEST_F(LuceneParserTest, PrefixIsNormalized) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "Hel*"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertPrefix(OptionalRoot()[0], kFieldId, "hel");
+}
+
+TEST_F(LuceneParserTest, FuzzyIsNormalized) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "Hello~1"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertFuzzy(OptionalRoot()[0], kFieldId, "hello", 1);
+}
+
+TEST_F(LuceneParserTest, RegexKeepsItsPattern) {
+  // `.` and `*` mean what a regular expression means by them
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "/hel.o/"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& regex = sdb::basics::downCast<irs::ByRegexp>(OptionalRoot()[0]);
+  EXPECT_EQ(kFieldId, regex.field_id());
+  EXPECT_EQ("hel.o",
+            irs::ViewCast<char>(irs::bytes_view{regex.options().pattern}));
+}
+
+// Phrases are read as a list of parts rather than one string taken apart
+// afterwards.
+
+TEST_F(LuceneParserTest, PhraseKeepsPunctuation) {
+  // the analyzer decides what `rock-n-roll` is, not the lexer
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "\"rock-n-roll\""));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertPhrase(OptionalRoot()[0], kFieldId);
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(3, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, PhraseWithNumber) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "\"world war 2\""));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(3, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, PhraseWithGap) {
+  // `1-3` says how far the part after it may sit from the part before
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "\"alpha 1-3 beta\""));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, PhraseWithPrefixPart) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "\"alpha bet*\""));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, PhraseWithFuzzyPart) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "\"alpha beta~1\""));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+// What the flexible parser adds: a minimum match, comparison bounds, and the
+// `fn:` family.
+
+TEST_F(LuceneParserTest, GroupMinMatch) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "(alpha beta gamma)@2"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& group =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0]);
+  EXPECT_EQ(3, group.GetOptional().size());
+  EXPECT_EQ(2, group.GetOptional().min_match_count());
+}
+
+TEST_F(LuceneParserTest, ComparisonLess) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "title<beta"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertRange(OptionalRoot()[0], kFieldId, "", irs::BoundType::Unbounded,
+              "beta", irs::BoundType::Exclusive);
+}
+
+TEST_F(LuceneParserTest, ComparisonGreaterOrEqual) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "title>=alpha"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  AssertRange(OptionalRoot()[0], kFieldId, "alpha", irs::BoundType::Inclusive,
+              "", irs::BoundType::Unbounded);
+}
+
+TEST_F(LuceneParserTest, FnOrIsADisjunction) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:or(Alpha beta)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& any =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0]);
+  ASSERT_EQ(2, any.GetOptional().size());
+  // the terms of a function are terms of the index, like every other term
+  AssertTerm(any.GetOptional()[0], kFieldId, "alpha");
+  AssertTerm(any.GetOptional()[1], kFieldId, "beta");
+}
+
+TEST_F(LuceneParserTest, FnUnorderedIsAConjunction) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:unordered(alpha beta)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& all =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0]);
+  EXPECT_EQ(2, all.GetRequired().size());
+}
+
+TEST_F(LuceneParserTest, FnOrderedIsAPhrase) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:ordered(alpha beta)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& phrase = sdb::basics::downCast<irs::ByPhrase>(OptionalRoot()[0]);
+  EXPECT_EQ(2, phrase.options().size());
+}
+
+TEST_F(LuceneParserTest, FnAtLeast) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:atLeast(2 alpha beta gamma)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& any =
+    sdb::basics::downCast<irs::MixedBooleanFilter>(OptionalRoot()[0]);
+  EXPECT_EQ(3, any.GetOptional().size());
+  EXPECT_EQ(2, any.GetOptional().min_match_count());
+}
+
+TEST_F(LuceneParserTest, NGram) {
+  ASSERT_TRUE(sdb::ParseQuery(ctx, "fn:ngram(0.6 alpha beta gamma)"));
+  ASSERT_EQ(1, OptionalRoot().size());
+  const auto& ngram =
+    sdb::basics::downCast<irs::ByNGramSimilarity>(OptionalRoot()[0]);
+  EXPECT_EQ(kFieldId, ngram.field_id());
+  EXPECT_FLOAT_EQ(0.6f, ngram.options().threshold);
+  EXPECT_EQ(3, ngram.options().ngrams.size());
+}
+
+// What is read and refused, so that the message names what was asked for.
+
+TEST_F(LuceneParserTest, FnWithoutAnAlgebraIsRefused) {
+  EXPECT_ANY_THROW(sdb::ParseQuery(ctx, "fn:before(alpha beta)"));
+}
+
+TEST_F(LuceneParserTest, FnOverANonTermIsRefused) {
+  EXPECT_ANY_THROW(sdb::ParseQuery(ctx, "fn:ordered(alpha \"beta gamma\")"));
+}
+
+TEST_F(LuceneParserTest, MaxGapsOverMoreThanAPairIsRefused) {
+  // over one pair a gap bound is a distance; over more it bounds a total,
+  // which a phrase cannot say
+  EXPECT_ANY_THROW(
+    sdb::ParseQuery(ctx, "fn:maxgaps(2 fn:ordered(alpha beta gamma))"));
+}
+
+TEST_F(LuceneParserTest, FieldExistenceIsRefused) {
+  EXPECT_ANY_THROW(sdb::ParseQuery(ctx, "title:*"));
+}

--- a/tests/libs/iresearch/search/boolean_filter_tests.cpp
+++ b/tests/libs/iresearch/search/boolean_filter_tests.cpp
@@ -6565,12 +6565,10 @@ TEST(block_disjunction_test, min_match_next) {
 // A seek counts the matches on the document it lands on, not on the target it
 // was given. With a target below the first match every sub lands past it, and
 // counting against the target left the count at one -- so the first document
-// of a min-match query was dropped.
-TEST(block_disjunction_test, min_match_seek_before_first_match) {
-  using Disjunction = irs::BlockDisjunction<
-    irs::ScoreAdapter, irs::ScoreMergeType::Noop,
-    irs::BlockDisjunctionTraits<irs::MatchType::MinMatch, false, 1>>;
-
+// of a min-match query was dropped. The same seek serves the read-ahead
+// traits, so both are checked.
+template<typename Disjunction>
+void AssertMinMatchSeekBeforeFirstMatch() {
   std::vector<std::vector<irs::doc_id_t>> docs{
     {5, 9},
     {5, 9},
@@ -6594,6 +6592,24 @@ TEST(block_disjunction_test, min_match_seek_before_first_match) {
     ASSERT_EQ(5, it.advance());
     ASSERT_EQ(2, it.MatchCount());
   }
+}
+
+TEST(block_disjunction_test, min_match_seek_before_first_match) {
+  AssertMinMatchSeekBeforeFirstMatch<irs::BlockDisjunction<
+    irs::ScoreAdapter, irs::ScoreMergeType::Noop,
+    irs::BlockDisjunctionTraits<irs::MatchType::MinMatch, false, 1>>>();
+}
+
+TEST(block_disjunction_test, min_match_seek_before_first_match_readahead) {
+  AssertMinMatchSeekBeforeFirstMatch<irs::BlockDisjunction<
+    irs::ScoreAdapter, irs::ScoreMergeType::Noop,
+    irs::BlockDisjunctionTraits<irs::MatchType::MinMatch, true, 1>>>();
+}
+
+TEST(block_disjunction_test, min_match_seek_before_first_match_scored) {
+  AssertMinMatchSeekBeforeFirstMatch<irs::BlockDisjunction<
+    irs::ScoreAdapter, irs::ScoreMergeType::Sum,
+    irs::BlockDisjunctionTraits<irs::MatchType::MinMatch, false, 1>>>();
 }
 
 TEST(block_disjunction_test, min_match_next_two_blocks) {

--- a/tests/libs/iresearch/search/boolean_filter_tests.cpp
+++ b/tests/libs/iresearch/search/boolean_filter_tests.cpp
@@ -6562,6 +6562,40 @@ TEST(block_disjunction_test, min_match_next) {
   }
 }
 
+// A seek counts the matches on the document it lands on, not on the target it
+// was given. With a target below the first match every sub lands past it, and
+// counting against the target left the count at one -- so the first document
+// of a min-match query was dropped.
+TEST(block_disjunction_test, min_match_seek_before_first_match) {
+  using Disjunction = irs::BlockDisjunction<
+    irs::ScoreAdapter, irs::ScoreMergeType::Noop,
+    irs::BlockDisjunctionTraits<irs::MatchType::MinMatch, false, 1>>;
+
+  std::vector<std::vector<irs::doc_id_t>> docs{
+    {5, 9},
+    {5, 9},
+    {7},
+  };
+
+  {
+    Disjunction it(detail::ExecuteAll<irs::ScoreAdapter>(docs), 2,
+                   irs::doc_limits::eof());
+    ASSERT_EQ(5, it.seek(3));
+    ASSERT_EQ(2, it.MatchCount());
+    ASSERT_EQ(9, it.advance());
+    ASSERT_EQ(2, it.MatchCount());
+    ASSERT_TRUE(irs::doc_limits::eof(it.advance()));
+  }
+
+  // the same document reached by advancing, for comparison
+  {
+    Disjunction it(detail::ExecuteAll<irs::ScoreAdapter>(docs), 2,
+                   irs::doc_limits::eof());
+    ASSERT_EQ(5, it.advance());
+    ASSERT_EQ(2, it.MatchCount());
+  }
+}
+
 TEST(block_disjunction_test, min_match_next_two_blocks) {
   using Disjunction = irs::BlockDisjunction<
     irs::ScoreAdapter, irs::ScoreMergeType::Noop,

--- a/tests/libs/iresearch/search/load_test.cpp
+++ b/tests/libs/iresearch/search/load_test.cpp
@@ -894,10 +894,14 @@ TEST_F(LoadTest, ScoreAccuracyAcrossQueryShapes) {
     return out;
   };
 
-  // Phrases are positional, not a sum over terms, so the oracle does not model
-  // them.
+  // The oracle sums what each term of a plain disjunction contributes, so it
+  // models nothing positional (a phrase), nothing that scores a chosen subset
+  // of its terms (a minimum match), nothing weighted (a boost), and nothing
+  // that stands for terms it cannot name (a wildcard, a fuzziness, an
+  // interval function).
   const auto skippable = [](std::string_view q) {
-    return q.find('"') != std::string_view::npos || q.starts_with('~');
+    return q.find_first_of("\"()@*?~^[]{}<>/") != std::string_view::npos ||
+           q.find("fn:") != std::string_view::npos;
   };
 
   size_t eligible_queries = 0;
@@ -961,8 +965,8 @@ TEST_F(LoadTest, ScoreAccuracyAcrossQueryShapes) {
   }
 
   // The query set is checked in, so coverage is a fixed number: 795 of the
-  // 1096 queries carry a term to score (the other 301 are phrases), and each
-  // is checked in both modes.
+  // 1457 queries are a sum over terms the oracle can name, and each is
+  // checked in both modes.
   EXPECT_EQ(eligible_queries, 795);
   EXPECT_EQ(checked_queries, 795 * 2);
 }
@@ -1113,6 +1117,50 @@ TEST_F(LoadTest, DisjunctionScoreAccuracy) {
   }
 }
 
+// Asking for the documents to be printed must not change which ones they are:
+// `_print` is a way of looking, not a different query.
+TEST_F(LoadTest, ReportIsOnlyAWayOfLooking) {
+  ASSERT_NE(nullptr, gExecutor);
+
+  for (auto query : kQueries) {
+    SCOPED_TRACE(query);
+
+    const auto docs = gExecutor->ExecuteEmitDocs(query, {});
+    const auto docs_hash = gExecutor->ExecuteEmitDocs(query, {.hash = true});
+    const auto docs_both =
+      gExecutor->ExecuteEmitDocs(query, {.hash = true, .print = true});
+    EXPECT_EQ(docs.count, docs_hash.count);
+    EXPECT_EQ(docs.count, docs_both.count);
+    EXPECT_EQ(docs_hash.hash, docs_both.hash);
+    EXPECT_NE(0, docs.count);
+
+    const auto scored = gExecutor->ExecuteEmitScoredDocs(query, {});
+    const auto scored_hash =
+      gExecutor->ExecuteEmitScoredDocs(query, {.hash = true});
+    const auto scored_both =
+      gExecutor->ExecuteEmitScoredDocs(query, {.hash = true, .print = true});
+    EXPECT_EQ(scored.count, scored_hash.count);
+    EXPECT_EQ(scored.count, scored_both.count);
+    EXPECT_EQ(scored_hash.hash, scored_both.hash);
+
+    // the same documents, however they were asked for
+    EXPECT_EQ(docs.count, scored.count);
+  }
+}
+
+TEST_F(LoadTest, TopKPrunedAndExactAgree) {
+  ASSERT_NE(nullptr, gExecutor);
+
+  for (auto query : kQueries) {
+    SCOPED_TRACE(query);
+
+    gExecutor->ExecuteTopK(100, query);
+    const auto pruned = gExecutor->HashResults();
+    gExecutor->ExecuteTopKWithCount(100, query);
+    EXPECT_EQ(pruned, gExecutor->HashResults());
+  }
+}
+
 TEST_F(LoadTest, AdvanceVsFillBlock) {
   auto factories = MakeFactories(*gExecutor);
   TestAdvanceVsFillBlock(gExecutor->GetReader(), factories, kWindowSizes);
@@ -1143,4 +1191,78 @@ TEST_F(LoadTest, SeekSkipFillBlock) {
   auto factories = MakeFactories(*gExecutor);
   TestSeekSkipFillBlock(gExecutor->GetReader(), factories, kWindowSizes,
                         kSeekSkips);
+}
+
+// The command grammar the benchmark driver speaks. Named `LoadTest...` so the
+// filter CI runs picks it up; it needs no corpus.
+TEST(LoadTestCommands, Kinds) {
+  using bench::Kind;
+
+  auto cmd = bench::ParseCommand("count");
+  EXPECT_EQ(Kind::Count, cmd.kind);
+  EXPECT_FALSE(cmd.report.hash);
+  EXPECT_FALSE(cmd.report.print);
+
+  EXPECT_EQ(Kind::Docs, bench::ParseCommand("docs").kind);
+  EXPECT_EQ(Kind::Scored, bench::ParseCommand("scored").kind);
+
+  cmd = bench::ParseCommand("top_100");
+  EXPECT_EQ(Kind::TopK, cmd.kind);
+  EXPECT_EQ(100, cmd.k);
+  EXPECT_TRUE(cmd.prune);
+}
+
+TEST(LoadTestCommands, AnyK) {
+  for (const auto [name, k] :
+       {std::pair<std::string_view, uint32_t>{"top_1", 1},
+        {"top_7", 7},
+        {"top_1000", 1000},
+        {"top_4294967295", 4294967295}}) {
+    const auto cmd = bench::ParseCommand(name);
+    EXPECT_EQ(bench::Kind::TopK, cmd.kind) << name;
+    EXPECT_EQ(k, cmd.k) << name;
+  }
+}
+
+TEST(LoadTestCommands, CountSuffixTurnsPruningOff) {
+  const auto cmd = bench::ParseCommand("top_100_count");
+  EXPECT_EQ(bench::Kind::TopK, cmd.kind);
+  EXPECT_EQ(100, cmd.k);
+  EXPECT_FALSE(cmd.prune);
+}
+
+TEST(LoadTestCommands, HashAndPrintEitherOrBoth) {
+  for (const auto* name :
+       {"docs_hash", "scored_hash", "top_10_hash", "top_10_count_hash"}) {
+    const auto cmd = bench::ParseCommand(name);
+    EXPECT_NE(bench::Kind::Unsupported, cmd.kind) << name;
+    EXPECT_TRUE(cmd.report.hash) << name;
+    EXPECT_FALSE(cmd.report.print) << name;
+  }
+
+  const auto printed = bench::ParseCommand("docs_print");
+  EXPECT_EQ(bench::Kind::Docs, printed.kind);
+  EXPECT_FALSE(printed.report.hash);
+  EXPECT_TRUE(printed.report.print);
+
+  for (const auto* name : {"docs_hash_print", "docs_print_hash",
+                           "top_3_print_hash", "scored_hash_print"}) {
+    const auto cmd = bench::ParseCommand(name);
+    EXPECT_NE(bench::Kind::Unsupported, cmd.kind) << name;
+    EXPECT_TRUE(cmd.report.hash) << name;
+    EXPECT_TRUE(cmd.report.print) << name;
+  }
+}
+
+TEST(LoadTestCommands, WhatIsNotACommand) {
+  for (const auto* name : {// a count is a number and nothing else
+                           "count_hash", "count_print",
+                           // each modifier at most once
+                           "docs_hash_hash", "docs_print_print",
+                           // a top-k needs a count of its own
+                           "top_", "top_0", "top_abc", "top_10x", "top_-1",
+                           // and the rest is not a command at all
+                           "", "bogus", "docs_debug", "_hash"}) {
+    EXPECT_EQ(bench::Kind::Unsupported, bench::ParseCommand(name).kind) << name;
+  }
 }

--- a/tests/libs/iresearch/search/regexp_filter_test.cpp
+++ b/tests/libs/iresearch/search/regexp_filter_test.cpp
@@ -18,6 +18,8 @@
 /// Copyright holder is SereneDB GmbH, Berlin, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <absl/strings/str_cat.h>
+
 #include <chrono>
 #include <type_traits>
 
@@ -195,7 +197,62 @@ TEST(by_regexp_test, type_of_prepared_query) {
 }
 
 // Parametrized tests
+namespace {
+
+class TermsGenerator : public tests::DocGeneratorBase {
+ public:
+  explicit TermsGenerator(std::vector<std::string> terms)
+    : _terms{std::move(terms)} {}
+
+  const tests::Document* next() final {
+    if (_pos == _terms.size()) {
+      return nullptr;
+    }
+    _doc.clear();
+    auto field = std::make_shared<tests::StringField>("name", _terms[_pos++]);
+    field->id = kNameId;
+    _doc.insert(field);
+    return &_doc;
+  }
+
+  void reset() final { _pos = 0; }
+
+ private:
+  std::vector<std::string> _terms;
+  size_t _pos{0};
+  tests::Document _doc;
+};
+
+}  // namespace
+
 class RegexpFilterTestCase : public tests::FilterTestCaseBase {};
+
+// A term other terms extend is written inside the block it names, as the
+// entry with an empty suffix. A pattern that ends where such a block begins
+// has to descend into it, which needs an acceptor that can still read -- see
+// `EmplaceSinkArcs`.
+TEST_P(RegexpFilterTestCase, term_a_block_is_named_by) {
+  constexpr size_t kTermsPerBlock = 32;  // over the dictionary's block minimum
+
+  std::vector<std::string> terms{"hello"};
+  for (size_t i = 0; i < kTermsPerBlock; ++i) {
+    terms.push_back(absl::StrCat("hello", i));
+  }
+  terms.emplace_back("hellp");
+
+  {
+    TermsGenerator gen{terms};
+    add_segment(gen);
+  }
+
+  auto rdr = open_reader();
+
+  const Docs both{1, irs::doc_id_t(terms.size())};  // hello, hellp
+  CheckQuery(*MakeRegexp("name", "hell."), both, Costs{both.size()}, rdr);
+  CheckQuery(*MakeRegexp("name", "hel(l|p)o"), Docs{1}, Costs{1}, rdr);
+  CheckQuery(*MakeRegexp("name", "(hello)"), Docs{1}, Costs{1}, rdr);
+  CheckQuery(*MakeRegexp("name", "hel[l]o"), Docs{1}, Costs{1}, rdr);
+}
 
 // Basic patterns
 

--- a/tests/libs/iresearch/search/score_prune_scoring_test.cpp
+++ b/tests/libs/iresearch/search/score_prune_scoring_test.cpp
@@ -48,6 +48,7 @@ std::ostream& operator<<(std::ostream& os, const std::pair<T1, T2>& p) {
 #include "iresearch/search/doc_collector.hpp"
 #include "iresearch/search/filter_optimizer.hpp"
 #include "iresearch/search/scorer.hpp"
+#include "iresearch/search/terms_filter.hpp"
 #include "iresearch/search/tfidf.hpp"
 #include "iresearch/types.hpp"
 #include "tests_shared.hpp"
@@ -418,6 +419,26 @@ TEST_P(ScorePruneScoringTestCase, TfidfPrunedVsBaseline) {
   ASSERT_NE(nullptr, filter);
 
   ComparePrunedVsBaseline(reader, *filter, scorer, 10);
+}
+
+// A query that takes the best of its terms rather than adding them up must be
+// scored that way whether or not it prunes. `MaxScoreIterator` bounds a sum,
+// so it cannot serve a `Max` query: with `index` and `search` in the same
+// documents, summing scores both differently and higher than taking the best.
+TEST_P(ScorePruneScoringTestCase, MaxMergePrunedVsBaseline) {
+  auto scorer = irs::BM25{irs::BM25::K(), irs::BM25::B()};
+  auto reader = CreateLargeIndex(scorer, 10);
+
+  irs::ByTerms filter;
+  *filter.mutable_field_id() = ColumnIdFor("content");
+  auto* options = filter.mutable_options();
+  options->merge_type = irs::ScoreMergeType::Max;
+  options->terms.emplace(
+    irs::ViewCast<irs::byte_type>(std::string_view{"index"}), irs::kNoBoost);
+  options->terms.emplace(
+    irs::ViewCast<irs::byte_type>(std::string_view{"search"}), irs::kNoBoost);
+
+  ComparePrunedVsBaseline(reader, filter, scorer, 10);
 }
 
 // BM25 single-term, 4200 docs (~840 matching "search" = ~6 blocks)

--- a/tests/libs/iresearch/search/score_prune_scoring_test.cpp
+++ b/tests/libs/iresearch/search/score_prune_scoring_test.cpp
@@ -421,6 +421,44 @@ TEST_P(ScorePruneScoringTestCase, TfidfPrunedVsBaseline) {
   ComparePrunedVsBaseline(reader, *filter, scorer, 10);
 }
 
+// Pruning has to do something, not merely be harmless: the pruned run reaches
+// fewer documents than the one that cannot skip. Which iterator serves it is
+// not visible from here -- the load test watches that, through the documents
+// TOP_100 reports over an index with score bounds.
+TEST_P(ScorePruneScoringTestCase, PruningIsTaken) {
+  auto scorer = irs::BM25{irs::BM25::K(), irs::BM25::B()};
+  auto reader = CreateLargeIndex(scorer, 10);
+  constexpr size_t k = 10;
+
+  auto reached = [&](const irs::Filter& filter, bool prune) {
+    std::vector<irs::ScoreDoc> hits(k);
+    return prune ? irs::ExecuteTopK(reader, filter, scorer, k, true,
+                                    std::span{hits})
+                 : irs::ExecuteTopKWithCount(reader, filter, scorer, k,
+                                             std::span{hits});
+  };
+
+  {
+    SCOPED_TRACE("single term");
+    auto filter = ParseQuery("topic:database");
+    ASSERT_NE(nullptr, filter);
+    EXPECT_LT(reached(*filter, true), reached(*filter, false));
+  }
+
+  {
+    SCOPED_TRACE("terms that add up");
+    irs::ByTerms filter;
+    *filter.mutable_field_id() = ColumnIdFor("content");
+    auto* options = filter.mutable_options();
+    options->merge_type = irs::ScoreMergeType::Sum;
+    options->terms.emplace(
+      irs::ViewCast<irs::byte_type>(std::string_view{"index"}), irs::kNoBoost);
+    options->terms.emplace(
+      irs::ViewCast<irs::byte_type>(std::string_view{"search"}), irs::kNoBoost);
+    EXPECT_LT(reached(filter, true), reached(filter, false));
+  }
+}
+
 // A query that takes the best of its terms rather than adding them up must be
 // scored that way whether or not it prunes. `MaxScoreIterator` bounds a sum,
 // so it cannot serve a `Max` query: with `index` and `search` in the same

--- a/tests/libs/iresearch/search/wildcard_filter_test.cpp
+++ b/tests/libs/iresearch/search/wildcard_filter_test.cpp
@@ -20,6 +20,8 @@
 /// @author Andrey Abramov
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <absl/strings/str_cat.h>
+
 #include "filter_test_case_base.hpp"
 #include "iresearch/search/all_filter.hpp"
 #include "iresearch/search/automaton_filter.hpp"
@@ -603,6 +605,64 @@ TEST_P(WildcardFilterTestCase, visit) {
 }
 
 static constexpr auto kTestDirs = tests::GetDirectories<tests::kTypesDefault>();
+
+// A term other terms extend is written inside the block it names, as the
+// entry with an empty suffix, so finding it means descending into that block.
+// The dictionary only makes such a block once a prefix has enough terms under
+// it, which is why nothing smaller catches this.
+namespace {
+
+class TermsGenerator : public tests::DocGeneratorBase {
+ public:
+  explicit TermsGenerator(std::vector<std::string> terms)
+    : _terms{std::move(terms)} {}
+
+  const tests::Document* next() final {
+    if (_pos == _terms.size()) {
+      return nullptr;
+    }
+    _doc.clear();
+    auto field = std::make_shared<tests::StringField>("name", _terms[_pos++]);
+    field->id = kNameId;
+    _doc.insert(field);
+    return &_doc;
+  }
+
+  void reset() final { _pos = 0; }
+
+ private:
+  std::vector<std::string> _terms;
+  size_t _pos{0};
+  tests::Document _doc;
+};
+
+}  // namespace
+
+TEST_P(WildcardFilterTestCase, term_a_block_is_named_by) {
+  constexpr size_t kTermsPerBlock = 32;  // over the dictionary's block minimum
+
+  std::vector<std::string> terms{"hello"};  // doc 1: the block's own term
+  for (size_t i = 0; i < kTermsPerBlock; ++i) {
+    terms.push_back(absl::StrCat("hello", i));  // and what extends it
+  }
+  terms.emplace_back("hellp");  // a neighbour with nothing under it
+
+  {
+    TermsGenerator gen{terms};
+    add_segment(gen);
+  }
+
+  auto rdr = open_reader();
+
+  // the term itself is still a term
+  CheckQuery(*MakeWildcard(kNameId, "hello"), Docs{1}, Costs{1}, rdr);
+
+  // and a pattern that ends where the block begins must find it
+  const Docs expected{1, irs::doc_id_t(terms.size())};  // hello, hellp
+  CheckQuery(*MakeWildcard(kNameId, "hell_"), expected, Costs{expected.size()},
+             rdr);
+  CheckQuery(*MakeWildcard(kNameId, "_ello"), Docs{1}, Costs{1}, rdr);
+}
 
 INSTANTIATE_TEST_SUITE_P(wildcard_filter_test, WildcardFilterTestCase,
                          ::testing::Combine(::testing::ValuesIn(kTestDirs),

--- a/tests/libs/iresearch/utils/regexp_utils_test.cpp
+++ b/tests/libs/iresearch/utils/regexp_utils_test.cpp
@@ -40,6 +40,20 @@ class RegexpUtilsTest : public TestBase {
     return irs::ViewCast<irs::byte_type>(sv);
   }
 
+  // Only the sink reads nothing, and the sink accepts nothing -- see
+  // `EmplaceSinkArcs`.
+  static void AssertSink(const irs::automaton& a) {
+    size_t without_arcs = 0;
+    for (irs::automaton::StateId state = 0; state < a.NumStates(); ++state) {
+      if (a.NumArcs(state)) {
+        continue;
+      }
+      ++without_arcs;
+      EXPECT_FALSE(bool(a.Final(state))) << "state " << state << " accepts";
+    }
+    EXPECT_LE(without_arcs, 1) << "more than one state reads nothing";
+  }
+
   static irs::automaton FromPosix(std::string_view pattern) {
     return irs::FromRegexp(pattern, irs::kDefaultMaxDfaStates,
                            irs::RegexpSyntax::PosixEre);
@@ -2786,4 +2800,28 @@ TEST_F(RegexpUtilsTest, posix_ere_default_is_perl) {
     AssertProperties(a);
     EXPECT_TRUE(Accepts(a, "ababc"));
   }
+}
+
+// EmplaceSinkArcs
+
+TEST_F(RegexpUtilsTest, sink_arcs) {
+  // patterns whose accepting state has nothing left to read
+  for (const auto* pattern :
+       {"foo", "f.o", "f[o]o", "(foo)", "foo|bar", "fo+", "f.?o"}) {
+    auto a = irs::FromRegexp(ToBytesView(pattern));
+    AssertProperties(a);
+    AssertSink(a);
+  }
+}
+
+TEST_F(RegexpUtilsTest, sink_arcs_accept_unchanged) {
+  auto a = irs::FromRegexp(ToBytesView("f.o"));
+  AssertSink(a);
+
+  EXPECT_TRUE(Accepts(a, "foo"));
+  EXPECT_TRUE(Accepts(a, "fao"));
+  // what the sink swallowed is still no match
+  EXPECT_FALSE(Accepts(a, "fooo"));
+  EXPECT_FALSE(Accepts(a, "fo"));
+  EXPECT_FALSE(Accepts(a, "bar"));
 }

--- a/tests/libs/iresearch/utils/regexp_utils_test.cpp
+++ b/tests/libs/iresearch/utils/regexp_utils_test.cpp
@@ -40,18 +40,14 @@ class RegexpUtilsTest : public TestBase {
     return irs::ViewCast<irs::byte_type>(sv);
   }
 
-  // Only the sink reads nothing, and the sink accepts nothing -- see
-  // `EmplaceSinkArcs`.
+  // A state that reads nothing accepts nothing -- see `EmplaceSinkArcs`.
   static void AssertSink(const irs::automaton& a) {
-    size_t without_arcs = 0;
     for (irs::automaton::StateId state = 0; state < a.NumStates(); ++state) {
-      if (a.NumArcs(state)) {
-        continue;
+      if (!a.NumArcs(state)) {
+        EXPECT_FALSE(bool(a.Final(state)))
+          << "state " << state << " accepts and reads nothing";
       }
-      ++without_arcs;
-      EXPECT_FALSE(bool(a.Final(state))) << "state " << state << " accepts";
     }
-    EXPECT_LE(without_arcs, 1) << "more than one state reads nothing";
   }
 
   static irs::automaton FromPosix(std::string_view pattern) {

--- a/tests/libs/iresearch/utils/wildcard_utils_test.cpp
+++ b/tests/libs/iresearch/utils/wildcard_utils_test.cpp
@@ -35,20 +35,17 @@ class WildcardUtilsTest : public TestBase {
     EXPECT_EQ(kExpectedProperties, a.Properties(kExpectedProperties, true));
   }
 
-  // Only the sink reads nothing, and the sink accepts nothing. The term
+  // A state that reads nothing accepts nothing -- it is a sink. The term
   // dictionary walk descends into a block while the acceptor has arcs, so a
   // state that accepts and reads nothing would stop it at the term a block is
   // named by.
   static void AssertSink(const irs::automaton& a) {
-    size_t without_arcs = 0;
     for (irs::automaton::StateId state = 0; state < a.NumStates(); ++state) {
-      if (a.NumArcs(state)) {
-        continue;
+      if (!a.NumArcs(state)) {
+        EXPECT_FALSE(bool(a.Final(state)))
+          << "state " << state << " accepts and reads nothing";
       }
-      ++without_arcs;
-      EXPECT_FALSE(bool(a.Final(state))) << "state " << state << " accepts";
     }
-    EXPECT_LE(without_arcs, 1) << "more than one state reads nothing";
   }
 };
 
@@ -68,6 +65,53 @@ TEST_F(WildcardUtilsTest, sink_arcs) {
     AssertProperties(a);
     AssertSink(a);
   }
+}
+
+// A dead state the builder already left behind serves as the sink, rather
+// than a second one being added beside it.
+TEST_F(WildcardUtilsTest, sink_arcs_reuse_dead_state) {
+  irs::automaton a;
+  a.AddStates(3);
+  a.SetStart(0);
+  // state 1 reads nothing and accepts nothing: a sink already
+  a.SetFinal(2);  // reads nothing, accepts: needs somewhere to read into
+  a.EmplaceArc(0, irs::RangeLabel::From(0, 'a' - 1), 1);
+  a.EmplaceArc(0, irs::RangeLabel::From('a'), 2);
+  a.EmplaceArc(0, irs::RangeLabel::From('a' + 1, 255), 1);
+
+  irs::EmplaceSinkArcs(a);
+
+  ASSERT_EQ(3, a.NumStates());  // the dead state served, none was added
+  ASSERT_EQ(1, a.NumArcs(2));   // the accepting state reads into it
+  ASSERT_EQ(0, a.NumArcs(1));
+  AssertSink(a);
+
+  ASSERT_TRUE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"a"})));
+  ASSERT_FALSE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"ab"})));
+  ASSERT_FALSE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"b"})));
+}
+
+// Nothing to do where every state can already read on.
+TEST_F(WildcardUtilsTest, sink_arcs_leaves_a_complete_automaton_alone) {
+  auto a =
+    irs::FromWildcard(irs::ViewCast<irs::byte_type>(std::string_view{"fo%"}));
+  const auto states = a.NumStates();
+  const auto arcs = [&] {
+    size_t n = 0;
+    for (irs::automaton::StateId s = 0; s < a.NumStates(); ++s) {
+      n += a.NumArcs(s);
+    }
+    return n;
+  };
+  const auto before = arcs();
+
+  irs::EmplaceSinkArcs(a);
+
+  ASSERT_EQ(states, a.NumStates());
+  ASSERT_EQ(before, arcs());
 }
 
 TEST_F(WildcardUtilsTest, sink_arcs_accept_unchanged) {

--- a/tests/libs/iresearch/utils/wildcard_utils_test.cpp
+++ b/tests/libs/iresearch/utils/wildcard_utils_test.cpp
@@ -34,7 +34,59 @@ class WildcardUtilsTest : public TestBase {
 
     EXPECT_EQ(kExpectedProperties, a.Properties(kExpectedProperties, true));
   }
+
+  // Only the sink reads nothing, and the sink accepts nothing. The term
+  // dictionary walk descends into a block while the acceptor has arcs, so a
+  // state that accepts and reads nothing would stop it at the term a block is
+  // named by.
+  static void AssertSink(const irs::automaton& a) {
+    size_t without_arcs = 0;
+    for (irs::automaton::StateId state = 0; state < a.NumStates(); ++state) {
+      if (a.NumArcs(state)) {
+        continue;
+      }
+      ++without_arcs;
+      EXPECT_FALSE(bool(a.Final(state))) << "state " << state << " accepts";
+    }
+    EXPECT_LE(without_arcs, 1) << "more than one state reads nothing";
+  }
 };
+
+TEST_F(WildcardUtilsTest, sink_arcs) {
+  // patterns whose accepting state has nothing left to read
+  for (const auto* pattern : {"foo", "f_o", "_oo", "fo_", "f_o_", "___"}) {
+    auto a = irs::FromWildcard(
+      irs::ViewCast<irs::byte_type>(std::string_view{pattern}));
+    AssertProperties(a);
+    AssertSink(a);
+  }
+
+  // and one that reads on where it accepts
+  {
+    auto a =
+      irs::FromWildcard(irs::ViewCast<irs::byte_type>(std::string_view{"fo%"}));
+    AssertProperties(a);
+    AssertSink(a);
+  }
+}
+
+TEST_F(WildcardUtilsTest, sink_arcs_accept_unchanged) {
+  auto a =
+    irs::FromWildcard(irs::ViewCast<irs::byte_type>(std::string_view{"f_o"}));
+  AssertSink(a);
+
+  ASSERT_TRUE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"foo"})));
+  ASSERT_TRUE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"fao"})));
+  // what the sink swallowed is still no match
+  ASSERT_FALSE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"fooo"})));
+  ASSERT_FALSE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"fo"})));
+  ASSERT_FALSE(irs::Accept<irs::byte_type>(
+    a, irs::ViewCast<irs::byte_type>(std::string_view{"bar"})));
+}
 
 TEST_F(WildcardUtilsTest, same_start) {
   {
@@ -1498,10 +1550,11 @@ TEST_F(WildcardUtilsTest, match_wildcard) {
       a, irs::ViewCast<irs::byte_type>(std::string_view("vczczvccccc"))));
   }
 
-  // invalid UTF-8 sequence
-  ASSERT_EQ(2, irs::FromWildcard("\xD0").NumStates());
-  ASSERT_EQ(3, irs::FromWildcard("\xE2\x9E").NumStates());
-  ASSERT_EQ(4, irs::FromWildcard("\xF0\x9F\x98").NumStates());
+  // invalid UTF-8 sequence -- one state per byte read, plus the sink the
+  // accepting state reads into
+  ASSERT_EQ(3, irs::FromWildcard("\xD0").NumStates());
+  ASSERT_EQ(4, irs::FromWildcard("\xE2\x9E").NumStates());
+  ASSERT_EQ(5, irs::FromWildcard("\xF0\x9F\x98").NumStates());
 }
 
 TEST_F(WildcardUtilsTest, wildcard_type) {


### PR DESCRIPTION
Three things a query could ask for came back wrong. Reading the Lucene syntax
the way Lucene reads it is what turned them up, so both are here.

## What was answered wrongly

**A term that other terms extend was lost by wildcard and regexp.** Such a term
is written inside the block it names, as the entry with an empty suffix, so
reaching it means descending into that block. The term dictionary walk descends
only where the acceptor still has arcs, which `MakeLevenshteinAutomaton`
guarantees by sending dead ends to an invalid state, and which `FromWildcard`
and `FromRegexp` did not: their accepting states can have no arcs at all.
`hell?` answered 105 documents instead of 5307, and `/(hello)/` none instead of
the 4034 that `/hello/` finds by the literal fast path -- the same language,
told apart only by which path served it. `EmplaceSinkArcs` gives such a state a
sink to read into, in one pass and without allocating, so the only state left
without arcs is the sink itself, which is not final: the shape `TableMatcher`
and the walk both expect. Measured over patterns whose accepting state lands on
a block boundary, it costs 0.5% of the walk and 0.5% of automaton construction.

**A min-match disjunction dropped its first document.** `BlockDisjunction`
counted a match against the seek target rather than the document it landed on,
so with a target below the first match every sub-iterator landed past it and
the count stayed at one -- the document was never credited and fell out of the
result.

**Score pruning summed the terms of a query that takes the best of them.**
`MaxScoreIterator` merges with `ScoreMergeType::Sum` and its block-max
arithmetic depends on that, but it was dispatched for any pruning query
regardless of how that query asked for its terms to be merged. A fuzzy query,
which takes its best matching term, came back with the sum instead: `the~1`
scored its top document 253.33 where the unpruned path says 61.55, and the two
paths returned different documents entirely. Pruning now serves a query with
nothing to merge or one that adds its terms up; everything else prunes in the
weak disjunction, which merges the way it was asked to.

**A quoted range bound was tokenized.** `Analyzer#normalize` is what Lucene
runs over the text of a prefix, a wildcard, a fuzziness or a range bound -- it
does not tokenize it. Taking the analyzer's first token threw the rest away, so
`["alpha beta" TO gamma]` searched from `alpha`, when a quoted bound exists to
hold spaces. The analyzer's answer is taken where it is the whole of what it
was given, and the text as written where it is not. A term the analyzer makes
nothing of -- a lone `+`, which is a term rather than an operator where nothing
follows it -- was stored as the empty term, matching nothing; it is now
searched for as it was written.

## The query syntax

Terms are what the syntax has not claimed, as Lucene's `_TERM_START_CHAR` says,
so `café`, `u.s.a` and `don't` are terms and a hyphen or a plus inside a word
belongs to it. A term goes through the analyzer, as `getFieldQuery` does, and
a word it splits is asked for under the default operator; a prefix, wildcard,
fuzziness or range bound is normalized rather than tokenized.

Phrases are parsed rather than taken apart afterwards: parts, gaps (`"alpha 1-3
beta"`), prefixes, wildcards and per-part fuzziness. From the flexible parser
come `@N` for a minimum match, the comparison bounds (`field<beta`,
`field>=alpha`), and the `fn:` family -- `fn:or`, `fn:unordered`, `fn:ordered`,
`fn:atLeast`, `fn:phrase`, `fn:wildcard`, `fn:fuzzyTerm`, `fn:ngram`, and
`fn:maxgaps`/`fn:maxwidth` over the pair they can bound. What this engine has
no algebra for is read and refused by name rather than silently ignored, with
issues for the gaps: #1051 (`fn:maxgaps`/`fn:maxwidth` over three or more
terms), #1052 (`field:*`), #1053 (relational interval functions).

Wildcards are translated to the alphabet the filters use (`*` and `?` become
`%` and `_`), escapes are removed including `\uXXXX`, a regular expression
keeps its own syntax, and a number or a float can be a term. A query that
cannot be read says so on stderr instead of quietly answering zero, and the
`SUFFIX` token nothing reached is gone.

## The benchmark harness

Commands name what to do rather than enumerating every combination: `count`,
`docs`, `scored` and `top_<N>` for any N, where a top-k reads `_count` as "do
not prune, take the exact total", and anything that is not a bare count takes
`_hash` for a checksum over what it found and `_print` for all of it -- either,
both, in either order. Matching ignores case, so `COUNT`, `TOP_100` and
`TOP_100_COUNT` still mean what the other engines mean by them. `ParseCommand`
lives in the bench library where a test can reach it, and returns
`Kind::Unsupported` rather than an optional. `SDB_DUMP_SCORES` is gone,
replaced by `_print`.

Output goes through `absl::PrintF`/`FPrintF` rather than iostreams. The result
line is flushed explicitly: the driver writes one query and blocks on the
reply, which used to work only because `std::cin` was tied to `std::cout`.

## Tests

Each of these fails with the fix it covers reverted:

- `EmplaceSinkArcs` for both builders: only the sink reads nothing, and the
  sink accepts nothing; an automaton that already has a dead state reuses it,
  and a complete one is left alone.
- `term_a_block_is_named_by`, through the wildcard and the regexp filter: 34
  terms under one prefix, over the dictionary's 25-entry block minimum, so
  `hello` is written inside the block it names.
- `min_match_seek_before_first_match`, in the plain, read-ahead and scored
  instantiations of the same seek.
- `MaxMergePrunedVsBaseline`: a two-term `Max` query over terms that share
  documents, pruned against unpruned.
- The Lucene parser: 188 tests covering terms through the analyzer, non-ASCII
  and punctuation, phrase parts and gaps, `@N`, comparisons, the `fn:` family
  and what it refuses, `\uXXXX`, `*:*`, quoted range bounds. Expectations that
  named the old behaviour now name the new one.
- The command grammar: every kind, any `N`, the modifiers in either order and
  together, and thirteen things that are not commands.
- Over the corpus: `PruningIsTaken` (pruning reaches fewer documents than the
  run that cannot skip), `ReportIsOnlyAWayOfLooking` (printing changes nothing
  about what was found), `TopKPrunedAndExactAgree`.

The load test now reads the benchmark's query set, so the two stay honest about
the same queries, and its reference is regenerated over the same index. Its
score oracle names what it cannot model -- anything positional, weighted,
partial, or standing for terms it cannot enumerate -- now that the set holds
all of those.

## Validation

906 unit tests across score-prune, wildcard, regexp, levenshtein,
block-disjunction, parser, merge-consistency and automaton; 16 load tests over
the wiki corpus. The benchmark's two query sets (1076 and 1437) were run under
count, docs and scored against an unmodified engine: no difference in any
document, count or checksum.

## Notes for review

`to_tsquery` reads this parser, so its terms are now analyzed and its wildcards
translated -- `Quick` finds what `quick` finds, and `qui*` reaches the terms it
names. sqllogic's fifteen `to_tsquery` strings were checked through the parser
and behave as before.
