### PR TITLE
chore: remove minizip-ng dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,10 +42,6 @@
 	path = third_party/liburing
 	url = https://github.com/serenedb/liburing.git
 	shallow = true
-[submodule "third_party/minizip-ng"]
-	path = third_party/minizip-ng
-	url = https://github.com/serenedb/minizip-ng.git
-	shallow = true
 [submodule "third_party/lz4"]
 	path = third_party/lz4
 	url = https://github.com/serenedb/lz4.git

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -149,32 +149,9 @@ set(WITH_SANITIZER "OFF" CACHE STRING "" FORCE)
 sdb_update_module(${GIT_EXECUTABLE} "zlib-ng" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
 add_subdirectory(zlib-ng)
 
-# Create ZLIB::ZLIB alias for velox compatibility
+# For compatibility
 add_library(ZLIB::ZLIB ALIAS zlib-ng)
-
-################################################################################
-## MINIZIP-NG
-################################################################################
-
-set(MZ_COMPAT ON CACHE BOOL "" FORCE)
-set(MZ_ZLIB ON CACHE BOOL "" FORCE)
 set(ZLIB_FOUND ON CACHE BOOL "" FORCE)
-set(MZ_BZIP2 OFF CACHE BOOL "" FORCE)
-set(MZ_LZMA OFF CACHE BOOL "" FORCE)
-set(MZ_ZSTD OFF CACHE BOOL "" FORCE)
-set(MZ_LIBCOMP OFF CACHE BOOL "" FORCE)
-set(MZ_FETCH_LIBS OFF CACHE BOOL "" FORCE)
-set(MZ_PKCRYPT OFF CACHE BOOL "" FORCE)
-set(MZ_WZAES OFF CACHE BOOL "" FORCE)
-set(MZ_OPENSSL OFF CACHE BOOL "" FORCE)
-set(MZ_LIBBSD OFF CACHE BOOL "" FORCE)
-set(MZ_ICONV OFF CACHE BOOL "" FORCE)
-set(MZ_SANITIZER "OFF" CACHE STRING "" FORCE)
-
-sdb_update_module(${GIT_EXECUTABLE} "minizip-ng" ${CMAKE_CURRENT_SOURCE_DIR} "README.md")
-add_subdirectory(minizip-ng)
-
-target_link_libraries(minizip PUBLIC zlib-ng)
 
 ################################################################################
 ## BOOST

--- a/third_party/LICENSES.md
+++ b/third_party/LICENSES.md
@@ -90,7 +90,6 @@
       of the GNU General Public License, version 3 ("GPLv3").
 
 * [zlib-ng](https://github.com/zlib-ng/zlib-ng/blob/develop/LICENSE.md)
-* [minizip-ng](https://github.com/zlib-ng/minizip-ng/blob/develop/LICENSE)
 * [PostgreSQL](https://github.com/postgres/postgres), [PostgreSQL License](https://www.postgresql.org/about/licence/) (libpq, statically linked by the postgres_scanner extension)
 * [wyhash](https://github.com/wangyi-fudan/wyhash), Unlicense (vendored in `libs/basics/wyhash.h`)
 


### PR DESCRIPTION
As a result, we get rid of the strange `FetchContent`, which causes CI to crash.