### PR TITLE
fix: sdb_metrics aborts on a search table's storage-less indexes

### DIFF
--- a/server/pg/sdb_catalog/sdb_metrics.cpp
+++ b/server/pg/sdb_catalog/sdb_metrics.cpp
@@ -30,10 +30,12 @@
 #include "catalog/ddl/catalog.h"
 #include "catalog/ddl/duckdb_catalog.h"
 #include "catalog/entry/duckdb_index_entry.h"
+#include "catalog/entry/duckdb_table_entry.h"
 #include "catalog/inverted_index.h"
 #include "catalog/log/duckdb_global_catalog.h"
 #include "catalog/read/duckdb_catalog_sets.h"
 #include "search/inverted_index_storage.h"
+#include "search/search_table.h"
 
 namespace sdb::pg {
 namespace {
@@ -51,32 +53,34 @@ constexpr uint64_t kPerIndexMask = MaskFromNonNulls({
   GetIndex(&SdbMetrics::relation_id),
 });
 
-using Stats = search::InvertedIndexStorage::Stats;
+using search::StoreStats;
 
 struct IndexMetricDesc {
   std::string_view metric;
-  uint64_t Stats::* field;
+  uint64_t StoreStats::* field;
   std::string_view description;
 };
 
 constexpr std::array<IndexMetricDesc, 12> kIndexMetrics = {{
-  {"num_docs", &Stats::numDocs, "documents in the index (including deleted)"},
-  {"num_live_docs", &Stats::numLiveDocs, "live (non-deleted) documents"},
-  {"num_buffered_docs", &Stats::numBufferedDocs,
+  {"num_docs", &StoreStats::numDocs,
+   "documents in the index (including deleted)"},
+  {"num_live_docs", &StoreStats::numLiveDocs, "live (non-deleted) documents"},
+  {"num_buffered_docs", &StoreStats::numBufferedDocs,
    "documents buffered in the writer, not yet committed"},
-  {"num_segments", &Stats::numSegments, "index segments"},
-  {"num_files", &Stats::numFiles, "files backing the index"},
-  {"index_size", &Stats::indexSize, "on-disk index size in bytes"},
-  {"num_failed_commits", &Stats::numFailedCommits, "failed commit operations"},
-  {"num_failed_cleanups", &Stats::numFailedCleanups,
+  {"num_segments", &StoreStats::numSegments, "index segments"},
+  {"num_files", &StoreStats::numFiles, "files backing the index"},
+  {"index_size", &StoreStats::indexSize, "on-disk index size in bytes"},
+  {"num_failed_commits", &StoreStats::numFailedCommits,
+   "failed commit operations"},
+  {"num_failed_cleanups", &StoreStats::numFailedCleanups,
    "failed cleanup operations"},
-  {"num_failed_consolidations", &Stats::numFailedConsolidations,
+  {"num_failed_consolidations", &StoreStats::numFailedConsolidations,
    "failed consolidation operations"},
-  {"avg_commit_time_ms", &Stats::avgCommitTimeMs,
+  {"avg_commit_time_ms", &StoreStats::avgCommitTimeMs,
    "average time of the last few commits, in ms"},
-  {"avg_cleanup_time_ms", &Stats::avgCleanupTimeMs,
+  {"avg_cleanup_time_ms", &StoreStats::avgCleanupTimeMs,
    "average time of the last few cleanups, in ms"},
-  {"avg_consolidation_time_ms", &Stats::avgConsolidationTimeMs,
+  {"avg_consolidation_time_ms", &StoreStats::avgConsolidationTimeMs,
    "average time of the last few consolidations, in ms"},
 }};
 
@@ -103,18 +107,33 @@ catalog::MaterializedData SystemTableSnapshot<SdbMetrics>::GetTableData() {
                       "current catalog wal file size in bytes");
   masks.insert(masks.end(), values.size() - wal_first, kPerProcessMask);
 
-  for (const auto* index :
-       catalog::DatabaseInvertedIndexes(nullptr, GetDatabaseId())) {
-    auto storage = index->GetInvertedData();
-    SDB_ASSERT(storage);
-    const auto stats = storage->GetStats();
-    const Oid relation_id = index->Definition().GetId().id();
+  const auto emit = [&](const StoreStats& stats, Oid relation_id) {
     for (const auto& desc : kIndexMetrics) {
       values.emplace_back(desc.metric, stats.*desc.field, desc.description,
                           relation_id);
       masks.emplace_back(kPerIndexMask);
     }
+  };
+  for (const auto* index :
+       catalog::DatabaseInvertedIndexes(nullptr, GetDatabaseId())) {
+    const auto& storage = index->GetInvertedData();
+    if (!storage) {
+      continue;
+    }
+    const auto stats = storage->GetStats();
+    const Oid relation_id = index->Definition().GetId().id();
+    emit(stats, relation_id);
   }
+  catalog::ScanDatabase(
+    nullptr, GetDatabaseId(), duckdb::CatalogType::TABLE_ENTRY,
+    [&](duckdb::CatalogEntry& entry) {
+      const auto* table = catalog::EntryOf<catalog::SereneDBTableEntry>(&entry);
+      if (!table || !table->IsSearchTable() || !table->GetSearchData()) {
+        return;
+      }
+      const auto& store = *table->GetSearchData();
+      emit(store.GetStats(), store.GetTableId().id());
+    });
 
   auto result = CreateColumns<SdbMetrics>(values.size());
   for (size_t row = 0; row < values.size(); ++row) {

--- a/server/search/CMakeLists.txt
+++ b/server/search/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
     sereneserver
     PRIVATE
         inverted_index_storage.cpp
+        store_stats.cpp
         search_analyzer_impl.cpp
         search_db_wal.cpp
         search_table.cpp

--- a/server/search/inverted_index_storage.cpp
+++ b/server/search/inverted_index_storage.cpp
@@ -356,34 +356,16 @@ void InvertedIndexStorage::CheckpointRefresh() {
                               /*for_checkpoint=*/true);
 }
 
-InvertedIndexStorage::Stats InvertedIndexStorage::UpdateStatsUnsafe(
+StoreStats InvertedIndexStorage::UpdateStatsUnsafe(
   InvertedIndexSnapshotPtr inverted_index_snapshot) const {
-  Stats stats;
+  StoreStats stats;
   if (inverted_index_snapshot) {
-    auto& reader = inverted_index_snapshot->reader;
-    SDB_ASSERT(reader);
-    auto& segments = reader->Meta().index_meta.segments;
-    stats.numSegments = segments.size();
-    stats.numDocs = reader->docs_count();
-    stats.numLiveDocs = reader->live_docs_count();
-    stats.numFiles = 1 + stats.numSegments;
-    for (const auto& segment : segments) {
-      const auto& meta = segment.meta;
-      stats.indexSize += meta.byte_size;
-      stats.numFiles += meta.files.size();
-    }
+    stats = StoreStats::FromReader(inverted_index_snapshot->reader);
   }
   if (_writer) {
     stats.numBufferedDocs = _writer->BufferedDocs();
   }
-  stats.numFailedCommits = _num_failed_commits.load(std::memory_order_relaxed);
-  stats.numFailedCleanups =
-    _num_failed_cleanups.load(std::memory_order_relaxed);
-  stats.numFailedConsolidations =
-    _num_failed_consolidations.load(std::memory_order_relaxed);
-  stats.avgCommitTimeMs = _avg_commit_time_ms.Average();
-  stats.avgCleanupTimeMs = _avg_cleanup_time_ms.Average();
-  stats.avgConsolidationTimeMs = _avg_consolidation_time_ms.Average();
+  _maintenance.Fill(stats);
   return stats;
 }
 
@@ -393,11 +375,7 @@ ResultWithTime InvertedIndexStorage::CleanupUnsafe() {
   uint64_t time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                        std::chrono::steady_clock::now() - begin)
                        .count();
-  if (!result.ok()) {
-    _num_failed_cleanups.fetch_add(1, std::memory_order_relaxed);
-  } else {
-    _avg_cleanup_time_ms.Record(time_ms);
-  }
+  _maintenance.RecordCleanup(result, time_ms);
   return {std::move(result), time_ms};
 }
 
@@ -425,11 +403,7 @@ ResultWithTime InvertedIndexStorage::CompactUnsafe(
   uint64_t time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                        std::chrono::steady_clock::now() - begin)
                        .count();
-  if (!result.ok()) {
-    _num_failed_consolidations.fetch_add(1, std::memory_order_relaxed);
-  } else if (!empty_compaction) {
-    _avg_consolidation_time_ms.Record(time_ms);
-  }
+  _maintenance.RecordCompaction(result, empty_compaction, time_ms);
   return {std::move(result), time_ms};
 }
 
@@ -447,11 +421,7 @@ ResultWithTime InvertedIndexStorage::RefreshUnsafe(
   }
   SDB_IF_FAILURE("Search::CrashAfterCommit") { SDB_IMMEDIATE_ABORT(); }
 
-  if (!result.ok()) {
-    _num_failed_commits.fetch_add(1, std::memory_order_relaxed);
-  } else if (code == RefreshResult::Done) {
-    _avg_commit_time_ms.Record(time_ms);
-  }
+  _maintenance.RecordCommit(result, code, time_ms);
 
   return {std::move(result), time_ms};
 }
@@ -635,7 +605,7 @@ void InvertedIndexStorage::FinishCreation() {
   _phase = Phase::Active;
 }
 
-InvertedIndexStorage::Stats InvertedIndexStorage::GetStats() const {
+StoreStats InvertedIndexStorage::GetStats() const {
   return UpdateStatsUnsafe(GetInvertedIndexSnapshot());
 }
 

--- a/server/search/inverted_index_storage.h
+++ b/server/search/inverted_index_storage.h
@@ -38,6 +38,7 @@
 #include "catalog/inverted_index.h"
 #include "connector/file_manifest.h"
 #include "search/maintenance.h"
+#include "search/store_stats.h"
 #include "search/tick_domain.h"
 #include "storage_engine/search_engine.h"
 
@@ -79,23 +80,6 @@ void RemoveDroppedStorageDir(const std::filesystem::path& path);
 class InvertedIndexStorage final
   : public std::enable_shared_from_this<InvertedIndexStorage> {
  public:
-  struct Stats {
-    // NOLINTBEGIN
-    uint64_t numDocs = 0;
-    uint64_t numLiveDocs = 0;
-    uint64_t numBufferedDocs = 0;
-    uint64_t numSegments = 0;
-    uint64_t numFiles = 0;
-    uint64_t indexSize = 0;
-    uint64_t numFailedCommits = 0;
-    uint64_t numFailedCleanups = 0;
-    uint64_t numFailedConsolidations = 0;
-    uint64_t avgCommitTimeMs = 0;
-    uint64_t avgCleanupTimeMs = 0;
-    uint64_t avgConsolidationTimeMs = 0;
-    // NOLINTEND
-  };
-
   InvertedIndexStorage(ObjectId db_id, const catalog::InvertedIndex& index,
                        bool is_new);
   ~InvertedIndexStorage();
@@ -164,7 +148,7 @@ class InvertedIndexStorage final
                                bool for_checkpoint = false);
 
   ResultWithTime CleanupUnsafe();
-  Stats UpdateStatsUnsafe(InvertedIndexSnapshotPtr data) const;
+  StoreStats UpdateStatsUnsafe(InvertedIndexSnapshotPtr data) const;
 
   void Refresh(const irs::ProgressReportCallback& progress = nullptr);
   // Refresh driven by the checkpoint barrier: the store WAL is about to be
@@ -177,7 +161,7 @@ class InvertedIndexStorage final
   // The database whose attachment holds this index's catalog entry.
   ObjectId GetDatabaseId() const noexcept { return _db_id; }
 
-  Stats GetStats() const;
+  StoreStats GetStats() const;
 
   InvertedIndexSnapshotPtr GetInvertedIndexSnapshot() const {
     return std::atomic_load(&_snapshot);
@@ -303,30 +287,6 @@ class InvertedIndexStorage final
   }
 
  private:
-  class MovingAverageMs {
-   public:
-    void Record(uint64_t time_ms) noexcept {
-      const uint64_t old =
-        _time_num.fetch_add((time_ms << 32U) + 1, std::memory_order_relaxed);
-      const uint64_t old_time = old >> 32U;
-      const uint64_t old_num = static_cast<uint32_t>(old);
-      if (old_num >= kWindow) {
-        _time_num.fetch_sub(((old_time / old_num) << 32U) + 1,
-                            std::memory_order_relaxed);
-      }
-    }
-    uint64_t Average() const noexcept {
-      const uint64_t v = _time_num.load(std::memory_order_relaxed);
-      const uint64_t time = v >> 32U;
-      const uint64_t num = static_cast<uint32_t>(v);
-      return num == 0 ? 0 : time / num;
-    }
-
-   private:
-    static constexpr uint64_t kWindow = 10;
-    std::atomic<uint64_t> _time_num{0};
-  };
-
   absl::Status CompactUnsafeImpl(
     const irs::CompactionPolicy& policy,
     const irs::MergeWriter::FlushProgress& progress, bool& empty_compaction,
@@ -382,12 +342,7 @@ class InvertedIndexStorage final
   std::vector<std::vector<int64_t>> _delete_log;
   std::atomic<uint64_t> _compaction_gen{0};
   std::atomic<uint32_t> _stale_pressure{0};
-  std::atomic<uint64_t> _num_failed_commits{0};
-  std::atomic<uint64_t> _num_failed_cleanups{0};
-  std::atomic<uint64_t> _num_failed_consolidations{0};
-  MovingAverageMs _avg_commit_time_ms;
-  MovingAverageMs _avg_cleanup_time_ms;
-  MovingAverageMs _avg_consolidation_time_ms;
+  MaintenanceCounters _maintenance;
   Phase _phase{Phase::Creating};
   std::atomic<Tick> _recovery_frontier_tick{0};
 

--- a/server/search/search_table.cpp
+++ b/server/search/search_table.cpp
@@ -442,6 +442,7 @@ ResultWithTime SearchTable::RefreshUnsafe(
     std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - begin)
       .count();
+  _maintenance.RecordCommit(result, code, time_ms);
   return {std::move(result), time_ms};
 }
 
@@ -477,7 +478,18 @@ ResultWithTime SearchTable::CompactUnsafe(
     std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - begin)
       .count();
+  _maintenance.RecordCompaction(result, empty_compaction, time_ms);
   return {std::move(result), time_ms};
+}
+
+StoreStats SearchTable::GetStats() const {
+  if (!_writer) {
+    return {};
+  }
+  auto stats = StoreStats::FromReader(_writer->GetSnapshot());
+  stats.numBufferedDocs = _writer->BufferedDocs();
+  _maintenance.Fill(stats);
+  return stats;
 }
 
 ResultWithTime SearchTable::CleanupUnsafe() {
@@ -493,6 +505,7 @@ ResultWithTime SearchTable::CleanupUnsafe() {
     std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - begin)
       .count();
+  _maintenance.RecordCleanup(result, time_ms);
   return {std::move(result), time_ms};
 }
 

--- a/server/search/search_table.cpp
+++ b/server/search/search_table.cpp
@@ -39,6 +39,7 @@
 #include <shared_mutex>
 #include <system_error>
 
+#include "basics/debugging.h"
 #include "basics/down_cast.h"
 #include "basics/duckdb_engine.h"
 #include "basics/lifecycle.h"
@@ -442,6 +443,9 @@ ResultWithTime SearchTable::RefreshUnsafe(
     std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - begin)
       .count();
+  SDB_IF_FAILURE("Search::FailOnCommit") {
+    result = absl::InternalError("debug failure point");
+  }
   _maintenance.RecordCommit(result, code, time_ms);
   return {std::move(result), time_ms};
 }

--- a/server/search/search_table.h
+++ b/server/search/search_table.h
@@ -42,6 +42,7 @@
 #include "catalog/persistence/search_table_options.h"
 #include "search/maintenance.h"
 #include "search/search_db_wal.h"
+#include "search/store_stats.h"
 
 namespace duckdb {
 
@@ -171,6 +172,8 @@ class SearchTable : public std::enable_shared_from_this<SearchTable> {
     return _writer->GetSnapshot();
   }
 
+  StoreStats GetStats() const;
+
   void Commit() {
     SDB_ASSERT(_writer && _wal);
     _writer->RefreshCommit();
@@ -269,6 +272,7 @@ class SearchTable : public std::enable_shared_from_this<SearchTable> {
   absl::Mutex _refresh_mutex;
   std::atomic<uint64_t> _compaction_gen{0};
   std::atomic<uint32_t> _stale_pressure{0};
+  MaintenanceCounters _maintenance;
 #ifdef SDB_DEV
   // Dev-only tripwire: asserts StartTasks runs at most once, so a bug can't
   // spawn competing maintenance loops.

--- a/server/search/store_stats.cpp
+++ b/server/search/store_stats.cpp
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "search/store_stats.h"
+
+#include <iresearch/index/directory_reader.hpp>
+
+#include "basics/assert.h"
+
+namespace sdb::search {
+
+StoreStats StoreStats::FromReader(const irs::DirectoryReader& reader) {
+  SDB_ASSERT(reader);
+  StoreStats stats;
+  auto& segments = reader->Meta().index_meta.segments;
+  stats.numSegments = segments.size();
+  stats.numDocs = reader->docs_count();
+  stats.numLiveDocs = reader->live_docs_count();
+  stats.numFiles = 1 + stats.numSegments;
+  for (const auto& segment : segments) {
+    const auto& meta = segment.meta;
+    stats.indexSize += meta.byte_size;
+    stats.numFiles += meta.files.size();
+  }
+  return stats;
+}
+
+}  // namespace sdb::search

--- a/server/search/store_stats.h
+++ b/server/search/store_stats.h
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2025 SereneDB GmbH, Berlin, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is SereneDB GmbH, Berlin, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <absl/status/status.h>
+
+#include <atomic>
+#include <cstdint>
+
+#include "search/maintenance.h"
+
+namespace irs {
+
+class DirectoryReader;
+
+}  // namespace irs
+namespace sdb::search {
+
+struct StoreStats {
+  // NOLINTBEGIN
+  uint64_t numDocs = 0;
+  uint64_t numLiveDocs = 0;
+  uint64_t numBufferedDocs = 0;
+  uint64_t numSegments = 0;
+  uint64_t numFiles = 0;
+  uint64_t indexSize = 0;
+  uint64_t numFailedCommits = 0;
+  uint64_t numFailedCleanups = 0;
+  uint64_t numFailedConsolidations = 0;
+  uint64_t avgCommitTimeMs = 0;
+  uint64_t avgCleanupTimeMs = 0;
+  uint64_t avgConsolidationTimeMs = 0;
+  // NOLINTEND
+
+  static StoreStats FromReader(const irs::DirectoryReader& reader);
+};
+
+class MovingAverageMs {
+ public:
+  void Record(uint64_t time_ms) noexcept {
+    const uint64_t old =
+      _time_num.fetch_add((time_ms << 32U) + 1, std::memory_order_relaxed);
+    const uint64_t old_time = old >> 32U;
+    const uint64_t old_num = static_cast<uint32_t>(old);
+    if (old_num >= kWindow) {
+      _time_num.fetch_sub(((old_time / old_num) << 32U) + 1,
+                          std::memory_order_relaxed);
+    }
+  }
+  uint64_t Average() const noexcept {
+    const uint64_t v = _time_num.load(std::memory_order_relaxed);
+    const uint64_t time = v >> 32U;
+    const uint64_t num = static_cast<uint32_t>(v);
+    return num == 0 ? 0 : time / num;
+  }
+
+ private:
+  static constexpr uint64_t kWindow = 10;
+  std::atomic<uint64_t> _time_num{0};
+};
+
+class MaintenanceCounters {
+ public:
+  void RecordCommit(const absl::Status& result, RefreshResult code,
+                    uint64_t time_ms) noexcept {
+    if (!result.ok()) {
+      _failed_commits.fetch_add(1, std::memory_order_relaxed);
+    } else if (code == RefreshResult::Done) {
+      _commit_time_ms.Record(time_ms);
+    }
+  }
+  void RecordCompaction(const absl::Status& result, bool empty_compaction,
+                        uint64_t time_ms) noexcept {
+    if (!result.ok()) {
+      _failed_consolidations.fetch_add(1, std::memory_order_relaxed);
+    } else if (!empty_compaction) {
+      _consolidation_time_ms.Record(time_ms);
+    }
+  }
+  void RecordCleanup(const absl::Status& result, uint64_t time_ms) noexcept {
+    if (!result.ok()) {
+      _failed_cleanups.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      _cleanup_time_ms.Record(time_ms);
+    }
+  }
+  void Fill(StoreStats& stats) const noexcept {
+    stats.numFailedCommits = _failed_commits.load(std::memory_order_relaxed);
+    stats.numFailedCleanups = _failed_cleanups.load(std::memory_order_relaxed);
+    stats.numFailedConsolidations =
+      _failed_consolidations.load(std::memory_order_relaxed);
+    stats.avgCommitTimeMs = _commit_time_ms.Average();
+    stats.avgCleanupTimeMs = _cleanup_time_ms.Average();
+    stats.avgConsolidationTimeMs = _consolidation_time_ms.Average();
+  }
+
+ private:
+  std::atomic<uint64_t> _failed_commits{0};
+  std::atomic<uint64_t> _failed_cleanups{0};
+  std::atomic<uint64_t> _failed_consolidations{0};
+  MovingAverageMs _commit_time_ms;
+  MovingAverageMs _cleanup_time_ms;
+  MovingAverageMs _consolidation_time_ms;
+};
+
+}  // namespace sdb::search

--- a/tests/sqllogic/recovery/search_table_metrics_failed_commit.test
+++ b/tests/sqllogic/recovery/search_table_metrics_failed_commit.test
@@ -1,0 +1,45 @@
+# A search table's refresh that fails is counted in sdb_metrics the same way an
+# index's own storage counts it. The fault point fires after the commit itself,
+# so the rows are published and the failure is only recorded.
+
+statement ok
+CREATE TABLE stf (id BIGINT PRIMARY KEY, r TEXT)
+WITH (storage = 'search', refresh_interval = 0, compaction_interval = 0);
+
+statement ok
+CREATE INDEX stf_idx ON stf USING inverted (r);
+
+statement ok
+INSERT INTO stf VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+SET sdb_faults = 'Search::FailOnCommit';
+
+statement ok
+VACUUM (REFRESH_TABLE) stf;
+
+statement ok
+RESET sdb_faults;
+
+query
+SELECT metric, value FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'stf')
+  AND metric IN ('num_docs', 'num_live_docs', 'num_failed_commits', 'num_failed_cleanups', 'num_failed_consolidations')
+ORDER BY metric;
+----
+metric	value
+num_docs	3
+num_failed_cleanups	0
+num_failed_commits	1
+num_failed_consolidations	0
+num_live_docs	3
+
+statement ok
+VACUUM (REFRESH_TABLE) stf;
+
+query
+SELECT value AS failed_commits FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'stf') AND metric = 'num_failed_commits';
+----
+failed_commits
+1

--- a/tests/sqllogic/sdb/pg/index/search_table_sdb_metrics.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_sdb_metrics.test
@@ -1,0 +1,108 @@
+# sdb_metrics for a search table's own store, through the store's lifecycle:
+# buffered rows before a refresh, one segment per refresh, and compaction
+# folding the segments back into one.
+
+statement ok
+CREATE TABLE st (id BIGINT PRIMARY KEY, r TEXT)
+WITH (storage = 'search', refresh_interval = 0, compaction_interval = 0);
+
+statement ok
+CREATE INDEX st_idx ON st USING inverted (r);
+
+statement ok
+INSERT INTO st VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+query
+SELECT metric, value FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'st')
+ORDER BY metric;
+----
+metric	value
+avg_cleanup_time_ms	0
+avg_commit_time_ms	0
+avg_consolidation_time_ms	0
+index_size	0
+num_buffered_docs	3
+num_docs	0
+num_failed_cleanups	0
+num_failed_commits	0
+num_failed_consolidations	0
+num_files	1
+num_live_docs	0
+num_segments	0
+
+statement ok
+VACUUM (REFRESH_TABLE) st;
+
+query
+SELECT metric, value FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'st')
+ORDER BY metric;
+----
+metric	value
+avg_cleanup_time_ms	<slt:ignore>
+avg_commit_time_ms	<slt:ignore>
+avg_consolidation_time_ms	0
+index_size	<slt:ignore>
+num_buffered_docs	0
+num_docs	3
+num_failed_cleanups	0
+num_failed_commits	0
+num_failed_consolidations	0
+num_files	5
+num_live_docs	3
+num_segments	1
+
+statement ok
+INSERT INTO st VALUES (4, 'd'), (5, 'e');
+
+statement ok
+VACUUM (REFRESH_TABLE) st;
+
+query
+SELECT metric, value FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'st')
+ORDER BY metric;
+----
+metric	value
+avg_cleanup_time_ms	<slt:ignore>
+avg_commit_time_ms	<slt:ignore>
+avg_consolidation_time_ms	0
+index_size	<slt:ignore>
+num_buffered_docs	0
+num_docs	5
+num_failed_cleanups	0
+num_failed_commits	0
+num_failed_consolidations	0
+num_files	9
+num_live_docs	5
+num_segments	2
+
+statement ok
+VACUUM (COMPACT_TABLE) st;
+
+query
+SELECT metric, value FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'st')
+ORDER BY metric;
+----
+metric	value
+avg_cleanup_time_ms	<slt:ignore>
+avg_commit_time_ms	<slt:ignore>
+avg_consolidation_time_ms	<slt:ignore>
+index_size	<slt:ignore>
+num_buffered_docs	0
+num_docs	5
+num_failed_cleanups	0
+num_failed_commits	0
+num_failed_consolidations	0
+num_files	5
+num_live_docs	5
+num_segments	1
+
+query
+SELECT count(*) AS storage_less_index_rows FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'st_idx');
+----
+storage_less_index_rows
+0

--- a/tests/sqllogic/sdb/pg/system/sdb_metrics_search_table.test
+++ b/tests/sqllogic/sdb/pg/system/sdb_metrics_search_table.test
@@ -28,24 +28,30 @@ statement ok
 CREATE TABLE sm_empty (id BIGINT PRIMARY KEY, body TEXT) WITH (storage = 'search', compaction_interval = 0);
 
 query
-SELECT metric, CASE WHEN metric IN ('index_size', 'num_files') THEN (value > 0)::VARCHAR WHEN metric LIKE 'avg_%' THEN (value >= 0)::VARCHAR ELSE value::VARCHAR END AS value
+SELECT metric, value
 FROM sdb_metrics
 WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'sm_s')
+  AND metric IN ('num_docs', 'num_live_docs', 'num_buffered_docs', 'num_segments',
+                 'num_failed_commits', 'num_failed_cleanups', 'num_failed_consolidations')
 ORDER BY metric;
 ----
 metric	value
-avg_cleanup_time_ms	true
-avg_commit_time_ms	true
-avg_consolidation_time_ms	true
-index_size	true
 num_buffered_docs	0
 num_docs	3
 num_failed_cleanups	0
 num_failed_commits	0
 num_failed_consolidations	0
-num_files	true
 num_live_docs	3
 num_segments	1
+
+query
+SELECT count(*) AS metrics,
+       count(*) FILTER (WHERE metric IN ('index_size', 'num_files') AND value > 0) AS sized
+FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'sm_s');
+----
+metrics	sized
+12	2
 
 query
 SELECT count(*) AS storage_less_index_rows

