### PR TITLE
fix: deadlock between catalog commits and object id allocation

### DIFF
--- a/scripts/ci/steps/050-ci-in-docker-run-catalog-deadlock-test.bash
+++ b/scripts/ci/steps/050-ci-in-docker-run-catalog-deadlock-test.bash
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Concurrent multi-entry catalog commits must not deadlock the server.
+#
+# Runs against a serened of its own rather than the shared sqllogic stack: the
+# failure this looks for takes the whole process down, so a regression here must
+# not take every other suite with it.
+
+set -o pipefail
+
+cd "${WORKSPACE}" || exit 1
+
+PORT="${CATALOG_DEADLOCK_PORT:-7899}"
+DATA_DIR="$(mktemp -d)"
+LOG_DIR="./out/logs"
+mkdir -p "${LOG_DIR}"
+
+"${BUILD_DIR}/bin/serened" "${DATA_DIR}" --listen="postgres://0.0.0.0:${PORT}" \
+	>"${LOG_DIR}/catalog-deadlock-serened.log" 2>&1 &
+server_pid=$!
+
+cleanup() {
+	kill -9 "${server_pid}" 2>/dev/null
+	wait "${server_pid}" 2>/dev/null
+	rm -rf "${DATA_DIR}"
+}
+trap cleanup EXIT
+
+ready=0
+for _ in $(seq 1 90); do
+	if ! kill -0 "${server_pid}" 2>/dev/null; then
+		break
+	fi
+	if timeout 5 psql -h 127.0.0.1 -p "${PORT}" -U postgres -d postgres -tAc "SELECT 1;" \
+		>/dev/null 2>&1; then
+		ready=1
+		break
+	fi
+	sleep 1
+done
+
+if [[ ${ready} -ne 1 ]]; then
+	echo "serened did not come up on port ${PORT}" >&2
+	tail -30 "${LOG_DIR}/catalog-deadlock-serened.log" >&2
+	echo "CATALOG_DEADLOCK_TEST=FAILED"
+	exit 123
+fi
+
+if ./tests/scripts/catalog_commit_deadlock.sh --port "${PORT}" \
+	--workers "${CATALOG_DEADLOCK_WORKERS:-8}" \
+	--seconds "${CATALOG_DEADLOCK_SECONDS:-40}" 2>&1 |
+	tee -a "${LOG_DIR}/catalog-deadlock.log"; then
+	test_result="PASSED"
+	exit_code=0
+else
+	test_result="FAILED"
+	exit_code=123
+	# A wedged server keeps its stacks; the log carries whatever it reported,
+	# including ThreadSanitizer's lock-order inversions on a tsan config.
+	tail -60 "${LOG_DIR}/catalog-deadlock-serened.log" >&2
+fi
+
+echo "CATALOG_DEADLOCK_TEST=${test_result}"
+exit ${exit_code}

--- a/scripts/ci/steps/run-suites.sh
+++ b/scripts/ci/steps/run-suites.sh
@@ -87,6 +87,9 @@ run_serened_core() {
 	[[ "${RUN_SQLITE:-false}" == "true" ]] && scope=all
 	run env SDB_SQLLOGIC_SCOPE="$scope" bash "${STEPS}/044-ci-in-docker-run-sqllogic-tests.bash"
 	run bash "${STEPS}/047-ci-in-docker-run-driver-tests.bash"
+	# Its own serened: the failure it looks for wedges the whole process, so a
+	# regression must not take the suites above down with it.
+	run bash "${STEPS}/050-ci-in-docker-run-catalog-deadlock-test.bash"
 }
 
 # Diff-gated heavy suite: sqlsmith fuzzing.

--- a/server/catalog/ddl/duckdb_catalog.cpp
+++ b/server/catalog/ddl/duckdb_catalog.cpp
@@ -2237,6 +2237,11 @@ duckdb::unique_ptr<duckdb::AlterInfo> UndoBufferRowRecipe(
 
 }  // namespace
 
