### PR TITLE
fix: an altered entry keeps the containment edge onto its schema

### DIFF
--- a/server/catalog/read/duckdb_dependency.cpp
+++ b/server/catalog/read/duckdb_dependency.cpp
@@ -150,6 +150,24 @@ duckdb::LogicalDependencyList EntryDependencies(
       add(kept);
     }
   }
+  switch (info.type) {
+    using enum duckdb::CatalogType;
+    case TABLE_ENTRY:
+    case VIEW_ENTRY:
+    case INDEX_ENTRY:
+    case SEQUENCE_ENTRY:
+    case TYPE_ENTRY:
+    case MACRO_ENTRY:
+    case TABLE_MACRO_ENTRY:
+    case TOKENIZER_ENTRY:
+      if (const auto parent = catalog::ParentIdOf(info); parent.isSet()) {
+        add(duckdb::LogicalDependency{nullptr, DependencyInfo(parent),
+                                      duckdb::Identifier{}});
+      }
+      break;
+    default:
+      break;
+  }
   if (info.type == duckdb::CatalogType::TABLE_ENTRY) {
     AddDefinitionEdges(basics::downCast<const duckdb::CreateTableInfo>(info),
                        add);

--- a/tests/sqllogic/recovery/drop_cascade_altered_table_recovery.test
+++ b/tests/sqllogic/recovery/drop_cascade_altered_table_recovery.test
@@ -1,0 +1,134 @@
+control substitution on
+
+
+statement ok
+CREATE SCHEMA dcr_altered;
+
+
+statement ok
+CREATE TABLE dcr_altered.entries (id INT, note TEXT);
+
+
+statement ok
+ALTER TABLE dcr_altered.entries ADD COLUMN extra TEXT;
+
+
+statement count 1
+INSERT INTO dcr_altered.entries (note, extra) VALUES ('pre_crash', 'x');
+
+
+statement error (?i)table "entries" depends on schema "dcr_altered"
+DROP SCHEMA dcr_altered;
+
+
+statement error (?i)table "entries" depends on schema "dcr_altered"
+DROP SCHEMA dcr_altered RESTRICT;
+
+
+statement ok
+DROP SCHEMA dcr_altered CASCADE;
+
+
+statement ok
+CREATE SCHEMA dcr_seq_src;
+
+
+statement ok
+CREATE SCHEMA dcr_seq_user;
+
+
+statement ok
+CREATE SEQUENCE dcr_seq_src.shared_id_seq START 7000;
+
+
+statement ok
+CREATE TABLE dcr_seq_user.entries (
+  id INT DEFAULT nextval('dcr_seq_src.shared_id_seq'),
+  note TEXT
+);
+
+
+statement count 1
+INSERT INTO dcr_seq_user.entries (note) VALUES ('pre_crash');
+
+
+statement ok
+DROP SCHEMA dcr_seq_src CASCADE;
+
+
+statement error (?i)table "entries" depends on schema "dcr_seq_user"
+DROP SCHEMA dcr_seq_user;
+
+
+statement ok
+DROP SCHEMA dcr_seq_user CASCADE;
+
+
+statement ok
+CREATE SCHEMA dcr_witness;
+
+
+statement ok
+CREATE TABLE dcr_witness.entries (id INT, body TEXT);
+
+
+statement count 1
+INSERT INTO dcr_witness.entries VALUES (1, 'unaffected');
+
+
+statement ok
+ALTER TABLE dcr_witness.entries ADD COLUMN extra TEXT;
+
+
+statement ok
+SET sdb_faults = 'crash_on_packet';
+
+
+statement error connection closed
+SELECT 1;
+
+
+connection after_crash
+query ok retry $RETRY_ATTEMPTS backoff $BACKOFF_DURATION
+SELECT count(*) FROM pg_namespace
+  WHERE nspname IN ('dcr_altered', 'dcr_seq_src', 'dcr_seq_user');
+----
+count
+0
+
+
+connection after_crash
+query
+SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname IN ('dcr_altered', 'dcr_seq_src', 'dcr_seq_user');
+----
+count
+0
+
+
+connection after_crash
+query
+SELECT id, body, extra FROM dcr_witness.entries;
+----
+id	body	extra
+1	unaffected	NULL
+
+
+connection after_crash
+statement ok
+CREATE SCHEMA dcr_altered;
+
+
+connection after_crash
+statement ok
+CREATE TABLE dcr_altered.entries (id INT);
+
+
+connection after_crash
+statement ok
+DROP SCHEMA dcr_altered CASCADE;
+
+
+connection after_crash
+statement ok
+DROP SCHEMA dcr_witness CASCADE;


### PR DESCRIPTION
An alter restates what an entry depends on in full -- both the entry alter and the
storage reshape hand duckdb the list `EntryDependencies` derives -- and
`ReplaceSubjects` retires every non-ownership subject edge that list does not carry.
The containment edge duckdb states for us on a create was not among them, so the
first ALTER took it out: DROP SCHEMA stopped naming the entry under RESTRICT, a
CASCADE never visited it, no drop record reached the catalog log, and the next boot
refused to open the database, replaying the schema drop against a relation still in
it:

```
serened terminated because of an exception: {"exception_type":"Dependency",
 "exception_message":"Cannot drop entry \"s\" because there are entries that depend
  on it.\ntable \"t\" depends on schema \"s\"..."}
```

That is the release Deb RTA's `FAIL: service restarted` (run 34501504320 and the
2026-09-07 one before it): the sqllogic run leaves such a schema behind, and serened
does not come back up.

Four statements and a restart reproduce it; an unaltered table replays fine:

```sql
CREATE SCHEMA s;
CREATE TABLE s.t (id INT);
ALTER TABLE s.t ADD COLUMN e TEXT;
DROP SCHEMA s CASCADE;
```

The edge is derived beside the definition edges rather than restated by each alter,
so a version placed by a statement and one replayed from a record still carry the
same edges; a create states it twice and the set keeps one.

`recovery/drop_cascade_altered_table_recovery.test` pins both halves -- the RESTRICT
refusal that names the altered table, and the boot after the cascade. Without the fix
the server does not come back after the crash; the full recovery suite is 237/237
with it, `sdb/**` 2338 and `any/**` 736 green with a clean restart on the datadir each
suite left behind.
