### PR TITLE
feat: optimize_top_k as a search-table option

### DIFF
--- a/server/catalog/ddl/indexes.cpp
+++ b/server/catalog/ddl/indexes.cpp
@@ -144,6 +144,15 @@ duckdb::optional_ptr<duckdb::CatalogEntry> CreateIndexImpl(
   // storage-less (GetInvertedData() == null) and folds its columns into the
   // shard's merged config.
   const bool search_backed = entry != nullptr && entry->IsSearchTable();
+  if (index.IsInverted() && search_backed &&
+      InvertedInfo(*index.GetIndex()).GetTopKScorer()) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_FEATURE_NOT_SUPPORTED),
+      ERR_MSG("optimize_top_k is a table option on a search-backed table"),
+      ERR_HINT("Set it in CREATE TABLE ... WITH (storage = 'search', "
+               "optimize_top_k = '...'); the table's store keeps the score "
+               "bounds every index on it prunes with."));
+  }
   auto storage = index.IsInverted() && !search_backed
                    ? search::InvertedIndexStorage::Create(
                        db_id, InvertedInfo(*index.GetIndex()), /*is_new=*/true)

--- a/server/catalog/entry/duckdb_index_scan_entry.cpp
+++ b/server/catalog/entry/duckdb_index_scan_entry.cpp
@@ -96,12 +96,14 @@ duckdb::TableFunction TableInvertedIndexScanEntry::GetScanFunction(
       GetIndexedRelationId(),
       [&] { return relation->GetSearchData()->GetDirectoryReader(); });
     data->entry_kind = connector::ScanEntryKind::SearchTableIndex;
+    data->topk_scorer = relation->SearchOptions().topk_scorer;
     data->lookup_label = "search";
     data->snapshot = std::make_shared<search::InvertedIndexSnapshot>(
       irs::DirectoryReader{*reader}, nullptr);
   } else {
     data->entry_kind = connector::ScanEntryKind::InvertedIndex;
     data->lookup_label = "table";
+    data->topk_scorer = data->ScannedIndex().GetTopKScorer();
     data->snapshot = conn_ctx.EnsureSearchSnapshot(
       _index_id, ::sdb::catalog::InvertedStorageIn(this->catalog, _index_id));
   }
