### PR TITLE
fix: exclude build_bench, not a repeated build_clangd, in find_unused_sources

### DIFF
--- a/scripts/find_unused_sources.py
+++ b/scripts/find_unused_sources.py
@@ -34,7 +34,7 @@ EXCLUDED_ROOTS = {
     REPO_ROOT / "build_clangd",
     REPO_ROOT / "third_party",
     REPO_ROOT / "build",
-    REPO_ROOT / "build_clangd",
+    REPO_ROOT / "build_bench",
     REPO_ROOT / "build_data",
     REPO_ROOT / ".cache",
     REPO_ROOT / ".git",


### PR DESCRIPTION
## Summary

`EXCLUDED_ROOTS` in `scripts/find_unused_sources.py` lists `build_clangd`
twice and never excludes `build_bench`, one of the four `binaryDir` values
defined in `CMakePresets.json` (`build`, `build_clangd`, `build_bench`,
`build_perf`). Any file generated under a bench build is walked as if it
were a project source.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/find_unused_sources.py').read())"`
- [x] Cross-checked the four `binaryDir` values against `CMakePresets.json`