### PR TITLE
fix: search table expression indexes bind their columns by the wrong ordinal

### DIFF
--- a/server/connector/duckdb_physical_create_index.cpp
+++ b/server/connector/duckdb_physical_create_index.cpp
@@ -367,11 +367,8 @@ SereneDBPhysicalCreateIndex::GetGlobalSinkState(
            std::ranges::to<std::vector<catalog::ColumnId>>();
   };
 
-  const auto col_index_to_id =
-    IsDuckDBTable()
-      ? make_column_ids(
-          BuildCreateIndexProjection(_pk_positions, _info->column_ids))
-      : make_column_ids(std::views::iota(size_t{0}, columns.size()));
+  const auto col_index_to_id = make_column_ids(
+    BuildCreateIndexProjection(_pk_positions, _info->column_ids));
   const auto relation_id = catalog::IdOf(_relation);
 
   // Normalize + serialize a bound expression (index key or partial-index

--- a/tests/sqllogic/sdb/pg/index/search_table_expression_index.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_expression_index.test
@@ -1,0 +1,72 @@
+statement ok
+CREATE TEXT SEARCH DICTIONARY sx_en (
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true, norm = true
+);
+
+statement ok
+CREATE TABLE sx_src AS SELECT (TIMESTAMP '2025-09-23' + INTERVAL (i) SECOND)::TIMESTAMPTZ_NS AS ts,
+	'svc' || (i % 3) AS svc, (i % 5)::SMALLINT AS sev,
+	CASE WHEN i % 2 = 0 THEN 'error in module ' || i ELSE 'all good in module ' || i END AS body
+FROM range(20) t(i);
+
+statement ok
+CREATE TABLE sx_last WITH (storage = 'search', compaction_interval = 0) AS SELECT ts, svc, sev, body FROM sx_src WHERE false;
+
+statement ok
+CREATE INDEX sx_last_idx ON sx_last USING inverted ((ts_split_by_non_alpha(body, true)) sx_en);
+
+statement ok
+INSERT INTO sx_last SELECT ts, svc, sev, body FROM sx_src;
+
+statement ok
+VACUUM (REFRESH_TABLE) sx_last;
+
+statement ok
+CREATE TABLE sx_second WITH (storage = 'search', compaction_interval = 0) AS SELECT svc, body, ts, sev FROM sx_src WHERE false;
+
+statement ok
+CREATE INDEX sx_second_idx ON sx_second USING inverted ((ts_split_by_non_alpha(body, true)) sx_en);
+
+statement ok
+INSERT INTO sx_second SELECT svc, body, ts, sev FROM sx_src;
+
+statement ok
+VACUUM (REFRESH_TABLE) sx_second;
+
+statement ok
+CREATE TABLE sx_first WITH (storage = 'search', compaction_interval = 0) AS SELECT body, ts, svc, sev FROM sx_src WHERE false;
+
+statement ok
+CREATE INDEX sx_first_idx ON sx_first USING inverted ((ts_split_by_non_alpha(body, true)) sx_en);
+
+statement ok
+INSERT INTO sx_first SELECT body, ts, svc, sev FROM sx_src;
+
+statement ok
+VACUUM (REFRESH_TABLE) sx_first;
+
+statement ok
+CREATE TABLE sx_txn AS SELECT ts, svc, sev, body FROM sx_src;
+
+statement ok
+CREATE INDEX sx_txn_idx ON sx_txn USING inverted ((ts_split_by_non_alpha(body, true)) sx_en);
+
+query
+SELECT 'body last' AS layout, count(*) AS errors FROM sx_last_idx WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error')
+UNION ALL SELECT 'body second', count(*) FROM sx_second_idx WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error')
+UNION ALL SELECT 'body first', count(*) FROM sx_first_idx WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error')
+UNION ALL SELECT 'transactional', count(*) FROM sx_txn_idx WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error')
+ORDER BY 1;
+----
+layout	errors
+body first	10
+body last	10
+body second	10
+transactional	10
+
+query
+SELECT count(*) AS rows, count(*) FILTER (WHERE body LIKE 'error%') AS errors FROM sx_second_idx;
+----
+rows	errors
+20	10


### PR DESCRIPTION
An expression index on a search table (`storage='search'`) is accepted by `CREATE INDEX` and then either breaks every `INSERT` or, worse, silently indexes the wrong column.

### Root cause

`CREATE INDEX` binds the index expression against the projection its scan produces, so each column reference inside it is a *position in that projection*. `NormalizeBoundExpression` then maps those positions to stable catalog column ids through `col_index_to_id`. The transactional path built that vector from the same projection (`BuildCreateIndexProjection`); the search table path built it from the table's column order:

```cpp
const auto col_index_to_id = IsDuckDBTable()
    ? make_column_ids(BuildCreateIndexProjection(_pk_positions, _info->column_ids))
    : make_column_ids(std::views::iota(size_t{0}, columns.size()));
```

So a reference to the indexed column resolved to whatever table column sat at its projection slot. Both paths now map through the projection.

### What it looked like

| table layout | before | after |
|---|---|---|
| `ts TIMESTAMPTZ_NS, svc, sev, body` | `INSERT` fails: `Failed to bind column reference "" [...]: inequal types (VARCHAR != TIMESTAMPTZ_NS)` | ok |
| `svc VARCHAR, body, ts, sev` | `INSERT` succeeds, index is built over `svc`; `@@` finds nothing and nothing says why | ok |
| `body, ...` | worked by coincidence | ok |

The type error reported against `main` is the lucky case; a VARCHAR column in first position gives a silently wrong index.

### Verification

`tests/sqllogic/sdb/pg/index/search_table_expression_index.test` covers the three layouts plus a transactional control and reads the matches back through the index relation (10/10 each). The existing index suite (`tests/sqllogic/sdb/pg/index`, 456 checks) and the search table tests pass on the fixed build.

Not in scope, noted while here: `@@` against a search *table* rather than its index relation errors by design (`search_table_create_index.test:143`, and the docs prescribe `FROM index_name`), but the hint still says to create an index when one already exists.