+void SereneDBCatalog::PrepareCatalogChange(
+  duckdb::DuckTransaction& /*transaction*/) {
+  catalog::ScopedCatalogWal();
+}
+
 void SereneDBCatalog::WriteCatalogChange(
   duckdb::DuckTransaction& /*transaction*/, duckdb::CatalogEntry& old_entry,
   duckdb::data_ptr_t extra_data) {

--- a/server/catalog/ddl/duckdb_catalog.h
+++ b/server/catalog/ddl/duckdb_catalog.h
@@ -320,6 +320,10 @@ class SereneDBCatalog final : public duckdb::DuckCatalog {
                           duckdb::CatalogEntry& entry,
                           duckdb::data_ptr_t extra_data) final;
 
+  // Taken before the catalog and set locks of the entry being committed, so the
+  // cluster-wide log lock is never acquired under them.
+  void PrepareCatalogChange(duckdb::DuckTransaction& transaction) final;
+
   // The per-database DDL surface: these live here rather than on
   // catalog::Catalog because the database they act on is this catalog.
   // The owner is `ax.role`: a dictionary has no ACL of its own, so its

--- a/server/catalog/log/duckdb_global_catalog.cpp
+++ b/server/catalog/log/duckdb_global_catalog.cpp
@@ -172,6 +172,9 @@ duckdb::shared_ptr<duckdb::WriteAheadLog> gClusterWal;
 // durable by whichever flushed first, so a commit holds the log for its run.
 absl::Mutex gClusterWalMutex;
 thread_local bool gHoldsClusterWal = false;
+// Set only where the caller is known to hold no catalog lock, which is the one
+// place waiting for the log lock cannot invert an order.
+thread_local bool gOidHorizonMayWait = false;
 thread_local uint64_t gClusterWalFlushedAt = 0;
 // Whether the open run carries a catalog decision -- a version of an object, or
 // the opening of a drop -- as opposed to only what describes one. That is where
@@ -342,12 +345,31 @@ void WriteSequenceValueTo(duckdb::WriteAheadLog& wal, ObjectId sequence_id,
   wal.WriteCatalogState(bytes, stream.GetPosition());
 }
 
-bool WriteOidHorizon(uint64_t horizon) {
+bool WriteOidHorizon(uint64_t horizon) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   auto wal = ClusterCatalogWal();
   if (!wal) {
     return false;
   }
-  absl::MutexLock lock{&gClusterWalMutex};
+  // An id is allocated wherever a catalog entry is built, which is under the
+  // catalog and set locks. The log lock sits outside those, so waiting for it
+  // here would close the cycle a commit walks the other way round. The run that
+  // already holds it writes straight through; anyone else takes it only if it
+  // is free, and otherwise reports a conflict the statement can be retried on.
+  if (gHoldsClusterWal) {
+    WriteOidHorizonTo(*wal, horizon);
+    wal->Flush();
+    return true;
+  }
+  if (gOidHorizonMayWait) {
+    gClusterWalMutex.Lock();
+  } else if (!gClusterWalMutex.TryLock()) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_T_R_SERIALIZATION_FAILURE),
+      ERR_MSG("catalog log: object id horizon is busy, retry the statement"));
+  }
+  const absl::Cleanup unlock = []() ABSL_NO_THREAD_SAFETY_ANALYSIS {
+    gClusterWalMutex.Unlock();
+  };
   WriteOidHorizonTo(*wal, horizon);
   wal->Flush();
   return true;
@@ -485,6 +507,12 @@ void EndCommittingCatalogRun(bool committed) ABSL_NO_THREAD_SAFETY_ANALYSIS {
     SDB_IF_FAILURE("crash_on_drop") { SDB_IMMEDIATE_ABORT(); }
   }
 }
