### PR TITLE
fix: term-dictionary and offsets pushdowns on search tables

### DIFF
--- a/server/connector/duckdb_table_function.cpp
+++ b/server/connector/duckdb_table_function.cpp
@@ -614,7 +614,7 @@ void SereneDBScanBindData::AppendSummary(
         ? std::string{"Index Filter"}
         : absl::StrCat(
             "Index Filter(",
-            display_field(static_cast<catalog::ColumnId>(req.field_id)), ")");
+            display_field(static_cast<catalog::ColumnId>(req.display_id)), ")");
     out.insert(std::move(key), duckdb::ExplainValue(irs::ToExplainNode(
                                  *req.having_filter, name_of, kind_of)));
   }
@@ -667,7 +667,7 @@ void SereneDBScanBindData::AppendSummary(
   if (TsDictMode()) {
     auto names =
       absl::StrJoin(ts_dicts | std::views::transform([&](const auto& req) {
-                      return display_field(catalog::ColumnId{req.field_id});
+                      return display_field(catalog::ColumnId{req.display_id});
                     }),
                     ", ");
     out.insert("TsDict", std::move(names));

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -111,6 +111,41 @@ std::vector<catalog::ColumnId> BuildProjectedColumnIds(
   return projected_ids;
 }
 
+void ResolveSearchTableIndexes(connector::SereneDBScanBindData& bind_data,
+                               duckdb::ClientContext& context) {
+  if (bind_data.IsIndexRelation() || !bind_data.IsSearchTableEntry() ||
+      !bind_data.indexes.empty() ||
+      bind_data.GetKind() != connector::SereneDBScanBindData::Kind::Table) {
+    return;
+  }
+  const auto& table_bd = bind_data.As<connector::TableScanBindData>();
+  const auto* entry = dynamic_cast<const catalog::SereneDBTableEntry*>(
+    table_bd.table_entry.get());
+  if (!entry || !entry->GetSearchData()) {
+    return;
+  }
+  const auto& shard = *entry->GetSearchData();
+  bind_data.indexes = catalog::RelationInvertedIndexes(
+    &context, shard.GetSchemaId(), shard.GetTableId());
+}
+
+std::shared_ptr<const catalog::InvertedIndex> TermDictIndexFor(
+  const connector::SereneDBScanBindData& bind_data, catalog::ColumnId col_id) {
+  if (bind_data.IsIndexRelation()) {
+    return std::static_pointer_cast<const catalog::InvertedIndex>(
+      bind_data.indexes.front());
+  }
+  for (const auto& index : bind_data.indexes) {
+    auto inverted =
+      std::static_pointer_cast<const catalog::InvertedIndex>(index);
+    const auto* info = inverted->FindColumnInfo(col_id);
+    if (info && info->IsTermDict()) {
+      return inverted;
+    }
+  }
+  return nullptr;
+}
+
 irs::field_id ResolveAnnTargetFieldId(
   const duckdb::Expression& col_arg, const duckdb::LogicalGet& get,
   const connector::SereneDBScanBindData& bind_data,
@@ -1174,6 +1209,17 @@ void IResearchPushdownComplexFilter(
         bind_data.GetKind() == connector::SereneDBScanBindData::Kind::Table) {
       const auto& table_bd = bind_data.As<connector::TableScanBindData>();
       // The shard comes off the entry the scan was bound to: a search table's
+    if (ss.TsDictMode()) {
+      const auto indexes = bind_data.InvertedIndexes();
+      const auto field = ss.ts_dicts.front().field_id;
+      const auto it = absl::c_find_if(indexes, [&](const auto* index) -> bool {
+        return index->FindEntry(field);
+      });
+      if (it != indexes.end()) {
+        ClaimTsDictFilter(filters, get, bind_data, ss, **it, context);
+      }
+      return;
+    }
       // bind data carries no catalog::Table of its own.
       const auto* entry = dynamic_cast<const catalog::SereneDBTableEntry*>(
         table_bd.table_entry.get());

--- a/server/connector/optimizer/iresearch_plan.cpp
+++ b/server/connector/optimizer/iresearch_plan.cpp
@@ -710,7 +710,8 @@ duckdb::unique_ptr<duckdb::Expression> PushdownDistanceCall(
 }
 
 duckdb::unique_ptr<duckdb::Expression> PushdownOffsetsCall(
-  duckdb::BoundFunctionExpression& func, duckdb::LogicalOperator& root) {
+  duckdb::BoundFunctionExpression& func, duckdb::LogicalOperator& root,
+  duckdb::ClientContext& context) {
   if (func.GetChildren().size() != 1 && func.GetChildren().size() != 2) {
     return nullptr;
   }
@@ -774,8 +775,9 @@ duckdb::unique_ptr<duckdb::Expression> PushdownOffsetsCall(
       ERR_MSG("ts_offsets(): column '", col_name(), "' not found in table"));
   }
 
-  const auto* col_info =
-    found.bind_data->ScannedIndex().FindColumnInfo(target_col_id);
+  ResolveSearchTableIndexes(*found.bind_data, context);
+  const auto index = TermDictIndexFor(*found.bind_data, target_col_id);
+  const auto* col_info = index ? index->FindColumnInfo(target_col_id) : nullptr;
   if (!col_info) {
     THROW_SQL_ERROR(
       ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -784,15 +786,15 @@ duckdb::unique_ptr<duckdb::Expression> PushdownOffsetsCall(
   const bool is_text = col_info->text_dictionary.isSet();
   const bool offs_stored =
     col_info->features.HasFeatures(irs::IndexFeatures::Offs);
-  const auto read_field = static_cast<catalog::ColumnId>(
-    found.bind_data->ScannedIndex().TermFieldForColumn(target_col_id));
+  const auto read_field =
+    static_cast<catalog::ColumnId>(index->TermFieldForColumn(target_col_id));
 
   if (is_text && !offs_stored) {
     auto bind = duckdb::make_uniq<connector::OffsetsBindData>();
-    bind->inverted_index = found.bind_data->indexes.front();
-    bind->column_id = target_col_id;
+    bind->inverted_index = index;
+    bind->column_id = read_field;
     bind->limit = limit;
-    search_scan.offsets.push_back({.column_id = target_col_id,
+    search_scan.offsets.push_back({.column_id = read_field,
                                    .display_id = target_col_id,
                                    .limit = limit,
                                    .bind = bind.get()});
@@ -861,7 +863,7 @@ void RewriteCallInExpr(duckdb::unique_ptr<duckdb::Expression>& expr,
                               "() requires an inverted index scan in the same "
                               "sub-query"));
     } else if (name == connector::kOffsets) {
-      if (auto repl = PushdownOffsetsCall(func, root)) {
+      if (auto repl = PushdownOffsetsCall(func, root, context)) {
         expr = std::move(repl);
         return;
       }
@@ -1205,10 +1207,6 @@ void IResearchPushdownComplexFilter(
   auto& bind_data = bind_data_ptr->Cast<connector::SereneDBScanBindData>();
   auto& ss = bind_data;
   if (!bind_data.IsIndexRelation()) {
-    if (!bind_data.stored_filter && bind_data.IsSearchTableEntry() &&
-        bind_data.GetKind() == connector::SereneDBScanBindData::Kind::Table) {
-      const auto& table_bd = bind_data.As<connector::TableScanBindData>();
-      // The shard comes off the entry the scan was bound to: a search table's
     if (ss.TsDictMode()) {
       const auto indexes = bind_data.InvertedIndexes();
       const auto field = ss.ts_dicts.front().field_id;
@@ -1220,6 +1218,10 @@ void IResearchPushdownComplexFilter(
       }
       return;
     }
+    if (!bind_data.stored_filter && bind_data.IsSearchTableEntry() &&
+        bind_data.GetKind() == connector::SereneDBScanBindData::Kind::Table) {
+      const auto& table_bd = bind_data.As<connector::TableScanBindData>();
+      // The shard comes off the entry the scan was bound to: a search table's
       // bind data carries no catalog::Table of its own.
       const auto* entry = dynamic_cast<const catalog::SereneDBTableEntry*>(
         table_bd.table_entry.get());

--- a/server/connector/optimizer/iresearch_plan_common.hpp
+++ b/server/connector/optimizer/iresearch_plan_common.hpp
@@ -52,6 +52,12 @@ std::vector<catalog::ColumnId> BuildProjectedColumnIds(
   const duckdb::LogicalGet& get,
   const connector::SereneDBScanBindData& bind_data);
 
+void ResolveSearchTableIndexes(connector::SereneDBScanBindData& bind_data,
+                               duckdb::ClientContext& context);
+
+std::shared_ptr<const catalog::InvertedIndex> TermDictIndexFor(
+  const connector::SereneDBScanBindData& bind_data, catalog::ColumnId col_id);
+
 struct FoundScan {
   duckdb::LogicalGet* get;
   connector::SereneDBScanBindData* bind_data;

--- a/server/connector/optimizer/iresearch_plan_common.hpp
+++ b/server/connector/optimizer/iresearch_plan_common.hpp
@@ -61,6 +61,8 @@ std::shared_ptr<const catalog::InvertedIndex> TermDictIndexFor(
 struct FoundScan {
   duckdb::LogicalGet* get;
   connector::SereneDBScanBindData* bind_data;
+
+  explicit operator bool() const noexcept { return get; }
 };
 
 std::optional<FoundScan> AsSearchScan(duckdb::LogicalOperator& op);

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -583,6 +583,7 @@ namespace {
 struct KeywordDictAgg {
   duckdb::ColumnBinding binding;
   irs::field_id field_id;
+  catalog::ColumnId col_id;
   std::string_view agg;
 };
 
@@ -698,6 +699,7 @@ struct TsDictFacetKey {
   irs::field_id field_id = irs::field_limits::invalid();
   catalog::ColumnId col_id = catalog::kInvalidColumnId;
   irs::field_id null_field_id = irs::field_limits::invalid();
+  const catalog::InvertedIndex* index = nullptr;
   duckdb::TableIndex anchor;
 
   bool nullable() const { return irs::field_limits::valid(null_field_id); }
@@ -736,6 +738,10 @@ class TsDictFacetPushdown {
 
   bool ShapeOk() const;
   bool AdoptScan(std::optional<FoundScan> here);
+  const catalog::InvertedIndex* ColumnIndex(catalog::ColumnId col_id) const;
+  const catalog::InvertedIndex& FacetIndex() const {
+    return _index ? *_index : *_keys.front().index;
+  }
   bool ResolveExpressionKey(const duckdb::Expression& expr,
                             TsDictFacetKey& key);
   bool ResolveKeys();
@@ -888,17 +894,19 @@ std::optional<KeywordDictAgg> ClassifyKeywordDictAgg(
   if (col_id == catalog::kInvalidColumnId) {
     return std::nullopt;
   }
-  if (!found.bind_data->IsIndexRelation()) {
+  ResolveSearchTableIndexes(*found.bind_data, context);
+  const auto index = TermDictIndexFor(*found.bind_data, col_id);
+  if (!index) {
     return std::nullopt;
   }
-  const auto field_id = static_cast<irs::field_id>(col_id);
-  if (!found.bind_data->ScannedIndex().IsKeywordField(context, field_id)) {
+  const auto field_id = index->TermFieldForColumn(col_id);
+  if (!index->IsKeywordField(context, field_id)) {
     return std::nullopt;
   }
   if (is_list && !found.bind_data->IsColumnNotNull(col_id)) {
     return std::nullopt;
   }
-  return KeywordDictAgg{col_ref.Binding(), field_id, agg_name};
+  return KeywordDictAgg{col_ref.Binding(), field_id, col_id, agg_name};
 }
 
 duckdb::unique_ptr<duckdb::Expression> BuildKeywordTsDictAggregate(
@@ -906,7 +914,8 @@ duckdb::unique_ptr<duckdb::Expression> BuildKeywordTsDictAggregate(
   duckdb::ClientContext& context, const duckdb::Identifier& alias,
   FoundScan& target) {
   return MakeTsDictAggregate(root, context, target, match.field_id,
-                             match.field_id, TsDictColKind::Term, match.agg,
+                             static_cast<irs::field_id>(match.col_id),
+                             TsDictColKind::Term, match.agg,
                              match.binding.table_index, alias);
 }
 
@@ -938,15 +947,27 @@ bool TsDictFacetPushdown::AdoptScan(std::optional<FoundScan> here) {
   if (!here || here->get != &_target) {
     return false;
   }
-  if (_index) {
+  if (_found) {
     return true;
   }
-  if (!here->bind_data->IsIndexRelation()) {
-    return false;
+  if (here->bind_data->IsIndexRelation()) {
+    _index = &here->bind_data->ScannedIndex();
+  } else {
+    ResolveSearchTableIndexes(*here->bind_data, _context);
+    if (here->bind_data->indexes.empty()) {
+      return false;
+    }
   }
   _found = *here;
-  _index = &here->bind_data->ScannedIndex();
   return true;
+}
+
+const catalog::InvertedIndex* TsDictFacetPushdown::ColumnIndex(
+  catalog::ColumnId col_id) const {
+  if (_index) {
+    return _index;
+  }
+  return TermDictIndexFor(*_found.bind_data, col_id).get();
 }
 
 // Expression keys have no NOT NULL proof, so they always carry the
@@ -960,18 +981,31 @@ bool TsDictFacetPushdown::ResolveExpressionKey(const duckdb::Expression& expr,
   if (!_projected_ids) {
     _projected_ids = BuildProjectedColumnIds(*_found.get, *_found.bind_data);
   }
-  auto normalized = connector::NormalizeBoundExpression(
-    expr, _index->GetRelationId(), *_projected_ids, _context);
-  const auto serialized = connector::SerializeBoundExpression(*normalized);
-  key.field_id = _index->FindFieldIdBySerialized(serialized);
-  if (!irs::field_limits::valid(key.field_id)) {
+  const auto resolve_in = [&](const catalog::InvertedIndex& index) {
+    auto normalized = connector::NormalizeBoundExpression(
+      expr, index.GetRelationId(), *_projected_ids, _context);
+    const auto serialized = connector::SerializeBoundExpression(*normalized);
+    const auto field_id = index.FindFieldIdBySerialized(serialized);
+    if (!irs::field_limits::valid(field_id)) {
+      return false;
+    }
+    const auto* info = index.FindEntry(field_id);
+    if (!info || !irs::field_limits::valid(info->null_field_id)) {
+      return false;
+    }
+    key.field_id = field_id;
+    key.null_field_id = info->null_field_id;
+    key.index = &index;
+    return true;
+  };
+  const auto resolved =
+    _index
+      ? resolve_in(*_index)
+      : absl::c_any_of(_found.bind_data->InvertedIndexes(),
+                       [&](const auto* index) { return resolve_in(*index); });
+  if (!resolved) {
     return false;
   }
-  const auto* info = _index->FindEntry(key.field_id);
-  if (!info || !irs::field_limits::valid(info->null_field_id)) {
-    return false;
-  }
-  key.null_field_id = info->null_field_id;
   key.anchor = _found.get->table_index;
   return true;
 }
@@ -1003,10 +1037,14 @@ bool TsDictFacetPushdown::ResolveKeys() {
           ResolveColumnId(walked.binding, *_found.bind_data, *_found.get);
       }
       if (col_id != catalog::kInvalidColumnId) {
-        key.field_id = static_cast<irs::field_id>(col_id);
+        key.index = ColumnIndex(col_id);
+        if (!key.index) {
+          return false;
+        }
+        key.field_id = key.index->TermFieldForColumn(col_id);
         key.col_id = col_id;
         if (!_found.bind_data->IsColumnNotNull(col_id)) {
-          const auto* col_info = _index->FindColumnInfo(col_id);
+          const auto* col_info = key.index->FindColumnInfo(col_id);
           if (!col_info || !irs::field_limits::valid(col_info->null_field_id)) {
             return false;
           }
@@ -1018,7 +1056,7 @@ bool TsDictFacetPushdown::ResolveKeys() {
       }
       key.anchor = ref.Binding().table_index;
     }
-    if (!_index->IsKeywordField(_context, key.field_id) ||
+    if (!key.index->IsKeywordField(_context, key.field_id) ||
         absl::c_any_of(_keys, [&](const TsDictFacetKey& k) {
           return k.field_id == key.field_id;
         })) {
@@ -1067,15 +1105,18 @@ void TsDictFacetPushdown::EmitScanColumns() {
   for (size_t g = 0; g < _aggr.groups.size(); ++g) {
     const auto& key = _keys[g];
     auto& req = _found.bind_data->TsDictFor(key.field_id);
+    if (key.col_id != catalog::kInvalidColumnId) {
+      req.display_id = static_cast<irs::field_id>(key.col_id);
+    }
     EnsureTsDictCol(*_found.bind_data, *_found.get, req, TsDictColKind::Term);
     EnsureTsDictCol(*_found.bind_data, *_found.get, req, TsDictColKind::Count);
     req.term_uses |= connector::TsDictTermUses::kFull;
     req.null_field_id = key.null_field_id;
 
     auto term_name =
-      TsDictColName(*_found.bind_data, key.field_id, TsDictColKind::Term);
+      TsDictColName(*_found.bind_data, req.display_id, TsDictColKind::Term);
     auto count_name =
-      TsDictColName(*_found.bind_data, key.field_id, TsDictColKind::Count);
+      TsDictColName(*_found.bind_data, req.display_id, TsDictColKind::Count);
     const auto term_binding =
       ExposeGetColumnAt(_root, key.anchor, *_found.get, req.term_col_idx,
                         term_name, duckdb::LogicalType::VARCHAR);
@@ -1641,8 +1682,9 @@ bool TsDictFacetPushdown::WhereOk() {
   for (size_t k = 0; k < _keys.size(); ++k) {
     key_by_field[_keys[k].field_id] = k;
   }
+  const auto indexes = _found.bind_data->InvertedIndexes();
   const bool claimable = WithSearchGetters(
-    *_found.get, *_found.bind_data, std::array{_index}, _context,
+    *_found.get, *_found.bind_data, indexes, _context,
     [&](const SearchGetters& getters) {
       auto& [getter, expr_getter, analyzed_fields, null_markers] = getters;
       size_t computed_residuals = 0;
@@ -1658,7 +1700,7 @@ bool TsDictFacetPushdown::WhereOk() {
         }
         if (!refs.matched_key && !refs.term_virtual && !refs.multi_enum &&
             IsCoveredColumnResidual(*expr, *_found.bind_data, *_found.get,
-                                    *_index)) {
+                                    FacetIndex())) {
           if (ResidualComputesOverColumn(*expr) && ++computed_residuals > 1) {
             return false;
           }

--- a/server/connector/optimizer/ts_dict_plan.cpp
+++ b/server/connector/optimizer/ts_dict_plan.cpp
@@ -269,7 +269,9 @@ duckdb::unique_ptr<duckdb::Expression> PushdownTsDictCall(
     THROW_SQL_ERROR(ERR_CODE(ERRCODE_INVALID_PARAMETER_VALUE),
                     ERR_MSG(fn, "(): column not found in index"));
   }
-  const auto* info = found.bind_data->ScannedIndex().FindColumnInfo(col_id);
+  ResolveSearchTableIndexes(*found.bind_data, context);
+  const auto index = TermDictIndexFor(*found.bind_data, col_id);
+  const auto* info = index ? index->FindColumnInfo(col_id) : nullptr;
   const auto& col_type = col_ref->GetReturnType();
   const auto text_type = [&] {
     switch (col_type.id()) {
@@ -294,8 +296,7 @@ duckdb::unique_ptr<duckdb::Expression> PushdownTsDictCall(
   }
 
   const auto [kind, agg_name] = *fn_info;
-  const auto read_field =
-    found.bind_data->ScannedIndex().TermFieldForColumn(col_id);
+  const auto read_field = index->TermFieldForColumn(col_id);
   return MakeTsDictAggregate(root, context, found, read_field,
                              static_cast<irs::field_id>(col_id), kind, agg_name,
                              col_ref->Binding().table_index, agg.GetAlias());
@@ -429,7 +430,7 @@ duckdb::unique_ptr<duckdb::LogicalOperator> InjectTsDictGroupBy(
         : get_ti;
     const auto source = ExposeGetColumnAt(
       *child, anchor, *found->get, req.term_col_idx,
-      TsDictColName(*found->bind_data, req.field_id, TsDictColKind::Term),
+      TsDictColName(*found->bind_data, req.display_id, TsDictColKind::Term),
       duckdb::LogicalType::VARCHAR);
     entries.push_back({.source = source,
                        .source_type = duckdb::LogicalType::VARCHAR,
@@ -1826,8 +1827,11 @@ class TsDictFilterClaim {
         }
         return true;
       }
-      const auto field = static_cast<irs::field_id>(col_id);
-      if (col_id == catalog::kInvalidColumnId || !Enumerated(field)) {
+      if (col_id == catalog::kInvalidColumnId) {
+        return false;
+      }
+      const auto field = _index.TermFieldForColumn(col_id);
+      if (!Enumerated(field)) {
         return false;
       }
       const auto type = _bind_data.ColumnTypeById(col_id).id();
@@ -2093,7 +2097,11 @@ void ClaimTsDictFilter(
       .Claim();
     return true;
   };
-  WithSearchGetters(get, bind_data, std::array{&index}, context, claim);
+  auto indexes = bind_data.InvertedIndexes();
+  if (indexes.empty()) {
+    indexes.push_back(&index);
+  }
+  WithSearchGetters(get, bind_data, indexes, context, claim);
 }
 
 }  // namespace sdb::optimizer

--- a/tests/sqllogic/sdb/pg/index/search_table_ts_dict.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_ts_dict.test
@@ -63,3 +63,126 @@ SELECT list_sort(ts_dict_agg(an)) AS terms FROM i_an WHERE an @@ 'quick';
 ----
 terms
 {brown,dog,fox,quick}
+
+# The same aggregates against the bare table. A search table's scan is already
+# an index scan, so the planner resolves the index covering the column itself
+# and reads that index's allocated term field.
+query
+SELECT list_sort(ts_dict_agg(an)) AS terms FROM t;
+----
+terms
+{brown,dog,fox,lazy,quick}
+
+query
+SELECT list_sort(ts_dict_agg(tag)) AS terms FROM t;
+----
+terms
+{blue,red}
+
+query
+SELECT list_sort(ts_dict_count(an)) AS counts FROM t;
+----
+counts
+{1,1,1,2,2}
+
+query
+SELECT ts_dict_min(an) AS lo, ts_dict_max(an) AS hi FROM t;
+----
+lo	hi
+brown	quick
+
+# Positionally aligned term / live-doc-count pairs.
+query
+SELECT unnest(ts_dict_agg(tag)) AS term, unnest(ts_dict_count(tag)) AS n
+FROM t ORDER BY term;
+----
+term	n
+blue	1
+red	2
+
+# The dictionary scan runs on the table's own store and names the column, not
+# the allocated term field.
+query
+EXPLAIN SELECT unnest(ts_dict_agg(tag)), unnest(ts_dict_count(tag)) FROM t
+----
+QUERY PLAN
+╭─ PROJECTION ────────────────────────────────────────╮
+│ Projections:                                        │
+│ sdb_inverted_index_term$tag,                        │
+│ CAST(sdb_inverted_index_term_count$tag AS INTEGER)  │
+│ ~1 row                                              │
+╰──────────────────────────┬──────────────────────────╯
+╭─ HASH_GROUP_BY ──────────┴──────────────────────────╮
+│ Groups: #0                                          │
+│ Aggregates: sum(#1)                                 │
+│ ~1 row                                              │
+╰──────────────────────────┬──────────────────────────╯
+╭─ IRESEARCH_SCAN ─────────┴──────────────────────────╮
+│ Index: t                                            │
+│ Lookup: search                                      │
+│ TsDict: tag                                         │
+│ Projections:                                        │
+│ sdb_inverted_index_term$tag,                        │
+│ sdb_inverted_index_term_count$tag                   │
+│ ~2 rows                                             │
+╰─────────────────────────────────────────────────────╯
+
+# Faceted against the bare table: the doc predicate is claimed into the
+# dictionary scan exactly as through the index relation.
+query
+SELECT list_sort(ts_dict_agg(an)) AS terms FROM t WHERE an @@ 'quick';
+----
+terms
+{brown,dog,fox,quick}
+
+query
+SELECT list_sort(ts_dict_agg(tag)) AS terms FROM t WHERE an @@ 'lazy';
+----
+terms
+{red}
+
+# A column no index covers has no dictionary to read: a clean error, not a
+# crash.
+statement error
+SELECT ts_dict_agg(id) FROM t;
+----
+db error: ERROR: ts_dict_agg(): column has no text term dictionary
+HINT: ts_dict_agg requires a text-tokenized or keyword VARCHAR column, or an array of such
+
+
+# Several indexes on one table: each column's dictionary is read from the index
+# that covers it, and a predicate on a column of another index still restricts
+# the facet.
+statement ok
+CREATE TABLE m (id BIGINT PRIMARY KEY, a TEXT, b TEXT)
+  WITH (storage='search', compaction_interval=0);
+
+statement ok
+CREATE INDEX m_a ON m USING inverted (a);
+
+statement ok
+CREATE INDEX m_b ON m USING inverted (b d1);
+
+statement ok
+INSERT INTO m VALUES (1, 'x', 'hello world'), (2, 'y', 'hello there');
+
+statement ok
+VACUUM (REFRESH_TABLE) m;
+
+query
+SELECT list_sort(ts_dict_agg(a)) AS terms FROM m;
+----
+terms
+{x,y}
+
+query
+SELECT list_sort(ts_dict_agg(b)) AS terms FROM m;
+----
+terms
+{hello,there,world}
+
+query
+SELECT list_sort(ts_dict_agg(b)) AS terms FROM m WHERE a @@ 'x';
+----
+terms
+{hello,world}

--- a/tests/sqllogic/sdb/pg/index/search_table_ts_dict.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_ts_dict.test
@@ -398,4 +398,3 @@ shoe	NULL	1
 NULL	acme	2
 NULL	NULL	1
 NULL	NULL	1
-

--- a/tests/sqllogic/sdb/pg/index/search_table_ts_dict.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_ts_dict.test
@@ -186,3 +186,216 @@ SELECT list_sort(ts_dict_agg(b)) AS terms FROM m WHERE a @@ 'x';
 ----
 terms
 {hello,world}
+
+
+# The implicit dictionary rewrites reach search tables too: a keyword GROUP BY
+# facet, count(DISTINCT) and min/max are served from the term dictionary,
+# through the index relation and the bare table alike.
+query
+SELECT tag, count(*) AS n FROM i_an GROUP BY tag ORDER BY tag;
+----
+tag	n
+blue	1
+red	2
+
+query
+SELECT tag, count(*) AS n FROM t GROUP BY tag ORDER BY tag;
+----
+tag	n
+blue	1
+red	2
+
+query
+SELECT tag, count(*) AS n FROM t WHERE an @@ 'quick' GROUP BY tag ORDER BY tag;
+----
+tag	n
+blue	1
+red	1
+
+query
+SELECT count(DISTINCT tag) AS n, min(tag) AS lo, max(tag) AS hi FROM t;
+----
+n	lo	hi
+2	blue	red
+
+query
+EXPLAIN SELECT tag, count(*) AS n FROM t WHERE an @@ 'quick' GROUP BY tag
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────╮
+│ Projections: sdb_inverted_index_term$tag, │
+│              CAST(#1 AS BIGINT)           │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ HASH_GROUP_BY ─────┴─────────────────────╮
+│ Groups: #0                                │
+│ Aggregates: sum(#1)                       │
+│ ~1 row                                    │
+╰─────────────────────┬─────────────────────╯
+╭─ IRESEARCH_SCAN ────┴─────────────────────╮
+│ Index: t                                  │
+│ Lookup: search                            │
+│ Index Filter:                             │
+│ ╭─ Term ────────────╮                     │
+│ │ Field: an(string) │                     │
+│ │ Value: quick      │                     │
+│ ╰───────────────────╯                     │
+│ TsDict: tag                               │
+│ Projections:                              │
+│ sdb_inverted_index_term$tag,              │
+│ sdb_inverted_index_term_count$tag         │
+│ ~2 rows                                   │
+╰───────────────────────────────────────────╯
+
+
+# GROUPING SETS facets on a search table: one dictionary pass over several
+# keyword keys, also when the keys live in different indexes. One nullable key
+# gets its NULL group synthesized from the null marker; two nullable keys
+# decline (their NULL groups would collide) and stay a plain scan with the same
+# answers.
+statement ok
+CREATE TABLE g (id BIGINT PRIMARY KEY, cat TEXT NOT NULL, brand TEXT NOT NULL,
+                note TEXT)
+  WITH (storage='search', compaction_interval=0);
+
+statement ok
+CREATE INDEX g_idx ON g USING inverted (cat, brand);
+
+statement ok
+INSERT INTO g VALUES (1, 'shoe', 'acme', 'x'), (2, 'shoe', 'zed', 'y'),
+  (3, 'hat', 'acme', 'z');
+
+statement ok
+VACUUM (REFRESH_TABLE) g;
+
+query TTI
+SELECT cat, brand, count(*) AS n FROM g
+GROUP BY GROUPING SETS ((cat), (brand))
+ORDER BY cat NULLS LAST, brand
+----
+cat	brand	n
+hat	NULL	1
+shoe	NULL	2
+NULL	acme	2
+NULL	zed	1
+
+query TTI
+SELECT cat, brand, count(*) AS n FROM g WHERE brand @@ 'acme'
+GROUP BY GROUPING SETS ((cat), (brand))
+ORDER BY cat NULLS LAST, brand
+----
+cat	brand	n
+hat	NULL	1
+shoe	NULL	1
+NULL	acme	2
+
+query
+EXPLAIN SELECT cat, brand, count(*) AS n FROM g
+GROUP BY GROUPING SETS ((cat), (brand))
+----
+QUERY PLAN
+╭─ PROJECTION ──────────────────────────────────────────────────────────────────────╮
+│ Projections:                                                                      │
+│ sdb_inverted_index_term$cat, sdb_inverted_index_term$brand, CAST(#2 AS BIGINT)    │
+│ ~3 rows                                                                           │
+╰─────────────────────────────────────────┬─────────────────────────────────────────╯
+╭─ HASH_GROUP_BY ─────────────────────────┴─────────────────────────────────────────╮
+│ Groups: #0, #1                                                                    │
+│ Aggregates: sum(#2)                                                               │
+│ ~3 rows                                                                           │
+╰─────────────────────────────────────────┬─────────────────────────────────────────╯
+╭─ PROJECTION ────────────────────────────┴─────────────────────────────────────────╮
+│ Projections:                                                                      │
+│ sdb_inverted_index_term$cat, sdb_inverted_index_term$brand,                       │
+│ COALESCE(sdb_inverted_index_term_count$cat, sdb_inverted_index_term_count$brand)  │
+│ ~4 rows                                                                           │
+╰─────────────────────────────────────────┬─────────────────────────────────────────╯
+╭─ IRESEARCH_SCAN ────────────────────────┴─────────────────────────────────────────╮
+│ Index: g                                                                          │
+│ Lookup: search                                                                    │
+│ TsDict: cat, brand                                                                │
+│ Projections:                                                                      │
+│ sdb_inverted_index_term$cat, sdb_inverted_index_term_count$cat,                   │
+│ sdb_inverted_index_term$brand, sdb_inverted_index_term_count$brand                │
+│ ~4 rows                                                                           │
+╰───────────────────────────────────────────────────────────────────────────────────╯
+
+# The keys served by two different indexes.
+statement ok
+CREATE TABLE g2 (id BIGINT PRIMARY KEY, cat TEXT NOT NULL, brand TEXT NOT NULL)
+  WITH (storage='search', compaction_interval=0);
+
+statement ok
+CREATE INDEX g2_cat ON g2 USING inverted (cat);
+
+statement ok
+CREATE INDEX g2_brand ON g2 USING inverted (brand);
+
+statement ok
+INSERT INTO g2 VALUES (1, 'shoe', 'acme'), (2, 'shoe', 'zed'), (3, 'hat', 'acme');
+
+statement ok
+VACUUM (REFRESH_TABLE) g2;
+
+query TTI
+SELECT cat, brand, count(*) AS n FROM g2
+GROUP BY GROUPING SETS ((cat), (brand))
+ORDER BY cat NULLS LAST, brand
+----
+cat	brand	n
+hat	NULL	1
+shoe	NULL	2
+NULL	acme	2
+NULL	zed	1
+
+# One nullable key.
+statement ok
+CREATE TABLE g3 (id BIGINT PRIMARY KEY, cat TEXT NOT NULL, brand TEXT)
+  WITH (storage='search', compaction_interval=0);
+
+statement ok
+CREATE INDEX g3_idx ON g3 USING inverted (cat, brand);
+
+statement ok
+INSERT INTO g3 VALUES (1, 'shoe', 'acme'), (2, 'shoe', NULL), (3, 'hat', 'acme');
+
+statement ok
+VACUUM (REFRESH_TABLE) g3;
+
+query TTI
+SELECT cat, brand, count(*) AS n FROM g3
+GROUP BY GROUPING SETS ((cat), (brand))
+ORDER BY cat NULLS LAST, brand NULLS LAST
+----
+cat	brand	n
+hat	NULL	1
+shoe	NULL	2
+NULL	acme	2
+NULL	NULL	1
+
+# Two nullable keys.
+statement ok
+CREATE TABLE g4 (id BIGINT PRIMARY KEY, cat TEXT, brand TEXT)
+  WITH (storage='search', compaction_interval=0);
+
+statement ok
+CREATE INDEX g4_idx ON g4 USING inverted (cat, brand);
+
+statement ok
+INSERT INTO g4 VALUES (1, 'shoe', 'acme'), (2, NULL, NULL), (3, 'hat', 'acme');
+
+statement ok
+VACUUM (REFRESH_TABLE) g4;
+
+query TTI
+SELECT cat, brand, count(*) AS n FROM g4
+GROUP BY GROUPING SETS ((cat), (brand))
+ORDER BY cat NULLS LAST, brand NULLS LAST, n
+----
+cat	brand	n
+hat	NULL	1
+shoe	NULL	1
+NULL	acme	2
+NULL	NULL	1
+NULL	NULL	1
+

--- a/tests/sqllogic/sdb/pg/index/search_table_ts_offsets.test
+++ b/tests/sqllogic/sdb/pg/index/search_table_ts_offsets.test
@@ -46,3 +46,68 @@ FROM d_off WHERE body @@ 'fox' ORDER BY id;
 ----
 id	hl
 1	the quick brown <b>fox</b>
+
+# The same through the bare table: the planner resolves the index covering
+# the column and reads the offsets from its allocated term field.
+query
+SELECT id, ts_offsets(body) AS bo FROM d WHERE body @@ 'quick' ORDER BY id;
+----
+id	bo
+1	{4,9}
+
+query
+SELECT id, ts_offsets(body) AS bo FROM d WHERE body @@ 'the' ORDER BY id;
+----
+id	bo
+1	{0,3}
+2	{0,3}
+
+query
+SELECT id, ts_highlight(body, ts_offsets(body)) AS hl
+FROM d WHERE body @@ 'fox' ORDER BY id;
+----
+id	hl
+1	the quick brown <b>fox</b>
+
+
+# A dictionary that stores no offsets: ts_offsets re-tokenizes the body and
+# matches the claimed term query against it. On a search table that match runs
+# on the index's allocated term field, not the column id.
+statement ok
+CREATE TEXT SEARCH DICTIONARY no_offs_en(
+    template = 'text', locale = 'en_US.UTF-8', case = 'lower',
+    stemming = false, accent = false, frequency = true, position = true
+);
+
+statement ok
+CREATE TABLE d2 (id BIGINT PRIMARY KEY, body TEXT)
+  WITH (storage='search', compaction_interval=0);
+
+statement ok
+CREATE INDEX d2_idx ON d2 USING inverted (body no_offs_en);
+
+statement ok
+INSERT INTO d2 VALUES (1, 'the quick brown fox'), (2, 'the lazy dog');
+
+statement ok
+VACUUM (REFRESH_TABLE) d2;
+
+query
+SELECT id, ts_offsets(body) AS bo FROM d2_idx WHERE body @@ 'quick' ORDER BY id;
+----
+id	bo
+1	{4,9}
+
+query
+SELECT id, ts_offsets(body) AS bo FROM d2 WHERE body @@ 'the' ORDER BY id;
+----
+id	bo
+1	{0,3}
+2	{0,3}
+
+query
+SELECT id, ts_highlight(body, ts_offsets(body)) AS hl
+FROM d2 WHERE body @@ 'fox' ORDER BY id;
+----
+id	hl
+1	the quick brown <b>fox</b>


### PR DESCRIPTION
Three planner bugs on search tables, all with the same root cause: code that resolved the scanned index with `ScannedIndex()` or keyed a lookup off the column id, where a search table's plain columns live under an index-allocated term field and a bare table scan carries no index at bind time. One commit per bug.

### 1. `ts_dict_*` aggregates crash on a bare search table
`SELECT unnest(ts_dict_agg(col)), unnest(ts_dict_count(col)) FROM t` (a search table, not its index relation) asserted in `SereneDBScanBindData::ScannedIndex()`. The planner now resolves the table's inverted indexes, picks the one whose term dictionary covers the column and reads its allocated term field; filter pushdown routes `TsDict` mode on a bare table into the dictionary claim (faceted `WHERE` works, also across several indexes on one table); term-level comparisons on the enumerated column map to the allocated field; EXPLAIN prints the column name for `TsDict` instead of the raw field id (this also fixes the display on search-table index relations). A column no index covers gets the existing `column has no text term dictionary` error.

### 2. Dictionary `GROUP BY` / `count(DISTINCT)` / `min` / `max` rewrites skipped search tables
The facet pushdown required an index relation and checked `IsKeywordField` with the column id, so keyword facets on search tables ran as hash aggregates over document rows. It now adopts bare search-table scans, resolves each key column to its covering index and allocated term field, and resolves `WHERE` predicates against every index on the scan.

### 3. `ts_offsets` on search tables
The bare-table scan hit the same `ScannedIndex()` assertion, and the recomputed-offsets path (a dictionary without `offset = true`) bound the column id into `OffsetsBindData`, failing with `Field id ... not found in the index definition` on the index relation as well. Both paths now use the covering index's allocated term field.

### Tests
`search_table_ts_dict.test` +23 cases (bare-table aggregates, `unnest` shape, faceted `WHERE`, multi-index table, clean error, facet rewrites and `GROUPING SETS` facets -- keys in one or two indexes, one nullable key with its synthesized NULL group, two nullable keys declining -- with three EXPLAIN pins) and `search_table_ts_offsets.test` +6 cases (stored and recomputed offsets through the bare table). Both pass under pg-wire-simple and pg-wire-extended; transactional-table behaviour is unchanged (identity mapping when no term field is allocated). Related files worth including in the CI sweep: `ts_dict*.test`, `ts_dict_facets.test`, `inverted_index_*offsets*`.
