### PR TITLE
perf: date_trunc fast paths for TIMESTAMP and TIMESTAMPTZ, ES date_histogram without per-row strftime

### DIFF
--- a/server/network/http/es/handlers.cpp
+++ b/server/network/http/es/handlers.cpp
@@ -495,11 +495,11 @@ yaclib::Task<bool> RunAggregation(RequestContext& ctx, const Aggregation& agg,
     case Aggregation::Kind::kDateHistogram:
       // agg.interval comes from the calendar_interval whitelist.
       sql = absl::StrCat(
-        "SELECT epoch_ms(date_trunc('", agg.interval, "', ", field,
-        ")) AS k, strftime(date_trunc('", agg.interval, "', ", field,
-        "), '%Y-%m-%dT%H:%M:%S.000Z') AS ks, count(*) AS c FROM ", relation,
+        "SELECT epoch_ms(b) AS k, strftime(b, '%Y-%m-%dT%H:%M:%S.000Z') AS "
+        "ks, c FROM (SELECT date_trunc('",
+        agg.interval, "', ", field, ") AS b, count(*) AS c FROM ", relation,
         " WHERE (", filter, ") AND ", field,
-        " IS NOT NULL GROUP BY 1, 2 ORDER BY 1");
+        " IS NOT NULL GROUP BY 1) ORDER BY 1");
       break;
     default: {
       std::string_view fn;

--- a/server/pg/deserialize.cpp
+++ b/server/pg/deserialize.cpp
@@ -27,6 +27,7 @@
 #include <fast_float/fast_float.h>
 
 #include <cstdint>
+#include <cstring>
 #include <duckdb/common/operator/cast_operators.hpp>
 #include <duckdb/common/operator/decimal_cast_operators.hpp>
 #include <duckdb/common/types/bit.hpp>
@@ -43,6 +44,7 @@
 #include <duckdb/function/cast/default_casts.hpp>
 #include <duckdb/inet/inet_ipaddress.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <icu-zone-lut.hpp>
 #include <limits>
 #include <string>
 #include <string_view>
@@ -621,10 +623,16 @@ void FillDeserializeContext(duckdb::ClientContext& client,
     return;
   }
   const auto tz_name = value.ToString();
+  context.session_lut.reset();
   if (IsUtcTimeZoneName(tz_name)) {
     context.session_calendar.reset();
   } else {
     context.session_calendar = MakeCalendar(tz_name);
+    if (context.session_calendar &&
+        std::strcmp(context.session_calendar->getType(), "gregorian") == 0) {
+      context.session_lut =
+        duckdb::ZoneLUT::Get(context.session_calendar->getTimeZone());
+    }
   }
 }
 