+
+OidHorizonWaitScope::OidHorizonWaitScope() : _previous{gOidHorizonMayWait} {
+  gOidHorizonMayWait = true;
+}
+
+OidHorizonWaitScope::~OidHorizonWaitScope() { gOidHorizonMayWait = _previous; }
 
 void EndClusterCatalogWal(bool committed) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   if (!gHoldsClusterWal) {

--- a/server/catalog/log/duckdb_global_catalog.h
+++ b/server/catalog/log/duckdb_global_catalog.h
@@ -217,6 +217,21 @@ enum class CatalogState : uint8_t {
 // False when the log is not up to take the record -- boot's own replay-time
 // allocations -- in which case the horizon must not be treated as raised.
 bool WriteOidHorizon(uint64_t horizon);
+
+// Marks a stretch where the object id horizon may be written by waiting for the
+// cluster log lock. Only valid where no catalog lock is held: everywhere else
+// the allocator refuses rather than waits, because the log lock sits outside
+// the catalog locks and waiting for it there would invert the order.
+class OidHorizonWaitScope {
+ public:
+  OidHorizonWaitScope();
+  ~OidHorizonWaitScope();
+  OidHorizonWaitScope(const OidHorizonWaitScope&) = delete;
+  OidHorizonWaitScope& operator=(const OidHorizonWaitScope&) = delete;
+
+ private:
+  bool _previous;
+};
 // The same records into a log of the caller's own, for the rewrite that folds
 // the state back into a fresh one.
 void WriteOidHorizonTo(duckdb::WriteAheadLog& wal, uint64_t horizon);

--- a/server/connector/duckdb_transaction.cpp
+++ b/server/connector/duckdb_transaction.cpp
@@ -31,10 +31,30 @@
 #include "catalog/log/store.h"
 
 namespace sdb::connector {
+namespace {
+
+// One statement allocates a handful of ids; a block this size covers a long run
+// of them, so the horizon is written about as often as it was before and never
+// from under a catalog lock.
+constexpr uint64_t kOidHeadroom = 4096;
+
+}  // namespace
 
 SereneDBTransactionManager::SereneDBTransactionManager(
   duckdb::AttachedDatabase& db)
   : duckdb::DuckTransactionManager(db) {}
+
+// Object ids are handed out wherever a catalog entry is built, under the
+// catalog locks, and raising their durable horizon writes to the cluster log --
+// whose lock has to stay outside those. Raise it here instead, where this
+// transaction holds no catalog lock, so the allocations it goes on to make are
+// already covered.
+duckdb::Transaction& SereneDBTransactionManager::StartTransaction(
+  duckdb::ClientContext& context) {
+  const catalog::OidHorizonWaitScope may_wait;
+  duckdb::DatabaseManager::Get(db).EnsureOidHeadroom(kOidHeadroom);
+  return duckdb::DuckTransactionManager::StartTransaction(context);
+}
 
 void SereneDBTransactionManager::Checkpoint(duckdb::ClientContext& context,
                                             bool force) {

--- a/server/connector/duckdb_transaction.h
+++ b/server/connector/duckdb_transaction.h
@@ -39,6 +39,8 @@ class SereneDBTransactionManager final : public duckdb::DuckTransactionManager {
  public:
   explicit SereneDBTransactionManager(duckdb::AttachedDatabase& db);
 
+  duckdb::Transaction& StartTransaction(duckdb::ClientContext& context) final;
+
   void Checkpoint(duckdb::ClientContext& context, bool force) final;
 
   duckdb::ErrorData CommitTransaction(duckdb::ClientContext& context,

--- a/tests/scripts/catalog_commit_deadlock.sh
+++ b/tests/scripts/catalog_commit_deadlock.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Concurrent multi-entry catalog commits must not deadlock.
+#
+# The cluster catalog log is guarded by one process-wide mutex. A commit takes
+# it and holds it for the rest of the transaction, while the per-catalog and
+# per-set locks are taken and released per undo entry. Any site that takes the
+# WAL mutex while already holding a catalog lock closes a cycle, and two
+# concurrent transactions that each commit several catalog entries wedge the
+# server for good.
+#
+# The load below is deliberately plain: CREATE TABLE with a primary key and a
+# check constraint puts several entries in one commit, and every worker touches
+# the same CatalogSet. Under a ThreadSanitizer build the cycles are also
+# reported as lock-order-inversion.
+#
+# Usage:
+#   tests/scripts/catalog_commit_deadlock.sh --port 7975 [--workers 8] [--seconds 40]
+#
+# Exits non-zero if the server stops answering a trivial query while, or after,
+# the load runs.
+
+set -u
+
+PORT=""
+WORKERS=8
+SECONDS_TO_RUN=40
+HOST=127.0.0.1
+USER_NAME=postgres
+DB=postgres
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--port) PORT="$2"; shift 2 ;;
+	--workers) WORKERS="$2"; shift 2 ;;
+	--seconds) SECONDS_TO_RUN="$2"; shift 2 ;;
+	--host) HOST="$2"; shift 2 ;;
+	--user) USER_NAME="$2"; shift 2 ;;
+	--database) DB="$2"; shift 2 ;;
+	*) echo "unknown argument: $1" >&2; exit 2 ;;
+	esac
+done
+
+if [[ -z "$PORT" ]]; then
+	echo "usage: $0 --port <port> [--workers N] [--seconds N]" >&2
+	exit 2
+fi
+
+# Bounded: against a wedged server an unbounded client never returns, and the
+# run has to end with a verdict rather than hang with it.
+psql_q() { timeout 20 psql -h "$HOST" -p "$PORT" -U "$USER_NAME" -d "$DB" -tA "$@"; }
+
+# A wedged server is the failure this looks for, so every probe is bounded.
+probe() {
+	timeout 15 psql -h "$HOST" -p "$PORT" -U "$USER_NAME" -d "$DB" -tAc "SELECT 1;" >/dev/null 2>&1
+}
+
+if ! probe; then
+	echo "FAIL: server at $HOST:$PORT is not answering before the load starts" >&2
+	exit 1
+fi
+
+echo "hammering $WORKERS workers for ${SECONDS_TO_RUN}s against $HOST:$PORT"
+
+pids=()
+for w in $(seq 1 "$WORKERS"); do
+	(
+		end=$(($(date +%s) + SECONDS_TO_RUN))
+		while [[ $(date +%s) -lt $end ]]; do
+			psql_q -q -v ON_ERROR_STOP=0 <<-SQL >/dev/null 2>&1
+				BEGIN;
+				CREATE TABLE IF NOT EXISTS ccd_a_$w (id INT PRIMARY KEY, v INT CHECK (v >= 0));
+				CREATE TABLE IF NOT EXISTS ccd_b_$w (id INT PRIMARY KEY, v INT CHECK (v >= 0));
+				COMMIT;
+				BEGIN;
+				DROP TABLE IF EXISTS ccd_a_$w;
+				DROP TABLE IF EXISTS ccd_b_$w;
+				COMMIT;
+			SQL
+		done
+	) &
+	pids+=($!)
+done
+
+# Probe while the load runs: a deadlock takes the whole server down, not just
+# the workers, so a plain SELECT stops answering.
+wedged=0
+deadline=$(($(date +%s) + SECONDS_TO_RUN))
+while [[ $(date +%s) -lt $deadline ]]; do
+	if ! probe; then
+		echo "FAIL: server stopped answering while the load was running" >&2
+		wedged=1
+		break
+	fi
+	sleep 3
+done
+
+for p in "${pids[@]}"; do
+	wait "$p" 2>/dev/null
+done
+
+if [[ $wedged -eq 0 ]] && ! probe; then
+	echo "FAIL: server stopped answering after the load finished" >&2
+	wedged=1
+fi
+
+for w in $(seq 1 "$WORKERS"); do
+	timeout 15 psql_q -q -c "DROP TABLE IF EXISTS ccd_a_$w; DROP TABLE IF EXISTS ccd_b_$w;" \
+		>/dev/null 2>&1
+done
+
+if [[ $wedged -ne 0 ]]; then
+	exit 1
+fi
+
+echo "PASS: server stayed responsive"


