### PR TITLE
fix: lower search-table predicates through the table's inverted indexes

### DIFF
--- a/server/catalog/entry/duckdb_index_scan_entry.cpp
+++ b/server/catalog/entry/duckdb_index_scan_entry.cpp
@@ -83,8 +83,8 @@ duckdb::TableFunction TableInvertedIndexScanEntry::GetScanFunction(
   }
   data->table_entry = this;
   // Carried in both roads, so pushdown targets this index's own term fields.
-  data->inverted_index =
-    ::sdb::catalog::InvertedDefinitionIn(&context, this->catalog, _index_id);
+  data->indexes = {
+    ::sdb::catalog::InvertedDefinitionIn(&context, this->catalog, _index_id)};
 
   const auto* relation =
     catalog::FindSessionTableEntry(context, GetIndexedRelationId());
@@ -95,7 +95,7 @@ duckdb::TableFunction TableInvertedIndexScanEntry::GetScanFunction(
     auto reader = conn_ctx.SearchTxn().EnsureSearchTableReader(
       GetIndexedRelationId(),
       [&] { return relation->GetSearchData()->GetDirectoryReader(); });
-    data->entry_kind = connector::ScanEntryKind::SearchTable;
+    data->entry_kind = connector::ScanEntryKind::SearchTableIndex;
     data->lookup_label = "search";
     data->snapshot = std::make_shared<search::InvertedIndexSnapshot>(
       irs::DirectoryReader{*reader}, nullptr);
@@ -197,10 +197,10 @@ duckdb::TableFunction ViewInvertedIndexScanEntry::GetScanFunction(
   }
   data->table_entry = this;
   data->entry_kind = connector::ScanEntryKind::InvertedIndex;
-  data->inverted_index =
-    ::sdb::catalog::InvertedDefinitionIn(&context, this->catalog, _index_id);
+  data->indexes = {
+    ::sdb::catalog::InvertedDefinitionIn(&context, this->catalog, _index_id)};
   std::span<const std::string> key_cols =
-    catalog::InvertedInfo(*data->inverted_index).GetOptions().key_columns;
+    data->ScannedIndex().GetOptions().key_columns;
   data->fast_path =
     connector::ResolveViewFastPath(context, *_sdb_view, key_cols);
   if (data->fast_path) {

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -768,9 +768,7 @@ void BuildTableFilter(IResearchScanGlobalState& state,
                       const SereneDBScanBindData& bind_data,
                       const duckdb::TableFilterSet& filters) {
   const catalog::InvertedIndex* index_meta =
-    bind_data.IsInvertedIndexEntry() && bind_data.inverted_index
-      ? &catalog::InvertedInfo(*bind_data.inverted_index)
-      : nullptr;
+    bind_data.IsInvertedIndexEntry() ? &bind_data.ScannedIndex() : nullptr;
   // Score-column filters, applied on the computed score vector (whatever
   // HandleScoreFilter left pushed: on top-k the collector-enforced conjuncts
   // were stripped; the floor was recorded on the bind data there). The
@@ -965,7 +963,7 @@ void ClassifyColumnstoreProjections(IResearchScanGlobalState& state,
     }
     return;
   }
-  if (!bind_data.IsInvertedIndexEntry() || !bind_data.inverted_index) {
+  if (!bind_data.IsInvertedIndexEntry()) {
     // Nothing is covered: every output column materializes through the source
     // (base-table scans never receive pushed filters, so output columns are
     // the only real ones scanned).
@@ -980,8 +978,7 @@ void ClassifyColumnstoreProjections(IResearchScanGlobalState& state,
       continue;
     }
     const auto col_id = bind_data.column_ids[bind_col];
-    const auto* info =
-      catalog::InvertedInfo(*bind_data.inverted_index).FindColumnInfo(col_id);
+    const auto* info = bind_data.ScannedIndex().FindColumnInfo(col_id);
     if (info && info->IsStored()) {
       state.lookup_projected_columns[proj] = duckdb::DConstants::INVALID_INDEX;
       if (!in_output(proj)) {
@@ -1343,13 +1340,12 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
                                    duckdb::GlobalTableFunctionState>(
       std::move(state));
   }
-  if (state->needs_lookup && ss.IsInvertedIndexEntry() && ss.inverted_index) {
-    const auto pk_kind =
-      catalog::InvertedInfo(*ss.inverted_index).GetOptions().pk_column;
+  if (state->needs_lookup && ss.IsInvertedIndexEntry()) {
+    const auto pk_kind = ss.ScannedIndex().GetOptions().pk_column;
     if (pk_kind == catalog::PkColumnKind::None) {
       THROW_SQL_ERROR(
         ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
-        ERR_MSG("inverted index \"", ss.inverted_index->GetName(),
+        ERR_MSG("inverted index \"", ss.indexes.front()->GetName(),
                 "\" was created WITH (store_pk = 'none'), so it does not store "
                 "row PKs and hits cannot be mapped back to source rows; select "
                 "only INCLUDE'd columns, counts or scores through this index"));
@@ -1425,11 +1421,9 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   }
 
   if (state->mode == ScanMode::TopK) {
-    state->prune_scorer =
-      ResolvePruneScorer(bind_data.inverted_index
-                           ? &catalog::InvertedInfo(*bind_data.inverted_index)
-                           : nullptr,
-                         state->scorer_obj.get());
+    state->prune_scorer = ResolvePruneScorer(
+      bind_data.IsIndexRelation() ? &bind_data.ScannedIndex() : nullptr,
+      state->scorer_obj.get());
     if (state->score_static_floor >
         std::numeric_limits<irs::score_t>::lowest()) {
       // Static score floor (Lucene min_score): the collectors start at the
@@ -1470,11 +1464,9 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
       state->score_static_floor > std::numeric_limits<irs::score_t>::lowest();
     if (!topk_disabled && ss.text_scorer && state->ScanScore() &&
         (dynamic_bound || static_bound)) {
-      state->prune_scorer =
-        ResolvePruneScorer(bind_data.inverted_index
-                             ? &catalog::InvertedInfo(*bind_data.inverted_index)
-                             : nullptr,
-                           state->scorer_obj.get());
+      state->prune_scorer = ResolvePruneScorer(
+        bind_data.IsIndexRelation() ? &bind_data.ScannedIndex() : nullptr,
+        state->scorer_obj.get());
     }
   }
 
@@ -1484,11 +1476,8 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   }
 
   if (state->mode == ScanMode::ColScan) {
-    // Search tables carry no inverted_index; fall back to the default unit.
-    uint64_t rg_rows = bind_data.inverted_index
-                         ? catalog::InvertedInfo(*bind_data.inverted_index)
-                             .GetOptions()
-                             .row_group_size
+    uint64_t rg_rows = bind_data.IsIndexRelation()
+                         ? bind_data.ScannedIndex().GetOptions().row_group_size
                          : 0;
     if (rg_rows == 0) {
       rg_rows = DEFAULT_ROW_GROUP_SIZE;
@@ -1866,9 +1855,7 @@ void IResearchSetScanOrder(
     // column's per-file statistics (duckdb's row-group reorder, one level up).
     // Only covered columns have `.col` statistics.
     const auto* info =
-      bd.inverted_index
-        ? catalog::InvertedInfo(*bd.inverted_index).FindColumnInfo(col_id)
-        : nullptr;
+      bd.IsIndexRelation() ? bd.ScannedIndex().FindColumnInfo(col_id) : nullptr;
     const bool stored =
       bd.IsSearchTableEntry() || (info != nullptr && info->IsStored());
     if (stored && !bd.scan_order) {

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -44,6 +44,7 @@
 #include <iresearch/search/all_filter.hpp>
 #include <iresearch/search/vector_radius_filter.hpp>
 #include <iresearch/search/vector_similarity_filter.hpp>
+#include <ranges>
 
 #include "catalog/ddl/catalog.h"
 #include "catalog/entry/duckdb_index_scan_entry.h"
@@ -67,6 +68,7 @@ void CopyCommon(const SereneDBScanBindData& src, SereneDBScanBindData& dst) {
   dst.table_entry = src.table_entry;
   dst.entry_kind = src.entry_kind;
   dst.inverted_index = src.inverted_index;
+  dst.search_indexes = src.search_indexes;
   dst.stored_filter = src.stored_filter;
   dst.filter_scorers = src.filter_scorers;
   dst.snapshot = src.snapshot;
@@ -396,6 +398,17 @@ irs::Filter::ptr MakeVectorFilter(const VectorScorerOptions& vs,
   o->max_search_fanout = vs.max_search_fanout;
   o->inner = std::move(inner);
   return f;
+}
+
+std::vector<const catalog::InvertedIndex*>
+SereneDBScanBindData::InvertedIndexes() const {
+  if (inverted_index) {
+    return {&catalog::InvertedInfo(*inverted_index)};
+  }
+  return search_indexes | std::views::transform([](const auto& index) {
+           return &catalog::InvertedInfo(*index);
+         }) |
+         std::ranges::to<std::vector>();
 }
 
 namespace {

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -409,12 +409,20 @@ SereneDBScanBindData::InvertedIndexes() const {
 
 namespace {
 
-const catalog::InvertedIndex* OwningIndex(
+struct FieldOwner {
+  const catalog::InvertedIndex* index = nullptr;
+  catalog::InvertedIndex::FieldLookup lookup;
+};
+
+FieldOwner FindFieldOwner(
   std::span<const catalog::InvertedIndex* const> indexes, irs::field_id fid) {
-  const auto it = absl::c_find_if(indexes, [&](const auto* index) -> bool {
-    return index->LookupField(fid).entry;
-  });
-  return it == indexes.end() ? nullptr : *it;
+  for (const auto* index : indexes) {
+    const auto lookup = index->LookupField(fid);
+    if (lookup.entry || irs::field_limits::valid(lookup.entry_field_id)) {
+      return {index, lookup};
+    }
+  }
+  return {};
 }
 
 auto MakeFieldNameResolver(
@@ -422,12 +430,10 @@ auto MakeFieldNameResolver(
   std::span<const catalog::InvertedIndex* const> indexes) {
   return [&bind_data, indexes](catalog::ColumnId col_id) -> std::string {
     const auto fid = static_cast<irs::field_id>(col_id);
-    const auto* index = OwningIndex(indexes, fid);
+    const auto [index, lookup] = FindFieldOwner(indexes, fid);
     auto base = std::string{bind_data.ColumnNameById(col_id)};
     const auto column_type = bind_data.ColumnTypeById(col_id);
     const bool found_type = column_type.id() != duckdb::LogicalTypeId::INVALID;
-    const auto lookup =
-      index ? index->LookupField(fid) : catalog::InvertedIndex::FieldLookup{};
     auto entry_base = [&](irs::field_id entry_fid) {
       std::string s;
       const auto* expr = index->ExpressionByFieldId(entry_fid);
@@ -519,9 +525,7 @@ auto MakeFieldKindResolver(
           indexes](catalog::ColumnId col_id) -> catalog::term_dict::Kind {
     using catalog::term_dict::Kind;
     const auto fid = static_cast<irs::field_id>(col_id);
-    const auto* index = OwningIndex(indexes, fid);
-    const auto lookup =
-      index ? index->LookupField(fid) : catalog::InvertedIndex::FieldLookup{};
+    const auto [index, lookup] = FindFieldOwner(indexes, fid);
     if (lookup.entry_field_id == catalog::term_dict::kPKFieldId) {
       return Kind::NumericI64;
     }

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -45,6 +45,7 @@
 #include <iresearch/search/vector_radius_filter.hpp>
 #include <iresearch/search/vector_similarity_filter.hpp>
 #include <ranges>
+#include <span>
 
 #include "catalog/ddl/catalog.h"
 #include "catalog/entry/duckdb_index_scan_entry.h"
@@ -413,21 +414,35 @@ SereneDBScanBindData::InvertedIndexes() const {
 
 namespace {
 
-auto MakeFieldNameResolver(const SereneDBScanBindData& bind_data,
-                           const catalog::InvertedIndex& index) {
-  return [&bind_data, &index](catalog::ColumnId col_id) -> std::string {
+const catalog::InvertedIndex* OwningIndex(
+  std::span<const catalog::InvertedIndex* const> indexes, irs::field_id fid) {
+  const auto it = absl::c_find_if(indexes, [&](const auto* index) -> bool {
+    return index->LookupField(fid).entry;
+  });
+  return it == indexes.end() ? nullptr : *it;
+}
+
+auto MakeFieldNameResolver(
+  const SereneDBScanBindData& bind_data,
+  std::span<const catalog::InvertedIndex* const> indexes) {
+  return [&bind_data, indexes](catalog::ColumnId col_id) -> std::string {
     const auto fid = static_cast<irs::field_id>(col_id);
+    const auto* index = OwningIndex(indexes, fid);
     auto base = std::string{bind_data.ColumnNameById(col_id)};
     const auto column_type = bind_data.ColumnTypeById(col_id);
     const bool found_type = column_type.id() != duckdb::LogicalTypeId::INVALID;
-    const auto lookup = index.LookupField(fid);
+    const auto lookup =
+      index ? index->LookupField(fid) : catalog::InvertedIndex::FieldLookup{};
     auto entry_base = [&](irs::field_id entry_fid) {
       std::string s;
-      const auto* expr = index.ExpressionByFieldId(entry_fid);
+      const auto* expr = index->ExpressionByFieldId(entry_fid);
       if (expr && !expr->pretty_printed.empty()) {
         s = expr->pretty_printed;
       } else {
         s = bind_data.ColumnNameById(catalog::ColumnId{entry_fid});
+      }
+      if (s.empty()) {
+        s = bind_data.ColumnNameById(index->ColumnForTermField(entry_fid));
       }
       if (s.empty()) {
         s = absl::StrCat("col", entry_fid);
@@ -443,13 +458,13 @@ auto MakeFieldNameResolver(const SereneDBScanBindData& bind_data,
     if (lookup.entry) {
       const auto& entry = *lookup.entry;
       if (fid == lookup.entry_field_id) {
-        const auto* expr = index.ExpressionByFieldId(fid);
+        const auto* expr = index->ExpressionByFieldId(fid);
         if (base.empty() && expr && !expr->pretty_printed.empty()) {
           base = expr->pretty_printed;
         }
         if (base.empty()) {
           base = std::string{
-            bind_data.ColumnNameById(index.ColumnForTermField(fid))};
+            bind_data.ColumnNameById(index->ColumnForTermField(fid))};
         }
         if (base.empty()) {
           base = absl::StrCat("col", fid);
@@ -502,45 +517,48 @@ catalog::term_dict::Kind ClassifyTerms(const duckdb::LogicalType& type) {
   }
 }
 
-auto MakeFieldKindResolver(const SereneDBScanBindData& bind_data,
-                           const catalog::InvertedIndex& index) {
-  return
-    [&bind_data, &index](catalog::ColumnId col_id) -> catalog::term_dict::Kind {
-      using catalog::term_dict::Kind;
-      const auto fid = static_cast<irs::field_id>(col_id);
-      const auto lookup = index.LookupField(fid);
-      if (lookup.entry_field_id == catalog::term_dict::kPKFieldId) {
-        return Kind::NumericI64;
+auto MakeFieldKindResolver(
+  const SereneDBScanBindData& bind_data,
+  std::span<const catalog::InvertedIndex* const> indexes) {
+  return [&bind_data,
+          indexes](catalog::ColumnId col_id) -> catalog::term_dict::Kind {
+    using catalog::term_dict::Kind;
+    const auto fid = static_cast<irs::field_id>(col_id);
+    const auto* index = OwningIndex(indexes, fid);
+    const auto lookup =
+      index ? index->LookupField(fid) : catalog::InvertedIndex::FieldLookup{};
+    if (lookup.entry_field_id == catalog::term_dict::kPKFieldId) {
+      return Kind::NumericI64;
+    }
+    if (lookup.entry) {
+      const auto& entry = *lookup.entry;
+      if (fid == lookup.entry_field_id) {
+        const auto* expr = index->ExpressionByFieldId(fid);
+        if (expr) {
+          return ClassifyTerms(expr->return_type);
+        }
+        const auto column_type = bind_data.ColumnTypeById(col_id);
+        if (column_type.id() != duckdb::LogicalTypeId::INVALID) {
+          return ClassifyTerms(column_type);
+        }
+        return Kind::String;
       }
-      if (lookup.entry) {
-        const auto& entry = *lookup.entry;
-        if (fid == lookup.entry_field_id) {
-          const auto* expr = index.ExpressionByFieldId(fid);
-          if (expr) {
-            return ClassifyTerms(expr->return_type);
-          }
-          const auto column_type = bind_data.ColumnTypeById(col_id);
-          if (column_type.id() != duckdb::LogicalTypeId::INVALID) {
-            return ClassifyTerms(column_type);
-          }
-          return Kind::String;
-        }
-        if (fid == entry.null_field_id) {
-          return Kind::Null;
-        }
-        if (fid == entry.bool_field_id) {
-          return Kind::Bool;
-        }
-        if (fid == entry.numeric_field_id) {
-          return Kind::NumericF64;
-        }
+      if (fid == entry.null_field_id) {
+        return Kind::Null;
       }
-      const auto column_type = bind_data.ColumnTypeById(col_id);
-      if (column_type.id() != duckdb::LogicalTypeId::INVALID) {
-        return ClassifyTerms(column_type);
+      if (fid == entry.bool_field_id) {
+        return Kind::Bool;
       }
-      return Kind::Unsupported;
-    };
+      if (fid == entry.numeric_field_id) {
+        return Kind::NumericF64;
+      }
+    }
+    const auto column_type = bind_data.ColumnTypeById(col_id);
+    if (column_type.id() != duckdb::LogicalTypeId::INVALID) {
+      return ClassifyTerms(column_type);
+    }
+    return Kind::Unsupported;
+  };
 }
 
 std::string_view VectorMetricFunctionName(irs::VectorMetric metric) {
@@ -576,53 +594,47 @@ void SereneDBScanBindData::AppendSummary(
     }
     return ColumnNameFor(bind, id);
   };
-  if (bind.inverted_index) {
-    const auto name_of =
-      MakeFieldNameResolver(bind, catalog::InvertedInfo(*bind.inverted_index));
-    const auto kind_of =
-      MakeFieldKindResolver(bind, catalog::InvertedInfo(*bind.inverted_index));
-    const bool vector_is_range =
-      vector_scorer &&
-      vector_scorer->radius != std::numeric_limits<float>::max();
-    if (vector_is_range) {
-      const auto display =
-        MakeVectorFilter(*vector_scorer, stored_filter, vector_scorer->radius);
-      out.insert("Index Filter", duckdb::ExplainValue(irs::ToExplainNode(
-                                   *display, name_of, kind_of)));
-    } else if (stored_filter) {
-      out.insert("Index Filter", duckdb::ExplainValue(irs::ToExplainNode(
-                                   *stored_filter, name_of, kind_of)));
+  const auto indexes = bind.InvertedIndexes();
+  const auto name_of = MakeFieldNameResolver(bind, indexes);
+  const auto kind_of = MakeFieldKindResolver(bind, indexes);
+  const bool vector_is_range =
+    vector_scorer && vector_scorer->radius != std::numeric_limits<float>::max();
+  if (vector_is_range) {
+    const auto display =
+      MakeVectorFilter(*vector_scorer, stored_filter, vector_scorer->radius);
+    out.insert("Index Filter", duckdb::ExplainValue(irs::ToExplainNode(
+                                 *display, name_of, kind_of)));
+  } else if (stored_filter) {
+    out.insert("Index Filter", duckdb::ExplainValue(irs::ToExplainNode(
+                                 *stored_filter, name_of, kind_of)));
+  }
+  for (const auto& req : ts_dicts) {
+    if (!req.having_filter) {
+      continue;
     }
-    for (const auto& req : ts_dicts) {
-      if (!req.having_filter) {
-        continue;
+    // TODO(gnusi): Maybe different name? But what?
+    auto key =
+      ts_dicts.size() == 1
+        ? std::string{"Index Filter"}
+        : absl::StrCat(
+            "Index Filter(",
+            display_field(static_cast<catalog::ColumnId>(req.field_id)), ")");
+    out.insert(std::move(key), duckdb::ExplainValue(irs::ToExplainNode(
+                                 *req.having_filter, name_of, kind_of)));
+  }
+  if (vector_scorer && !vector_is_range) {
+    const auto col_id = static_cast<catalog::ColumnId>(vector_scorer->field_id);
+    const auto fname = name_of(col_id);
+    auto ctype = bind.ColumnTypeById(col_id);
+    if (ctype.id() == duckdb::LogicalTypeId::INVALID) {
+      if (const auto* expr = catalog::InvertedInfo(*bind.inverted_index)
+                               .ExpressionByFieldId(vector_scorer->field_id)) {
+        ctype = expr->return_type;
       }
-      // TODO(gnusi): Maybe different name? But what?
-      auto key =
-        ts_dicts.size() == 1
-          ? std::string{"Index Filter"}
-          : absl::StrCat(
-              "Index Filter(",
-              display_field(static_cast<catalog::ColumnId>(req.field_id)), ")");
-      out.insert(std::move(key), duckdb::ExplainValue(irs::ToExplainNode(
-                                   *req.having_filter, name_of, kind_of)));
     }
-    if (vector_scorer && !vector_is_range) {
-      const auto col_id =
-        static_cast<catalog::ColumnId>(vector_scorer->field_id);
-      const auto fname = name_of(col_id);
-      auto ctype = bind.ColumnTypeById(col_id);
-      if (ctype.id() == duckdb::LogicalTypeId::INVALID) {
-        if (const auto* expr =
-              catalog::InvertedInfo(*bind.inverted_index)
-                .ExpressionByFieldId(vector_scorer->field_id)) {
-          ctype = expr->return_type;
-        }
-      }
-      out.insert("Score",
-                 absl::StrCat(VectorMetricFunctionName(vector_scorer->metric),
-                              "(", fname, ", ", ctype.ToString(), ")"));
-    }
+    out.insert("Score",
+               absl::StrCat(VectorMetricFunctionName(vector_scorer->metric),
+                            "(", fname, ", ", ctype.ToString(), ")"));
   }
   std::unique_ptr<irs::Scorer> query_scorer;
   if (text_scorer) {

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -68,8 +68,7 @@ void CopyCommon(const SereneDBScanBindData& src, SereneDBScanBindData& dst) {
   dst.column_types = src.column_types;
   dst.table_entry = src.table_entry;
   dst.entry_kind = src.entry_kind;
-  dst.inverted_index = src.inverted_index;
-  dst.search_indexes = src.search_indexes;
+  dst.indexes = src.indexes;
   dst.stored_filter = src.stored_filter;
   dst.filter_scorers = src.filter_scorers;
   dst.snapshot = src.snapshot;
@@ -299,8 +298,8 @@ std::optional<duckdb::LogicalType> GeneratedPkTypeOf(
 }
 
 std::optional<catalog::PkSpec> ViewPkSpecOf(const SereneDBScanBindData& bind) {
-  if (bind.IsViewBacked() && bind.inverted_index &&
-      catalog::InvertedInfo(*bind.inverted_index).GetOptions().pk_column ==
+  if (bind.IsViewBacked() && bind.IsIndexRelation() &&
+      bind.ScannedIndex().GetOptions().pk_column ==
         catalog::PkColumnKind::Has) {
     if (const auto& fp = bind.As<ViewScanBindData>().fast_path) {
       return fp->pk_spec;
@@ -350,10 +349,9 @@ std::string SereneDBScanBindData::DisplayColumnName(
   if (!name.empty()) {
     return std::string{name};
   }
-  if (inverted_index) {
+  if (IsIndexRelation()) {
     const auto* expr =
-      catalog::InvertedInfo(*inverted_index)
-        .ExpressionByFieldId(static_cast<irs::field_id>(col_id));
+      ScannedIndex().ExpressionByFieldId(static_cast<irs::field_id>(col_id));
     if (expr && !expr->pretty_printed.empty()) {
       return expr->pretty_printed;
     }
@@ -403,10 +401,7 @@ irs::Filter::ptr MakeVectorFilter(const VectorScorerOptions& vs,
 
 std::vector<const catalog::InvertedIndex*>
 SereneDBScanBindData::InvertedIndexes() const {
-  if (inverted_index) {
-    return {&catalog::InvertedInfo(*inverted_index)};
-  }
-  return search_indexes | std::views::transform([](const auto& index) {
+  return indexes | std::views::transform([](const auto& index) {
            return &catalog::InvertedInfo(*index);
          }) |
          std::ranges::to<std::vector>();
@@ -584,10 +579,9 @@ void SereneDBScanBindData::AppendSummary(
   // field ids come from a global allocator; display the pretty-printed
   // expression so EXPLAIN output is meaningful and deterministic.
   const auto display_field = [&](catalog::ColumnId id) -> std::string {
-    if (bind.inverted_index) {
-      if (const auto* expr =
-            catalog::InvertedInfo(*bind.inverted_index)
-              .ExpressionByFieldId(static_cast<irs::field_id>(id));
+    if (bind.IsIndexRelation()) {
+      if (const auto* expr = bind.ScannedIndex().ExpressionByFieldId(
+            static_cast<irs::field_id>(id));
           expr && !expr->pretty_printed.empty()) {
         return expr->pretty_printed;
       }
@@ -627,8 +621,8 @@ void SereneDBScanBindData::AppendSummary(
     const auto fname = name_of(col_id);
     auto ctype = bind.ColumnTypeById(col_id);
     if (ctype.id() == duckdb::LogicalTypeId::INVALID) {
-      if (const auto* expr = catalog::InvertedInfo(*bind.inverted_index)
-                               .ExpressionByFieldId(vector_scorer->field_id)) {
+      if (const auto* expr =
+            bind.ScannedIndex().ExpressionByFieldId(vector_scorer->field_id)) {
         ctype = expr->return_type;
       }
     }
@@ -647,9 +641,7 @@ void SereneDBScanBindData::AppendSummary(
     // TODO(mbkkt): prunnable/etc instead of optimized?
     // TODO(mbkkt): streaming top k also should be marked when pruning enabled
     std::string topk_val = absl::StrCat(*score_top_k);
-    const auto* index = bind.inverted_index
-                          ? &catalog::InvertedInfo(*bind.inverted_index)
-                          : nullptr;
+    const auto* index = bind.IsIndexRelation() ? &bind.ScannedIndex() : nullptr;
     const auto* pruning = ResolvePruneScorer(index, query_scorer.get());
     if (pruning) {
       absl::StrAppend(&topk_val, ", optimized");
@@ -737,7 +729,7 @@ std::string ProjectionDisplayName(const SereneDBScanBindData& bind,
 
 bool ProjectionIsFromIndex(const SereneDBScanBindData& bind,
                            const duckdb::ColumnIndex& column_index) {
-  if (!bind.IsInvertedIndexEntry() || !bind.inverted_index) {
+  if (!bind.IsInvertedIndexEntry()) {
     return false;
   }
   const auto col_id = column_index.GetPrimaryIndex();
@@ -750,8 +742,7 @@ bool ProjectionIsFromIndex(const SereneDBScanBindData& bind,
   if (catalog_col_id == catalog::kGeneratedPKId) {
     return true;
   }
-  const auto* info =
-    catalog::InvertedInfo(*bind.inverted_index).FindColumnInfo(catalog_col_id);
+  const auto* info = bind.ScannedIndex().FindColumnInfo(catalog_col_id);
   return info != nullptr && info->IsStored();
 }
 
@@ -878,7 +869,7 @@ SereneDBScanToValue(duckdb::TableFunctionToStringInput& input) {
   // even when the scan's output is count-only.
   bool has_lookup_filter = false;
   if (input.filters && input.projected_column_ids &&
-      bind.IsInvertedIndexEntry() && bind.inverted_index) {
+      bind.IsInvertedIndexEntry()) {
     const auto& column_ids = *input.projected_column_ids;
     for (const auto& entry : *input.filters) {
       const auto proj = static_cast<duckdb::idx_t>(entry.GetIndex());
@@ -893,8 +884,7 @@ SereneDBScanToValue(duckdb::TableFunctionToStringInput& input) {
       if (col_id == catalog::kInvertedIndexScoreId) {
         continue;
       }
-      const auto* info =
-        catalog::InvertedInfo(*bind.inverted_index).FindColumnInfo(col_id);
+      const auto* info = bind.ScannedIndex().FindColumnInfo(col_id);
       if (!info || !info->IsStored()) {
         has_lookup_filter = true;
         break;
@@ -942,7 +932,7 @@ namespace {
 bool IResearchSupportsPushdownExtract(const duckdb::FunctionData& bind_data_p,
                                       const duckdb::LogicalIndex& col_idx) {
   const auto& bind = bind_data_p.Cast<SereneDBScanBindData>();
-  if (!bind.IsInvertedIndexEntry() || !bind.inverted_index) {
+  if (!bind.IsInvertedIndexEntry()) {
     return false;
   }
   const auto bind_col = col_idx.index;
@@ -954,8 +944,8 @@ bool IResearchSupportsPushdownExtract(const duckdb::FunctionData& bind_data_p,
       type_id != duckdb::LogicalTypeId::STRUCT) {
     return false;
   }
-  const auto* info = catalog::InvertedInfo(*bind.inverted_index)
-                       .FindColumnInfo(bind.column_ids[bind_col]);
+  const auto* info =
+    bind.ScannedIndex().FindColumnInfo(bind.column_ids[bind_col]);
   return info != nullptr && info->store_values;
 }
 
@@ -1063,9 +1053,8 @@ duckdb::TableFilterPushdown IResearchSupportsPushdownFilter(
   if (bind.IsSearchTableEntry()) {
     return duckdb::TableFilterPushdown::BeforeLimit;
   }
-  if (bind.IsInvertedIndexEntry() && bind.inverted_index) {
-    const auto* info =
-      catalog::InvertedInfo(*bind.inverted_index).FindColumnInfo(col_id);
+  if (bind.IsInvertedIndexEntry()) {
+    const auto* info = bind.ScannedIndex().FindColumnInfo(col_id);
     if (info && info->IsStored()) {
       return duckdb::TableFilterPushdown::BeforeLimit;
     }
@@ -1117,9 +1106,8 @@ bool IResearchPushdownExpression(duckdb::ClientContext&,
   if (bind.IsSearchTableEntry()) {
     return true;
   }
-  if (bind.IsInvertedIndexEntry() && bind.inverted_index) {
-    const auto* info =
-      catalog::InvertedInfo(*bind.inverted_index).FindColumnInfo(col_id);
+  if (bind.IsInvertedIndexEntry()) {
+    const auto* info = bind.ScannedIndex().FindColumnInfo(col_id);
     return info != nullptr && info->IsStored();
   }
   return false;
@@ -1139,9 +1127,8 @@ duckdb::unique_ptr<duckdb::BaseStatistics> IResearchScanStatistics(
     return nullptr;
   }
   const auto col_id = bind.column_ids[column_index];
-  if (bind.IsInvertedIndexEntry() && bind.inverted_index) {
-    const auto* info =
-      catalog::InvertedInfo(*bind.inverted_index).FindColumnInfo(col_id);
+  if (bind.IsInvertedIndexEntry()) {
+    const auto* info = bind.ScannedIndex().FindColumnInfo(col_id);
     if (!info || !info->store_values) {
       return nullptr;
     }

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -160,6 +160,7 @@ struct SereneDBScanBindData : public duckdb::FunctionData {
   ScanEntryKind entry_kind = ScanEntryKind::BaseTable;
 
   std::shared_ptr<const catalog::Index> inverted_index;
+  std::vector<std::shared_ptr<const catalog::Index>> search_indexes;
 
   // The iresearch snapshot plus the query's search configuration (stored
   // filter, scorer, offsets, ts-dict requests). Every scan bound through this
@@ -254,6 +255,7 @@ struct SereneDBScanBindData : public duckdb::FunctionData {
   bool IsSearchTableEntry() const noexcept {
     return entry_kind == ScanEntryKind::SearchTable;
   }
+  std::vector<const catalog::InvertedIndex*> InvertedIndexes() const;
 
   template<typename T>
   T& As() & {

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -146,6 +146,7 @@ enum class ScanEntryKind : uint8_t {
   // A TableEngine::Search table: its iresearch store IS the table, so every
   // column is covered in `.col` and there is no separate lookup source.
   SearchTable,
+  SearchTableIndex,
 };
 
 struct SereneDBScanBindData : public duckdb::FunctionData {
@@ -159,8 +160,7 @@ struct SereneDBScanBindData : public duckdb::FunctionData {
   duckdb::optional_ptr<duckdb::TableCatalogEntry> table_entry;
   ScanEntryKind entry_kind = ScanEntryKind::BaseTable;
 
-  std::shared_ptr<const catalog::Index> inverted_index;
-  std::vector<std::shared_ptr<const catalog::Index>> search_indexes;
+  std::vector<std::shared_ptr<const catalog::Index>> indexes;
 
   // The iresearch snapshot plus the query's search configuration (stored
   // filter, scorer, offsets, ts-dict requests). Every scan bound through this
@@ -253,7 +253,16 @@ struct SereneDBScanBindData : public duckdb::FunctionData {
     return entry_kind == ScanEntryKind::InvertedIndex;
   }
   bool IsSearchTableEntry() const noexcept {
-    return entry_kind == ScanEntryKind::SearchTable;
+    return entry_kind == ScanEntryKind::SearchTable ||
+           entry_kind == ScanEntryKind::SearchTableIndex;
+  }
+  bool IsIndexRelation() const noexcept {
+    return entry_kind == ScanEntryKind::InvertedIndex ||
+           entry_kind == ScanEntryKind::SearchTableIndex;
+  }
+  const catalog::InvertedIndex& ScannedIndex() const noexcept {
+    SDB_ASSERT(IsIndexRelation() && !indexes.empty());
+    return catalog::InvertedInfo(*indexes.front());
   }
   std::vector<const catalog::InvertedIndex*> InvertedIndexes() const;
 

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -622,7 +622,7 @@ duckdb::unique_ptr<duckdb::Expression> PushdownDistanceCall(
     return nullptr;
   }
 
-  const auto& index = catalog::InvertedInfo(*found->bind_data->inverted_index);
+  const auto& index = found->bind_data->ScannedIndex();
   const auto call_field_id = ResolveAnnTargetFieldId(
     *col_arg, *found->get, *found->bind_data, index, context);
   if (!irs::field_limits::valid(call_field_id)) {
@@ -739,8 +739,8 @@ duckdb::unique_ptr<duckdb::Expression> PushdownOffsetsCall(
       ERR_MSG("ts_offsets(): column '", col_name(), "' not found in table"));
   }
 
-  const auto* col_info = catalog::InvertedInfo(*found.bind_data->inverted_index)
-                           .FindColumnInfo(target_col_id);
+  const auto* col_info =
+    found.bind_data->ScannedIndex().FindColumnInfo(target_col_id);
   if (!col_info) {
     THROW_SQL_ERROR(
       ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -750,12 +750,11 @@ duckdb::unique_ptr<duckdb::Expression> PushdownOffsetsCall(
   const bool offs_stored =
     col_info->features.HasFeatures(irs::IndexFeatures::Offs);
   const auto read_field = static_cast<catalog::ColumnId>(
-    catalog::InvertedInfo(*found.bind_data->inverted_index)
-      .TermFieldForColumn(target_col_id));
+    found.bind_data->ScannedIndex().TermFieldForColumn(target_col_id));
 
   if (is_text && !offs_stored) {
     auto bind = duckdb::make_uniq<connector::OffsetsBindData>();
-    bind->inverted_index = found.bind_data->inverted_index;
+    bind->inverted_index = found.bind_data->indexes.front();
     bind->column_id = target_col_id;
     bind->limit = limit;
     search_scan.offsets.push_back({.column_id = target_col_id,
@@ -1114,7 +1113,7 @@ bool TryClaimSearchTableFilter(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& filters,
   duckdb::LogicalGet& get, connector::SereneDBScanBindData& bind_data,
   const search::SearchTable& shard, duckdb::ClientContext& context) {
-  bind_data.search_indexes = catalog::RelationInvertedIndexes(
+  bind_data.indexes = catalog::RelationInvertedIndexes(
     &context, shard.GetSchemaId(), shard.GetTableId());
   const auto indexes = bind_data.InvertedIndexes();
   // Hold one immutable config snapshot for the whole claim so entry pointers
@@ -1170,7 +1169,7 @@ void IResearchPushdownComplexFilter(
   }
   auto& bind_data = bind_data_ptr->Cast<connector::SereneDBScanBindData>();
   auto& ss = bind_data;
-  if (!bind_data.inverted_index) {
+  if (!bind_data.IsIndexRelation()) {
     if (!bind_data.stored_filter && bind_data.IsSearchTableEntry() &&
         bind_data.GetKind() == connector::SereneDBScanBindData::Kind::Table) {
       const auto& table_bd = bind_data.As<connector::TableScanBindData>();
@@ -1186,8 +1185,7 @@ void IResearchPushdownComplexFilter(
     return;
   }
   if (ss.TsDictMode()) {
-    ClaimTsDictFilter(filters, get, bind_data, ss,
-                      catalog::InvertedInfo(*bind_data.inverted_index),
+    ClaimTsDictFilter(filters, get, bind_data, ss, bind_data.ScannedIndex(),
                       context);
     return;
   }

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -39,6 +39,8 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ranges>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -47,6 +49,7 @@
 #include "basics/containers/flat_hash_set.h"
 #include "catalog/entry/duckdb_table_entry.h"
 #include "catalog/inverted_index.h"
+#include "catalog/read/duckdb_catalog_sets.h"
 #include "catalog/scorer_options.h"
 #include "catalog/table.h"
 #include "connector/duckdb_client_state.h"
@@ -306,15 +309,22 @@ bool TryClaimIResearchConjunct(
 
 bool WithSearchGetters(duckdb::LogicalGet& get,
                        connector::SereneDBScanBindData& bind_data,
-                       const catalog::InvertedIndex& index,
+                       std::span<const catalog::InvertedIndex* const> indexes,
                        duckdb::ClientContext& context,
                        absl::FunctionRef<bool(const SearchGetters&)> fn) {
+  struct IndexTokenizers {
+    const catalog::InvertedIndex* index;
+    catalog::TokenizerMap dicts;
+  };
   // Resolved once for the whole claim: every column of this scan reads its
-  // dictionary out of this map instead of the catalog.
-  const auto dicts = catalog::ResolveTokenizers(context, index);
+  // dictionary out of these maps instead of the catalog.
+  const auto resolved = indexes | std::views::transform([&](const auto* index) {
+                          return IndexTokenizers{
+                            index, catalog::ResolveTokenizers(context, *index)};
+                        }) |
+                        std::ranges::to<std::vector>();
   const auto projected_ids = BuildProjectedColumnIds(get, bind_data);
   const auto table_index = get.table_index;
-  const auto relation_id = index.GetRelationId();
   const bool table_backed =
     bind_data.GetKind() == connector::SereneDBScanBindData::Kind::Table;
 
@@ -330,24 +340,25 @@ bool WithSearchGetters(duckdb::LogicalGet& get,
     return it->second;
   };
 
-  const auto make_info = [&](irs::field_id field_id, catalog::ColumnId col_id,
-                             const catalog::InvertedIndexEntryInfo* info,
-                             duckdb::LogicalType type, bool column) {
-    auto column_info = MakeSearchColumnInfo(
-      field_id, info, std::move(type), index.GetTokenizer(dicts, field_id));
-    if (column && table_backed &&
-        column_not_null(static_cast<catalog::ColumnId>(field_id))) {
-      column_info.null_field_id = irs::field_limits::invalid();
-    }
-    if (irs::field_limits::valid(column_info.null_field_id)) {
-      null_markers[column_info.null_field_id] = column_info.field_id;
-    }
-    if (column_info.tokenizer.analyzer->type() !=
-        irs::Type<irs::StringTokenizer>::id()) {
-      analyzed_fields.insert(field_id);
-    }
-    return column_info;
-  };
+  const auto make_info =
+    [&](const IndexTokenizers& resolved_index, irs::field_id field_id,
+        const catalog::InvertedIndexEntryInfo* info, duckdb::LogicalType type,
+        std::optional<catalog::ColumnId> column) {
+      const auto& [index, dicts] = resolved_index;
+      auto column_info = MakeSearchColumnInfo(
+        field_id, info, std::move(type), index->GetTokenizer(dicts, field_id));
+      if (column && table_backed && column_not_null(*column)) {
+        column_info.null_field_id = irs::field_limits::invalid();
+      }
+      if (irs::field_limits::valid(column_info.null_field_id)) {
+        null_markers[column_info.null_field_id] = column_info.field_id;
+      }
+      if (column_info.tokenizer.analyzer->type() !=
+          irs::Type<irs::StringTokenizer>::id()) {
+        analyzed_fields.insert(field_id);
+      }
+      return column_info;
+    };
 
   connector::ColumnGetter getter =
     [&](const duckdb::BoundColumnRefExpression& ref)
@@ -356,16 +367,19 @@ bool WithSearchGetters(duckdb::LogicalGet& get,
     if (col_id == catalog::kInvalidColumnId) {
       return std::nullopt;
     }
-    const auto* info = index.FindColumnInfo(col_id);
-    if (!info || !info->IsTermDict()) {
-      return std::nullopt;
-    }
     auto type = bind_data.ColumnTypeById(col_id);
     if (type.id() == duckdb::LogicalTypeId::INVALID) {
       return std::nullopt;
     }
-    return make_info(index.TermFieldForColumn(col_id), col_id, info,
-                     std::move(type), true);
+    for (const auto& resolved_index : resolved) {
+      const auto& index = *resolved_index.index;
+      const auto* info = index.FindColumnInfo(col_id);
+      if (info && info->IsTermDict()) {
+        return make_info(resolved_index, index.TermFieldForColumn(col_id), info,
+                         std::move(type), col_id);
+      }
+    }
+    return std::nullopt;
   };
 
   connector::ExpressionGetter expr_getter = [&](const duckdb::Expression& expr)
@@ -373,17 +387,20 @@ bool WithSearchGetters(duckdb::LogicalGet& get,
     if (SingleReferencedTableIndex(expr) != table_index) {
       return std::nullopt;
     }
-    auto normalized = connector::NormalizeBoundExpression(
-      expr, relation_id, projected_ids, context);
-    auto serialized = connector::SerializeBoundExpression(*normalized);
-    const auto field_id = index.FindFieldIdBySerialized(serialized);
-    const auto* expr_data = index.ExpressionByFieldId(field_id);
-    if (!expr_data) {
-      return std::nullopt;
+    for (const auto& resolved_index : resolved) {
+      const auto& index = *resolved_index.index;
+      auto normalized = connector::NormalizeBoundExpression(
+        expr, index.GetRelationId(), projected_ids, context);
+      const auto field_id = index.FindFieldIdBySerialized(
+        connector::SerializeBoundExpression(*normalized));
+      const auto* expr_data = index.ExpressionByFieldId(field_id);
+      if (!expr_data) {
+        continue;
+      }
+      return make_info(resolved_index, field_id, index.FindEntry(field_id),
+                       expr_data->return_type, std::nullopt);
     }
-    const auto* info = index.FindEntry(field_id);
-    return make_info(field_id, catalog::kInvalidColumnId, info,
-                     expr_data->return_type, false);
+    return std::nullopt;
   };
 
   return fn(SearchGetters{getter, expr_getter, analyzed_fields, null_markers});
@@ -1051,9 +1068,10 @@ bool ClaimSearchConjuncts(
 
   auto root_and = std::make_unique<irs::BooleanFilter>();
   bool any_claimed = false;
+  connector::FilterScorers filter_scorers;
   for (size_t i = 0; i < filters.size();) {
     if (TryClaimIResearchConjunct(*root_and, filters[i], getter, expr_getter,
-                                  context)) {
+                                  context, &filter_scorers)) {
       any_claimed = true;
       std::swap(filters[i], filters.back());
       filters.pop_back();
@@ -1072,6 +1090,7 @@ bool ClaimSearchConjuncts(
                        .null_markers = &null_markers});
 
   scan.stored_filter = std::move(root);
+  scan.filter_scorers = std::move(filter_scorers);
   for (auto& req : scan.offsets) {
     if (req.bind) {
       req.bind->stored_filter = scan.stored_filter;
@@ -1083,43 +1102,11 @@ bool ClaimSearchConjuncts(
 bool TryClaimSearchFilter(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& filters,
   duckdb::LogicalGet& get, connector::SereneDBScanBindData& bind_data,
-  const catalog::InvertedIndex& index, duckdb::ClientContext& context) {
+  duckdb::ClientContext& context) {
+  const auto indexes = bind_data.InvertedIndexes();
   return WithSearchGetters(
-    get, bind_data, index, context, [&](const SearchGetters& getters) {
-      auto& [getter, expr_getter, analyzed_fields, null_markers] = getters;
-      auto& scan = bind_data;
-
-      auto root_node = std::make_unique<irs::BooleanFilter>();
-      bool any_claimed = false;
-      connector::FilterScorers filter_scorers;
-      for (size_t i = 0; i < filters.size();) {
-        if (TryClaimIResearchConjunct(*root_node, filters[i], getter,
-                                      expr_getter, context, &filter_scorers)) {
-          any_claimed = true;
-          std::swap(filters[i], filters.back());
-          filters.pop_back();
-        } else {
-          ++i;
-        }
-      }
-      if (!any_claimed) {
-        return false;
-      }
-
-      irs::Filter::ptr root = std::move(root_node);
-      connector::EnsureIncludeSides(*root);
-      irs::Optimize(root, {.scored = scan.text_scorer.has_value(),
-                           .analyzed_fields = std::move(analyzed_fields),
-                           .null_markers = &null_markers});
-
-      scan.stored_filter = std::move(root);
-      scan.filter_scorers = std::move(filter_scorers);
-      for (auto& req : scan.offsets) {
-        if (req.bind) {
-          req.bind->stored_filter = scan.stored_filter;
-        }
-      }
-      return true;
+    get, bind_data, indexes, context, [&](const SearchGetters& getters) {
+      return ClaimSearchConjuncts(filters, bind_data, getters, context);
     });
 }
 
@@ -1127,35 +1114,42 @@ bool TryClaimSearchTableFilter(
   duckdb::vector<duckdb::unique_ptr<duckdb::Expression>>& filters,
   duckdb::LogicalGet& get, connector::SereneDBScanBindData& bind_data,
   const search::SearchTable& shard, duckdb::ClientContext& context) {
+  bind_data.search_indexes = catalog::RelationInvertedIndexes(
+    &context, shard.GetSchemaId(), shard.GetTableId());
+  const auto indexes = bind_data.InvertedIndexes();
   // Hold one immutable config snapshot for the whole claim so entry pointers
   // stay valid if DDL swaps the config mid-plan.
-  auto config = shard.GetIndexConfig();
-  containers::FlatHashSet<irs::field_id> analyzed_fields;
-  containers::FlatHashMap<irs::field_id, irs::field_id> null_markers;
-  connector::ColumnGetter getter =
-    [&](const duckdb::BoundColumnRefExpression& ref)
-    -> std::optional<connector::SearchColumnInfo> {
-    const auto col_id = ResolveColumnId(ref.Binding(), bind_data, get);
-    if (col_id == catalog::kInvalidColumnId) {
-      return std::nullopt;
-    }
-    const auto field_id = static_cast<irs::field_id>(col_id);
-    auto it = config->find(field_id);
-    if (it == config->end() || !it->second.IsTermDict()) {
-      return std::nullopt;
-    }
-    auto type = bind_data.ColumnTypeById(col_id);
-    if (type.id() == duckdb::LogicalTypeId::INVALID) {
-      return std::nullopt;
-    }
-    return MakeSearchColumnInfo(col_id, &it->second, std::move(type),
-                                shard.GetTokenizer(context, field_id));
-  };
-  connector::ExpressionGetter expr_getter = [](const duckdb::Expression&)
-    -> std::optional<connector::SearchColumnInfo> { return std::nullopt; };
-  return ClaimSearchConjuncts(
-    filters, bind_data,
-    SearchGetters{getter, expr_getter, analyzed_fields, null_markers}, context);
+  const auto config = shard.GetIndexConfig();
+  return WithSearchGetters(
+    get, bind_data, indexes, context, [&](const SearchGetters& getters) {
+      const connector::ColumnGetter getter =
+        [&](const duckdb::BoundColumnRefExpression& ref)
+        -> std::optional<connector::SearchColumnInfo> {
+        if (auto info = getters.getter(ref)) {
+          return info;
+        }
+        const auto col_id = ResolveColumnId(ref.Binding(), bind_data, get);
+        if (col_id == catalog::kInvalidColumnId) {
+          return std::nullopt;
+        }
+        const auto field_id = static_cast<irs::field_id>(col_id);
+        const auto it = config->find(field_id);
+        if (it == config->end() || !it->second.IsTermDict()) {
+          return std::nullopt;
+        }
+        auto type = bind_data.ColumnTypeById(col_id);
+        if (type.id() == duckdb::LogicalTypeId::INVALID) {
+          return std::nullopt;
+        }
+        return MakeSearchColumnInfo(field_id, &it->second, std::move(type),
+                                    shard.GetTokenizer(context, field_id));
+      };
+      return ClaimSearchConjuncts(
+        filters, bind_data,
+        SearchGetters{getter, getters.expr_getter, getters.analyzed_fields,
+                      getters.null_markers},
+        context);
+    });
 }
 
 void RewriteSearchCallsToColumnRefs(
@@ -1204,9 +1198,7 @@ void IResearchPushdownComplexFilter(
   if (filters.empty()) {
     return;
   }
-  TryClaimSearchFilter(filters, get, bind_data,
-                       catalog::InvertedInfo(*bind_data.inverted_index),
-                       context);
+  TryClaimSearchFilter(filters, get, bind_data, context);
 }
 
 void RegisterIResearchPlanOptimizer(duckdb::DatabaseInstance& db) {

--- a/server/connector/optimizer/iresearch_plan_common.hpp
+++ b/server/connector/optimizer/iresearch_plan_common.hpp
@@ -26,6 +26,7 @@
 #include <duckdb/planner/operator/logical_get.hpp>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -120,7 +121,7 @@ struct SearchGetters {
 
 bool WithSearchGetters(duckdb::LogicalGet& get,
                        connector::SereneDBScanBindData& bind_data,
-                       const catalog::InvertedIndex& index,
+                       std::span<const catalog::InvertedIndex* const> indexes,
                        duckdb::ClientContext& context,
                        absl::FunctionRef<bool(const SearchGetters&)> fn);
 

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -269,8 +269,7 @@ duckdb::unique_ptr<duckdb::Expression> PushdownTsDictCall(
     THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                     ERR_MSG(fn, "(): column not found in index"));
   }
-  const auto* info = catalog::InvertedInfo(*found.bind_data->inverted_index)
-                       .FindColumnInfo(col_id);
+  const auto* info = found.bind_data->ScannedIndex().FindColumnInfo(col_id);
   const auto& col_type = col_ref->GetReturnType();
   const auto text_type = [&] {
     switch (col_type.id()) {
@@ -296,8 +295,7 @@ duckdb::unique_ptr<duckdb::Expression> PushdownTsDictCall(
 
   const auto [kind, agg_name] = *fn_info;
   const auto read_field =
-    catalog::InvertedInfo(*found.bind_data->inverted_index)
-      .TermFieldForColumn(col_id);
+    found.bind_data->ScannedIndex().TermFieldForColumn(col_id);
   return MakeTsDictAggregate(root, context, found, read_field,
                              static_cast<irs::field_id>(col_id), kind, agg_name,
                              col_ref->Binding().table_index, agg.GetAlias());
@@ -889,12 +887,11 @@ std::optional<KeywordDictAgg> ClassifyKeywordDictAgg(
   if (col_id == catalog::kInvalidColumnId) {
     return std::nullopt;
   }
-  const auto* index = found.bind_data->inverted_index.get();
-  if (!index) {
+  if (!found.bind_data->IsIndexRelation()) {
     return std::nullopt;
   }
   const auto field_id = static_cast<irs::field_id>(col_id);
-  if (!catalog::InvertedInfo(*index).IsKeywordField(context, field_id)) {
+  if (!found.bind_data->ScannedIndex().IsKeywordField(context, field_id)) {
     return std::nullopt;
   }
   if (is_list && !found.bind_data->IsColumnNotNull(col_id)) {
@@ -943,11 +940,11 @@ bool TsDictFacetPushdown::AdoptScan(std::optional<FoundScan> here) {
   if (_index) {
     return true;
   }
-  if (!here->bind_data->inverted_index) {
+  if (!here->bind_data->IsIndexRelation()) {
     return false;
   }
   _found = *here;
-  _index = &catalog::InvertedInfo(*here->bind_data->inverted_index);
+  _index = &here->bind_data->ScannedIndex();
   return true;
 }
 

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -24,6 +24,7 @@
 #include <absl/strings/str_cat.h>
 
 #include <algorithm>
+#include <array>
 #include <duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp>
 #include <duckdb/function/function_binder.hpp>
 #include <duckdb/main/config.hpp>
@@ -1643,7 +1644,7 @@ bool TsDictFacetPushdown::WhereOk() {
     key_by_field[_keys[k].field_id] = k;
   }
   const bool claimable = WithSearchGetters(
-    *_found.get, *_found.bind_data, *_index, _context,
+    *_found.get, *_found.bind_data, std::array{_index}, _context,
     [&](const SearchGetters& getters) {
       auto& [getter, expr_getter, analyzed_fields, null_markers] = getters;
       size_t computed_residuals = 0;
@@ -2090,12 +2091,12 @@ void ClaimTsDictFilter(
   duckdb::LogicalGet& get, connector::SereneDBScanBindData& bind_data,
   connector::SereneDBScanBindData& ss, const catalog::InvertedIndex& index,
   duckdb::ClientContext& context) {
-  WithSearchGetters(
-    get, bind_data, index, context, [&](const SearchGetters& getters) {
-      TsDictFilterClaim{filters, get, bind_data, ss, index, context, getters}
-        .Claim();
-      return true;
-    });
+  const auto claim = [&](const SearchGetters& getters) {
+    TsDictFilterClaim{filters, get, bind_data, ss, index, context, getters}
+      .Claim();
+    return true;
+  };
+  WithSearchGetters(get, bind_data, std::array{&index}, context, claim);
 }
 
 }  // namespace sdb::optimizer

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -1589,8 +1589,9 @@ void FromTSQueryMatch(BoolTarget filter, const FilterContext& ctx,
     THROW_SQL_ERROR(
       ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
       ERR_MSG("@@ requires an inverted-indexed column on one side"),
-      ERR_HINT("Use: <indexed_col> @@ <tsquery_expr>. CREATE INDEX ... "
-               "USING inverted(<col>) if missing."));
+      ERR_HINT("Use: <indexed_col> @@ <tsquery_expr>, or query through the "
+               "index relation (FROM <index_name>). CREATE INDEX ... USING "
+               "inverted(<col>) if none exists."));
   }
   const auto& expr = left_info ? rhs : lhs;
   auto* tokenizer = column_info->tokenizer.analyzer.get();

--- a/tests/sqllogic/recovery/search_table_index_recovery.test
+++ b/tests/sqllogic/recovery/search_table_index_recovery.test
@@ -60,17 +60,21 @@ id	tag
 1	red
 3	red
 
-# The bare table scan no longer term-indexes a non-PK column: it falls back to a
-# columnstore Column Filter (still correct, over the rebuilt stored values).
+# The bare table scan lowers a non-PK predicate through the rebuilt inverted
+# index, the same term filter the index relation uses.
 connection after_crash
 query
 EXPLAIN SELECT id FROM sidx WHERE tag = 'red';
 ----
 QUERY PLAN
-╭─ IRESEARCH_SCAN ───────────╮
-│ Index: sidx                │
-│ Lookup: search             │
-│ Projections: id            │
-│ Column Filter: tag = 'red' │
-│ ~1 row                     │
-╰────────────────────────────╯
+╭─ IRESEARCH_SCAN ─╮
+│ Index: sidx      │
+│ Lookup: search   │
+│ Index Filter:    │
+│ ╭─ Term ─────╮   │
+│ │ Field: tag │   │
+│ │ Value: red │   │
+│ ╰────────────╯   │
+│ Projections: id  │
+│ ~1 row           │
+╰──────────────────╯

--- a/tests/sqllogic/sdb/pg/index/search_table_create_index.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_create_index.test
@@ -68,6 +68,11 @@ QUERY PLAN
 ╭─ IRESEARCH_SCAN ─╮
 │ Index: t         │
 │ Lookup: search   │
+│ Index Filter:    │
+│ ╭─ Term ─────╮   │
+│ │ Field: tag │   │
+│ │ Value: red │   │
+│ ╰────────────╯   │
 │ Projections: id  │
 │ ~1 row           │
 ╰──────────────────╯

--- a/tests/sqllogic/sdb/pg/index/search_table_create_index.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_create_index.test
@@ -65,13 +65,12 @@ query
 EXPLAIN SELECT id FROM t WHERE tag = 'red';
 ----
 QUERY PLAN
-╭─ IRESEARCH_SCAN ───────────╮
-│ Index: t                   │
-│ Lookup: search             │
-│ Projections: id            │
-│ Column Filter: tag = 'red' │
-│ ~1 row                     │
-╰────────────────────────────╯
+╭─ IRESEARCH_SCAN ─╮
+│ Index: t         │
+│ Lookup: search   │
+│ Projections: id  │
+│ ~1 row           │
+╰──────────────────╯
 
 # A direct index scan pushes the predicate down through the index's own term
 # field.
@@ -141,14 +140,14 @@ INSERT INTO doc VALUES
 statement ok
 VACUUM (REFRESH_TABLE) doc;
 
-# A bare @@ on a non-PK column errors (matches transactional): the term filter is
-# reachable only through the index scan.
-statement error
-SELECT id FROM doc WHERE body @@ 'fox';
+# A bare @@ on the table itself reaches the same term filter the index scan
+# uses: a search table's scan is already an index scan.
+query
+SELECT id FROM doc WHERE body @@ 'fox' ORDER BY id;
 ----
-db error: ERROR: @@ requires an inverted-indexed column on one side
-HINT: Use: <indexed_col> @@ <tsquery_expr>. CREATE INDEX ... USING inverted(<col>) if missing.
-
+id
+1
+3
 
 # Full-text via the index: 'fox' matches the two rows that contain the tokenized
 # term.

--- a/tests/sqllogic/sdb/pg/index/search_table_match_on_table.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_match_on_table.test
@@ -1,0 +1,139 @@
+statement ok
+CREATE TEXT SEARCH DICTIONARY mt_en (
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true, norm = true
+);
+
+statement ok
+CREATE TABLE mt_src AS SELECT (TIMESTAMP '2025-09-23' + INTERVAL (i) SECOND)::TIMESTAMPTZ_NS AS ts,
+	'svc' || (i % 3) AS svc,
+	CASE WHEN i % 2 = 0 THEN 'error in module ' || (i % 4) ELSE 'all good in module ' || (i % 4) END AS body
+FROM range(24) t(i);
+
+statement ok
+CREATE TABLE mt WITH (storage = 'search', compaction_interval = 0) AS SELECT ts, svc, body FROM mt_src WHERE false;
+
+statement ok
+CREATE INDEX mt_svc ON mt USING inverted (svc);
+
+statement ok
+CREATE INDEX mt_body ON mt USING inverted (body mt_en);
+
+statement ok
+INSERT INTO mt SELECT ts, svc, body FROM mt_src;
+
+statement ok
+VACUUM (REFRESH_TABLE) mt;
+
+statement ok
+CREATE TABLE mt_expr WITH (storage = 'search', compaction_interval = 0) AS SELECT body, ts, svc FROM mt_src WHERE false;
+
+statement ok
+CREATE INDEX mt_expr_idx ON mt_expr USING inverted ((ts_split_by_non_alpha(body, true)) mt_en);
+
+statement ok
+INSERT INTO mt_expr SELECT body, ts, svc FROM mt_src;
+
+statement ok
+VACUUM (REFRESH_TABLE) mt_expr;
+
+statement ok
+CREATE TABLE mt_bare WITH (storage = 'search', compaction_interval = 0) AS SELECT ts, svc, body FROM mt_src WHERE false;
+
+statement ok
+INSERT INTO mt_bare SELECT ts, svc, body FROM mt_src;
+
+statement ok
+VACUUM (REFRESH_TABLE) mt_bare;
+
+query
+SELECT 'table' AS via, count(*) AS errors, count(*) FILTER (WHERE svc = 'svc1') AS svc1 FROM mt WHERE body @@ ts_phrase('error')
+UNION ALL SELECT 'index', count(*), count(*) FILTER (WHERE svc = 'svc1') FROM mt_body WHERE body @@ ts_phrase('error')
+ORDER BY 1;
+----
+via	errors	svc1
+index	12	4
+table	12	4
+
+query
+SELECT 'table' AS via, count(*) AS matches FROM mt WHERE body @@ ts_phrase('module 2') AND svc = 'svc0'
+UNION ALL SELECT 'index', count(*) FROM mt_body WHERE body @@ ts_phrase('module 2') AND svc = 'svc0'
+ORDER BY 1;
+----
+via	matches
+index	2
+table	2
+
+query
+SELECT 'table' AS via, count(*) AS errors FROM mt_expr WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error')
+UNION ALL SELECT 'index', count(*) FROM mt_expr_idx WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error')
+ORDER BY 1;
+----
+via	errors
+index	12
+table	12
+
+query
+SELECT ts::VARCHAR AS ts, svc, body FROM mt WHERE body @@ ts_phrase('module 3') ORDER BY ts LIMIT 3;
+----
+ts	svc	body
+2025-09-23 00:00:03+00	svc0	all good in module 3
+2025-09-23 00:00:07+00	svc1	all good in module 3
+2025-09-23 00:00:11+00	svc2	all good in module 3
+
+statement ok
+CREATE TABLE mt_pk (id BIGINT PRIMARY KEY, svc TEXT NOT NULL, body TEXT, n INT) WITH (storage = 'search', compaction_interval = 0);
+
+statement ok
+CREATE INDEX mt_pk_svc ON mt_pk USING inverted (svc);
+
+statement ok
+CREATE INDEX mt_pk_body ON mt_pk USING inverted (body);
+
+statement ok
+INSERT INTO mt_pk SELECT i, 'svc' || (i % 3), CASE WHEN i % 2 = 0 THEN 'error in module ' || (i % 4) ELSE 'all good in module ' || (i % 4) END, i * 10 FROM range(24) t(i);
+
+statement ok
+VACUUM (REFRESH_TABLE) mt_pk;
+
+query
+SELECT id, svc FROM mt_pk WHERE id = 3 AND svc = 'svc0';
+----
+id	svc
+3	svc0
+
+query
+SELECT count(*) AS c FROM mt_pk WHERE svc = 'svc0' AND n > 100;
+----
+c
+4
+
+query
+SELECT count(*) AS c FROM mt_pk WHERE svc <> 'svc0';
+----
+c
+16
+
+query
+SELECT count(*) AS c FROM mt_pk WHERE body <> 'error in module 0';
+----
+c
+18
+
+statement ok
+CREATE TABLE mt_tx (id INT, body TEXT);
+
+statement ok
+INSERT INTO mt_tx VALUES (1, 'x y'), (2, 'zzz');
+
+statement error
+SELECT count(*) FROM mt_bare WHERE body @@ ts_phrase('error');
+----
+db error: ERROR: @@ requires an inverted-indexed column on one side
+HINT: Use: <indexed_col> @@ <tsquery_expr>, or query through the index relation (FROM <index_name>). CREATE INDEX ... USING inverted(<col>) if none exists.
+
+
+statement error
+SELECT count(*) FROM mt_tx WHERE body @@ 'x';
+----
+db error: ERROR: TSQUERY expression evaluated outside an `@@` match against an inverted-indexed column.

--- a/tests/sqllogic/sdb/pg/index/search_table_match_on_table.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_match_on_table.test
@@ -81,6 +81,49 @@ ts	svc	body
 2025-09-23 00:00:07+00	svc1	all good in module 3
 2025-09-23 00:00:11+00	svc2	all good in module 3
 
+query
+EXPLAIN SELECT count(*) FROM mt WHERE body @@ ts_phrase('module 2') AND svc = 'svc0';
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ────────────────────────────────────────────╮
+│ Aggregates: count_star()                                         │
+│ ~1 row                                                           │
+╰─────────────────────────────────┬────────────────────────────────╯
+╭─ IRESEARCH_SCAN ────────────────┴────────────────────────────────╮
+│ Index: mt                                                        │
+│ Lookup: search                                                   │
+│ Index Filter:                                                    │
+│ ╭─ And ──────────╮                                               │
+│ ╰────────┬───────╯                                               │
+│          ├────────────────────────────────╮                      │
+│ ╭─ Terms ┴───────╮  ╭─ Phrase ────────────┴────────────────────╮ │
+│ │ Field: svc     │  │ Field: body(string)                      │ │
+│ │ Values: 'svc0' │  │ Parts: Term:module(0, 0); Term:2(1, 1);  │ │
+│ ╰────────────────╯  ╰──────────────────────────────────────────╯ │
+│ Output: row-count only                                           │
+│ ~4 rows                                                          │
+╰──────────────────────────────────────────────────────────────────╯
+
+query
+EXPLAIN SELECT count(*) FROM mt_expr WHERE ts_split_by_non_alpha(body, true) @@ ts_phrase('error');
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ────────────────────────╮
+│ Aggregates: count_star()                     │
+│ ~1 row                                       │
+╰───────────────────────┬──────────────────────╯
+╭─ IRESEARCH_SCAN ──────┴──────────────────────╮
+│ Index: mt_expr                               │
+│ Lookup: search                               │
+│ Index Filter:                                │
+│ ╭─ Term ───────────────────────────────────╮ │
+│ │ Field: ts_split_by_non_alpha(body, true) │ │
+│ │ Value: error                             │ │
+│ ╰──────────────────────────────────────────╯ │
+│ Output: row-count only                       │
+│ ~4 rows                                      │
+╰──────────────────────────────────────────────╯
+
 statement ok
 CREATE TABLE mt_pk (id BIGINT PRIMARY KEY, svc TEXT NOT NULL, body TEXT, n INT) WITH (storage = 'search', compaction_interval = 0);
 
@@ -103,10 +146,50 @@ id	svc
 3	svc0
 
 query
+EXPLAIN SELECT id FROM mt_pk WHERE id = 3 AND svc = 'svc0';
+----
+QUERY PLAN
+╭─ IRESEARCH_SCAN ───────────────────────────╮
+│ Index: mt_pk                               │
+│ Lookup: search                             │
+│ Index Filter:                              │
+│ ╭─ And ──────────────╮                     │
+│ ╰──────────┬─────────╯                     │
+│            ├─────────────────────╮         │
+│ ╭─ Terms ──┴─────────╮  ╭─ Terms ┴───────╮ │
+│ │ Field: id(numeric) │  │ Field: svc     │ │
+│ │ Values: 3          │  │ Values: 'svc0' │ │
+│ ╰────────────────────╯  ╰────────────────╯ │
+│ Projections: id                            │
+│ ~4 rows                                    │
+╰────────────────────────────────────────────╯
+
+query
 SELECT count(*) AS c FROM mt_pk WHERE svc = 'svc0' AND n > 100;
 ----
 c
 4
+
+query
+EXPLAIN SELECT count(*) FROM mt_pk WHERE svc = 'svc0' AND n > 100;
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ────╮
+│ Aggregates: count_star() │
+│ ~1 row                   │
+╰─────────────┬────────────╯
+╭─ IRESEARCH_SCAN ─────────╮
+│ Index: mt_pk             │
+│ Lookup: search           │
+│ Index Filter:            │
+│ ╭─ Term ──────╮          │
+│ │ Field: svc  │          │
+│ │ Value: svc0 │          │
+│ ╰─────────────╯          │
+│ Column Filter: n > 100   │
+│ Output: row-count only   │
+│ ~1 row                   │
+╰──────────────────────────╯
 
 query
 SELECT count(*) AS c FROM mt_pk WHERE svc <> 'svc0';
@@ -115,10 +198,55 @@ c
 16
 
 query
+EXPLAIN SELECT count(*) FROM mt_pk WHERE svc <> 'svc0';
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ────╮
+│ Aggregates: count_star() │
+│ ~1 row                   │
+╰─────────────┬────────────╯
+╭─ IRESEARCH_SCAN ─────────╮
+│ Index: mt_pk             │
+│ Lookup: search           │
+│ Index Filter:            │
+│ ╭─ Not ──────────╮       │
+│ ╰────────┬───────╯       │
+│ ╭─ Terms ┴───────╮       │
+│ │ Field: svc     │       │
+│ │ Values: 'svc0' │       │
+│ ╰────────────────╯       │
+│ Output: row-count only   │
+│ ~4 rows                  │
+╰──────────────────────────╯
+
+query
 SELECT count(*) AS c FROM mt_pk WHERE body <> 'error in module 0';
 ----
 c
 18
+
+query
+EXPLAIN SELECT count(*) FROM mt_pk WHERE body <> 'error in module 0';
+----
+QUERY PLAN
+╭─ UNGROUPED_AGGREGATE ──────────────────────────────────╮
+│ Aggregates: count_star()                               │
+│ ~1 row                                                 │
+╰────────────────────────────┬───────────────────────────╯
+╭─ IRESEARCH_SCAN ───────────┴───────────────────────────╮
+│ Index: mt_pk                                           │
+│ Lookup: search                                         │
+│ Index Filter:                                          │
+│ ╭─ Not ───────────────────────╮                        │
+│ ╰──────────────┬──────────────╯                        │
+│                ├───────────────────────────╮           │
+│ ╭─ Terms ──────┴──────────────╮  ╭─ Terms ─┴─────────╮ │
+│ │ Field: body                 │  │ Field: body(null) │ │
+│ │ Values: 'error in module 0' │  ╰───────────────────╯ │
+│ ╰─────────────────────────────╯                        │
+│ Output: row-count only                                 │
+│ ~4 rows                                                │
+╰────────────────────────────────────────────────────────╯
 
 statement ok
 CREATE TABLE mt_tx (id INT, body TEXT);

--- a/tests/sqllogic/sdb/pg/index/search_table_pk_pushdown.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_pk_pushdown.test
@@ -152,13 +152,17 @@ query
 EXPLAIN SELECT pk, x FROM te WHERE pk = 5;
 ----
 QUERY PLAN
-╭─ IRESEARCH_SCAN ─╮
-│ Index: te        │
-│ Lookup: search   │
-│ Projections: pk, │
-│              x   │
-│ ~2 rows          │
-╰──────────────────╯
+╭─ IRESEARCH_SCAN ───────╮
+│ Index: te              │
+│ Lookup: search         │
+│ Index Filter:          │
+│ ╭─ Term ─────────────╮ │
+│ │ Field: pk(numeric) │ │
+│ │ Value: 5           │ │
+│ ╰────────────────────╯ │
+│ Projections: pk, x     │
+│ ~2 rows                │
+╰────────────────────────╯
 
 query
 EXPLAIN SELECT pk, x FROM te WHERE x = 50;
@@ -196,28 +200,37 @@ query
 EXPLAIN SELECT a, b, s FROM tec WHERE a = 3 AND b = 300;
 ----
 QUERY PLAN
-╭─ IRESEARCH_SCAN ─╮
-│ Index: tec       │
-│ Lookup: search   │
-│ Projections: a,  │
-│              b,  │
-│              s   │
-│ ~2 rows          │
-╰──────────────────╯
+╭─ IRESEARCH_SCAN ─────────────────────────────╮
+│ Index: tec                                   │
+│ Lookup: search                               │
+│ Index Filter:                                │
+│ ╭─ And ─────────────╮                        │
+│ ╰─────────┬─────────╯                        │
+│           ├──────────────────────╮           │
+│ ╭─ Terms ─┴─────────╮  ╭─ Terms ─┴─────────╮ │
+│ │ Field: a(numeric) │  │ Field: b(numeric) │ │
+│ │ Values: 3         │  │ Values: 300       │ │
+│ ╰───────────────────╯  ╰───────────────────╯ │
+│ Projections: a, b, s                         │
+│ ~2 rows                                      │
+╰──────────────────────────────────────────────╯
 
 # Partial composite PK (leading column only): claimed -> no Column Filter.
 query
 EXPLAIN SELECT a, b, s FROM tec WHERE a = 3;
 ----
 QUERY PLAN
-╭─ IRESEARCH_SCAN ─╮
-│ Index: tec       │
-│ Lookup: search   │
-│ Projections: a,  │
-│              b,  │
-│              s   │
-│ ~2 rows          │
-╰──────────────────╯
+╭─ IRESEARCH_SCAN ──────╮
+│ Index: tec            │
+│ Lookup: search        │
+│ Index Filter:         │
+│ ╭─ Term ────────────╮ │
+│ │ Field: a(numeric) │ │
+│ │ Value: 3          │ │
+│ ╰───────────────────╯ │
+│ Projections: a, b, s  │
+│ ~2 rows               │
+╰───────────────────────╯
 
 # Mixed: key column a claimed as a term filter; non-key column s stays a
 # columnstore Column Filter (only s appears).
@@ -228,8 +241,13 @@ QUERY PLAN
 ╭─ IRESEARCH_SCAN ────────╮
 │ Index: tec              │
 │ Lookup: search          │
-│ Projections: a, b       │
+│ Index Filter:           │
+│ ╭─ Term ────────────╮   │
+│ │ Field: a(numeric) │   │
+│ │ Value: 3          │   │
+│ ╰───────────────────╯   │
 │ Column Filter: s = 't3' │
+│ Projections: a, b       │
 │ ~1 row                  │
 ╰─────────────────────────╯
 
@@ -247,14 +265,20 @@ query
 EXPLAIN SELECT a, b, s FROM tec WHERE a = 3 OR b = 300;
 ----
 QUERY PLAN
-╭─ IRESEARCH_SCAN ─╮
-│ Index: tec       │
-│ Lookup: search   │
-│ Projections: a,  │
-│              b,  │
-│              s   │
-│ ~2 rows          │
-╰──────────────────╯
+╭─ IRESEARCH_SCAN ─────────────────────────────╮
+│ Index: tec                                   │
+│ Lookup: search                               │
+│ Index Filter:                                │
+│ ╭─ Or ──────────────╮                        │
+│ ╰─────────┬─────────╯                        │
+│           ├──────────────────────╮           │
+│ ╭─ Terms ─┴─────────╮  ╭─ Terms ─┴─────────╮ │
+│ │ Field: a(numeric) │  │ Field: b(numeric) │ │
+│ │ Values: 3         │  │ Values: 300       │ │
+│ ╰───────────────────╯  ╰───────────────────╯ │
+│ Projections: a, b, s                         │
+│ ~2 rows                                      │
+╰──────────────────────────────────────────────╯
 
 # An OR mixing a key column with a non-key column cannot be split, so the whole
 # disjunction stays a FILTER over a full scan (nothing claimed).


### PR DESCRIPTION
## Problem

`col @@ q` on a search table's own relation failed with "@@ requires an inverted-indexed column on one side" even when `col` had an inverted index; only `FROM <index>` worked. The same root cause left `tag = 'red'` as a post-scan Column Filter on the table while the index relation answered it from the term dictionary. The table scan resolved WHERE columns through the shard config by column id, but an inverted index's term field is allocated separately, so an indexed column was never claimable.

## Changes

- The table scan resolves columns through the table's inverted indexes, with the shard's own term dicts (the PK columns) as fallback, so the table form and the index relation lower to the same iresearch filter. `WithSearchGetters` takes the set of indexes; the NOT NULL check that drops a column's null marker keys by column id instead of term field.
- EXPLAIN renders the Index Filter for search-table scans. It was gated on the index relation, so claimed filters, PK term filters included, were invisible and tests pinned "no Column Filter line" as the signal. The field resolvers pick the owning index per field and map a null marker back to its column instead of printing `col<id>(null)`.
- Refactor: `inverted_index` doubled as "this scan is an index relation" (an index relation over a search table was `SearchTable` plus a pointer). `ScanEntryKind::SearchTableIndex`, `IsIndexRelation()` and `ScannedIndex()` make that explicit, and the bind data holds one `indexes` vector: the scanned index, or the search table's indexes.
- The bare-table hint mentions the index relation. `@@` on transactional tables still errors.

## Tests

- `search_table_match_on_table.test` (new): table vs index parity for `@@` (counts, combined predicate, expression index, ordered rows), multi-index `And(svc, Phrase body)` plan, PK + indexed predicate composition, indexed + residual Column Filter, NOT NULL vs nullable negation plans, bare-table and transactional errors.
- `search_table_create_index.test`: `@@` on the table returns rows; the `tag = 'red'` plan moves from Column Filter to Index Filter.
- `search_table_pk_pushdown.test`: PK term filters are now visible in the plans.

Each commit builds and passes `tests/sqllogic/sdb/pg/index` on its own; the final state also passes `pg/simple` and every other sqllogic file touching search tables or inverted indexes.
