### PR TITLE
fix: VACUUM (COMPACT_TABLE) crashed on search tables with norm columns

### DIFF
--- a/server/search/search_table.cpp
+++ b/server/search/search_table.cpp
@@ -533,7 +533,8 @@ void SearchTable::VacuumCompact() {
   RefreshResult code = RefreshResult::Undefined;
   RefreshUnsafe(/*wait=*/true, nullptr, code);
   bool empty = false;
-  CompactUnsafe(kFullMerge, kProgress, empty, /*field_options=*/nullptr);
+  const auto field_options = GetFieldOptions();
+  CompactUnsafe(kFullMerge, kProgress, empty, field_options.get());
   if (!empty) {
     RefreshUnsafe(/*wait=*/true, nullptr, code);
   }

--- a/tests/sqllogic/sdb/pg/index/search_table_compact_norms.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_compact_norms.test
@@ -1,0 +1,95 @@
+statement ok
+CREATE TEXT SEARCH DICTIONARY cn_en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true,
+    norm = true
+);
+
+statement ok
+CREATE TABLE cn (id BIGINT PRIMARY KEY, body TEXT)
+WITH (storage = 'search', refresh_interval = 0, compaction_interval = 0);
+
+statement ok
+CREATE INDEX cn_idx ON cn USING inverted (body cn_en);
+
+statement ok
+CREATE TABLE cn_topk (id BIGINT PRIMARY KEY, body TEXT)
+WITH (storage = 'search', refresh_interval = 0, compaction_interval = 0,
+      optimize_top_k = 'bm25(1.2, 0.75)');
+
+statement ok
+CREATE INDEX cn_topk_idx ON cn_topk USING inverted (body cn_en);
+
+statement ok
+INSERT INTO cn SELECT i, 'fox ' || repeat('dog ', i % 5) FROM generate_series(1, 200) s(i);
+
+statement ok
+INSERT INTO cn_topk SELECT i, 'fox ' || repeat('dog ', i % 5) FROM generate_series(1, 200) s(i);
+
+statement ok
+VACUUM (REFRESH_TABLE) cn;
+
+statement ok
+VACUUM (REFRESH_TABLE) cn_topk;
+
+statement ok
+INSERT INTO cn SELECT i, 'fox ' || repeat('dog ', i % 5) FROM generate_series(201, 400) s(i);
+
+statement ok
+INSERT INTO cn_topk SELECT i, 'fox ' || repeat('dog ', i % 5) FROM generate_series(201, 400) s(i);
+
+statement ok
+VACUUM (REFRESH_TABLE) cn;
+
+statement ok
+VACUUM (REFRESH_TABLE) cn_topk;
+
+query
+SELECT c.relname, m.value FROM sdb_metrics m JOIN pg_class c ON c.oid = m.relation_id
+WHERE m.metric = 'num_segments' AND c.relname IN ('cn', 'cn_topk') ORDER BY c.relname;
+----
+relname	value
+cn	2
+cn_topk	2
+
+statement ok
+VACUUM (COMPACT_TABLE) cn;
+
+statement ok
+VACUUM (COMPACT_TABLE) cn_topk;
+
+query
+SELECT c.relname, m.value FROM sdb_metrics m JOIN pg_class c ON c.oid = m.relation_id
+WHERE m.metric = 'num_segments' AND c.relname IN ('cn', 'cn_topk') ORDER BY c.relname;
+----
+relname	value
+cn	1
+cn_topk	1
+
+query
+SELECT count(*) FROM cn_idx WHERE body @@ ts_phrase('fox');
+----
+count
+400
+
+query
+SELECT id FROM cn_idx WHERE body @@ ts_phrase('fox') ORDER BY BM25(cn_idx.tableoid) DESC, id LIMIT 3;
+----
+id
+5
+10
+15
+
+query
+SELECT count(*) FROM cn_topk_idx WHERE body @@ ts_phrase('fox');
+----
+count
+400
+
+query
+SELECT id FROM cn_topk WHERE body @@ ts_phrase('fox') ORDER BY BM25(cn_topk.tableoid) DESC, id LIMIT 3;
+----
+id
+5
+10
+15


### PR DESCRIPTION
## Bug

`VACUUM (COMPACT_TABLE)` on a search table whose text dictionary has `norm = true` aborts the server once there is more than one segment to merge:

```
assertion failed in libs/iresearch/include/iresearch/index/merge_writer.cpp:518
[MergeNormColumnFromSources]: GetNormColumnId did not mint a valid id for field
```

`SearchTable::VacuumCompact` passed `field_options = nullptr` to `CompactUnsafe`. The norm-column merge needs the shard's field options to allocate the merged norm column id, so it hit the `SDB_ENSURE`. Keyword-only search tables were unaffected (no norm column), which is why the existing compaction tests passed. The periodic compaction task was also unaffected: `PinCompactionOptions(SearchTable&)` pins `GetFieldOptions()` for the merge.

## Fix

`VacuumCompact` pins `GetFieldOptions()` for the duration of the merge and passes it, matching the periodic path.

## Test

`sdb/pg/index/search_table_compact_norms.test`: two search tables with a norm dictionary, one with `optimize_top_k`, two segments each (checked through `sdb_metrics`), `VACUUM (COMPACT_TABLE)` on both, segment count back to one, counts intact, and BM25 still ranks the shortest documents first after the merge, which checks the merged norms.