### PR DESCRIPTION
Two concurrent transactions that each commit several catalog entries could deadlock the server for good. The process stayed alive and stopped answering any query.

## The cycle

The cluster catalog log is guarded by one process-wide mutex. It is taken on the first record a transaction writes and held until that transaction ends (`gHoldsClusterWal`, released in `EndClusterCatalogWal`). The per-catalog write lock and the per-`CatalogSet` lock, by contrast, are taken and released **once per undo entry** in `CommitState::CommitEntry`.

The log lock was reached from under those, from two different directions:

1. **Commit** — `WriteCatalogChange` runs under both entry locks and takes the log lock there. Thread A commits entry 1, takes the log lock, keeps it, releases the entry locks, then re-takes them for entry 2 while still holding it; thread B holds those entry locks and waits for the log lock.
2. **Object id allocation** — an id is handed out wherever a catalog entry is built, which is also under the catalog locks. Raising its durable horizon writes to the same log, taking the same mutex. Same inversion, reached the other way round.

## Reproducer

`tests/scripts/catalog_commit_deadlock.sh` — eight workers, each committing multi-entry DDL (`CREATE TABLE` with a primary key and a check constraint, then `DROP`) against the same `CatalogSet`, with a bounded probe throughout and after:

```
$ tests/scripts/catalog_commit_deadlock.sh --port 7978 --workers 8 --seconds 40
FAIL: server stopped answering while the load was running
```

