### PR TITLE
fix: one reflection of the ngram mode names, beside the enum

### DIFF
--- a/libs/iresearch/include/iresearch/analysis/ngram_tokenizer.hpp
+++ b/libs/iresearch/include/iresearch/analysis/ngram_tokenizer.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <magic_enum/magic_enum.hpp>
 #include <tuple>
 #include <vector>
 
@@ -111,3 +112,27 @@ class NGramTokenizer final : public TypedTokenizer<NGramTokenizer>,
 extern template class TypedTokenizer<NGramTokenizer>;
 
 }  // namespace irs::analysis
+namespace magic_enum {
+
+// The one reflection of NGramMode, beside the enum: every TU that reflects it
+// must see the same names, or the linker mixes the per-TU tables (ODR). The
+// names are the user surface -- the `mode` option of the ngram dictionary.
+template<>
+constexpr customize::customize_t
+customize::enum_name<irs::analysis::NGramTokenizer::NGramMode>(
+  irs::analysis::NGramTokenizer::NGramMode value) noexcept {
+  using NGramMode = irs::analysis::NGramTokenizer::NGramMode;
+  switch (value) {
+    case NGramMode::All:
+      return "all";
+    case NGramMode::Prefix:
+      return "only_prefix";
+    case NGramMode::Suffix:
+      return "only_suffix";
+    case NGramMode::PrefixAndSuffix:
+      return "only_prefix_and_suffix";
+  }
+  return invalid_tag;
+}
+
+}  // namespace magic_enum

--- a/server/pg/tokenizer_options.h
+++ b/server/pg/tokenizer_options.h
@@ -50,31 +50,9 @@
 #include <variant>
 
 #include "basics/assert.h"
-#include "magic_enum/magic_enum.hpp"
 #include "pg/geo_tokenizer_options.h"
 #include "pg/option_help.h"
 
-namespace magic_enum {
-
-template<>
-constexpr customize::customize_t
-customize::enum_name<irs::analysis::NGramTokenizer::NGramMode>(
-  irs::analysis::NGramTokenizer::NGramMode value) noexcept {
-  using NGramMode = irs::analysis::NGramTokenizer::NGramMode;
-  switch (value) {
-    case NGramMode::All:
-      return "all";
-    case NGramMode::Prefix:
-      return "only_prefix";
-    case NGramMode::Suffix:
-      return "only_suffix";
-    case NGramMode::PrefixAndSuffix:
-      return "only_prefix_and_suffix";
-  }
-  return invalid_tag;
-}
-
-}  // namespace magic_enum
 namespace sdb::pg::tokenizer_options {
 
 using namespace std::string_view_literals;

--- a/tests/libs/iresearch/analysis/ngram_tokenizer_test.cpp
+++ b/tests/libs/iresearch/analysis/ngram_tokenizer_test.cpp
@@ -44,6 +44,23 @@ TEST(ngram_token_stream_test, consts) {
   static_assert("ngram" == irs::Type<irs::analysis::NGramTokenizer>::name());
 }
 
+TEST(ngram_token_stream_test, mode_names) {
+  using Mode = irs::analysis::NGramTokenizer::NGramMode;
+  static_assert(magic_enum::enum_count<Mode>() == 4);
+  static_assert(magic_enum::enum_name(Mode::All) == "all");
+  static_assert(magic_enum::enum_name(Mode::Prefix) == "only_prefix");
+  static_assert(magic_enum::enum_name(Mode::Suffix) == "only_suffix");
+  static_assert(magic_enum::enum_name(Mode::PrefixAndSuffix) ==
+                "only_prefix_and_suffix");
+  EXPECT_EQ(Mode::PrefixAndSuffix,
+            magic_enum::enum_cast<Mode>("only_prefix_and_suffix",
+                                        magic_enum::case_insensitive));
+  volatile auto raw =
+    static_cast<std::underlying_type_t<Mode>>(Mode::PrefixAndSuffix);
+  EXPECT_EQ("only_prefix_and_suffix",
+            magic_enum::enum_name(static_cast<Mode>(raw)));
+}
+
 TEST(ngram_token_stream_test, construct) {
   // 1..3, preserve_original=true
   {


### PR DESCRIPTION
The `mode` names lived in a magic_enum customization in `server/pg/tokenizer_options.h`,
which `server/catalog/tokenizer.cpp` does not include -- so that TU reflected
`NGramMode` with magic_enum's default names while the option check reflected it with
ours. Both define the same weak `enum_name_v` symbols, and the linker keeps one of
each, so the table the binary ends up with takes its **sizes** from one definition and
its **characters** from the other. A stderr probe in `CheckEnumValue` on a local build:

```
SDBDIAG option=mode value='only_prefix_and_suffix' size=22 count=4
SDBDIAG   name='All' size=3
SDBDIAG   name='Prefix' size=11          <- default characters, our size
SDBDIAG   name='Suffix' size=11
SDBDIAG   name='PrefixAndSuffix' size=22
```

Which definition wins is the link's to decide, so the same source behaves differently
per build: the arm64 release refuses `mode = 'only_prefix_and_suffix'` while amd64
accepts it. That is `sdb/pg/simple/tokenizers/ngram_tokenizer.test:126` failing the
arm64 Deb RTA since the value landed (runs 34501504320 and 34532965634), with amd64
green on the same SHA. The shorter names survive the mix by accident -- `all`,
`only_prefix` and `only_suffix` either fold onto the default names case-insensitively
or fit inside the size the other table states.

Moved beside the enum, the way `SegmentationTokenizer::Options::Accept` already states
its names, so every TU that reflects the mode sees the same table. Persistence is
unaffected: the catalog record writes the enum as its underlying integer
(`WriteTuple`); only the JSON rendering carried the mixed name, and it was garbage --
the characters of one name with the length of another.

The gtest lives in a TU that only has the iresearch header, which is exactly the view
that was wrong; before this change its `static_assert`s do not hold.

Two sibling customizations (`SegmentationTokenizer::Options::Separate` and
`IcuTextTokenizer::Options::Separate`, both in `create_tsdictionary.cpp`) have the same
split -- `catalog/tokenizer.cpp` reflects them too, and there the two tables disagree on
the enumerator *count*, not just the names. Left for a separate change.