@@ -199,6 +201,7 @@ duckdb::TableFunction ViewInvertedIndexScanEntry::GetScanFunction(
   data->entry_kind = connector::ScanEntryKind::InvertedIndex;
   data->indexes = {
     ::sdb::catalog::InvertedDefinitionIn(&context, this->catalog, _index_id)};
+  data->topk_scorer = data->ScannedIndex().GetTopKScorer();
   std::span<const std::string> key_cols =
     data->ScannedIndex().GetOptions().key_columns;
   data->fast_path =

--- a/server/catalog/entry/duckdb_table_entry.cpp
+++ b/server/catalog/entry/duckdb_table_entry.cpp
@@ -348,6 +348,7 @@ duckdb::TableFunction SereneDBTableEntry::GetScanFunction(
     }
     data->table_entry = this;
     data->entry_kind = connector::ScanEntryKind::SearchTable;
+    data->topk_scorer = SearchOptions().topk_scorer;
     data->lookup_label = "search";
     data->snapshot = std::make_shared<search::InvertedIndexSnapshot>(
       irs::DirectoryReader{*reader}, nullptr);

--- a/server/catalog/persistence/search_table_options.h
+++ b/server/catalog/persistence/search_table_options.h
@@ -21,6 +21,9 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
+
+#include "catalog/persistence/scorer_options.h"
 
 namespace sdb::catalog::persistence {
 
@@ -32,6 +35,7 @@ struct SearchTableOptions {
   uint32_t compaction_interval_ms = 0;
   uint32_t cleanup_interval_step = 0;
   uint64_t segment_memory_max = uint64_t{256} << 20;
+  std::optional<ScorerOptions> topk_scorer;
 };
 
 }  // namespace sdb::catalog::persistence

--- a/server/catalog/scorer_options.cpp
+++ b/server/catalog/scorer_options.cpp
@@ -35,7 +35,10 @@
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression_binder/constant_binder.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <ranges>
+#include <span>
 #include <string>
+#include <vector>
 
 #include "pg/errcodes.h"
 #include "pg/sql_exception_macro.h"
@@ -50,26 +53,16 @@ const duckdb::Value* TryGetConstantValue(const duckdb::Expression& expr) {
   return &expr.Cast<duckdb::BoundConstantExpression>().GetValue();
 }
 
-}  // namespace
-
-std::unique_ptr<irs::Scorer> MakeScorer(const ScorerOptions& spec) {
-  return std::visit(
-    []<typename P>(const P& p) -> std::unique_ptr<irs::Scorer> {
-      return P::Owner::Make(p);
-    },
-    spec.params);
-}
-
-std::optional<ScorerOptions> ExtractScorerFromBound(
-  const duckdb::BoundFunctionExpression& func, std::string_view name) {
+std::optional<ScorerOptions> ExtractScorer(
+  std::string_view name, std::span<const duckdb::Value* const> args) {
   using S = ScorerOptions;
   S scorer;
 
   if (name == S::Bm25::Owner::type_name()) {
     S::Bm25 p;
-    if (func.GetChildren().size() == 3) {
-      auto* k1v = TryGetConstantValue(*func.GetChildren()[1]);
-      auto* bv = TryGetConstantValue(*func.GetChildren()[2]);
+    if (args.size() == 2) {
+      auto* k1v = args[0];
+      auto* bv = args[1];
       if (!k1v || !bv) {
         return std::nullopt;
       }
@@ -79,8 +72,8 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = p;
   } else if (name == S::Tfidf::Owner::type_name()) {
     S::Tfidf p;
-    if (func.GetChildren().size() == 2) {
-      auto* cv = TryGetConstantValue(*func.GetChildren()[1]);
+    if (args.size() == 1) {
+      auto* cv = args[0];
       if (!cv) {
         return std::nullopt;
       }
@@ -89,8 +82,8 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = p;
   } else if (name == S::LmJm::Owner::type_name()) {
     S::LmJm p;
-    if (func.GetChildren().size() == 2) {
-      auto* lv = TryGetConstantValue(*func.GetChildren()[1]);
+    if (args.size() == 1) {
+      auto* lv = args[0];
       if (!lv) {
         return std::nullopt;
       }
@@ -104,8 +97,8 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = p;
   } else if (name == S::LmDirichlet::Owner::type_name()) {
     S::LmDirichlet p;
-    if (func.GetChildren().size() == 2) {
-      auto* mv = TryGetConstantValue(*func.GetChildren()[1]);
+    if (args.size() == 1) {
+      auto* mv = args[0];
       if (!mv) {
         return std::nullopt;
       }
@@ -120,8 +113,8 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = p;
   } else if (name == S::IndriDirichlet::Owner::type_name()) {
     S::IndriDirichlet p;
-    if (func.GetChildren().size() == 2) {
-      auto* mv = TryGetConstantValue(*func.GetChildren()[1]);
+    if (args.size() == 1) {
+      auto* mv = args[0];
       if (!mv) {
         return std::nullopt;
       }
@@ -137,8 +130,8 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = p;
   } else if (name == S::Dfi::Owner::type_name()) {
     S::Dfi p;
-    if (func.GetChildren().size() == 2) {
-      auto* mv = TryGetConstantValue(*func.GetChildren()[1]);
+    if (args.size() == 1) {
+      auto* mv = args[0];
       if (!mv) {
         return std::nullopt;
       }
@@ -166,8 +159,8 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
     scorer.params = S::Idf{};
   } else if (name == S::Constant::Owner::type_name()) {
     S::Constant p;
-    if (func.GetChildren().size() == 2) {
-      auto* vv = TryGetConstantValue(*func.GetChildren()[1]);
+    if (args.size() == 1) {
+      auto* vv = args[0];
       if (!vv) {
         return std::nullopt;
       }
@@ -189,7 +182,26 @@ std::optional<ScorerOptions> ExtractScorerFromBound(
   return scorer;
 }
 
-ScorerOptions ParseScorerExpression(duckdb::ClientContext& context,
+}  // namespace
+
+std::unique_ptr<irs::Scorer> MakeScorer(const ScorerOptions& spec) {
+  return std::visit(
+    []<typename P>(const P& p) -> std::unique_ptr<irs::Scorer> {
+      return P::Owner::Make(p);
+    },
+    spec.params);
+}
+
+std::optional<ScorerOptions> ExtractScorerFromBound(
+  const duckdb::BoundFunctionExpression& func, std::string_view name) {
+  std::vector<const duckdb::Value*> args;
+  for (const auto& child : func.GetChildren() | std::views::drop(1)) {
+    args.push_back(TryGetConstantValue(*child));
+  }
+  return ExtractScorer(name, args);
+}
+
+ScorerOptions ParseScorerExpression(duckdb::ClientContext* context,
                                     std::string input, std::string_view what) {
   using namespace duckdb;
   auto exprs = Parser::ParseExpressionList(input);
@@ -207,20 +219,36 @@ ScorerOptions ParseScorerExpression(duckdb::ClientContext& context,
       ERR_HINT("Use e.g. 'tfidf()' or 'bm25(1.2, 0.75)'"));
   }
 
+  auto& fn = fn_expr->Cast<FunctionExpression>();
+  std::string name = fn.FunctionName().GetIdentifierName();
+  absl::AsciiStrToLower(&name);
+
+  std::vector<const Value*> literals;
+  for (const auto& arg : fn.GetArguments()) {
+    const auto& expr = arg.GetExpression();
+    if (expr.GetExpressionClass() == ExpressionClass::CONSTANT) {
+      literals.push_back(&expr.Cast<ConstantExpression>().GetValue());
+    }
+  }
+  if (literals.size() == fn.GetArguments().size()) {
+    return *ExtractScorer(name, literals);
+  }
+  if (!context) {
+    THROW_SQL_ERROR(
+      ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
+      ERR_MSG("'", what, "' scorer args must be constants: '", input, "'"),
+      ERR_HINT("Use e.g. 'tfidf()' or 'bm25(1.2, 0.75)'"));
+  }
+
   // Prepend a tableoid placeholder to match the SQL `BM25(idx.tableoid, ...)`
   // overload that ConstantBinder will resolve.
-  auto& fn = fn_expr->Cast<FunctionExpression>();
   fn.GetArgumentsMutable().insert(
     fn.GetArgumentsMutable().begin(),
     FunctionArgument{unique_ptr<ParsedExpression>(
       make_uniq<ConstantExpression>(Value::BIGINT(0)))});
 
-  // Capture the name now -- Bind() consumes fn_expr.
-  std::string name = fn.FunctionName().GetIdentifierName();
-  absl::AsciiStrToLower(&name);
-
-  auto binder = Binder::CreateBinder(context);
-  ConstantBinder cb(*binder, context, "optimize_top_k");
+  auto binder = Binder::CreateBinder(*context);
+  ConstantBinder cb(*binder, *context, std::string{kOptimizeTopKSetting});
   auto bound = cb.Bind(fn_expr);
   if (!bound ||
       bound->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
@@ -233,7 +261,7 @@ ScorerOptions ParseScorerExpression(duckdb::ClientContext& context,
   for (auto& child : bound_fn.GetChildrenMutable()) {
     if (child->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT &&
         child->IsFoldable()) {
-      auto val = ExpressionExecutor::EvaluateScalar(context, *child);
+      auto val = ExpressionExecutor::EvaluateScalar(*context, *child);
       child = make_uniq<BoundConstantExpression>(std::move(val));
     }
   }

--- a/server/catalog/scorer_options.h
+++ b/server/catalog/scorer_options.h
@@ -26,6 +26,7 @@
 #include <string_view>
 
 #include "catalog/persistence/scorer_options.h"
+#include "query/config_variable_names.h"
 
 namespace duckdb {
 
@@ -42,8 +43,8 @@ std::unique_ptr<irs::Scorer> MakeScorer(const ScorerOptions& spec);
 std::optional<ScorerOptions> ExtractScorerFromBound(
   const duckdb::BoundFunctionExpression& func, std::string_view name);
 
-ScorerOptions ParseScorerExpression(duckdb::ClientContext& context,
-                                    std::string input,
-                                    std::string_view what = "optimize_top_k");
+ScorerOptions ParseScorerExpression(
+  duckdb::ClientContext* context, std::string input,
+  std::string_view what = kOptimizeTopKSetting);
 
 }  // namespace sdb::catalog

--- a/server/catalog/table.cpp
+++ b/server/catalog/table.cpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <utility>
 
+#include "catalog/scorer_options.h"
 #include "pg/errcodes.h"
 #include "pg/sql_exception_macro.h"
 #include "query/config_variable_names.h"
@@ -61,13 +62,23 @@ T TagUint(const TableTags& tags, std::string_view key) noexcept {
   return absl::SimpleAtoi(TagValue(tags, key), &parsed) ? parsed : T{0};
 }
 
+std::optional<persistence::ScorerOptions> ReadScorerTag(
+  std::string_view text) noexcept {
+  if (text.empty()) {
+    return std::nullopt;
+  }
+  try {
+    return ParseScorerExpression(nullptr, std::string{text});
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
 }  // namespace
 
 void WriteTableTags(TableTags& tags, TableEngine engine,
                     const persistence::SearchTableOptions& search_options,
                     ObjectId generated_pk_seq_id) {
-  // duckdb's insert is first-write-wins, so a rewrite has to clear first: this
-  // is the one writer of all four keys and it must be idempotent.
   for (const auto& key :
        {kStorageOption, kRefreshIntervalSetting, kCompactionIntervalSetting,
         kCleanupIntervalStepSetting, kSegmentMemoryMaxSetting,
@@ -114,6 +125,7 @@ persistence::SearchTableOptions ReadSearchOptionTags(
     .cleanup_interval_step =
       TagUint<uint32_t>(tags, kCleanupIntervalStepSetting),
     .segment_memory_max = TagUint<uint64_t>(tags, kSegmentMemoryMaxSetting),
+    .topk_scorer = ReadScorerTag(TagValue(tags, kOptimizeTopKSetting)),
   };
 }
 

--- a/server/connector/duckdb_physical_create_index.cpp
+++ b/server/connector/duckdb_physical_create_index.cpp
@@ -206,10 +206,10 @@ catalog::InvertedIndexOptions ResolveInvertedIndexOptions(
     .compaction_floor_segment_bytes =
       resolve_ubigint(kCompactionFloorSegmentBytesSetting),
   };
-  if (auto* v = find("optimize_top_k")) {
+  if (auto* v = find(kOptimizeTopKSetting)) {
     auto value =
       v->DefaultCastAs(duckdb::LogicalType::VARCHAR).GetValue<std::string>();
-    options.topk_scorer = catalog::ParseScorerExpression(context, value);
+    options.topk_scorer = catalog::ParseScorerExpression(&context, value);
   }
   options.key_columns = KeyColumnsFromOptions(with);
   std::string store_pk = "auto";

--- a/server/connector/duckdb_search_full_scan.cpp
+++ b/server/connector/duckdb_search_full_scan.cpp
@@ -1421,9 +1421,8 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
   }
 
   if (state->mode == ScanMode::TopK) {
-    state->prune_scorer = ResolvePruneScorer(
-      bind_data.IsIndexRelation() ? &bind_data.ScannedIndex() : nullptr,
-      state->scorer_obj.get());
+    state->prune_scorer =
+      ResolvePruneScorer(bind_data.topk_scorer, state->scorer_obj.get());
     if (state->score_static_floor >
         std::numeric_limits<irs::score_t>::lowest()) {
       // Static score floor (Lucene min_score): the collectors start at the
@@ -1464,9 +1463,8 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> IResearchScanInitGlobal(
       state->score_static_floor > std::numeric_limits<irs::score_t>::lowest();
     if (!topk_disabled && ss.text_scorer && state->ScanScore() &&
         (dynamic_bound || static_bound)) {
-      state->prune_scorer = ResolvePruneScorer(
-        bind_data.IsIndexRelation() ? &bind_data.ScannedIndex() : nullptr,
-        state->scorer_obj.get());
+      state->prune_scorer =
+        ResolvePruneScorer(bind_data.topk_scorer, state->scorer_obj.get());
     }
   }
 

--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -69,6 +69,7 @@ void CopyCommon(const SereneDBScanBindData& src, SereneDBScanBindData& dst) {
   dst.table_entry = src.table_entry;
   dst.entry_kind = src.entry_kind;
   dst.indexes = src.indexes;
+  dst.topk_scorer = src.topk_scorer;
   dst.stored_filter = src.stored_filter;
   dst.filter_scorers = src.filter_scorers;
   dst.snapshot = src.snapshot;
@@ -334,13 +335,10 @@ static duckdb::vector<duckdb::column_t> SereneDBScanGetRowIdColumns(
   return result;
 }
 
-const irs::Scorer* ResolvePruneScorer(const catalog::InvertedIndex* index,
-                                      const irs::Scorer* scorer) {
-  if (!index || !scorer) {
-    return nullptr;
-  }
-  const auto& topk = index->GetTopKScorer();
-  return topk && scorer->Compatible(*topk) ? scorer : nullptr;
+const irs::Scorer* ResolvePruneScorer(
+  const std::optional<catalog::ScorerOptions>& topk,
+  const irs::Scorer* scorer) {
+  return topk && scorer && scorer->Compatible(*topk) ? scorer : nullptr;
 }
 
 std::string SereneDBScanBindData::DisplayColumnName(
@@ -645,13 +643,13 @@ void SereneDBScanBindData::AppendSummary(
     // TODO(mbkkt): prunnable/etc instead of optimized?
     // TODO(mbkkt): streaming top k also should be marked when pruning enabled
     std::string topk_val = absl::StrCat(*score_top_k);
-    const auto* index = bind.IsIndexRelation() ? &bind.ScannedIndex() : nullptr;
-    const auto* pruning = ResolvePruneScorer(index, query_scorer.get());
+    const auto* pruning =
+      ResolvePruneScorer(bind.topk_scorer, query_scorer.get());
     if (pruning) {
       absl::StrAppend(&topk_val, ", optimized");
     }
     out.insert("Top", std::move(topk_val));
-    if (const auto& topk = index->GetTopKScorer();
+    if (const auto& topk = bind.topk_scorer;
         pruning && topk && topk != text_scorer) {
       if (auto bounds = catalog::MakeScorer(*topk)) {
         out.insert("Bounds", bounds->ToString());

--- a/server/connector/duckdb_table_function.h
+++ b/server/connector/duckdb_table_function.h
@@ -134,11 +134,11 @@ enum class TsDictTermUses : uint8_t {
 
 ENABLE_BITMASK_ENUM(TsDictTermUses);
 
-// The scorer `index`'s persisted per-block bounds may be pruned against, or
-// null when they cannot be: no index, no query scorer, no bounds, or bounds a
-// different scorer wrote.
-const irs::Scorer* ResolvePruneScorer(const catalog::InvertedIndex* index,
-                                      const irs::Scorer* scorer);
+// The scorer whose persisted per-block bounds may be pruned against, or null
+// when they cannot be: no query scorer, no bounds, or bounds a different scorer
+// wrote.
+const irs::Scorer* ResolvePruneScorer(
+  const std::optional<catalog::ScorerOptions>& topk, const irs::Scorer* scorer);
 
 enum class ScanEntryKind : uint8_t {
   BaseTable,
@@ -161,6 +161,7 @@ struct SereneDBScanBindData : public duckdb::FunctionData {
   ScanEntryKind entry_kind = ScanEntryKind::BaseTable;
 
   std::vector<std::shared_ptr<const catalog::Index>> indexes;
+  std::optional<catalog::ScorerOptions> topk_scorer;
 
   // The iresearch snapshot plus the query's search configuration (stored
   // filter, scorer, offsets, ts-dict requests). Every scan bound through this

--- a/server/connector/inverted_index_options_util.h
+++ b/server/connector/inverted_index_options_util.h
@@ -71,7 +71,7 @@ inline constexpr auto kCreateInvertedOptions = [] {
   for (size_t i = 0; i < kNumericInvertedOptions.size(); ++i) {
     all[i] = kNumericInvertedOptions[i];
   }
-  all[kNumericInvertedOptions.size()] = "optimize_top_k";
+  all[kNumericInvertedOptions.size()] = kOptimizeTopKSetting;
   all[kNumericInvertedOptions.size() + 1] = "store_pk";
   all[kNumericInvertedOptions.size() + 2] = "key_columns";
   return all;

--- a/server/connector/search_filter_builder.cpp
+++ b/server/connector/search_filter_builder.cpp
@@ -1322,7 +1322,7 @@ const irs::Scorer* ResolveScoreOverride(const FilterContext& ctx,
                "index."));
   }
   auto owned = catalog::MakeScorer(catalog::ParseScorerExpression(
-    ctx.client_context, std::string{expr}, "::score"));
+    &ctx.client_context, std::string{expr}, "::score"));
   if (!owned) {
     THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                     ERR_MSG("::score(...) is not a known scorer"));

--- a/server/connector/search_table_dispatch.cpp
+++ b/server/connector/search_table_dispatch.cpp
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "basics/assert.h"
+#include "catalog/scorer_options.h"
 #include "catalog/table.h"
 #include "connector/inverted_index_options_util.h"
 #include "connector/with_option_resolver.h"
@@ -231,6 +232,13 @@ void ApplyStorageKind(
     } else {
       search_options.segment_memory_max = ResolveUbigintWithOption(
         context, kSegmentMemoryMaxSetting, /*with_value=*/nullptr);
+    }
+    if (const auto topk = with_options.find(std::string{kOptimizeTopKSetting});
+        topk != with_options.end() && topk->second) {
+      auto text = *ExtractString(kOptimizeTopKSetting, *topk->second);
+      catalog::ParseScorerExpression(nullptr, text);
+      info.tags.insert(std::string{kOptimizeTopKSetting}, std::move(text));
+      with_options.erase(std::string{kOptimizeTopKSetting});
     }
   }
   // The sequence feeding the synthetic primary key is not known until the

--- a/server/query/config_variable_names.h
+++ b/server/query/config_variable_names.h
@@ -33,6 +33,7 @@ inline constexpr std::string_view kCleanupIntervalStepSetting =
   "cleanup_interval_step";
 inline constexpr std::string_view kSegmentMemoryMaxSetting =
   "segment_memory_max";
+inline constexpr std::string_view kOptimizeTopKSetting = "optimize_top_k";
 inline constexpr std::string_view kSegmentDocsMaxSetting = "segment_docs_max";
 inline constexpr std::string_view kCompactionMaxSegmentsSetting =
   "compaction_max_segments";

--- a/server/search/search_table.cpp
+++ b/server/search/search_table.cpp
@@ -49,6 +49,7 @@
 #include "catalog/index.h"
 #include "catalog/inverted_index.h"
 #include "catalog/read/duckdb_catalog_sets.h"
+#include "catalog/scorer_options.h"
 #include "pg/sql_exception_macro.h"
 #include "scheduler/background_scheduler.h"
 #include "search/inverted_index_storage.h"
@@ -197,6 +198,9 @@ SearchTable::SearchTable(
     std::make_shared<const catalog::InvertedIndex::Entries>(std::move(entries));
   _terms_by_column = std::make_shared<const TermsByColumn>(std::move(terms));
   _field_options = MakeFieldOptions(_entries);
+  if (options.topk_scorer) {
+    _topk_scorer = catalog::MakeScorer(*options.topk_scorer);
+  }
   OpenWriter();
 
   _maint_settings.refresh_interval_msec = options.refresh_interval_ms;
@@ -336,6 +340,9 @@ void SearchTable::OpenWriter() {
   writer_options.lock_repository = false;
   writer_options.db = &sdb::DuckDBEngine::Instance().instance();
   writer_options.reader_options.db = writer_options.db;
+  if (_topk_scorer) {
+    writer_options.reader_options.scorer = _topk_scorer.get();
+  }
 
   writer_options.meta_payload_provider = [this](uint64_t tick,
                                                 irs::bstring& out) {

--- a/server/search/search_table.h
+++ b/server/search/search_table.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <iresearch/index/index_writer.hpp>
+#include <iresearch/search/scorer.hpp>
 #include <iresearch/store/directory.hpp>
 #include <memory>
 #include <mutex>
@@ -260,6 +261,7 @@ class SearchTable : public std::enable_shared_from_this<SearchTable> {
   std::shared_ptr<const TermsByColumn> _terms_by_column;
   // Writer encoding config over the merged _entries, RCU-swapped with them.
   std::shared_ptr<const irs::IndexFieldOptions> _field_options;
+  std::unique_ptr<irs::Scorer> _topk_scorer;
   std::unique_ptr<irs::Directory> _dir;
   std::shared_ptr<irs::IndexWriter> _writer;
   // Borrowed from the search engine (set in OpenWriter). Outlives this object.

--- a/tests/sqllogic/recovery/search_table_optimize_top_k_recovery.test
+++ b/tests/sqllogic/recovery/search_table_optimize_top_k_recovery.test
@@ -1,0 +1,138 @@
+control substitution on
+
+statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+CREATE TEXT SEARCH DICTIONARY rk_en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true,
+    norm = true
+);
+
+statement ok
+CREATE TABLE rk (id BIGINT PRIMARY KEY, body TEXT)
+  WITH (storage = 'search', compaction_interval = 0,
+        optimize_top_k = 'bm25(1.2, 0.75)');
+
+statement ok
+CREATE INDEX rk_idx ON rk USING inverted (body rk_en);
+
+statement ok
+RESET sdb_faults;
+
+statement ok
+INSERT INTO rk VALUES (1, 'fox'), (2, 'fox fox'), (3, 'dog');
+
+statement ok
+VACUUM (REFRESH_TABLE) rk;
+
+statement ok
+SET sdb_faults = 'crash_after_search_wal_commit';
+
+statement error connection closed
+INSERT INTO rk
+SELECT i, CASE WHEN i % 1000 = 0 THEN repeat('fox ', 40)
+              ELSE 'fox ' || repeat('dog ', i % 7) END
+FROM generate_series(4, 20000) AS s(i);
+
+connection after_crash
+statement ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+VACUUM (REFRESH_TABLE) rk;
+
+connection after_crash
+query
+SELECT count(*) FROM rk_idx WHERE body @@ ts_phrase('fox');
+----
+count
+19999
+
+connection after_crash
+query
+EXPLAIN SELECT id FROM rk WHERE body @@ ts_phrase('fox') ORDER BY BM25(rk.tableoid) DESC LIMIT 3;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 3                                 │
+│ Order By: #1 DESC                      │
+│ ~3 rows                                │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: rk                              │
+│ Lookup: search                         │
+│ Index Filter:                          │
+│ ╭─ Term ──────────────╮                │
+│ │ Field: body(string) │                │
+│ │ Value: fox          │                │
+│ ╰─────────────────────╯                │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Top: 3, optimized                      │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~4,000 rows                            │
+╰────────────────────────────────────────╯
+
+connection after_crash
+query
+EXPLAIN SELECT id FROM rk_idx WHERE body @@ ts_phrase('fox') ORDER BY BM25(rk_idx.tableoid) DESC LIMIT 3;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 3                                 │
+│ Order By: #1 DESC                      │
+│ ~3 rows                                │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: rk_idx                          │
+│ Lookup: search                         │
+│ Index Filter:                          │
+│ ╭─ Term ──────────────╮                │
+│ │ Field: body(string) │                │
+│ │ Value: fox          │                │
+│ ╰─────────────────────╯                │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Top: 3, optimized                      │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~4,000 rows                            │
+╰────────────────────────────────────────╯
+
+connection after_crash
+statement ok
+SET sdb_faults = 'irs::PruningIterator';
+
+connection after_crash
+statement error db error: ERROR: intentional debug error
+SELECT id FROM rk WHERE body @@ ts_phrase('fox') ORDER BY BM25(rk.tableoid) DESC LIMIT 3;
+
+connection after_crash
+statement error db error: ERROR: intentional debug error
+SELECT id FROM rk_idx WHERE body @@ ts_phrase('fox') ORDER BY BM25(rk_idx.tableoid) DESC LIMIT 3;
+
+connection after_crash
+query
+SELECT id FROM rk_idx WHERE body @@ ts_phrase('fox') ORDER BY TFIDF(rk_idx.tableoid) DESC, id LIMIT 3;
+----
+id
+1000
+2000
+3000
+
+connection after_crash
+statement ok
+SET sdb_faults = '-irs::PruningIterator';
+
+connection after_crash
+query
+SELECT id FROM rk WHERE body @@ ts_phrase('fox') ORDER BY BM25(rk.tableoid) DESC, id LIMIT 3;
+----
+id
+1000
+2000
+3000
+
+connection after_crash
+query
+SELECT id FROM rk_idx WHERE body @@ ts_phrase('fox') ORDER BY BM25(rk_idx.tableoid) DESC, id LIMIT 3;
+----
+id
+1000
+2000
+3000

--- a/tests/sqllogic/sdb/pg/index/search_table_optimize_top_k.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_optimize_top_k.test
@@ -1,0 +1,160 @@
+# optimize_top_k on a search table is a table option: the table's store writes
+# the score bounds, so top-k queries prune through the table scan and through
+# every index relation on it alike. The index-level option is refused there.
+
+statement ok
+CREATE TEXT SEARCH DICTIONARY st_topk_en (template = 'text', locale = 'en_US.UTF-8', case = 'none', stemming = false, accent = false, frequency = true, position = true, norm = true);
+
+statement ok
+CREATE TABLE st_topk (id INTEGER PRIMARY KEY, body VARCHAR)
+WITH (storage = 'search', compaction_interval = 0, optimize_top_k = 'bm25(1.2, 0.75)');
+
+statement ok
+CREATE INDEX st_topk_idx ON st_topk USING inverted (body st_topk_en);
+
+statement ok
+INSERT INTO st_topk SELECT i, CASE WHEN i % 1000 = 500 THEN repeat('fox ', 30 + i / 1000) WHEN i % 17 = 0 THEN repeat('fox ', 1 + i % 3) ELSE 'dog ' END || repeat('filler ', (i * 104729) % 30) FROM range(30000) t(i);
+
+statement ok
+VACUUM (REFRESH_TABLE) st_topk;
+
+query
+EXPLAIN SELECT id FROM st_topk WHERE body @@ ts_phrase('fox') ORDER BY BM25(st_topk.tableoid) DESC LIMIT 8;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 8                                 │
+│ Order By: #1 DESC                      │
+│ ~8 rows                                │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: st_topk                         │
+│ Lookup: search                         │
+│ Index Filter:                          │
+│ ╭─ Term ──────────────╮                │
+│ │ Field: body(string) │                │
+│ │ Value: fox          │                │
+│ ╰─────────────────────╯                │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Top: 8, optimized                      │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~6,000 rows                            │
+╰────────────────────────────────────────╯
+
+query
+EXPLAIN SELECT id FROM st_topk_idx WHERE body @@ ts_phrase('fox') ORDER BY BM25(st_topk_idx.tableoid) DESC LIMIT 8;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 8                                 │
+│ Order By: #1 DESC                      │
+│ ~8 rows                                │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: st_topk_idx                     │
+│ Lookup: search                         │
+│ Index Filter:                          │
+│ ╭─ Term ──────────────╮                │
+│ │ Field: body(string) │                │
+│ │ Value: fox          │                │
+│ ╰─────────────────────╯                │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Top: 8, optimized                      │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~6,000 rows                            │
+╰────────────────────────────────────────╯
+
+query
+SELECT (SELECT list(id) FROM (SELECT id FROM st_topk WHERE body @@ ts_phrase('fox') ORDER BY BM25(st_topk.tableoid) DESC LIMIT 8)) AS table_top8,
+       (SELECT list(id) FROM (SELECT id FROM st_topk_idx WHERE body @@ ts_phrase('fox') ORDER BY BM25(st_topk_idx.tableoid) DESC LIMIT 8)) AS index_top8,
+       (SELECT list(id) FROM (SELECT id FROM (SELECT id, BM25(st_topk_idx.tableoid) AS s FROM st_topk_idx WHERE body @@ ts_phrase('fox')) q ORDER BY s DESC LIMIT 8)) AS full_sort_top8;
+----
+table_top8	index_top8	full_sort_top8
+{28500,25500,22500,19500,16500,13500,10500,7500}	{28500,25500,22500,19500,16500,13500,10500,7500}	{28500,25500,22500,19500,16500,13500,10500,7500}
+
+query
+EXPLAIN SELECT id FROM st_topk_idx WHERE body @@ ts_phrase('fox') ORDER BY TFIDF(st_topk_idx.tableoid) DESC LIMIT 8;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 8                                 │
+│ Order By: #1 DESC                      │
+│ ~8 rows                                │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: st_topk_idx                     │
+│ Lookup: search                         │
+│ Index Filter:                          │
+│ ╭─ Term ──────────────╮                │
+│ │ Field: body(string) │                │
+│ │ Value: fox          │                │
+│ ╰─────────────────────╯                │
+│ Score: tfidf(with_norms=false)         │
+│ Top: 8                                 │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~6,000 rows                            │
+╰────────────────────────────────────────╯
+
+statement ok
+CREATE TABLE st_plain (id INTEGER PRIMARY KEY, body VARCHAR)
+WITH (storage = 'search', compaction_interval = 0);
+
+statement ok
+CREATE INDEX st_plain_idx ON st_plain USING inverted (body st_topk_en);
+
+statement ok
+INSERT INTO st_plain VALUES (1, 'fox quick'), (2, 'fox lazy'), (3, 'lazy dog');
+
+statement ok
+VACUUM (REFRESH_TABLE) st_plain;
+
+query
+EXPLAIN SELECT id FROM st_plain WHERE body @@ ts_phrase('fox') ORDER BY BM25(st_plain.tableoid) DESC LIMIT 2;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 2                                 │
+│ Order By: #1 DESC                      │
+│ ~1 row                                 │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: st_plain                        │
+│ Lookup: search                         │
+│ Index Filter:                          │
+│ ╭─ Term ──────────────╮                │
+│ │ Field: body(string) │                │
+│ │ Value: fox          │                │
+│ ╰─────────────────────╯                │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Top: 2                                 │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~1 row                                 │
+╰────────────────────────────────────────╯
+
+statement ok
+CREATE TABLE st_empty (id INTEGER PRIMARY KEY, body VARCHAR)
+WITH (storage = 'search', compaction_interval = 0);
+
+statement error
+CREATE INDEX st_empty_topk ON st_empty USING inverted (body st_topk_en) WITH (optimize_top_k = 'bm25(1.2, 0.75)');
+----
+db error: ERROR: optimize_top_k is a table option on a search-backed table
+HINT: Set it in CREATE TABLE ... WITH (storage = 'search', optimize_top_k = '...'); the table's store keeps the score bounds every index on it prunes with.
+
+
+statement error
+CREATE TABLE st_expr (id INTEGER PRIMARY KEY, body VARCHAR) WITH (storage = 'search', optimize_top_k = 'bm25(1 + 0.2, 0.75)');
+----
+db error: ERROR: 'optimize_top_k' scorer args must be constants: 'bm25(1 + 0.2, 0.75)'
+HINT: Use e.g. 'tfidf()' or 'bm25(1.2, 0.75)'
+
+
+statement error
+CREATE TABLE st_bad (id INTEGER PRIMARY KEY, body VARCHAR) WITH (storage = 'search', optimize_top_k = 'nope()');
+----
+db error: ERROR: Unknown scorer 'nope'
+HINT: Expected one of: bm25, tfidf, lm_jm, lm_dirichlet, indri_dirichlet, dfi, idf, raw_boost, raw_tf, raw_dl

--- a/tests/sqllogic/sdb/pg/index/search_table_wand.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_wand.test
@@ -13,11 +13,11 @@ CREATE TEXT SEARCH DICTIONARY bm(
 
 statement ok
 CREATE TABLE w (id BIGINT PRIMARY KEY, body TEXT)
-  WITH (storage='search', compaction_interval=0);
+  WITH (storage='search', compaction_interval=0,
+        optimize_top_k = 'bm25(1.2, 0.75)');
 
 statement ok
-CREATE INDEX w_idx ON w USING inverted (body bm)
-  WITH (optimize_top_k = 'bm25(1.2, 0.75)');
+CREATE INDEX w_idx ON w USING inverted (body bm);
 
 statement ok
 INSERT INTO w VALUES


### PR DESCRIPTION
## Why

A search table's inverted indexes are storage-less: they share the table's iresearch store. `optimize_top_k` tells the store's writer which scorer's per-block score bounds to keep, so it is a property of the table, not of an index on it. Before this change the option was accepted on a search-table index but the shard writer never saw a scorer, so no bounds were written and the `optimized` plan label was cosmetic (results were still correct through the no-bounds fallback).

## What

- `CREATE TABLE ... WITH (storage = 'search', optimize_top_k = 'bm25(1.2, 0.75)')`. The value is validated with the existing scorer parser and stored as text in the table tags next to the other search options. Reading the options back goes through the same parser, which now skips binding when every argument is a literal, so the boot path (no `ClientContext`) works too. Non-literal arguments are rejected at CREATE.
- The shard writer gets the scorer, so segments carry bounds; the table scan and every index relation on the table resolve the prune scorer from the table option.
- `CREATE INDEX ... WITH (optimize_top_k = ...)` on a search-backed table is rejected with a hint pointing at the table option, whether or not it matches. `ALTER INDEX SET` already refused the option as create-time only; `ALTER TABLE SET` is not supported for search options.
- The option name literal is replaced by `kOptimizeTopKSetting` where it was spelled out.

## Tests

- `sdb/pg/index/search_table_optimize_top_k.test`: `Top: k, optimized` for the table form and the index relation, result parity against a full sort, TFIDF against a bm25 option stays unoptimized, plain search table stays unoptimized, index-level option rejected, non-literal args and unknown scorers rejected.
- `recovery/search_table_optimize_top_k_recovery.test`: crash after the search WAL commit of a 19,997-row insert; after restart both forms plan `optimized`, and with `sdb_faults = 'irs::PruningIterator'` both BM25 top-k queries trip the fault while the TFIDF query runs clean. The fault only fires when the pruned iterator is built over postings that actually carry bounds, so it proves runtime pruning on the replayed segments.
- `search_table_wand.test` moved to the table option.

Docs follow-up in serenedb-site: the inverted index and ranking pages still describe only the index-level option.