Before this PR it wedges in about 25 seconds and stays wedged after the load stops. The load is deliberately plain DDL.

It runs in CI as `scripts/ci/steps/050-ci-in-docker-run-catalog-deadlock-test.bash`, called from `run_serened_core`. It brings up **its own serened** rather than sharing the sqllogic stack: the failure it looks for takes the whole process down, so a regression must not drag the other suites with it.

## The fix

**Commit path.** `PrepareCatalogChange` (added in serenedb/duckdb#78) is announced in `CommitState::CommitEntry` before the per-entry locks are taken, and `SereneDBCatalog` overrides it to acquire the log lock there. The log lock is now unambiguously outermost on that path.

**Object id horizon.** The horizon is raised at transaction start instead, in `SereneDBTransactionManager::StartTransaction`, where no catalog lock is held, with `kOidHeadroom = 4096` ids of headroom covering what the transaction goes on to allocate (`DatabaseManager::EnsureOidHeadroom`, also in serenedb/duckdb#78).

An allocation that still runs out *while under a catalog lock* refuses rather than waits, and reports a retryable `ERRCODE_T_R_SERIALIZATION_FAILURE`. That asymmetry is the point: the horizon has to be durable before an id is handed out, so waiting is the only alternative, and waiting under the catalog locks is exactly what deadlocks. Waiting is permitted in one place only, marked by `OidHorizonWaitScope` — the transaction-start top-up itself.

## Results

| | lock-order inversions | reproducer |
|---|---|---|
| before | 2738 | wedges in ~25s |
| commit path only | 10 | still wedges |
| both | **0** | **passes**, also at 16 workers / 60s |

No retryable conflict fired in any of those runs, so the refuse path stays theoretical in practice.

Regression run on `sdb/pg/ddl`, `sdb/pg/system` and `sdb/pg/rbac`: **102 passing, 0 failing**.

An earlier attempt regressed 22 of those with `object id horizon is busy`: the transaction-start top-up was itself taking the refuse path, in the one place where waiting is safe. That is what `OidHorizonWaitScope` exists to separate, and why the distinction is explicit rather than implied.

## Depends on

serenedb/duckdb#78 — `PrepareCatalogChange` and `EnsureOidHeadroom`. The submodule bump in this PR points at that branch.
