### PR TITLE
fix: sse2neon shim for <tmmintrin.h>, the arm64 release build stopped at term_view.hpp

### DIFF
--- a/third_party/sse2neon/tmmintrin.h
+++ b/third_party/sse2neon/tmmintrin.h
@@ -1,0 +1,1 @@
+#include <sse2neon.h>


### PR DESCRIPTION
The arm64 package build of main fails in every TU that includes `term_view.hpp`:

```
tmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
pmmintrin.h:53:19: error: use of undeclared identifier '__builtin_ia32_lddqu'
```

On aarch64 `third_party/sse2neon` is on the system include path and its one-line `emmintrin.h` and `smmintrin.h` shims redirect those includes to `sse2neon.h`. `term_view.hpp` also includes `<tmmintrin.h>` for `_mm_shuffle_epi8`, and with no shim of that name it reached clang's x86-only header, whose `pmmintrin.h` then collided with the SSE3 functions sse2neon had already defined. sse2neon implements every intrinsic the header uses, so the fix is the same shim for `tmmintrin.h`.

Reproduced and verified with clang 21 as `--target=aarch64-linux-gnu -fsyntax-only` on `case.cpp`: the exact CI errors without the shim, clean with it.