@@ -652,6 +660,11 @@ inline bool ConvertTimestampTzText(DeserializeContext& ctx,
     }
   } else {
     // No zone in the text: interpret in the session zone (null = UTC).
+    int64_t instant = 0;
+    if (ctx.session_lut && ctx.session_lut->TryResolve(result.value, instant)) {
+      result = duckdb::timestamp_t{instant};
+      return true;
+    }
     calendar = ctx.session_calendar.get();
   }
   if (calendar) {

--- a/server/pg/deserialize.h
+++ b/server/pg/deserialize.h
@@ -47,6 +47,7 @@ struct RecordDeserializers;
 struct DeserializeContext {
   std::unique_ptr<RecordDeserializers> record_cache;
   std::unique_ptr<icu::Calendar> session_calendar;
+  duckdb::shared_ptr<const duckdb::ZoneLUT> session_lut;
   containers::FlatHashMap<std::string, std::unique_ptr<icu::Calendar>>
     named_calendars;
 

--- a/server/pg/serialize.cpp
+++ b/server/pg/serialize.cpp
@@ -51,6 +51,7 @@
 #include <duckdb/common/types/uhugeint.hpp>
 #include <duckdb/common/types/uuid.hpp>
 #include <duckdb/inet/inet_ipaddress.hpp>
+#include <icu-zone-lut.hpp>
 #include <limits>
 #include <string_view>
 #include <type_traits>
@@ -937,14 +938,21 @@ int32_t SessionTzOffsetSeconds(const icu::TimeZone& tz, int64_t utc_ms) {
   return (raw_ms + dst_ms) / 1000;
 }
 
+int32_t SessionOffsetSeconds(const SerializationContext& ctx, int64_t utc_us) {
+  int64_t offset_us = 0;
+  if (ctx.zone_lut && ctx.zone_lut->TryOffset(utc_us, offset_us)) {
+    return static_cast<int32_t>(offset_us / 1'000'000);
+  }
+  return SessionTzOffsetSeconds(*ctx.time_zone, utc_us / 1000);
+}
+
 template<WrapContext InContainer>
 struct TimestampTzTextCore {
   using Value = duckdb::timestamp_tz_t;
   IRS_FORCE_INLINE static void Render(SerializationContext& ctx, Value tz) {
     const auto ts = duckdb::timestamp_t{tz};
     if (ctx.time_zone && ts.IsFinite()) {
-      const auto offset_secs =
-        SessionTzOffsetSeconds(*ctx.time_zone, ts.value / 1000);
+      const auto offset_secs = SessionOffsetSeconds(ctx, ts.value);
       int64_t local_us = 0;
       if (duckdb::TryAddOperator::Operation(
             ts.value, int64_t{offset_secs} * 1'000'000, local_us)) {
@@ -981,8 +989,7 @@ struct TimestampTzNsTextCore {
   IRS_FORCE_INLINE static void Render(SerializationContext& ctx, Value tz) {
     duckdb::StringHeap heap{duckdb::Allocator::DefaultAllocator()};
     if (ctx.time_zone && tz.IsFinite()) {
-      const auto offset_secs =
-        SessionTzOffsetSeconds(*ctx.time_zone, tz.value / 1'000'000);
+      const auto offset_secs = SessionOffsetSeconds(ctx, tz.value / 1'000);
       int64_t local_ns = 0;
       if (duckdb::TryAddOperator::Operation(
             tz.value, int64_t{offset_secs} * 1'000'000'000, local_ns)) {
@@ -2335,9 +2342,11 @@ void FillContext(const Config& config, SerializationContext& context) {
   const auto tz_name = config.GetTimeZone();
   if (IsUtcTimeZoneName(tz_name)) {
     context.time_zone.reset();
+    context.zone_lut.reset();
   } else {
     context.time_zone.reset(
       icu::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(tz_name)));
+    context.zone_lut = duckdb::ZoneLUT::Get(*context.time_zone);
   }
   context.client = &config.GetClientContext();
   // types_cache stays lazy (GetSerializersCache); record results only.

--- a/server/pg/serialize.h
+++ b/server/pg/serialize.h
@@ -23,6 +23,7 @@
 #include <absl/functional/function_ref.h>
 #include <unicode/timezone.h>
 
+#include <duckdb/common/shared_ptr.hpp>
 #include <duckdb/common/typedefs.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/vector/unified_vector_format.hpp>
@@ -31,6 +32,10 @@
 #include "basics/containers/node_hash_map.h"
 #include "basics/message_buffer.h"
 #include "query/config.h"
+
+namespace duckdb {
+class ZoneLUT;
+}
 
 namespace sdb::pg {
 
@@ -79,6 +84,7 @@ struct SerializationContext {
   std::string copy_null = "\\N";
   // Null means UTC (the default) and keeps the cheap ToString + "+00" path.
   std::unique_ptr<icu::TimeZone> time_zone;
+  duckdb::shared_ptr<const duckdb::ZoneLUT> zone_lut;
   std::unique_ptr<TypesSerializationCache> types_cache;
   std::vector<duckdb::RecursiveUnifiedVectorFormat> decoded;
 };

--- a/tests/sqllogic/sdb/pg/simple/temporal/date_part_timestamptz.test
+++ b/tests/sqllogic/sdb/pg/simple/temporal/date_part_timestamptz.test
@@ -1,0 +1,69 @@
+statement ok
+SET TimeZone = 'Europe/Berlin';
+
+query
+SELECT
+  date_part('hour', TIMESTAMPTZ '2024-10-27 00:30:00+00') AS hour_first_occurrence,
+  date_part('timezone', TIMESTAMPTZ '2024-10-27 00:30:00+00') AS offset_before_fallback,
+  date_part('timezone', TIMESTAMPTZ '2024-10-27 01:30:00+00') AS offset_after_fallback,
+  date_part('isodow', TIMESTAMPTZ '2024-10-27 00:30:00+00') AS isodow,
+  date_part('epoch', TIMESTAMPTZ '2024-10-27 00:30:00.5+00') AS epoch,
+  date_part('julian', TIMESTAMPTZ '2024-10-27 00:30:00+00') AS julian;
+----
+hour_first_occurrence	offset_before_fallback	offset_after_fallback	isodow	epoch	julian
+2	7200	3600	7	1729989000.5	2460611.1041666665
+
+query
+SELECT
+  (TIMESTAMPTZ '2024-03-31 01:30:00+00')::TIMESTAMP::VARCHAR AS to_naive_after_gap,
+  (TIMESTAMP '2024-03-31 02:30:00')::TIMESTAMPTZ::VARCHAR AS from_naive_in_gap,
+  (TIMESTAMP '2024-10-27 02:30:00')::TIMESTAMPTZ::VARCHAR AS from_naive_duplicated,
+  (TIMESTAMPTZ '2024-10-27 00:30:00+00')::TIMETZ::VARCHAR AS to_timetz,
+  timezone('America/New_York', TIMESTAMPTZ '2024-03-10 06:30:00+00')::VARCHAR AS at_time_zone_to_naive,
+  timezone('America/New_York', TIMESTAMP '2024-03-10 02:30:00')::VARCHAR AS at_time_zone_from_naive_in_gap;
+----
+to_naive_after_gap	from_naive_in_gap	from_naive_duplicated	to_timetz	at_time_zone_to_naive	at_time_zone_from_naive_in_gap
+2024-03-31 03:30:00	2024-03-31 03:30:00+02	2024-10-27 02:30:00+01	02:30:00+02	2024-03-10 01:30:00	2024-03-10 08:30:00+01
+
+query
+SELECT u, date_part(u, TIMESTAMPTZ '2024-10-27 00:30:00+00') AS part
+FROM (VALUES ('hour'), ('minute'), ('dow'), ('week'), ('timezone')) t(u) ORDER BY u;
+----
+u	part
+dow	0
+hour	2
+minute	30
+timezone	7200
+week	43
+
+
+statement ok
+SET TimeZone = 'America/Sao_Paulo';
+
+query
+SELECT
+  last_day(TIMESTAMPTZ '1965-01-15 12:00:00-03')::VARCHAR AS last_day_before_midnight_gap,
+  last_day(TIMESTAMPTZ '2024-02-10 12:00:00-03')::VARCHAR AS last_day_leap_february,
+  monthname(TIMESTAMPTZ '2024-02-29 02:59:59-03') AS monthname,
+  dayname(TIMESTAMPTZ '2024-02-29 02:59:59-03') AS dayname;
+----
+last_day_before_midnight_gap	last_day_leap_february	monthname	dayname
+1965-01-31	2024-02-29	February	Thursday
+
+
+statement ok
+SET TimeZone = 'Asia/Kolkata';
+
+query
+SELECT
+  date_part('hour', TIMESTAMPTZ '2024-03-15 14:45:00+00') AS hour,
+  date_part('minute', TIMESTAMPTZ '2024-03-15 14:45:00+00') AS minute,
+  date_part('timezone_hour', TIMESTAMPTZ '2024-03-15 14:45:00+00') AS timezone_hour,
+  date_part('timezone_minute', TIMESTAMPTZ '2024-03-15 14:45:00+00') AS timezone_minute;
+----
+hour	minute	timezone_hour	timezone_minute
+20	15	5	30
+
+
+statement ok
+RESET TimeZone;

--- a/tests/sqllogic/sdb/pg/simple/temporal/date_trunc_bucket_groups.test
+++ b/tests/sqllogic/sdb/pg/simple/temporal/date_trunc_bucket_groups.test
@@ -1,0 +1,188 @@
+statement ok
+CREATE TABLE events AS SELECT TIMESTAMP '2024-03-01 00:00:00' + INTERVAL (i * 37) MINUTE AS ts, i AS v FROM range(0, 2000) t(i);
+
+statement ok
+INSERT INTO events VALUES (NULL, -1), (NULL, -2);
+
+query
+EXPLAIN SELECT date_trunc('hour', ts) AS h, count(*) AS c FROM events GROUP BY 1;
+----
+QUERY PLAN
+╭─ PROJECTION ───────────────────────────────────────╮
+│ Projections:                                       │
+│ __internal_date_trunc_unbucket(#0, 3600000000, 0), │
+│ #1                                                 │
+│ ~1,001 rows                                        │
+╰──────────────────────────┬─────────────────────────╯
+╭─ PERFECT_HASH_GROUP_BY ──┴─────────────────────────╮
+│ Groups: #0                                         │
+│ Aggregates: count_star()                           │
+│ ~1,001 rows                                        │
+╰──────────────────────────┬─────────────────────────╯
+╭─ PROJECTION ─────────────┴─────────────────────────╮
+│ Projections:                                       │
+│ __internal_date_trunc_bucket(ts, 3600000000, 0)    │
+│ ~2,002 rows                                        │
+╰──────────────────────────┬─────────────────────────╯
+╭─ SEQ_SCAN ───────────────┴─────────────────────────╮
+│ Table: events                                      │
+│ Type: Sequential Scan                              │
+│ Projections: ts                                    │
+│ ~2,002 rows                                        │
+╰────────────────────────────────────────────────────╯
+
+query
+SELECT coalesce(date_trunc('hour', ts)::VARCHAR, 'null') AS h, count(*) AS c, sum(v) AS s FROM events GROUP BY 1 ORDER BY 1 LIMIT 5;
+----
+h	c	s
+2024-03-01 00:00:00	2	1
+2024-03-01 01:00:00	2	5
+2024-03-01 02:00:00	1	4
+2024-03-01 03:00:00	2	11
+2024-03-01 04:00:00	2	15
+
+query
+SELECT coalesce(date_trunc('week', ts)::VARCHAR, 'null') AS w, count(*) AS c, min(v) AS lo, max(v) AS hi FROM events GROUP BY 1 ORDER BY 1;
+----
+w	c	lo	hi
+2024-02-26 00:00:00	117	0	116
+2024-03-04 00:00:00	273	117	389
+2024-03-11 00:00:00	272	390	661
+2024-03-18 00:00:00	273	662	934
+2024-03-25 00:00:00	272	935	1206
+2024-04-01 00:00:00	272	1207	1478
+2024-04-08 00:00:00	273	1479	1751
+2024-04-15 00:00:00	248	1752	1999
+null	2	-2	-1
+
+query
+SELECT date_trunc('day', ts)::VARCHAR AS d, count(*) AS c FROM events GROUP BY 1 HAVING count(*) > 38 ORDER BY 1 LIMIT 3;
+----
+d	c
+2024-03-01 00:00:00	39
+2024-03-02 00:00:00	39
+2024-03-03 00:00:00	39
+
+query
+SELECT coalesce(date_trunc('hour', ts)::VARCHAR, 'null') AS h, v % 3 AS r, count(*) AS c FROM events GROUP BY 1, 2 ORDER BY 1, 2 LIMIT 4;
+----
+h	r	c
+2024-03-01 00:00:00	0	1
+2024-03-01 00:00:00	1	1
+2024-03-01 01:00:00	0	1
+2024-03-01 01:00:00	2	1
+
+query
+SELECT coalesce(d::VARCHAR, 'null') AS d, coalesce(r::VARCHAR, 'null') AS r, c
+FROM (SELECT date_trunc('day', ts) AS d, v % 2 AS r, count(*) AS c FROM events WHERE v < 80 GROUP BY ROLLUP (1, 2))
+ORDER BY 1, 2, 3;
+----
+d	r	c
+2024-03-01 00:00:00	0	20
+2024-03-01 00:00:00	1	19
+2024-03-01 00:00:00	null	39
+2024-03-02 00:00:00	0	19
+2024-03-02 00:00:00	1	20
+2024-03-02 00:00:00	null	39
+2024-03-03 00:00:00	0	1
+2024-03-03 00:00:00	1	1
+2024-03-03 00:00:00	null	2
+null	-1	1
+null	0	1
+null	null	2
+null	null	82
+
+statement ok
+CREATE TABLE inf_events AS SELECT * FROM events UNION ALL SELECT TIMESTAMP 'infinity', 9999 UNION ALL SELECT TIMESTAMP '-infinity', -9999;
+
+query
+EXPLAIN SELECT date_trunc('hour', ts) AS h, count(*) AS c FROM inf_events GROUP BY 1;
+----
+QUERY PLAN
+╭─ HASH_GROUP_BY ──────────╮
+│ Groups: #0               │
+│ Aggregates: count_star() │
+│ ~1,002 rows              │
+╰─────────────┬────────────╯
+╭─ PROJECTION ┴────────────╮
+│ Projections: h           │
+│ ~2,004 rows              │
+╰─────────────┬────────────╯
+╭─ SEQ_SCAN ──┴────────────╮
+│ Table: inf_events        │
+│ Type: Sequential Scan    │
+│ Projections: ts          │
+│ ~2,004 rows              │
+╰──────────────────────────╯
+
+query
+SELECT coalesce(date_trunc('hour', ts)::VARCHAR, 'null') AS h, count(*) AS c FROM inf_events GROUP BY 1 ORDER BY 1 LIMIT 3;
+----
+h	c
+-infinity	1
+2024-03-01 00:00:00	2
+2024-03-01 01:00:00	2
+
+query
+SELECT coalesce(date_trunc('month', ts)::VARCHAR, 'null') AS m, count(*) AS c FROM events GROUP BY 1 ORDER BY 1;
+----
+m	c
+2024-03-01 00:00:00	1207
+2024-04-01 00:00:00	793
+null	2
+
+query
+SELECT coalesce(date_trunc(u, ts)::VARCHAR, 'null') AS h, count(*) AS c FROM events, (VALUES ('hour')) t(u) WHERE v < 3 GROUP BY 1 ORDER BY 1;
+----
+h	c
+2024-03-01 00:00:00	2
+2024-03-01 01:00:00	1
+null	2
+
+query
+SELECT coalesce(date_trunc('day', ts::DATE)::VARCHAR, 'null') AS d, count(*) AS c FROM events WHERE v < 80 GROUP BY 1 ORDER BY 1;
+----
+d	c
+2024-03-01 00:00:00	39
+2024-03-02 00:00:00	39
+2024-03-03 00:00:00	2
+null	2
+
+query
+SELECT coalesce(date_trunc('minute', ts)::VARCHAR, 'null') AS m, count(*) AS c FROM events WHERE v < 3 GROUP BY 1 ORDER BY 1;
+----
+m	c
+2024-03-01 00:00:00	1
+2024-03-01 00:37:00	1
+2024-03-01 01:14:00	1
+null	2
+
+statement ok
+SET disabled_optimizers = 'compressed_materialization';
+
+query
+SELECT coalesce(date_trunc('hour', ts)::VARCHAR, 'null') AS h, count(*) AS c, sum(v) AS s FROM events GROUP BY 1 ORDER BY 1 LIMIT 5;
+----
+h	c	s
+2024-03-01 00:00:00	2	1
+2024-03-01 01:00:00	2	5
+2024-03-01 02:00:00	1	4
+2024-03-01 03:00:00	2	11
+2024-03-01 04:00:00	2	15
+
+query
+SELECT coalesce(date_trunc('week', ts)::VARCHAR, 'null') AS w, count(*) AS c, min(v) AS lo, max(v) AS hi FROM events GROUP BY 1 ORDER BY 1;
+----
+w	c	lo	hi
+2024-02-26 00:00:00	117	0	116
+2024-03-04 00:00:00	273	117	389
+2024-03-11 00:00:00	272	390	661
+2024-03-18 00:00:00	273	662	934
+2024-03-25 00:00:00	272	935	1206
+2024-04-01 00:00:00	272	1207	1478
+2024-04-08 00:00:00	273	1479	1751
+2024-04-15 00:00:00	248	1752	1999
+null	2	-2	-1
+
+statement ok
+RESET disabled_optimizers;

--- a/tests/sqllogic/sdb/pg/simple/temporal/date_trunc_bucket_groups.test
+++ b/tests/sqllogic/sdb/pg/simple/temporal/date_trunc_bucket_groups.test
@@ -186,3 +186,47 @@ null	2	-2	-1
 
 statement ok
 RESET disabled_optimizers;
+
+query
+SELECT coalesce(m::VARCHAR, 'null') AS m, c FROM (SELECT date_trunc('month', ts) AS m, count(*) AS c FROM events GROUP BY 1) ORDER BY 1;
+----
+m	c
+2024-03-01 00:00:00	1207
+2024-04-01 00:00:00	793
+null	2
+
+query
+SELECT count(*) AS groups, sum(c) AS rows_total FROM (SELECT ts, count(*) AS c FROM events GROUP BY 1);
+----
+groups	rows_total
+2001	2002
+
+query
+SELECT coalesce(d::VARCHAR, 'null') AS d, c FROM (SELECT ts::DATE AS d, count(*) AS c FROM events WHERE v < 80 GROUP BY 1) ORDER BY 1;
+----
+d	c
+2024-03-01	39
+2024-03-02	39
+2024-03-03	2
+null	2
+
+query
+SELECT coalesce(d::VARCHAR, 'null') AS d, r, c FROM (SELECT date_trunc('day', ts) AS d, v % 2 AS r, count(*) AS c FROM events WHERE v < 80 GROUP BY 1, 2) ORDER BY 1, 2;
+----
+d	r	c
+2024-03-01 00:00:00	0	20
+2024-03-01 00:00:00	1	19
+2024-03-02 00:00:00	0	19
+2024-03-02 00:00:00	1	20
+2024-03-03 00:00:00	0	1
+2024-03-03 00:00:00	1	1
+null	-1	1
+null	0	1
+
+query
+SELECT date_trunc('day', ts)::VARCHAR AS d, v, count(*) AS c FROM events WHERE v < 80 GROUP BY 1, 2 ORDER BY 1, 2 LIMIT 3;
+----
+d	v	c
+2024-03-01 00:00:00	0	1
+2024-03-01 00:00:00	1	1
+2024-03-01 00:00:00	2	1

--- a/tests/sqllogic/sdb/pg/simple/temporal/date_trunc_timestamptz.test
+++ b/tests/sqllogic/sdb/pg/simple/temporal/date_trunc_timestamptz.test
@@ -1,0 +1,274 @@
+statement ok
+SET TimeZone = 'Etc/UTC';
+
+query
+SELECT
+  date_trunc('hour', TIMESTAMPTZ '2024-03-15 14:30:45.123456+00')::VARCHAR AS hour,
+  date_trunc('day', TIMESTAMPTZ '2024-03-15 14:30:45.123456+00')::VARCHAR AS day,
+  date_trunc('week', TIMESTAMPTZ '2024-03-15 14:30:45.123456+00')::VARCHAR AS week,
+  date_trunc('month', TIMESTAMPTZ '2024-03-15 14:30:45.123456+00')::VARCHAR AS month,
+  date_trunc('quarter', TIMESTAMPTZ '2024-05-15 14:30:45.123456+00')::VARCHAR AS quarter,
+  date_trunc('year', TIMESTAMPTZ '2024-03-15 14:30:45.123456+00')::VARCHAR AS year,
+  date_trunc('isoyear', TIMESTAMPTZ '2021-01-03 12:00:00+00')::VARCHAR AS isoyear,
+  date_trunc('decade', TIMESTAMPTZ '2024-03-15 14:30:45.123456+00')::VARCHAR AS decade;
+----
+hour	day	week	month	quarter	year	isoyear	decade
+2024-03-15 14:00:00+00	2024-03-15 00:00:00+00	2024-03-11 00:00:00+00	2024-03-01 00:00:00+00	2024-04-01 00:00:00+00	2024-01-01 00:00:00+00	2019-12-30 00:00:00+00	2020-01-01 00:00:00+00
+
+query
+SELECT
+  date_trunc('decade', TIMESTAMPTZ '0015-06-15 (BC) 12:00:00+00')::VARCHAR AS decade_bc,
+  date_trunc('year', TIMESTAMPTZ '0015-06-15 (BC) 12:00:00+00')::VARCHAR AS year_bc,
+  date_trunc('hour', TIMESTAMPTZ 'infinity')::VARCHAR AS pinf,
+  date_trunc('day', TIMESTAMPTZ '-infinity')::VARCHAR AS ninf,
+  date_trunc('month', NULL::TIMESTAMPTZ) IS NULL AS null_in;
+----
+decade_bc	year_bc	pinf	ninf	null_in
+0010-01-01 (BC) 00:00:00+00	0015-01-01 (BC) 00:00:00+00	infinity	-infinity	t
+
+
+statement ok
+SET TimeZone = 'Etc/GMT-5';
+
+query
+SELECT
+  date_trunc('hour', TIMESTAMPTZ '2024-03-15 22:30:00+00')::VARCHAR AS hour,
+  date_trunc('day', TIMESTAMPTZ '2024-03-15 22:30:00+00')::VARCHAR AS day,
+  date_trunc('month', TIMESTAMPTZ '2024-03-31 22:30:00+00')::VARCHAR AS month;
+----
+hour	day	month
+2024-03-16 03:00:00+05	2024-03-16 00:00:00+05	2024-04-01 00:00:00+05
+
+
+statement ok
+SET TimeZone = 'Europe/Berlin';
+
+query
+SELECT
+  date_trunc('hour', TIMESTAMPTZ '2024-03-31 01:30:00+00')::VARCHAR AS hour,
+  date_trunc('day', TIMESTAMPTZ '2024-03-31 01:30:00+00')::VARCHAR AS day,
+  date_trunc('week', TIMESTAMPTZ '2024-03-31 01:30:00+00')::VARCHAR AS week,
+  date_trunc('month', TIMESTAMPTZ '2024-03-31 01:30:00+00')::VARCHAR AS month;
+----
+hour	day	week	month
+2024-03-31 03:00:00+02	2024-03-31 00:00:00+01	2024-03-25 00:00:00+01	2024-03-01 00:00:00+01
+
+query
+SELECT
+  date_trunc('hour', TIMESTAMPTZ '2024-10-27 00:30:00+00')::VARCHAR AS hour_first_occurrence,
+  date_trunc('hour', TIMESTAMPTZ '2024-10-27 01:30:00+00')::VARCHAR AS hour_second_occurrence,
+  date_trunc('minute', TIMESTAMPTZ '2024-10-27 00:30:30+00')::VARCHAR AS minute_keeps_offset,
+  date_trunc('day', TIMESTAMPTZ '2024-10-27 00:30:00+00')::VARCHAR AS day_before_transition,
+  date_trunc('day', TIMESTAMPTZ '2024-10-27 12:00:00+00')::VARCHAR AS day_after_transition;
+----
+hour_first_occurrence	hour_second_occurrence	minute_keeps_offset	day_before_transition	day_after_transition
+2024-10-27 02:00:00+01	2024-10-27 02:00:00+01	2024-10-27 02:30:00+02	2024-10-27 00:00:00+02	2024-10-27 00:00:00+02
+
+query
+SELECT
+  date_trunc('day', TIMESTAMPTZ '1850-06-15 12:34:56+00')::VARCHAR AS before_1900,
+  date_trunc('hour', TIMESTAMPTZ '2350-07-04 12:34:56+00')::VARCHAR AS after_2300,
+  date_trunc('hour', TIMESTAMPTZ '1899-12-31 23:30:00+00')::VARCHAR AS at_lower_bound,
+  date_trunc('day', TIMESTAMPTZ '2299-12-31 23:30:00+00')::VARCHAR AS at_upper_bound;
+----
+before_1900	after_2300	at_lower_bound	at_upper_bound
+1850-06-15 00:00:00+00:53	2350-07-04 14:00:00+02	1900-01-01 00:00:00+01	2300-01-01 00:00:00+01
+
+query
+SELECT u, date_trunc(u, TIMESTAMPTZ '2024-10-27 00:30:00+00')::VARCHAR AS truncated
+FROM (VALUES ('day'), ('hour'), ('week')) t(u) ORDER BY u;
+----
+u	truncated
+day	2024-10-27 00:00:00+02
+hour	2024-10-27 02:00:00+01
+week	2024-10-21 00:00:00+02
+
+
+statement ok
+SET TimeZone = 'America/Sao_Paulo';
+
+query
+SELECT
+  date_trunc('year', TIMESTAMPTZ '1914-05-01 12:00:00-03')::VARCHAR AS year_start_in_gap,
+  date_trunc('decade', TIMESTAMPTZ '1914-05-01 12:00:00-03')::VARCHAR AS decade_start_in_gap,
+  date_trunc('quarter', TIMESTAMPTZ '1914-02-15 12:00:00-03')::VARCHAR AS quarter_start_in_gap,
+  date_trunc('month', TIMESTAMPTZ '1914-01-15 12:00:00-03')::VARCHAR AS month_start_in_gap;
+----
+year_start_in_gap	decade_start_in_gap	quarter_start_in_gap	month_start_in_gap
+1914-01-01 00:06:28-03	1910-01-01 00:06:28-03:06	1914-01-01 00:06:28-03	1914-01-01 00:06:28-03
+
+
+statement ok
+SET TimeZone = 'America/Havana';
+
+query
+SELECT
+  date_trunc('quarter', TIMESTAMPTZ '2024-05-15 12:00:00+00')::VARCHAR AS quarter,
+  date_trunc('day', TIMESTAMPTZ '2024-03-10 05:30:00+00')::VARCHAR AS day_starting_in_gap;
+----
+quarter	day_starting_in_gap
+2024-04-01 00:00:00-04	2024-03-10 01:00:00-04
+
+
+statement ok
+SET TimeZone = 'Asia/Kolkata';
+
+query
+SELECT
+  date_trunc('hour', TIMESTAMPTZ '2024-03-15 14:45:00+00')::VARCHAR AS hour,
+  date_trunc('day', TIMESTAMPTZ '2024-03-15 14:45:00+00')::VARCHAR AS day,
+  make_timestamptz(10000000000)::VARCHAR AS near_epoch,
+  date_trunc('hour', make_timestamptz(10000000000))::VARCHAR AS near_epoch_hour,
+  date_trunc('minute', make_timestamptz(10000000000))::VARCHAR AS near_epoch_minute;
+----
+hour	day	near_epoch	near_epoch_hour	near_epoch_minute
+2024-03-15 20:00:00+05:30	2024-03-15 00:00:00+05:30	1970-01-01 08:16:40+05:30	1970-01-01 08:00:00+05:30	1970-01-01 08:16:00+05:30
+
+
+statement ok
+SET TimeZone = 'Africa/Monrovia';
+
+query
+SELECT
+  date_trunc('minute', TIMESTAMPTZ '1970-06-15 12:00:45+00')::VARCHAR AS minute_with_second_offset,
+  date_trunc('hour', TIMESTAMPTZ '1970-06-15 12:00:45+00')::VARCHAR AS hour_with_second_offset,
+  date_trunc('minute', TIMESTAMPTZ '1980-06-15 12:00:45+00')::VARCHAR AS minute_after_1972;
+----
+minute_with_second_offset	hour_with_second_offset	minute_after_1972
+1970-06-15 11:16:00-00:44	1970-06-15 11:00:00-00:44	1980-06-15 12:00:00+00
+
+
+statement ok
+SET TimeZone = 'Pacific/Apia';
+
+query
+SELECT
+  date_trunc('day', TIMESTAMPTZ '2020-01-02 03:04:05')::VARCHAR AS day,
+  date_trunc('day', TIMESTAMPTZ '2011-12-30 09:59:59+00')::VARCHAR AS day_before_skipped_day,
+  date_trunc('day', TIMESTAMPTZ '2011-12-30 10:00:00+00')::VARCHAR AS day_after_skipped_day,
+  date_trunc('week', TIMESTAMPTZ '2011-12-30 10:00:00+00')::VARCHAR AS week_across_skipped_day,
+  date_trunc('month', TIMESTAMPTZ '2011-12-30 10:00:00+00')::VARCHAR AS month_across_skipped_day;
+----
+day	day_before_skipped_day	day_after_skipped_day	week_across_skipped_day	month_across_skipped_day
+2020-01-02 00:00:00+14	2011-12-29 00:00:00-10	2011-12-31 00:00:00+14	2011-12-26 00:00:00-10	2011-12-01 00:00:00-10
+
+
+statement ok
+SET TimeZone = 'Pacific/Kiritimati';
+
+query
+SELECT
+  date_trunc('day', TIMESTAMPTZ '2020-01-02 03:04:05')::VARCHAR AS day,
+  date_trunc('hour', TIMESTAMPTZ '2020-01-02 03:04:05')::VARCHAR AS hour,
+  date_trunc('day', TIMESTAMPTZ '1995-01-01 09:59:59+00')::VARCHAR AS day_before_skipped_day,
+  date_trunc('day', TIMESTAMPTZ '1995-01-01 10:00:00+00')::VARCHAR AS day_after_skipped_day;
+----
+day	hour	day_before_skipped_day	day_after_skipped_day
+2020-01-02 00:00:00+14	2020-01-02 03:00:00+14	1995-01-01 00:00:00+14	1995-01-02 00:00:00+14
+
+
+statement ok
+SET TimeZone = 'Pacific/Kwajalein';
+
+query
+SELECT
+  date_trunc('day', TIMESTAMPTZ '2020-01-02 03:04:05')::VARCHAR AS day,
+  date_trunc('day', TIMESTAMPTZ '1993-08-20 23:00:00+00')::VARCHAR AS day_before_date_line_move,
+  date_trunc('day', TIMESTAMPTZ '1993-08-21 00:00:00+00')::VARCHAR AS day_after_date_line_move;
+----
+day	day_before_date_line_move	day_after_date_line_move
+2020-01-02 00:00:00+12	1993-08-20 00:00:00-12	1993-08-20 00:00:00-12
+
+
+statement ok
+SET TimeZone = 'Asia/Pyongyang';
+
+query
+SELECT
+  date_trunc('day', TIMESTAMPTZ '2020-01-02 03:04:05')::VARCHAR AS day,
+  date_trunc('hour', TIMESTAMPTZ '2016-06-01 03:04:05')::VARCHAR AS hour_half_hour_era;
+----
+day	hour_half_hour_era
+2020-01-02 00:00:00+09	2016-06-01 03:00:00+08:30
+
+
+statement ok
+SET TimeZone = 'Europe/Moscow';
+
+query
+SELECT i, src::VARCHAR AS src, date_trunc('hour', src)::VARCHAR AS hour
+FROM (SELECT i, TIMESTAMPTZ '2010-03-27 22:00:00+00' + INTERVAL (15 * i) MINUTE AS src FROM range(3, 10) t(i))
+ORDER BY i;
+----
+i	src	hour
+3	2010-03-28 01:45:00+03	2010-03-28 01:00:00+03
+4	2010-03-28 03:00:00+04	2010-03-28 03:00:00+04
+5	2010-03-28 03:15:00+04	2010-03-28 03:00:00+04
+6	2010-03-28 03:30:00+04	2010-03-28 03:00:00+04
+7	2010-03-28 03:45:00+04	2010-03-28 03:00:00+04
+8	2010-03-28 04:00:00+04	2010-03-28 04:00:00+04
+9	2010-03-28 04:15:00+04	2010-03-28 04:00:00+04
+
+query
+SELECT i, src::VARCHAR AS src, date_trunc('hour', src)::VARCHAR AS hour, date_trunc('day', src)::VARCHAR AS day
+FROM (SELECT i, TIMESTAMPTZ '2010-10-30 20:00:00+00' + INTERVAL (15 * i) MINUTE AS src FROM range(6, 17) t(i))
+ORDER BY i;
+----
+i	src	hour	day
+6	2010-10-31 01:30:00+04	2010-10-31 01:00:00+04	2010-10-31 00:00:00+04
+7	2010-10-31 01:45:00+04	2010-10-31 01:00:00+04	2010-10-31 00:00:00+04
+8	2010-10-31 02:00:00+04	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+9	2010-10-31 02:15:00+04	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+10	2010-10-31 02:30:00+04	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+11	2010-10-31 02:45:00+04	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+12	2010-10-31 02:00:00+03	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+13	2010-10-31 02:15:00+03	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+14	2010-10-31 02:30:00+03	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+15	2010-10-31 02:45:00+03	2010-10-31 02:00:00+03	2010-10-31 00:00:00+04
+16	2010-10-31 03:00:00+03	2010-10-31 03:00:00+03	2010-10-31 00:00:00+04
+
+
+statement ok
+SET TimeZone = 'Australia/Lord_Howe';
+
+query
+SELECT i, src::VARCHAR AS src, date_trunc('hour', src)::VARCHAR AS hour, date_trunc('minute', src)::VARCHAR AS minute
+FROM (SELECT i, TIMESTAMPTZ '2020-04-04 13:00:00+00' + INTERVAL (15 * i) MINUTE AS src FROM range(6, 12) t(i))
+ORDER BY i;
+----
+i	src	hour	minute
+6	2020-04-05 01:30:00+11	2020-04-05 01:00:00+11	2020-04-05 01:30:00+11
+7	2020-04-05 01:45:00+11	2020-04-05 01:00:00+11	2020-04-05 01:45:00+11
+8	2020-04-05 01:30:00+10:30	2020-04-05 01:00:00+11	2020-04-05 01:30:00+10:30
+9	2020-04-05 01:45:00+10:30	2020-04-05 01:00:00+11	2020-04-05 01:45:00+10:30
+10	2020-04-05 02:00:00+10:30	2020-04-05 02:00:00+10:30	2020-04-05 02:00:00+10:30
+11	2020-04-05 02:15:00+10:30	2020-04-05 02:00:00+10:30	2020-04-05 02:15:00+10:30
+
+query
+SELECT i, src::VARCHAR AS src, date_trunc('hour', src)::VARCHAR AS hour
+FROM (SELECT i, TIMESTAMPTZ '2020-10-03 13:00:00+00' + INTERVAL (15 * i) MINUTE AS src FROM range(8, 13) t(i))
+ORDER BY i;
+----
+i	src	hour
+8	2020-10-04 01:30:00+10:30	2020-10-04 01:00:00+10:30
+9	2020-10-04 01:45:00+10:30	2020-10-04 01:00:00+10:30
+10	2020-10-04 02:30:00+11	2020-10-04 02:30:00+11
+11	2020-10-04 02:45:00+11	2020-10-04 02:30:00+11
+12	2020-10-04 03:00:00+11	2020-10-04 03:00:00+11
+
+
+statement ok
+RESET TimeZone;
+
+query
+SELECT
+  date_trunc('isoyear', TIMESTAMP '2021-01-03 12:00:00')::VARCHAR AS isoyear,
+  date_trunc('week', TIMESTAMP '1969-12-28 12:00:00')::VARCHAR AS week,
+  date_trunc('hour', TIMESTAMP '1969-12-31 23:59:59.999999')::VARCHAR AS hour,
+  date_trunc('month', TIMESTAMP '2000-02-29 23:59:59')::VARCHAR AS month,
+  date_trunc('quarter', DATE '1999-12-31')::VARCHAR AS quarter,
+  date_trunc('year', TIMESTAMP '0001-06-15 (BC) 12:00:00')::VARCHAR AS year_bc,
+  date_trunc('decade', TIMESTAMP '0015-06-15 (BC) 12:00:00')::VARCHAR AS decade_bc;
+----
+isoyear	week	hour	month	quarter	year_bc	decade_bc
+2019-12-30 00:00:00	1969-12-22 00:00:00	1969-12-31 23:00:00	2000-02-01 00:00:00	1999-10-01 00:00:00	0001-01-01 (BC) 00:00:00	0011-01-01 (BC) 00:00:00


### PR DESCRIPTION
First part of the `date_trunc`/GROUP BY work. Continued in serenedb/serenedb#1075, whose description explains the whole picture (scalar fast paths, the zone table, the GROUP BY bucket rewrite and the results).

Speeds up `date_trunc` on TIMESTAMP, DATE and TIMESTAMPTZ and fixes the SQL shape the ES `date_histogram` handler emits.

**duckdb submodule** -> serenedb/duckdb PR https://github.com/serenedb/duckdb/pull/83 (branch `gnusi/date-trunc-lut` on top of `v2026.08.25`; the pointer here is that branch head and has to be moved to the merged commit once the fork PR lands, so the submodule-pointer check fails until then):
- TIMESTAMP/DATE: the truncation arithmetic is shared via `duckdb/common/operator/date_trunc_operators.hpp`, runs as an inlined functor (the function-pointer executor never inlined, even under LTO), fixed units are one floor division, calendar units use DuckDB's cumulative tables inlined with a fast path inside the 1970-2369 cycle.
- TIMESTAMPTZ: a per-zone lookup table (one 16-byte entry per day for 1900-2299, built from ICU's transition list, cached by zone id) replaces per-row `icu::Calendar` work. Wall-clock results resolve back to instants with ICU's rules (later offset for duplicated wall times, earlier for skipped ones). Rows outside the window, on days with several transitions, non-Gregorian calendars, `era`, BC decades and the quarter/decade gap quirk fall back to ICU, so results are identical.

**ES `date_histogram`** (`server/network/http/es/handlers.cpp`): aggregate on the truncated timestamp and format `key_as_string` in an outer projection instead of running `strftime` on every row and grouping on a VARCHAR key.

**Test**: `tests/sqllogic/sdb/pg/simple/temporal/date_trunc_timestamptz.test` pins fixed-offset zones, DST transitions (Europe/Berlin, Europe/Moscow, Australia/Lord_Howe), date-line jumps (Pacific/Apia, Pacific/Kiritimati, Pacific/Kwajalein), the São Paulo/Havana gap quirks, Africa/Monrovia's seconds offset, out-of-window fallback, BC `decade` semantics and the TIMESTAMP path. Several cases come from ClickHouse's and DuckDB's own test suites.

Numbers (100M rows, 32 threads):

| query | before | after |
|---|---|---|
| TIMESTAMP `hour` | 34 ms | 22 ms |
| TIMESTAMP `month` | 82 ms | 35 ms |
| TIMESTAMPTZ Etc/UTC `hour` | ~1000 ms | 37 ms |
| TIMESTAMPTZ Europe/Berlin `hour` / `day` | ~1000 ms | 74 / 62 ms |
| ES date_histogram SQL shape | 300 ms | 29 ms |

Verified against the previous binary: every representable day for all calendar units (TIMESTAMP and DATE), and for TIMESTAMPTZ a 15-minute grid over 1899-2300 with ±1 µs neighbours plus 10M random instants in 16 DST/odd-offset zones and 4 fixed-offset zones, all units, constant and non-constant specifier: identical checksums. The ES SQL shapes are set-equal.

### Second commit

- duckdb pointer -> `4a5882a0dda`: `date_part`/`extract` (all parts and forms), `last_day`, `monthname`, `dayname`, the `TIMESTAMP <-> TIMESTAMPTZ` / `-> TIMETZ` casts and `timezone()` with a constant zone go through the same per-zone table; identical to ICU on the same 19-zone grid, except `last_day` no longer returns the first day of the next month for São Paulo January 1965 (an ICU-path bug: truncating division of a negative epoch after a midnight gap).
- `server/pg/serialize.cpp`: the TIMESTAMPTZ / TIMESTAMPTZ_NS text renderers take the session offset from the table instead of `icu::TimeZone::getOffset` per value.
- `server/pg/deserialize.cpp`: zone-less TIMESTAMPTZ text input resolves through the table (same duplicated/skipped wall-time rules as the casts), falling back to ICU outside the table.
- `tests/sqllogic/sdb/pg/simple/temporal/date_part_timestamptz.test`: parts across the Berlin fall-back, both cast directions through a gap and a duplicated hour, `TIMETZ`, `timezone()`, the 1965 `last_day`, Kolkata half-hour offsets.

100M rows, 32 threads, Europe/Berlin: `date_part('hour')` 409 -> 55 ms, `TIMESTAMPTZ -> TIMESTAMP` 532 -> 50 ms, `TIMESTAMP -> TIMESTAMPTZ` 52 ms, `last_day` 71 ms.

### Third and fourth commits

- duckdb pointer -> the fewer-divisions table path (Europe/Berlin `hour` 74 -> 55 ms, `day` 62 -> 50) and the dense-bucket `GROUP BY` rewrite: `GROUP BY date_trunc(<second|minute|hour|day|week>, ts)` with a finite range that fits the perfect-hash threshold becomes a bucket-index key with the timestamp restored above the aggregate, so the plan uses `PERFECT_HASH_GROUP_BY` (100M rows: 720 hourly groups 29 -> 21 ms, 30 daily groups 27 -> 20 ms). Larger ranges, non-integral co-groups, grouping sets, distinct aggregates and columns with infinities are left alone.
- `tests/sqllogic/sdb/pg/simple/temporal/date_trunc_bucket_groups.test`: pins the rewritten plan and the untouched plans (infinity, minute range too wide), results for hour/week/day/minute/month buckets, HAVING, two groups, ROLLUP, NULL timestamps, DATE and non-constant units, and the same results with `compressed_materialization` disabled.