--- a/tests/sqllogic/sdb/pg/system/sdb_metrics_search_table.test
+++ b/tests/sqllogic/sdb/pg/system/sdb_metrics_search_table.test
@@ -1,0 +1,84 @@
+# A search table's inverted indexes are storage-less: their terms live in the
+# table's own iresearch store. sdb_metrics reports that store once, under the
+# table, with the same metrics an index with its own storage gets; the
+# storage-less indexes add no rows.
+
+statement ok
+CREATE TABLE sm_t (id BIGINT PRIMARY KEY, body TEXT);
+
+statement ok
+INSERT INTO sm_t VALUES (1, 'alpha cat'), (2, 'beta dog');
+
+statement ok
+CREATE INDEX sm_t_idx ON sm_t USING inverted (body);
+
+statement ok
+CREATE TABLE sm_s (id BIGINT PRIMARY KEY, body TEXT) WITH (storage = 'search', compaction_interval = 0);
+
+statement ok
+CREATE INDEX sm_s_idx ON sm_s USING inverted (body);
+
+statement ok
+INSERT INTO sm_s VALUES (1, 'gamma cat'), (2, 'delta dog'), (3, 'epsilon cat');
+
+statement ok
+VACUUM (REFRESH_TABLE) sm_s;
+
+statement ok
+CREATE TABLE sm_empty (id BIGINT PRIMARY KEY, body TEXT) WITH (storage = 'search', compaction_interval = 0);
+
+query
+SELECT metric, CASE WHEN metric IN ('index_size', 'num_files') THEN (value > 0)::VARCHAR WHEN metric LIKE 'avg_%' THEN (value >= 0)::VARCHAR ELSE value::VARCHAR END AS value
+FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'sm_s')
+ORDER BY metric;
+----
+metric	value
+avg_cleanup_time_ms	true
+avg_commit_time_ms	true
+avg_consolidation_time_ms	true
+index_size	true
+num_buffered_docs	0
+num_docs	3
+num_failed_cleanups	0
+num_failed_commits	0
+num_failed_consolidations	0
+num_files	true
+num_live_docs	3
+num_segments	1
+
+query
+SELECT count(*) AS storage_less_index_rows
+FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'sm_s_idx');
+----
+storage_less_index_rows
+0
+
+query
+SELECT count(*) AS own_storage_index_rows
+FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'sm_t_idx');
+----
+own_storage_index_rows
+12
+
+query
+SELECT metric, value
+FROM sdb_metrics
+WHERE relation_id = (SELECT oid FROM pg_class WHERE relname = 'sm_empty')
+ORDER BY metric;
+----
+metric	value
+avg_cleanup_time_ms	0
+avg_commit_time_ms	0
+avg_consolidation_time_ms	0
+index_size	0
+num_buffered_docs	0
+num_docs	0
+num_failed_cleanups	0
+num_failed_commits	0
+num_failed_consolidations	0
+num_files	1
+num_live_docs	0
+num_segments	0


