### PR TITLE
perf: adaptive MaxScore disjunction when block maxima cannot prune

### DIFF
--- a/libs/iresearch/include/iresearch/search/top/max_score_disjunction.hpp
+++ b/libs/iresearch/include/iresearch/search/top/max_score_disjunction.hpp
@@ -65,6 +65,10 @@ class MaxScoreDisjunction : public Root {
     _num_candidates = 0;
     _num_outer_windows = 0;
     _min_window_size = 1;
+    _window_candidates = 0;
+    _window_probes = 0;
+    _dense_left = 0;
+    _dense_streak = 0;
 
   outer:
     while (window_min < max) {
@@ -98,6 +102,7 @@ class MaxScoreDisjunction : public Root {
 
       window_min = std::min(Top(), window_max);
       ++_num_outer_windows;
+      UpdateDensity();
     }
     _admit.Flush(collector);
   }
@@ -166,6 +171,25 @@ class MaxScoreDisjunction : public Root {
     }
   }
 
+  static constexpr uint32_t kDenseSample = doc_limits::kBlockSize;
+  static constexpr uint32_t kDenseStreakMax = 64;
+
+  void UpdateDensity() noexcept {
+    if (_dense_left != 0) {
+      --_dense_left;
+    } else if (_window_candidates >= kDenseSample &&
+               uint64_t{_window_probes} * 4 >=
+                 uint64_t{3} * _window_candidates * _window_non_essential) {
+      _dense_streak =
+        std::min(std::max(2 * _dense_streak, 1U), kDenseStreakMax);
+      _dense_left = _dense_streak;
+    } else {
+      _dense_streak = 0;
+    }
+    _window_candidates = 0;
+    _window_probes = 0;
+  }
+
   bool Split(score_t score_threshold) {
     absl::c_sort(_sorted, [](const Entry* lhs, const Entry* rhs) noexcept {
       return static_cast<double>(lhs->max_score) / lhs->cost <
@@ -195,6 +219,10 @@ class MaxScoreDisjunction : public Root {
     if (_first_essential == size) {
       return false;
     }
+    if (_dense_left != 0) {
+      _first_essential = 0;
+    }
+    _window_non_essential = static_cast<uint32_t>(_first_essential);
 
     _num_essential = size - _first_essential;
     _has_non_essential = _first_essential != 0;
@@ -324,6 +352,7 @@ class MaxScoreDisjunction : public Root {
   template<typename Docs, typename Scores>
   void ProcessNonEssential(Docs& cand_docs, Scores& cand_scores, doc_id_t max) {
     _num_candidates += static_cast<uint32_t>(cand_docs.size());
+    _window_candidates += static_cast<uint32_t>(cand_docs.size());
     const score_t threshold = _collector->ScoreThreshold();
 
     for (size_t i = _first_essential; i-- != 0;) {
@@ -336,6 +365,7 @@ class MaxScoreDisjunction : public Root {
           return;
         }
       }
+      _window_probes += static_cast<uint32_t>(cand_docs.size());
       entry.leaf.ScoreCandidates(cand_docs, cand_scores, i >= _first_required,
                                  max);
     }
@@ -355,6 +385,11 @@ class MaxScoreDisjunction : public Root {
   bool _has_non_essential = false;
   uint32_t _num_candidates = 0;
   uint32_t _num_outer_windows = 0;
+  uint32_t _window_candidates = 0;
+  uint32_t _window_probes = 0;
+  uint32_t _window_non_essential = 0;
+  uint32_t _dense_left = 0;
+  uint32_t _dense_streak = 0;
   doc_id_t _min_window_size = 1;
   score_t _next_threshold = std::numeric_limits<score_t>::lowest();
   [[no_unique_address]] Admit<Table> _admit;

--- a/libs/iresearch/include/iresearch/search/top/posting_pruned_disj.hpp
+++ b/libs/iresearch/include/iresearch/search/top/posting_pruned_disj.hpp
@@ -177,10 +177,15 @@ class PostingPrunedDisj : public PruneLeafBase<InputType, false> {
       max, [&](const doc_id_t* IRS_RESTRICT docs, uint32_t len,
                const score_t* IRS_RESTRICT scores) IRS_FORCE_INLINE {
         static constexpr auto kBits = BitsRequired<uint64_t>();
-        for (uint32_t i = 0; i != len; ++i) {
+        const auto add = [&](uint32_t i) IRS_FORCE_INLINE {
           const size_t offset = docs[i] - min;
           SetBit(mask[offset / kBits], offset % kBits);
           window[offset] += scores[i];
+        };
+        if (len == doc_limits::kBlockSize) [[likely]] {
+          VisitDocs<doc_limits::kBlockSize>(doc_limits::kBlockSize, add);
+        } else {
+          VisitDocs<std::dynamic_extent>(len, add);
         }
       });
   }

--- a/libs/iresearch/include/iresearch/search/top/posting_pruned_disj.hpp
+++ b/libs/iresearch/include/iresearch/search/top/posting_pruned_disj.hpp
@@ -233,8 +233,14 @@ class PostingPrunedDisj : public PruneLeafBase<InputType, false> {
         if (cand > *(end - 1)) {
           break;
         }
-        const auto* const it = std::find(begin, end, cand);
-        if (it != end) {
+        size_t step = 1;
+        while (begin + step < end && begin[step] < cand) {
+          begin += step;
+          step <<= 1;
+        }
+        begin = std::lower_bound(begin, std::min(begin + step, end), cand);
+        const auto* const it = begin;
+        if (*it == cand) {
           if (required) {
             cand_docs[out] = cand_docs[cand_idx];
             cand_scores[out] = cand_scores[cand_idx];

--- a/tests/sqllogic/sdb/pg/index/inverted_index_score_prune_dense_disjunction.test
+++ b/tests/sqllogic/sdb/pg/index/inverted_index_score_prune_dense_disjunction.test
@@ -1,0 +1,77 @@
+statement ok
+CREATE TEXT SEARCH DICTIONARY dd_en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true,
+    norm = true
+);
+
+statement ok
+CREATE TABLE dd (id INTEGER PRIMARY KEY, body VARCHAR);
+
+statement ok
+INSERT INTO dd
+SELECT i, CASE WHEN i % 2 = 0 THEN 'fox ' ELSE 'cat ' END || repeat('dog ', (i * 7) % 11)
+FROM generate_series(1, 6000) s(i);
+
+statement ok
+CREATE INDEX dd_idx ON dd USING inverted (body dd_en) WITH (optimize_top_k = 'bm25(1.2, 0.75)');
+
+statement ok
+VACUUM (REFRESH_TABLE) dd;
+
+query
+EXPLAIN SELECT id FROM dd_idx WHERE body @@ ts_any(['fox', 'cat']) ORDER BY BM25(dd_idx.tableoid) DESC LIMIT 10;
+----
+QUERY PLAN
+╭─ TOP_N ────────────────────────────────╮
+│ Top: 10                                │
+│ Order By: #1 DESC                      │
+│ ~10 rows                               │
+╰────────────────────┬───────────────────╯
+╭─ IRESEARCH_SCAN ───┴───────────────────╮
+│ Index: dd_idx                          │
+│ Lookup: table                          │
+│ Index Filter:                          │
+│ ╭─ Or ─────────────────╮               │
+│ ╰───────────┬──────────╯               │
+│ ╭─ Terms ───┴──────────╮               │
+│ │ Field: body(string)  │               │
+│ │ Values: 'cat', 'fox' │               │
+│ ╰──────────────────────╯               │
+│ Score: bm25(k1=1.2, b=0.75)            │
+│ Top: 10, optimized                     │
+│ Projections: id,                       │
+│              sdb_inverted_index_score  │
+│ ~1,200 rows                            │
+╰────────────────────────────────────────╯
+
+query
+SELECT id FROM dd_idx WHERE body @@ ts_any(['fox', 'cat']) ORDER BY BM25(dd_idx.tableoid) DESC, id LIMIT 10;
+----
+id
+11
+22
+33
+44
+55
+66
+77
+88
+99
+110
+
+query
+SELECT
+  (SELECT list(id) FROM (SELECT id FROM dd_idx WHERE body @@ ts_any(['fox', 'cat']) ORDER BY BM25(dd_idx.tableoid) DESC, id LIMIT 100))
+  = (SELECT list(id) FROM (SELECT id FROM (SELECT id, BM25(dd_idx.tableoid) AS s FROM dd_idx WHERE body @@ ts_any(['fox', 'cat'])) q ORDER BY s DESC, id LIMIT 100)) AS top100_equal,
+  (SELECT list(id) FROM (SELECT id FROM dd_idx WHERE body @@ ts_any(['fox', 'cat']) ORDER BY BM25(dd_idx.tableoid) DESC, id LIMIT 1000))
+  = (SELECT list(id) FROM (SELECT id FROM (SELECT id, BM25(dd_idx.tableoid) AS s FROM dd_idx WHERE body @@ ts_any(['fox', 'cat'])) q ORDER BY s DESC, id LIMIT 1000)) AS top1000_equal;
+----
+top100_equal	top1000_equal
+t	t
+
+query
+SELECT count(*) FROM dd_idx WHERE body @@ ts_any(['fox', 'cat']);
+----
+count
+6000


### PR DESCRIPTION
## Problem

With `optimize_top_k`, a scored `ts_any` over two common terms was slower than the same query without the option: 34.9 ms vs 16.1 ms single-threaded on identical 20M-row tables (release build). Profile: 67% of the time was self time in `PostingPrunedDisj::ScoreCandidates`.

Causes:

1. `ScoreCandidates` matched candidates against a block with `std::find` from the block start and never advanced on a miss. Both sides are sorted, so a block whose documents mostly miss the candidates (the normal situation for a non-essential term) did quadratic work.
2. MaxScore partitions lists into essential and non-essential by block maxima. When the non-essential term's maximum keeps every essential document competitive, `FilterCompetitive` removes nothing and every candidate is probed doc-at-a-time, while the unpruned `WindowDisjunction` fills windows with SIMD. No bound can fix that: a document could legitimately contain both terms.
3. Once promotion routes dense windows through `Fill`, the pruned leaf's `Fill` scattered a block with a sequential loop, where `PostingLeaf::AddWhole` walks a full block through `VisitDocs<kBlockSize>` (eight interleaved chains, overlapping stores).

## Change

- `ScoreCandidates`: gallop then `lower_bound`, and advance past misses.
- `MaxScoreDisjunction`: count per outer window how many candidates reach `ScoreCandidates`. When at least three quarters of candidates × non-essential lists get probed, run the next windows with every list essential, which is the window fill path and still skips windows whose summed maxima cannot beat the threshold. Exponential backoff up to 64 windows, then one normal window to resample.
- `PostingPrunedDisj::Fill`: scatter a full block through `VisitDocs<kBlockSize>`, like `AddWhole`.

## Numbers

Release build, identical data, single thread, `LIMIT 10`, min of 5 interleaved runs:

| shape | with option, before | with option, after | without option |
|---|---|---|---|
| `ts_any` two 50% terms, 20M | 34.9 ms | 16.6 ms | 16.2 ms |
| `ts_any` 50% + 97% term, 20M | 5.9 ms | 6.1 ms | 25.0 ms |
| conjunction, 20M | 20.5 ms | 20.5 ms | 39.9 ms |
| single term, 20M | 1.6 ms | 1.6 ms | 4.1 ms |
| `ts_any` five terms, 2M | 4.2 ms | 4.2 ms | 4.5 ms |

Results are identical to the unpruned tables for k = 10, 100 and 1000 on every shape. The 2M-row tables keep the option's fixed per-segment setup cost of a fraction of a millisecond, unchanged by this PR.

## Test

`sdb/pg/index/inverted_index_score_prune_dense_disjunction.test`: dense two-term disjunction under the option, pruned plan, tied top 10 by id, parity with a full sort at k = 100 and 1000. All scorer and prune sqllogic suites and the recovery prune tests pass.