### PR TITLE
fix: view-backed index crashes when the view spells file columns in a different case

### DIFF
--- a/server/connector/index_source_external_lookup.cpp
+++ b/server/connector/index_source_external_lookup.cpp
@@ -82,15 +82,16 @@ ExternalLookupIndexSource::ExternalLookupIndexSource(
   auto names = entry.GetColumns().GetColumnNames();
   auto types = entry.GetColumns().GetColumnTypes();
 
-  const std::vector<std::string_view> source_names(names.begin(), names.end());
   std::vector<std::string> select_names;
   select_names.reserve(projected_columns.size());
-  InitProjection(context, projected_columns, projected_types, bind_column_ids,
-                 source_names, [&](duckdb::idx_t source_col) {
-                   SDB_ASSERT(source_col < names.size());
-                   select_names.push_back(names[source_col]);
-                   return types[source_col];
-                 });
+  InitProjection(
+    context, projected_columns, projected_types, bind_column_ids,
+    [&](std::string_view name) { return SourceColumn(name, names); },
+    [&](duckdb::idx_t source_col) {
+      SDB_ASSERT(source_col < names.size());
+      select_names.push_back(names[source_col]);
+      return types[source_col];
+    });
 
   _postgres_ctid = _fast_path.pk_spec == catalog::PkSpec::ExternalPostgresCtid;
   _num_key_cols = _postgres_ctid ? 1 : _fast_path.key_columns.size();

--- a/server/connector/index_source_external_lookup.cpp
+++ b/server/connector/index_source_external_lookup.cpp
@@ -82,27 +82,15 @@ ExternalLookupIndexSource::ExternalLookupIndexSource(
   auto names = entry.GetColumns().GetColumnNames();
   auto types = entry.GetColumns().GetColumnTypes();
 
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> name_to_col;
-  if (!_fast_path.projection_columns.empty()) {
-    name_to_col.reserve(names.size());
-    for (duckdb::idx_t i = 0; i < names.size(); ++i) {
-      name_to_col.emplace(names[i], i);
-    }
-  }
+  const std::vector<std::string_view> source_names(names.begin(), names.end());
   std::vector<std::string> select_names;
   select_names.reserve(projected_columns.size());
-  InitProjection(
-    context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view name) {
-      auto it = name_to_col.find(name);
-      SDB_ASSERT(it != name_to_col.end());
-      return it->second;
-    },
-    [&](duckdb::idx_t source_col) {
-      SDB_ASSERT(source_col < names.size());
-      select_names.push_back(names[source_col]);
-      return types[source_col];
-    });
+  InitProjection(context, projected_columns, projected_types, bind_column_ids,
+                 source_names, [&](duckdb::idx_t source_col) {
+                   SDB_ASSERT(source_col < names.size());
+                   select_names.push_back(names[source_col]);
+                   return types[source_col];
+                 });
 
   _postgres_ctid = _fast_path.pk_spec == catalog::PkSpec::ExternalPostgresCtid;
   _num_key_cols = _postgres_ctid ? 1 : _fast_path.key_columns.size();

--- a/server/connector/index_source_external_lookup.cpp
+++ b/server/connector/index_source_external_lookup.cpp
@@ -84,14 +84,12 @@ ExternalLookupIndexSource::ExternalLookupIndexSource(
 
   std::vector<std::string> select_names;
   select_names.reserve(projected_columns.size());
-  InitProjection(
-    context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view name) { return SourceColumn(name, names); },
-    [&](duckdb::idx_t source_col) {
-      SDB_ASSERT(source_col < names.size());
-      select_names.push_back(names[source_col]);
-      return types[source_col];
-    });
+  InitProjection(context, projected_columns, projected_types, bind_column_ids,
+                 SourceColumns{names}, [&](duckdb::idx_t source_col) {
+                   SDB_ASSERT(source_col < names.size());
+                   select_names.push_back(names[source_col]);
+                   return types[source_col];
+                 });
 
   _postgres_ctid = _fast_path.pk_spec == catalog::PkSpec::ExternalPostgresCtid;
   _num_key_cols = _postgres_ctid ? 1 : _fast_path.key_columns.size();

--- a/server/connector/index_source_view.cpp
+++ b/server/connector/index_source_view.cpp
@@ -20,8 +20,6 @@
 
 #include "connector/index_source_view.h"
 
-#include <absl/strings/ascii.h>
-
 #include <algorithm>
 #include <duckdb/common/types/vector.hpp>
 #include <duckdb/common/vector/struct_vector.hpp>
@@ -36,11 +34,7 @@
 namespace sdb::connector {
 
 duckdb::idx_t SourceColumns::operator()(std::string_view name) const {
-  if (const auto it = _exact.find(name); it != _exact.end()) {
-    return it->second;
-  }
-  if (const auto it = _folded.find(absl::AsciiStrToLower(name));
-      it != _folded.end()) {
+  if (const auto it = _by_name.find(name); it != _by_name.end()) {
     return it->second;
   }
   THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),

--- a/server/connector/index_source_view.cpp
+++ b/server/connector/index_source_view.cpp
@@ -20,6 +20,9 @@
 
 #include "connector/index_source_view.h"
 
+#include <absl/algorithm/container.h>
+#include <absl/strings/match.h>
+
 #include <algorithm>
 #include <duckdb/common/types/vector.hpp>
 #include <duckdb/common/vector/struct_vector.hpp>
@@ -28,15 +31,37 @@
 #include <numeric>
 
 #include "basics/assert.h"
+#include "pg/errcodes.h"
+#include "pg/sql_exception_macro.h"
 
 namespace sdb::connector {
+namespace {
+
+duckdb::idx_t SourceColumn(std::span<const std::string_view> names,
+                           std::string_view name) {
+  auto it = absl::c_find(names, name);
+  if (it == names.end()) {
+    it = absl::c_find_if(names, [&](std::string_view candidate) {
+      return absl::EqualsIgnoreCase(candidate, name);
+    });
+  }
+  if (it == names.end()) {
+    THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),
+                    ERR_MSG("column \"", name,
+                            "\" of the indexed view is not a column of its "
+                            "source"));
+  }
+  return static_cast<duckdb::idx_t>(it - names.begin());
+}
+
+}  // namespace
 
 void ViewIndexSourceBase::InitProjection(
   duckdb::ClientContext& context,
   std::span<const duckdb::idx_t> projected_columns,
   std::span<const duckdb::LogicalType> projected_types,
   std::span<const catalog::ColumnId> bind_column_ids,
-  absl::FunctionRef<duckdb::idx_t(std::string_view)> col_by_name,
+  std::span<const std::string_view> source_names,
   absl::FunctionRef<duckdb::LogicalType(duckdb::idx_t)> add_source_column) {
   _real_proj_slots.reserve(projected_columns.size());
   _scratch_types.reserve(projected_columns.size());
@@ -54,7 +79,8 @@ void ViewIndexSourceBase::InitProjection(
       const auto view_col_idx =
         static_cast<duckdb::idx_t>(bind_column_ids[bind_col]);
       SDB_ASSERT(view_col_idx < _fast_path.projection_columns.size());
-      source_col = col_by_name(_fast_path.projection_columns[view_col_idx]);
+      source_col =
+        SourceColumn(source_names, _fast_path.projection_columns[view_col_idx]);
     }
     _real_proj_slots.push_back(proj);
     _scratch_types.push_back(add_source_column(source_col));

--- a/server/connector/index_source_view.cpp
+++ b/server/connector/index_source_view.cpp
@@ -34,7 +34,7 @@
 namespace sdb::connector {
 
 duckdb::idx_t SourceColumns::operator()(std::string_view name) const {
-  if (const auto it = _by_name.find(std::string{name}); it != _by_name.end()) {
+  if (const auto it = _by_name.find(name); it != _by_name.end()) {
     return it->second;
   }
   THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),

--- a/server/connector/index_source_view.cpp
+++ b/server/connector/index_source_view.cpp
@@ -20,9 +20,6 @@
 
 #include "connector/index_source_view.h"
 
-#include <absl/algorithm/container.h>
-#include <absl/strings/match.h>
-
 #include <algorithm>
 #include <duckdb/common/types/vector.hpp>
 #include <duckdb/common/vector/struct_vector.hpp>
@@ -35,33 +32,20 @@
 #include "pg/sql_exception_macro.h"
 
 namespace sdb::connector {
-namespace {
 
-duckdb::idx_t SourceColumn(std::span<const std::string_view> names,
-                           std::string_view name) {
-  auto it = absl::c_find(names, name);
-  if (it == names.end()) {
-    it = absl::c_find_if(names, [&](std::string_view candidate) {
-      return absl::EqualsIgnoreCase(candidate, name);
-    });
-  }
-  if (it == names.end()) {
-    THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),
-                    ERR_MSG("column \"", name,
-                            "\" of the indexed view is not a column of its "
-                            "source"));
-  }
-  return static_cast<duckdb::idx_t>(it - names.begin());
+void ThrowUnknownSourceColumn(std::string_view name) {
+  THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),
+                  ERR_MSG("column \"", name,
+                          "\" of the indexed view is not a column of its "
+                          "source"));
 }
-
-}  // namespace
 
 void ViewIndexSourceBase::InitProjection(
   duckdb::ClientContext& context,
   std::span<const duckdb::idx_t> projected_columns,
   std::span<const duckdb::LogicalType> projected_types,
   std::span<const catalog::ColumnId> bind_column_ids,
-  std::span<const std::string_view> source_names,
+  absl::FunctionRef<duckdb::idx_t(std::string_view)> col_by_name,
   absl::FunctionRef<duckdb::LogicalType(duckdb::idx_t)> add_source_column) {
   _real_proj_slots.reserve(projected_columns.size());
   _scratch_types.reserve(projected_columns.size());
@@ -79,8 +63,7 @@ void ViewIndexSourceBase::InitProjection(
       const auto view_col_idx =
         static_cast<duckdb::idx_t>(bind_column_ids[bind_col]);
       SDB_ASSERT(view_col_idx < _fast_path.projection_columns.size());
-      source_col =
-        SourceColumn(source_names, _fast_path.projection_columns[view_col_idx]);
+      source_col = col_by_name(_fast_path.projection_columns[view_col_idx]);
     }
     _real_proj_slots.push_back(proj);
     _scratch_types.push_back(add_source_column(source_col));

--- a/server/connector/index_source_view.cpp
+++ b/server/connector/index_source_view.cpp
@@ -34,7 +34,7 @@
 namespace sdb::connector {
 
 duckdb::idx_t SourceColumns::operator()(std::string_view name) const {
-  if (const auto it = _by_name.find(name); it != _by_name.end()) {
+  if (const auto it = _by_name.find(std::string{name}); it != _by_name.end()) {
     return it->second;
   }
   THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),

--- a/server/connector/index_source_view.cpp
+++ b/server/connector/index_source_view.cpp
@@ -20,6 +20,8 @@
 
 #include "connector/index_source_view.h"
 
+#include <absl/strings/ascii.h>
+
 #include <algorithm>
 #include <duckdb/common/types/vector.hpp>
 #include <duckdb/common/vector/struct_vector.hpp>
@@ -33,7 +35,14 @@
 
 namespace sdb::connector {
 
-void ThrowUnknownSourceColumn(std::string_view name) {
+duckdb::idx_t SourceColumns::operator()(std::string_view name) const {
+  if (const auto it = _exact.find(name); it != _exact.end()) {
+    return it->second;
+  }
+  if (const auto it = _folded.find(absl::AsciiStrToLower(name));
+      it != _folded.end()) {
+    return it->second;
+  }
   THROW_SQL_ERROR(ERR_CODE(ERRCODE_UNDEFINED_COLUMN),
                   ERR_MSG("column \"", name,
                           "\" of the indexed view is not a column of its "

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -21,10 +21,8 @@
 #pragma once
 
 #include <absl/functional/function_ref.h>
-#include <absl/hash/hash.h>
-#include <absl/strings/ascii.h>
-#include <absl/strings/match.h>
 
+#include <duckdb/common/case_insensitive_map.hpp>
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
 #include <duckdb/execution/expression_executor.hpp>
@@ -33,26 +31,14 @@
 #include <iresearch/index/index_source.hpp>
 #include <ranges>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
-#include "basics/containers/flat_hash_map.h"
 #include "catalog/table_options.h"
 #include "connector/view_fast_path.h"
 
 namespace sdb::connector {
-
-struct CaseFoldedHash {
-  size_t operator()(std::string_view name) const {
-    return absl::HashOf(absl::AsciiStrToLower(name));
-  }
-};
-
-struct CaseFoldedEqual {
-  bool operator()(std::string_view lhs, std::string_view rhs) const {
-    return absl::EqualsIgnoreCase(lhs, rhs);
-  }
-};
 
 class SourceColumns {
  public:
@@ -60,17 +46,14 @@ class SourceColumns {
   explicit SourceColumns(const Names& names, Proj proj = {}) {
     duckdb::idx_t index = 0;
     for (const auto& candidate : names) {
-      _by_name.try_emplace(std::string_view{std::invoke(proj, candidate)},
-                           index++);
+      _by_name.try_emplace(std::string{std::invoke(proj, candidate)}, index++);
     }
   }
 
   duckdb::idx_t operator()(std::string_view name) const;
 
  private:
-  containers::FlatHashMap<std::string_view, duckdb::idx_t, CaseFoldedHash,
-                          CaseFoldedEqual>
-    _by_name;
+  duckdb::case_insensitive_map_t<duckdb::idx_t> _by_name;
 };
 
 class ViewIndexSourceBase : public IndexSource {

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <absl/algorithm/container.h>
+#include <absl/container/inlined_vector.h>
 #include <absl/functional/function_ref.h>
 #include <absl/hash/hash.h>
 #include <absl/strings/ascii.h>
@@ -42,21 +44,11 @@
 
 namespace sdb::connector {
 
-struct CaseFoldedName {
-  std::string_view name;
-
-  template<typename H>
-  friend H AbslHashValue(H state, CaseFoldedName folded) {
-    for (const char c : folded.name) {
-      state = H::combine(std::move(state), absl::ascii_tolower(c));
-    }
-    return H::combine(std::move(state), folded.name.size());
-  }
-};
-
 struct CaseFoldedHash {
   size_t operator()(std::string_view name) const {
-    return absl::HashOf(CaseFoldedName{name});
+    absl::InlinedVector<char, 64> folded(name.size());
+    absl::c_transform(name, folded.begin(), absl::ascii_tolower);
+    return absl::HashOf(std::string_view{folded.data(), folded.size()});
   }
 };
 

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <absl/functional/function_ref.h>
-#include <absl/strings/match.h>
+#include <absl/strings/ascii.h>
 
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
@@ -31,36 +31,35 @@
 #include <iresearch/index/index_source.hpp>
 #include <ranges>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
+#include "basics/containers/flat_hash_map.h"
 #include "catalog/table_options.h"
 #include "connector/view_fast_path.h"
 
 namespace sdb::connector {
 
-[[noreturn]] void ThrowUnknownSourceColumn(std::string_view name);
+class SourceColumns {
+ public:
+  template<std::ranges::input_range Names, typename Proj = std::identity>
+  explicit SourceColumns(const Names& names, Proj proj = {}) {
+    duckdb::idx_t index = 0;
+    for (const auto& candidate : names) {
+      const std::string_view name{std::invoke(proj, candidate)};
+      _exact.try_emplace(name, index);
+      _folded.try_emplace(absl::AsciiStrToLower(name), index);
+      ++index;
+    }
+  }
 
-template<std::ranges::forward_range Names, typename Proj = std::identity>
-duckdb::idx_t SourceColumn(std::string_view name, const Names& names,
-                           Proj proj = {}) {
-  const auto find = [&](auto&& matches) {
-    return std::ranges::find_if(names, [&](const auto& candidate) {
-      return matches(std::string_view{std::invoke(proj, candidate)}, name);
-    });
-  };
-  auto it = find(std::ranges::equal_to{});
-  if (it == std::ranges::end(names)) {
-    it = find([](std::string_view lhs, std::string_view rhs) {
-      return absl::EqualsIgnoreCase(lhs, rhs);
-    });
-  }
-  if (it == std::ranges::end(names)) {
-    ThrowUnknownSourceColumn(name);
-  }
-  return static_cast<duckdb::idx_t>(
-    std::ranges::distance(std::ranges::begin(names), it));
-}
+  duckdb::idx_t operator()(std::string_view name) const;
+
+ private:
+  containers::FlatHashMap<std::string_view, duckdb::idx_t> _exact;
+  containers::FlatHashMap<std::string, duckdb::idx_t> _folded;
+};
 
 class ViewIndexSourceBase : public IndexSource {
  protected:

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -46,7 +46,7 @@ class SourceColumns {
   explicit SourceColumns(const Names& names, Proj proj = {}) {
     duckdb::idx_t index = 0;
     for (const auto& candidate : names) {
-      _by_name.try_emplace(std::string{std::invoke(proj, candidate)}, index++);
+      _by_name.try_emplace(std::invoke(proj, candidate), index++);
     }
   }
 

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -46,7 +46,7 @@ class ViewIndexSourceBase : public IndexSource {
     std::span<const duckdb::idx_t> projected_columns,
     std::span<const duckdb::LogicalType> projected_types,
     std::span<const catalog::ColumnId> bind_column_ids,
-    absl::FunctionRef<duckdb::idx_t(std::string_view)> col_by_name,
+    std::span<const std::string_view> source_names,
     absl::FunctionRef<duckdb::LogicalType(duckdb::idx_t)> add_source_column);
 
   std::span<const int64_t> SortRows(const duckdb::Vector& pk,

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -21,7 +21,9 @@
 #pragma once
 
 #include <absl/functional/function_ref.h>
+#include <absl/hash/hash.h>
 #include <absl/strings/ascii.h>
+#include <absl/strings/match.h>
 
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
@@ -31,7 +33,6 @@
 #include <iresearch/index/index_source.hpp>
 #include <ranges>
 #include <span>
-#include <string>
 #include <string_view>
 #include <vector>
 
@@ -41,24 +42,47 @@
 
 namespace sdb::connector {
 
+struct CaseFoldedName {
+  std::string_view name;
+
+  template<typename H>
+  friend H AbslHashValue(H state, CaseFoldedName folded) {
+    for (const char c : folded.name) {
+      state = H::combine(std::move(state), absl::ascii_tolower(c));
+    }
+    return H::combine(std::move(state), folded.name.size());
+  }
+};
+
+struct CaseFoldedHash {
+  size_t operator()(std::string_view name) const {
+    return absl::HashOf(CaseFoldedName{name});
+  }
+};
+
+struct CaseFoldedEqual {
+  bool operator()(std::string_view lhs, std::string_view rhs) const {
+    return absl::EqualsIgnoreCase(lhs, rhs);
+  }
+};
+
 class SourceColumns {
  public:
   template<std::ranges::input_range Names, typename Proj = std::identity>
   explicit SourceColumns(const Names& names, Proj proj = {}) {
     duckdb::idx_t index = 0;
     for (const auto& candidate : names) {
-      const std::string_view name{std::invoke(proj, candidate)};
-      _exact.try_emplace(name, index);
-      _folded.try_emplace(absl::AsciiStrToLower(name), index);
-      ++index;
+      _by_name.try_emplace(std::string_view{std::invoke(proj, candidate)},
+                           index++);
     }
   }
 
   duckdb::idx_t operator()(std::string_view name) const;
 
  private:
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> _exact;
-  containers::FlatHashMap<std::string, duckdb::idx_t> _folded;
+  containers::FlatHashMap<std::string_view, duckdb::idx_t, CaseFoldedHash,
+                          CaseFoldedEqual>
+    _by_name;
 };
 
 class ViewIndexSourceBase : public IndexSource {

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include <absl/algorithm/container.h>
-#include <absl/container/inlined_vector.h>
 #include <absl/functional/function_ref.h>
 #include <absl/hash/hash.h>
 #include <absl/strings/ascii.h>
@@ -46,9 +44,7 @@ namespace sdb::connector {
 
 struct CaseFoldedHash {
   size_t operator()(std::string_view name) const {
-    absl::InlinedVector<char, 64> folded(name.size());
-    absl::c_transform(name, folded.begin(), absl::ascii_tolower);
-    return absl::HashOf(std::string_view{folded.data(), folded.size()});
+    return absl::HashOf(absl::AsciiStrToLower(name));
   }
 };
 

--- a/server/connector/index_source_view.h
+++ b/server/connector/index_source_view.h
@@ -21,12 +21,15 @@
 #pragma once
 
 #include <absl/functional/function_ref.h>
+#include <absl/strings/match.h>
 
 #include <duckdb/common/types.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
 #include <duckdb/execution/expression_executor.hpp>
 #include <duckdb/planner/table_filter_set.hpp>
+#include <functional>
 #include <iresearch/index/index_source.hpp>
+#include <ranges>
 #include <span>
 #include <string_view>
 #include <vector>
@@ -35,6 +38,29 @@
 #include "connector/view_fast_path.h"
 
 namespace sdb::connector {
+
+[[noreturn]] void ThrowUnknownSourceColumn(std::string_view name);
+
+template<std::ranges::forward_range Names, typename Proj = std::identity>
+duckdb::idx_t SourceColumn(std::string_view name, const Names& names,
+                           Proj proj = {}) {
+  const auto find = [&](auto&& matches) {
+    return std::ranges::find_if(names, [&](const auto& candidate) {
+      return matches(std::string_view{std::invoke(proj, candidate)}, name);
+    });
+  };
+  auto it = find(std::ranges::equal_to{});
+  if (it == std::ranges::end(names)) {
+    it = find([](std::string_view lhs, std::string_view rhs) {
+      return absl::EqualsIgnoreCase(lhs, rhs);
+    });
+  }
+  if (it == std::ranges::end(names)) {
+    ThrowUnknownSourceColumn(name);
+  }
+  return static_cast<duckdb::idx_t>(
+    std::ranges::distance(std::ranges::begin(names), it));
+}
 
 class ViewIndexSourceBase : public IndexSource {
  protected:
@@ -46,7 +72,7 @@ class ViewIndexSourceBase : public IndexSource {
     std::span<const duckdb::idx_t> projected_columns,
     std::span<const duckdb::LogicalType> projected_types,
     std::span<const catalog::ColumnId> bind_column_ids,
-    std::span<const std::string_view> source_names,
+    absl::FunctionRef<duckdb::idx_t(std::string_view)> col_by_name,
     absl::FunctionRef<duckdb::LogicalType(duckdb::idx_t)> add_source_column);
 
   std::span<const int64_t> SortRows(const duckdb::Vector& pk,

--- a/server/connector/index_source_view_file.cpp
+++ b/server/connector/index_source_view_file.cpp
@@ -23,9 +23,9 @@
 #include <duckdb/common/multi_file/multi_file_states.hpp>
 #include <duckdb/common/vector_operations/vector_operations.hpp>
 #include <duckdb/planner/filter/expression_filter.hpp>
+#include <ranges>
 
 #include "basics/assert.h"
-#include "basics/containers/flat_hash_map.h"
 
 namespace sdb::connector {
 
@@ -40,26 +40,18 @@ ViewFileIndexSourceBase::ViewFileIndexSourceBase(
   _lookup_func = MakeFastPathLookupFunction(_fast_path);
 
   auto& multi_bd = _bind_data->Cast<duckdb::MultiFileBindData>();
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> name_to_file_col;
-  if (!_fast_path.projection_columns.empty()) {
-    name_to_file_col.reserve(multi_bd.names.size());
-    for (duckdb::idx_t i = 0; i < multi_bd.names.size(); ++i) {
-      name_to_file_col.emplace(multi_bd.names[i].GetIdentifierName(), i);
-    }
-  }
+  const auto source_names =
+    multi_bd.names | std::views::transform([](const duckdb::Identifier& name) {
+      return std::string_view{name.GetIdentifierName()};
+    }) |
+    std::ranges::to<std::vector>();
   _column_indexes.reserve(projected_columns.size());
-  InitProjection(
-    context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view name) {
-      auto it = name_to_file_col.find(name);
-      SDB_ASSERT(it != name_to_file_col.end());
-      return it->second;
-    },
-    [&](duckdb::idx_t file_col_idx) {
-      SDB_ASSERT(file_col_idx < multi_bd.types.size());
-      _column_indexes.emplace_back(file_col_idx);
-      return multi_bd.types[file_col_idx];
-    });
+  InitProjection(context, projected_columns, projected_types, bind_column_ids,
+                 source_names, [&](duckdb::idx_t file_col_idx) {
+                   SDB_ASSERT(file_col_idx < multi_bd.types.size());
+                   _column_indexes.emplace_back(file_col_idx);
+                   return multi_bd.types[file_col_idx];
+                 });
   BuildPushedFilters(pushed_filters);
 }
 

--- a/server/connector/index_source_view_file.cpp
+++ b/server/connector/index_source_view_file.cpp
@@ -23,7 +23,6 @@
 #include <duckdb/common/multi_file/multi_file_states.hpp>
 #include <duckdb/common/vector_operations/vector_operations.hpp>
 #include <duckdb/planner/filter/expression_filter.hpp>
-#include <ranges>
 
 #include "basics/assert.h"
 
@@ -40,18 +39,18 @@ ViewFileIndexSourceBase::ViewFileIndexSourceBase(
   _lookup_func = MakeFastPathLookupFunction(_fast_path);
 
   auto& multi_bd = _bind_data->Cast<duckdb::MultiFileBindData>();
-  const auto source_names =
-    multi_bd.names | std::views::transform([](const duckdb::Identifier& name) {
-      return std::string_view{name.GetIdentifierName()};
-    }) |
-    std::ranges::to<std::vector>();
   _column_indexes.reserve(projected_columns.size());
-  InitProjection(context, projected_columns, projected_types, bind_column_ids,
-                 source_names, [&](duckdb::idx_t file_col_idx) {
-                   SDB_ASSERT(file_col_idx < multi_bd.types.size());
-                   _column_indexes.emplace_back(file_col_idx);
-                   return multi_bd.types[file_col_idx];
-                 });
+  InitProjection(
+    context, projected_columns, projected_types, bind_column_ids,
+    [&](std::string_view name) {
+      return SourceColumn(name, multi_bd.names,
+                          &duckdb::Identifier::GetIdentifierName);
+    },
+    [&](duckdb::idx_t file_col_idx) {
+      SDB_ASSERT(file_col_idx < multi_bd.types.size());
+      _column_indexes.emplace_back(file_col_idx);
+      return multi_bd.types[file_col_idx];
+    });
   BuildPushedFilters(pushed_filters);
 }
 

--- a/server/connector/index_source_view_file.cpp
+++ b/server/connector/index_source_view_file.cpp
@@ -42,10 +42,7 @@ ViewFileIndexSourceBase::ViewFileIndexSourceBase(
   _column_indexes.reserve(projected_columns.size());
   InitProjection(
     context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view name) {
-      return SourceColumn(name, multi_bd.names,
-                          &duckdb::Identifier::GetIdentifierName);
-    },
+    SourceColumns{multi_bd.names, &duckdb::Identifier::GetIdentifierName},
     [&](duckdb::idx_t file_col_idx) {
       SDB_ASSERT(file_col_idx < multi_bd.types.size());
       _column_indexes.emplace_back(file_col_idx);

--- a/server/connector/index_source_view_table.cpp
+++ b/server/connector/index_source_view_table.cpp
@@ -141,16 +141,15 @@ ViewTableIndexSource::ViewTableIndexSource(
   // alive for the query even if it is detached concurrently.
   duckdb::DuckTransaction::Get(context, table.ParentCatalog());
   const auto& columns = table.GetColumns();
-  const auto column_names =
-    std::views::iota(duckdb::idx_t{0}, columns.LogicalColumnCount()) |
-    std::views::transform([&](duckdb::idx_t i) -> std::string_view {
-      return columns.GetColumn(duckdb::LogicalIndex(i))
-        .Name()
-        .GetIdentifierName();
-    });
   InitProjection(
     context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view name) { return SourceColumn(name, column_names); },
+    SourceColumns{
+      std::views::iota(duckdb::idx_t{0}, columns.LogicalColumnCount()) |
+      std::views::transform([&](duckdb::idx_t i) -> std::string_view {
+        return columns.GetColumn(duckdb::LogicalIndex(i))
+          .Name()
+          .GetIdentifierName();
+      })},
     [&](duckdb::idx_t table_col_idx) {
       SDB_ASSERT(table_col_idx < columns.LogicalColumnCount());
       return AddFetchColumn(

--- a/server/connector/index_source_view_table.cpp
+++ b/server/connector/index_source_view_table.cpp
@@ -140,26 +140,17 @@ ViewTableIndexSource::ViewTableIndexSource(
   // alive for the query even if it is detached concurrently.
   duckdb::DuckTransaction::Get(context, table.ParentCatalog());
   const auto& columns = table.GetColumns();
-  containers::FlatHashMap<std::string_view, duckdb::idx_t> name_to_col;
-  if (!_fast_path.projection_columns.empty()) {
-    name_to_col.reserve(columns.LogicalColumnCount());
-    duckdb::idx_t logical = 0;
-    for (const auto& col : columns.Logical()) {
-      name_to_col.emplace(col.Name().GetIdentifierName(), logical++);
-    }
+  std::vector<std::string_view> source_names;
+  source_names.reserve(columns.LogicalColumnCount());
+  for (const auto& col : columns.Logical()) {
+    source_names.emplace_back(col.Name().GetIdentifierName());
   }
-  InitProjection(
-    context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view name) {
-      auto it = name_to_col.find(name);
-      SDB_ASSERT(it != name_to_col.end());
-      return it->second;
-    },
-    [&](duckdb::idx_t table_col_idx) {
-      SDB_ASSERT(table_col_idx < columns.LogicalColumnCount());
-      return AddFetchColumn(
-        columns.GetColumn(duckdb::LogicalIndex(table_col_idx)));
-    });
+  InitProjection(context, projected_columns, projected_types, bind_column_ids,
+                 source_names, [&](duckdb::idx_t table_col_idx) {
+                   SDB_ASSERT(table_col_idx < columns.LogicalColumnCount());
+                   return AddFetchColumn(
+                     columns.GetColumn(duckdb::LogicalIndex(table_col_idx)));
+                 });
   FinishInit(context);
   BuildPushedFilters(pushed_filters);
 }
@@ -184,19 +175,15 @@ TableRowIdIndexSource::TableRowIdIndexSource(
   for (const auto& col : scan_columns.Logical()) {
     id_to_pos.emplace(col.CatalogOid(), pos++);
   }
-  InitProjection(
-    context, projected_columns, projected_types, bind_column_ids,
-    [&](std::string_view) -> duckdb::idx_t {
-      SDB_ASSERT(false, "table index sources resolve columns by id");
-      return 0;
-    },
-    [&](duckdb::idx_t col_id) {
-      auto it = id_to_pos.find(col_id);
-      SDB_ENSURE(it != id_to_pos.end(), "column id is not on the store table");
-      SDB_ASSERT(it->second < columns.LogicalColumnCount());
-      return AddFetchColumn(
-        columns.GetColumn(duckdb::LogicalIndex(it->second)));
-    });
+  InitProjection(context, projected_columns, projected_types, bind_column_ids,
+                 {}, [&](duckdb::idx_t col_id) {
+                   auto it = id_to_pos.find(col_id);
+                   SDB_ENSURE(it != id_to_pos.end(),
+                              "column id is not on the store table");
+                   SDB_ASSERT(it->second < columns.LogicalColumnCount());
+                   return AddFetchColumn(
+                     columns.GetColumn(duckdb::LogicalIndex(it->second)));
+                 });
   FinishInit(context);
   BuildPushedFilters(pushed_filters);
 }

--- a/server/connector/index_source_view_table.cpp
+++ b/server/connector/index_source_view_table.cpp
@@ -28,6 +28,7 @@
 #include <duckdb/storage/data_table.hpp>
 #include <duckdb/storage/table/scan_state.hpp>
 #include <duckdb/transaction/duck_transaction.hpp>
+#include <ranges>
 
 #include "basics/assert.h"
 #include "basics/containers/flat_hash_map.h"
@@ -140,17 +141,21 @@ ViewTableIndexSource::ViewTableIndexSource(
   // alive for the query even if it is detached concurrently.
   duckdb::DuckTransaction::Get(context, table.ParentCatalog());
   const auto& columns = table.GetColumns();
-  std::vector<std::string_view> source_names;
-  source_names.reserve(columns.LogicalColumnCount());
-  for (const auto& col : columns.Logical()) {
-    source_names.emplace_back(col.Name().GetIdentifierName());
-  }
-  InitProjection(context, projected_columns, projected_types, bind_column_ids,
-                 source_names, [&](duckdb::idx_t table_col_idx) {
-                   SDB_ASSERT(table_col_idx < columns.LogicalColumnCount());
-                   return AddFetchColumn(
-                     columns.GetColumn(duckdb::LogicalIndex(table_col_idx)));
-                 });
+  const auto column_names =
+    std::views::iota(duckdb::idx_t{0}, columns.LogicalColumnCount()) |
+    std::views::transform([&](duckdb::idx_t i) -> std::string_view {
+      return columns.GetColumn(duckdb::LogicalIndex(i))
+        .Name()
+        .GetIdentifierName();
+    });
+  InitProjection(
+    context, projected_columns, projected_types, bind_column_ids,
+    [&](std::string_view name) { return SourceColumn(name, column_names); },
+    [&](duckdb::idx_t table_col_idx) {
+      SDB_ASSERT(table_col_idx < columns.LogicalColumnCount());
+      return AddFetchColumn(
+        columns.GetColumn(duckdb::LogicalIndex(table_col_idx)));
+    });
   FinishInit(context);
   BuildPushedFilters(pushed_filters);
 }
@@ -175,15 +180,19 @@ TableRowIdIndexSource::TableRowIdIndexSource(
   for (const auto& col : scan_columns.Logical()) {
     id_to_pos.emplace(col.CatalogOid(), pos++);
   }
-  InitProjection(context, projected_columns, projected_types, bind_column_ids,
-                 {}, [&](duckdb::idx_t col_id) {
-                   auto it = id_to_pos.find(col_id);
-                   SDB_ENSURE(it != id_to_pos.end(),
-                              "column id is not on the store table");
-                   SDB_ASSERT(it->second < columns.LogicalColumnCount());
-                   return AddFetchColumn(
-                     columns.GetColumn(duckdb::LogicalIndex(it->second)));
-                 });
+  InitProjection(
+    context, projected_columns, projected_types, bind_column_ids,
+    [&](std::string_view) -> duckdb::idx_t {
+      SDB_ASSERT(false, "table index sources resolve columns by id");
+      return 0;
+    },
+    [&](duckdb::idx_t col_id) {
+      auto it = id_to_pos.find(col_id);
+      SDB_ENSURE(it != id_to_pos.end(), "column id is not on the store table");
+      SDB_ASSERT(it->second < columns.LogicalColumnCount());
+      return AddFetchColumn(
+        columns.GetColumn(duckdb::LogicalIndex(it->second)));
+    });
   FinishInit(context);
   BuildPushedFilters(pushed_filters);
 }

--- a/tests/sqllogic/sdb/pg/duckdb_postgres/inverted_index_column_case_pgscan.test_slow
+++ b/tests/sqllogic/sdb/pg/duckdb_postgres/inverted_index_column_case_pgscan.test_slow
@@ -1,0 +1,75 @@
+control substitution on
+
+hash-threshold 100
+
+# A view over an ATTACH'd postgres table may spell quoted mixed-case columns in
+# lowercase (the catalog binds them case-insensitively). Materialising a real
+# column through the index re-fetches the matched rows from postgres and must
+# resolve the view's names the same way.
+
+
+statement ok
+ATTACH 'host=${PGHOST} port=${PGPORT} dbname=postgres user=${PGUSER}' AS pg_${__DATABASE__} (TYPE postgres);
+
+
+statement ok
+CREATE SCHEMA pg_${__DATABASE__}.iipgcase_docs;
+
+
+statement ok
+CREATE TABLE pg_${__DATABASE__}.iipgcase_docs.articles (
+  "Id"   BIGINT PRIMARY KEY,
+  "Body" TEXT,
+  "Tag"  TEXT
+);
+
+
+statement count 3
+INSERT INTO pg_${__DATABASE__}.iipgcase_docs.articles VALUES
+  (1, 'pudge goes mid and dominates the lane', 'gameplay'),
+  (2, 'anchin reads manga every weekend',      'reading'),
+  (3, 'pudge plays again in a ranked match',   'gameplay');
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY iipgcase_en(template = 'keyword', frequency = true, norm = true, position = true);
+
+
+statement ok
+CREATE VIEW iipgcase_v AS SELECT id AS I, body AS Body, tag AS Tag FROM pg_${__DATABASE__}.iipgcase_docs.articles;
+
+
+statement ok
+CREATE INDEX iipgcase_idx ON iipgcase_v USING inverted ((ts_split_by_non_alpha(Body, true)) iipgcase_en) INCLUDE (Tag);
+
+
+query
+SELECT Body FROM iipgcase_idx ORDER BY I;
+----
+body
+pudge goes mid and dominates the lane
+anchin reads manga every weekend
+pudge plays again in a ranked match
+
+query
+SELECT I, Tag, Body FROM iipgcase_idx WHERE ts_split_by_non_alpha(Body, true) @@ 'pudge' ORDER BY I;
+----
+i	tag	body
+1	gameplay	pudge goes mid and dominates the lane
+3	gameplay	pudge plays again in a ranked match
+
+
+statement ok
+DROP VIEW iipgcase_v;
+
+
+statement ok
+DROP TABLE pg_${__DATABASE__}.iipgcase_docs.articles;
+
+
+statement ok
+DROP SCHEMA pg_${__DATABASE__}.iipgcase_docs;
+
+
+statement ok
+DETACH pg_${__DATABASE__};

--- a/tests/sqllogic/sdb/pg/index/inverted_index_view_attached_column_case.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_view_attached_column_case.test
@@ -1,0 +1,51 @@
+# A view over an ATTACHed duckdb table may spell quoted mixed-case columns in
+# lowercase (the catalog binds them case-insensitively). Materialising a real
+# column through the index must resolve the view's names the same way.
+control substitution on
+
+
+statement ok
+DETACH DATABASE IF EXISTS dbcase;
+
+
+statement ok
+ATTACH '${__TEST_DIR__}/dbcase.duckdb' AS dbcase;
+
+
+statement ok
+CREATE TABLE dbcase.main.docs("Id" INTEGER, "Body" TEXT, "Score" INTEGER);
+
+
+statement ok
+INSERT INTO dbcase.main.docs VALUES
+  (1, 'alpha cat runs', 10),
+  (2, 'beta dog sleeps', 20),
+  (3, 'gamma cat jumps', 30);
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY view_attached_case_en(template = 'keyword', frequency = true, norm = true, position = true);
+
+
+statement ok
+CREATE VIEW v_att_case AS SELECT id AS I, body AS Body, score AS S FROM dbcase.main.docs;
+
+
+statement ok
+CREATE INDEX v_att_case_idx ON v_att_case USING inverted ((ts_split_by_non_alpha(Body, true)) view_attached_case_en) INCLUDE (S);
+
+
+query
+SELECT Body FROM v_att_case_idx ORDER BY I;
+----
+body
+alpha cat runs
+beta dog sleeps
+gamma cat jumps
+
+query
+SELECT I, S, Body FROM v_att_case_idx WHERE ts_split_by_non_alpha(Body, true) @@ 'cat' ORDER BY I;
+----
+i	s	body
+1	10	alpha cat runs
+3	30	gamma cat jumps

--- a/tests/sqllogic/sdb/pg/index/inverted_index_view_column_case.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_view_column_case.test
@@ -1,0 +1,43 @@
+# A view over a file reader may spell its columns in a different case than the
+# file does (DuckDB binds them case-insensitively). Materialising a real column
+# through the index must resolve the view's names the same way.
+control substitution on
+
+
+statement count 20
+COPY (SELECT TIMESTAMP '2025-01-01 00:00:00' + INTERVAL (i) SECOND AS "Timestamp",
+             'trace' || i AS "TraceId",
+             (i % 5)::INTEGER AS "SeverityNumber",
+             CASE WHEN i % 2 = 0 THEN 'error in module ' || (i % 4) ELSE 'all good in module ' || (i % 4) END AS "Body"
+      FROM range(20) t(i))
+TO '${__TEST_DIR__}/view_column_case.parquet' (FORMAT PARQUET);
+
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY view_column_case_en (template = 'keyword', frequency = true, norm = true, position = true);
+
+statement ok
+CREATE VIEW view_column_case_v AS SELECT timestamp AS Ts, body AS Body FROM read_parquet('${__TEST_DIR__}/view_column_case.parquet');
+
+statement ok
+CREATE INDEX view_column_case_idx ON view_column_case_v USING inverted ((ts_split_by_non_alpha(Body, true)) view_column_case_en) INCLUDE (Ts);
+
+query
+SELECT Body FROM view_column_case_idx ORDER BY Ts LIMIT 1;
+----
+body
+error in module 0
+
+query
+SELECT Ts::VARCHAR AS ts, Body FROM view_column_case_idx WHERE ts_split_by_non_alpha(Body, true) @@ 'error' ORDER BY Ts LIMIT 3;
+----
+ts	body
+2025-01-01 00:00:00	error in module 0
+2025-01-01 00:00:02	error in module 2
+2025-01-01 00:00:04	error in module 0
+
+query
+SELECT count(*) AS c FROM view_column_case_idx WHERE ts_split_by_non_alpha(Body, true) @@ 'module';
+----
+c
+20


### PR DESCRIPTION
## Problem

`SELECT Body FROM ixr LIMIT 1` over an inverted index on `CREATE VIEW vr AS SELECT timestamp AS Ts, body AS Body FROM read_parquet(...)` crashed the server whenever the parquet file spells its columns `Timestamp`/`Body`, the usual OTel export layout. DuckDB binds file columns case-insensitively, so the view is valid, but the fast path keyed the file schema by exact name and dereferenced the miss: `SDB_ASSERT` in assert builds, SIGSEGV in release. The "not a recognised fast-path source" guard never applies here because a column projection over `read_parquet` is a recognised fast path.

## Fix

`InitProjection` takes the source's column names and resolves each projection name once: exact match first, case-insensitive fallback; a miss raises `undefined_column`. The three per-source lookup maps (file reader, attached catalog, serenedb table) are gone. Exact-first keeps serenedb tables, which bind case-sensitively today, right while file readers and attached catalogs get DuckDB's case-insensitive semantics.

## Tests

`inverted_index_view_column_case.test`: capitalised parquet columns referenced in lowercase by the view; real-column materialisation through the index, an `@@` lookup returning the `INCLUDE`d column, and a count. The report's four statements pass verbatim on such a file. `pg/index` and the site-docs inverted-index suites pass.