### PR DESCRIPTION
## Problem

`SELECT * FROM sdb_metrics` took the server down. The per-index loop asserted that every inverted index owns an `InvertedIndexStorage` (`SDB_ASSERT(storage)` at `sdb_metrics.cpp:109`). Since #1050, an index on a search table is storage-less and shares the table's own iresearch store, so the pointer is null: an assert build aborts, a release build dereferences null. One indexed search table in the database is enough. The loop dates from #930 (Aug 30), when the invariant held; #1050 (Sep 1) updated the other `GetInvertedData()` callers but not this one, and no test read `sdb_metrics` with a search table present.

## Fix

- Storage-less indexes contribute no rows; each search table's store is reported once, under the table's oid, with the same twelve metrics an index with its own storage gets.
- The stats struct becomes `search::StoreStats` with `FromReader` for the snapshot-derived half; the storage's failure counters and moving averages move into a `MaintenanceCounters` shared by both stores, and `search::SearchTable` records its refresh, compaction and cleanup outcomes the same way `InvertedIndexStorage` does.
- Both live in the new `search/store_stats.{h,cpp}` so the shard does not depend on the storage header.

## Tests

`system/sdb_metrics_search_table.test`: the crash setup (search table with a storage-less index) now yields twelve rows under the table (`num_docs 3`, `num_live_docs 3`, `num_segments 1`, zero failures, timings recorded), zero rows for the storage-less index, twelve for an own-storage index, and zeros for an empty search table. `pg/system`, `pg/index` and the recovery tests that read `sdb_metrics` or exercise search-table indexes pass.
