### PR TITLE
perf: fold on the copy, and split literal alternations without RE2

### DIFF
--- a/libs/iresearch/include/iresearch/analysis/pattern_tokenizer.cpp
+++ b/libs/iresearch/include/iresearch/analysis/pattern_tokenizer.cpp
@@ -124,19 +124,54 @@ re2::RE2::Options RegexOptions(int group) {
   return options;
 }
 
-delim::Finder SplitOnLiteral(std::span<const re2::Rune> runes, bool fold_case) {
-  bstring literal;
-  literal.reserve(runes.size() * utf8_utils::kMaxCharSize);
+bool AppendLiteral(std::span<const re2::Rune> runes, bool fold_case,
+                   bstring& literal) {
   for (const auto rune : runes) {
     if (fold_case && (rune >= 128 ||
                       absl::ascii_isalpha(static_cast<unsigned char>(rune)))) {
-      return {};
+      return false;
     }
     byte_type buf[utf8_utils::kMaxCharSize];
     literal.append(buf,
                    utf8_utils::FromChar32(static_cast<uint32_t>(rune), buf));
   }
+  return true;
+}
+
+bool AppendLiteralOf(re2::Regexp& re, bool fold_case, bstring& literal) {
+  const bool fold =
+    fold_case || (re.parse_flags() & re2::Regexp::FoldCase) != 0;
+  if (re.op() == re2::kRegexpLiteral) {
+    const re2::Rune rune = re.rune();
+    return AppendLiteral({&rune, 1}, fold, literal);
+  }
+  if (re.op() == re2::kRegexpLiteralString) {
+    return AppendLiteral({re.runes(), static_cast<size_t>(re.nrunes())}, fold,
+                         literal);
+  }
+  return false;
+}
+
+delim::Finder SplitOnLiteral(std::span<const re2::Rune> runes, bool fold_case) {
+  bstring literal;
+  literal.reserve(runes.size() * utf8_utils::kMaxCharSize);
+  if (!AppendLiteral(runes, fold_case, literal)) {
+    return {};
+  }
   return delim::FinderFor(std::move(literal));
+}
+
+delim::Finder SplitOnAlternation(re2::Regexp& re, bool fold_case) {
+  std::vector<bstring> delimiters;
+  delimiters.reserve(static_cast<size_t>(re.nsub()));
+  for (int i = 0; i < re.nsub(); ++i) {
+    bstring literal;
+    if (!AppendLiteralOf(*re.sub()[i], fold_case, literal) || literal.empty()) {
+      return {};
+    }
+    delimiters.push_back(std::move(literal));
+  }
+  return delim::FinderFor(std::move(delimiters));
 }
 
 delim::Finder DetectSplit(const re2::RE2& pattern, int group) {
@@ -158,6 +193,9 @@ delim::Finder DetectSplit(const re2::RE2& pattern, int group) {
   if (group < 0 && re->op() == re2::kRegexpLiteralString) {
     return SplitOnLiteral({re->runes(), static_cast<size_t>(re->nrunes())},
                           fold_case);
+  }
+  if (group < 0 && re->op() == re2::kRegexpAlternate) {
+    return SplitOnAlternation(*re, fold_case);
   }
   if (re->op() != re2::kRegexpCharClass || (group == 0 && !(plus && greedy))) {
     return {};

--- a/libs/iresearch/include/iresearch/analysis/pattern_tokenizer.cpp
+++ b/libs/iresearch/include/iresearch/analysis/pattern_tokenizer.cpp
@@ -174,6 +174,30 @@ delim::Finder SplitOnAlternation(re2::Regexp& re, bool fold_case) {
   return delim::FinderFor(std::move(delimiters));
 }
 
+inline constexpr int kMaxClassRunes = 8;
+
+delim::Finder SplitOnRunes(re2::CharClass& cc) {
+  if (cc.size() > kMaxClassRunes) {
+    return {};
+  }
+  std::vector<bstring> delimiters;
+  delimiters.reserve(static_cast<size_t>(cc.size()));
+  for (const auto& range : cc) {
+    if (range.lo <= 0xDFFF && range.hi >= 0xD800) {
+      return {};
+    }
+    for (auto r = range.lo; r <= range.hi; ++r) {
+      byte_type buf[utf8_utils::kMaxCharSize];
+      delimiters.emplace_back(
+        buf, utf8_utils::FromChar32(static_cast<uint32_t>(r), buf));
+    }
+  }
+  if (delimiters.empty()) {
+    return {};
+  }
+  return delim::FinderFor(std::move(delimiters));
+}
+
 delim::Finder DetectSplit(const re2::RE2& pattern, int group) {
   if (group > 0) {
     return {};
@@ -206,7 +230,7 @@ delim::Finder DetectSplit(const re2::RE2& pattern, int group) {
   }
   const auto last = *(cc->end() - 1);
   if (last.hi >= 128 && (last.lo > 128 || last.hi != re2::Runemax)) {
-    return {};
+    return group < 0 ? SplitOnRunes(*cc) : delim::Finder{};
   }
   classify::ByteSet set;
   for (const auto& range : *cc) {

--- a/libs/iresearch/include/iresearch/analysis/text/case/case.hpp
+++ b/libs/iresearch/include/iresearch/analysis/text/case/case.hpp
@@ -81,6 +81,25 @@ IRS_FORCE_INLINE inline void CaseConvertAsciiWide(char* dst, const char* src,
 }
 
 template<bool ToLower>
+IRS_FORCE_INLINE inline void CaseConvertAsciiExact(char* dst, const char* src,
+                                                   size_t n) noexcept {
+  if (n >= kCaseLane) {
+    CaseConvertAsciiLanes<ToLower, kCaseLane>(dst, src, n);
+    return;
+  }
+  if (n >= kCaseLane / 2) {
+    CaseConvertAsciiLanes<ToLower, kCaseLane / 2>(dst, src, n);
+    return;
+  }
+  constexpr uint8_t kLo = ToLower ? 'A' : 'a';
+  for (size_t i = 0; i < n; ++i) {
+    const auto c = static_cast<uint8_t>(src[i]);
+    dst[i] = static_cast<char>(
+      c ^ (static_cast<uint8_t>(c - kLo) <= uint8_t{25} ? 0x20U : 0U));
+  }
+}
+
+template<bool ToLower>
 IRS_NO_INLINE inline void CaseConvertAsciiTerm(char* dst, const char* src,
                                                size_t n) noexcept {
   if (n >= kCaseBulk) {

--- a/server/connector/functions/split_by_non_alpha.cpp
+++ b/server/connector/functions/split_by_non_alpha.cpp
@@ -20,8 +20,6 @@
 
 #include "connector/functions/split_by_non_alpha.h"
 
-#include <absl/strings/ascii.h>
-
 #include <duckdb/common/types/value.hpp>
 #include <duckdb/common/vector/flat_vector.hpp>
 #include <duckdb/common/vector/list_vector.hpp>
@@ -30,6 +28,7 @@
 #include <duckdb/function/function_set.hpp>
 #include <duckdb/function/scalar_function.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <iresearch/analysis/text/case/case.hpp>
 #include <iresearch/analysis/text/words/split_by_non_alpha.hpp>
 #include <string_view>
 
@@ -47,29 +46,33 @@ class ListSink {
 
   duckdb::idx_t Offset() const noexcept { return _offset; }
 
-  template<bool ToLower>
   void Push(std::string_view token) {
+    Slot() = duckdb::StringVector::AddStringOrBlob(_result_child, token.data(),
+                                                   token.size());
+    ++_offset;
+  }
+
+  void PushFolded(std::string_view token) {
+    auto folded =
+      duckdb::StringVector::EmptyString(_result_child, token.size());
+    irs::analysis::casing::CaseConvertAsciiExact<true>(
+      folded.GetDataWriteable(), token.data(), token.size());
+    folded.Finalize();
+    Slot() = folded;
+    ++_offset;
+  }
+
+ private:
+  duckdb::string_t& Slot() {
     if (_offset >= duckdb::ListVector::GetListCapacity(_result_list)) {
       duckdb::ListVector::SetListSize(_result_list, _offset);
       duckdb::ListVector::Reserve(
         _result_list, duckdb::ListVector::GetListCapacity(_result_list) * 2);
     }
-    auto* data =
-      duckdb::FlatVector::GetDataMutable<duckdb::string_t>(_result_child);
-    if constexpr (ToLower) {
-      auto str = duckdb::StringVector::EmptyString(_result_child, token.size());
-      absl::ascii_internal::AsciiStrToLower(str.GetDataWriteable(),
-                                            token.data(), token.size());
-      str.Finalize();
-      data[_offset] = str;
-    } else {
-      data[_offset] = duckdb::StringVector::AddStringOrBlob(
-        _result_child, token.data(), token.size());
-    }
-    ++_offset;
+    return duckdb::FlatVector::GetDataMutable<duckdb::string_t>(
+      _result_child)[_offset];
   }
 
- private:
   duckdb::Vector& _result_list;
   duckdb::Vector& _result_child;
   duckdb::idx_t _offset = 0;
@@ -104,12 +107,22 @@ void Split(duckdb::DataChunk& args, duckdb::Vector& result, PushRow push_row) {
 }
 
 template<bool ToLower>
+void PushTokens(ListSink& sink, duckdb::string_t text) {
+  irs::analysis::words::SplitByNonAlpha(text, [&](size_t begin, size_t end) {
+    const std::string_view token{text.GetData() + begin, end - begin};
+    if constexpr (ToLower) {
+      sink.PushFolded(token);
+    } else {
+      sink.Push(token);
+    }
+  });
+}
+
+template<bool ToLower>
 void SplitConstant(duckdb::DataChunk& args, duckdb::ExpressionState&,
                    duckdb::Vector& result) {
   Split(args, result, [](ListSink& sink, duckdb::idx_t, duckdb::string_t text) {
-    irs::analysis::words::SplitByNonAlpha(text, [&](size_t begin, size_t end) {
-      sink.Push<ToLower>(std::string_view{text.GetData() + begin, end - begin});
-    });
+    PushTokens<ToLower>(sink, text);
   });
 }
 
@@ -123,18 +136,12 @@ void SplitDynamic(duckdb::DataChunk& args, duckdb::ExpressionState&,
   Split(args, result,
         [&](ListSink& sink, duckdb::idx_t row, duckdb::string_t text) {
           auto to_lower_row = to_lower_format.sel->get_index(row);
-          const bool to_lower =
-            to_lower_format.validity.RowIsValid(to_lower_row) &&
-            to_lower_values[to_lower_row];
-          irs::analysis::words::SplitByNonAlpha(
-            text, [&](size_t begin, size_t end) {
-              const std::string_view token{text.GetData() + begin, end - begin};
-              if (to_lower) {
-                sink.Push<true>(token);
-              } else {
-                sink.Push<false>(token);
-              }
-            });
+          if (to_lower_format.validity.RowIsValid(to_lower_row) &&
+              to_lower_values[to_lower_row]) {
+            PushTokens<true>(sink, text);
+          } else {
+            PushTokens<false>(sink, text);
+          }
         });
 }
 

--- a/tests/bench/micro/split_by_non_alpha.cpp
+++ b/tests/bench/micro/split_by_non_alpha.cpp
@@ -23,9 +23,11 @@
 #include <benchmark/benchmark.h>
 
 #include <cstdint>
+#include <cstring>
 #include <iresearch/analysis/pattern_tokenizer.hpp>
 #include <iresearch/analysis/segmentation_tokenizer.hpp>
 #include <iresearch/analysis/split_by_non_alpha_tokenizer.hpp>
+#include <iresearch/analysis/text/case/case.hpp>
 #include <iresearch/analysis/text/words/split_by_non_alpha.hpp>
 #include <string>
 
@@ -103,6 +105,42 @@ void RunSplit(benchmark::State& state, const std::string& data) {
   for (auto _ : state) {
     stream->Fill(data, sink.writer, {sink.layout});
     benchmark::DoNotOptimize(sink.Consume());
+  }
+  SetBytes(state, data);
+}
+
+enum class Fold : uint8_t { None, PerTokenAbsl, PerTokenExact, PerValueAbsl };
+
+template<Fold F>
+void RunEmit(benchmark::State& state, const std::string& data) {
+  std::string out(data.size(), '\0');
+  std::string value(data.size(), '\0');
+  for (auto _ : state) {
+    const char* src = data.data();
+    if constexpr (F == Fold::PerValueAbsl) {
+      absl::ascii_internal::AsciiStrToLower(value.data(), data.data(),
+                                            data.size());
+      src = value.data();
+    }
+    size_t at = 0;
+    words::SplitByNonAlpha(duckdb::string_t{src, static_cast<uint32_t>(
+                                                   data.size())},
+                           [&](size_t begin, size_t end) {
+                             const size_t n = end - begin;
+                             char* dst = out.data() + at;
+                             if constexpr (F == Fold::PerTokenAbsl) {
+                               absl::ascii_internal::AsciiStrToLower(
+                                 dst, src + begin, n);
+                             } else if constexpr (F == Fold::PerTokenExact) {
+                               irs::analysis::casing::CaseConvertAsciiExact<
+                                 true>(dst, src + begin, n);
+                             } else {
+                               std::memcpy(dst, src + begin, n);
+                             }
+                             at += n;
+                           });
+    benchmark::DoNotOptimize(out.data());
+    benchmark::ClobberMemory();
   }
   SetBytes(state, data);
 }
@@ -194,6 +232,46 @@ BENCHMARK_DEFINE_F(LongTokenCorpus, BmPattern)(benchmark::State& state) {
 BENCHMARK_DEFINE_F(LongTokenCorpus, BmSegmentation)(benchmark::State& state) {
   RunSegmentation(state, data);
 }
+
+BENCHMARK_DEFINE_F(MixedCorpus, BmEmitCopy)(benchmark::State& state) {
+  RunEmit<Fold::None>(state, data);
+}
+BENCHMARK_DEFINE_F(MixedCorpus, BmEmitFoldPerTokenAbsl)
+(benchmark::State& state) {
+  RunEmit<Fold::PerTokenAbsl>(state, data);
+}
+BENCHMARK_DEFINE_F(MixedCorpus, BmEmitFoldPerTokenExact)
+(benchmark::State& state) {
+  RunEmit<Fold::PerTokenExact>(state, data);
+}
+BENCHMARK_DEFINE_F(MixedCorpus, BmEmitFoldPerValueAbsl)
+(benchmark::State& state) {
+  RunEmit<Fold::PerValueAbsl>(state, data);
+}
+BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitCopy)(benchmark::State& state) {
+  RunEmit<Fold::None>(state, data);
+}
+BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerTokenAbsl)
+(benchmark::State& state) {
+  RunEmit<Fold::PerTokenAbsl>(state, data);
+}
+BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerTokenExact)
+(benchmark::State& state) {
+  RunEmit<Fold::PerTokenExact>(state, data);
+}
+BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerValueAbsl)
+(benchmark::State& state) {
+  RunEmit<Fold::PerValueAbsl>(state, data);
+}
+
+BENCHMARK_REGISTER_F(MixedCorpus, BmEmitCopy);
+BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerTokenAbsl);
+BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerTokenExact);
+BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerValueAbsl);
+BENCHMARK_REGISTER_F(LongTokenCorpus, BmEmitCopy);
+BENCHMARK_REGISTER_F(LongTokenCorpus, BmEmitFoldPerTokenAbsl);
+BENCHMARK_REGISTER_F(LongTokenCorpus, BmEmitFoldPerTokenExact);
+BENCHMARK_REGISTER_F(LongTokenCorpus, BmEmitFoldPerValueAbsl);
 
 BENCHMARK_REGISTER_F(MixedCorpus, BmFunction)->Arg(0)->Arg(1);
 BENCHMARK_REGISTER_F(MixedCorpus, BmSplit)->Arg(0)->Arg(1);

--- a/tests/bench/micro/split_by_non_alpha.cpp
+++ b/tests/bench/micro/split_by_non_alpha.cpp
@@ -226,6 +226,12 @@ BENCHMARK_DEFINE_F(MixedCorpus, BmPatternLiterals)(benchmark::State& state) {
 }
 BENCHMARK_DEFINE_F(MixedCorpus, BmPatternLiteralsRegex)
 (benchmark::State& state) { RunPatternWith(state, data, "(?:, |! |-_){1}"); }
+BENCHMARK_DEFINE_F(MixedCorpus, BmPatternRunes)(benchmark::State& state) {
+  RunPatternWith(state, data, "[,;§]");
+}
+BENCHMARK_DEFINE_F(MixedCorpus, BmPatternRunesRegex)(benchmark::State& state) {
+  RunPatternWith(state, data, "(?:[,;§]){1}");
+}
 BENCHMARK_DEFINE_F(MixedCorpus, BmSegmentation)(benchmark::State& state) {
   RunSegmentation(state, data);
 }
@@ -263,6 +269,8 @@ BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerValueAbsl)
 
 BENCHMARK_REGISTER_F(MixedCorpus, BmPatternLiterals);
 BENCHMARK_REGISTER_F(MixedCorpus, BmPatternLiteralsRegex);
+BENCHMARK_REGISTER_F(MixedCorpus, BmPatternRunes);
+BENCHMARK_REGISTER_F(MixedCorpus, BmPatternRunesRegex);
 BENCHMARK_REGISTER_F(MixedCorpus, BmEmitCopy);
 BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerTokenAbsl);
 BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerTokenExact);

--- a/tests/bench/micro/split_by_non_alpha.cpp
+++ b/tests/bench/micro/split_by_non_alpha.cpp
@@ -123,31 +123,31 @@ void RunEmit(benchmark::State& state, const std::string& data) {
       src = value.data();
     }
     size_t at = 0;
-    words::SplitByNonAlpha(duckdb::string_t{src, static_cast<uint32_t>(
-                                                   data.size())},
-                           [&](size_t begin, size_t end) {
-                             const size_t n = end - begin;
-                             char* dst = out.data() + at;
-                             if constexpr (F == Fold::PerTokenAbsl) {
-                               absl::ascii_internal::AsciiStrToLower(
-                                 dst, src + begin, n);
-                             } else if constexpr (F == Fold::PerTokenExact) {
-                               irs::analysis::casing::CaseConvertAsciiExact<
-                                 true>(dst, src + begin, n);
-                             } else {
-                               std::memcpy(dst, src + begin, n);
-                             }
-                             at += n;
-                           });
+    words::SplitByNonAlpha(
+      duckdb::string_t{src, static_cast<uint32_t>(data.size())},
+      [&](size_t begin, size_t end) {
+        const size_t n = end - begin;
+        char* dst = out.data() + at;
+        if constexpr (F == Fold::PerTokenAbsl) {
+          absl::ascii_internal::AsciiStrToLower(dst, src + begin, n);
+        } else if constexpr (F == Fold::PerTokenExact) {
+          irs::analysis::casing::CaseConvertAsciiExact<true>(dst, src + begin,
+                                                             n);
+        } else {
+          std::memcpy(dst, src + begin, n);
+        }
+        at += n;
+      });
     benchmark::DoNotOptimize(out.data());
     benchmark::ClobberMemory();
   }
   SetBytes(state, data);
 }
 
-void RunPattern(benchmark::State& state, const std::string& data) {
+void RunPatternWith(benchmark::State& state, const std::string& data,
+                    std::string_view pattern) {
   PatternTokenizer::Options opts;
-  opts.pattern = "[^A-Za-z0-9]+";
+  opts.pattern = std::string{pattern};
   opts.group = -1;
   auto stream = PatternTokenizer::Make(std::move(opts));
   bench::DrainSink sink;
@@ -156,6 +156,10 @@ void RunPattern(benchmark::State& state, const std::string& data) {
     benchmark::DoNotOptimize(sink.Consume());
   }
   SetBytes(state, data);
+}
+
+void RunPattern(benchmark::State& state, const std::string& data) {
+  RunPatternWith(state, data, "[^A-Za-z0-9]+");
 }
 
 void RunSegmentation(benchmark::State& state, const std::string& data) {
@@ -217,6 +221,11 @@ BENCHMARK_DEFINE_F(MixedCorpus, BmSplit)(benchmark::State& state) {
 BENCHMARK_DEFINE_F(MixedCorpus, BmPattern)(benchmark::State& state) {
   RunPattern(state, data);
 }
+BENCHMARK_DEFINE_F(MixedCorpus, BmPatternLiterals)(benchmark::State& state) {
+  RunPatternWith(state, data, ", |! |-_");
+}
+BENCHMARK_DEFINE_F(MixedCorpus, BmPatternLiteralsRegex)
+(benchmark::State& state) { RunPatternWith(state, data, "(?:, |! |-_){1}"); }
 BENCHMARK_DEFINE_F(MixedCorpus, BmSegmentation)(benchmark::State& state) {
   RunSegmentation(state, data);
 }
@@ -237,33 +246,23 @@ BENCHMARK_DEFINE_F(MixedCorpus, BmEmitCopy)(benchmark::State& state) {
   RunEmit<Fold::None>(state, data);
 }
 BENCHMARK_DEFINE_F(MixedCorpus, BmEmitFoldPerTokenAbsl)
-(benchmark::State& state) {
-  RunEmit<Fold::PerTokenAbsl>(state, data);
-}
+(benchmark::State& state) { RunEmit<Fold::PerTokenAbsl>(state, data); }
 BENCHMARK_DEFINE_F(MixedCorpus, BmEmitFoldPerTokenExact)
-(benchmark::State& state) {
-  RunEmit<Fold::PerTokenExact>(state, data);
-}
+(benchmark::State& state) { RunEmit<Fold::PerTokenExact>(state, data); }
 BENCHMARK_DEFINE_F(MixedCorpus, BmEmitFoldPerValueAbsl)
-(benchmark::State& state) {
-  RunEmit<Fold::PerValueAbsl>(state, data);
-}
+(benchmark::State& state) { RunEmit<Fold::PerValueAbsl>(state, data); }
 BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitCopy)(benchmark::State& state) {
   RunEmit<Fold::None>(state, data);
 }
 BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerTokenAbsl)
-(benchmark::State& state) {
-  RunEmit<Fold::PerTokenAbsl>(state, data);
-}
+(benchmark::State& state) { RunEmit<Fold::PerTokenAbsl>(state, data); }
 BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerTokenExact)
-(benchmark::State& state) {
-  RunEmit<Fold::PerTokenExact>(state, data);
-}
+(benchmark::State& state) { RunEmit<Fold::PerTokenExact>(state, data); }
 BENCHMARK_DEFINE_F(LongTokenCorpus, BmEmitFoldPerValueAbsl)
-(benchmark::State& state) {
-  RunEmit<Fold::PerValueAbsl>(state, data);
-}
+(benchmark::State& state) { RunEmit<Fold::PerValueAbsl>(state, data); }
 
+BENCHMARK_REGISTER_F(MixedCorpus, BmPatternLiterals);
+BENCHMARK_REGISTER_F(MixedCorpus, BmPatternLiteralsRegex);
 BENCHMARK_REGISTER_F(MixedCorpus, BmEmitCopy);
 BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerTokenAbsl);
 BENCHMARK_REGISTER_F(MixedCorpus, BmEmitFoldPerTokenExact);

--- a/tests/bench/micro/split_by_non_alpha.cpp
+++ b/tests/bench/micro/split_by_non_alpha.cpp
@@ -109,7 +109,12 @@ void RunSplit(benchmark::State& state, const std::string& data) {
   SetBytes(state, data);
 }
 
-enum class Fold : uint8_t { None, PerTokenAbsl, PerTokenExact, PerValueAbsl };
+enum class Fold : uint8_t {
+  None,
+  PerTokenAbsl,
+  PerTokenExact,
+  PerValueAbsl,
+};
 
 template<Fold F>
 void RunEmit(benchmark::State& state, const std::string& data) {

--- a/tests/libs/iresearch/analysis/pattern_tokenizer_tests.cpp
+++ b/tests/libs/iresearch/analysis/pattern_tokenizer_tests.cpp
@@ -642,8 +642,15 @@ TEST(PatternTokenizerFastSplit, eligibility) {
   ASSERT_TRUE(Detects<Regex>("ab|a"));
   ASSERT_TRUE(Detects<delim::MultiStringFinder>("(?:,|;;)+"));
   ASSERT_TRUE(Detects<delim::MultiStringFinder>("(?i),|;;"));
-  ASSERT_TRUE(Detects<Regex>("§|€"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("§|€"));
   ASSERT_TRUE(Detects<delim::MultiStringFinder>("§x|€y"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("[§€]"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("[§€]+"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("[,;§]"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("[€汉]"));
+  ASSERT_TRUE(Detects<Regex>("[§€]", 0));
+  ASSERT_TRUE(Detects<Regex>("[\\x{4E00}-\\x{9FFF}]"));
+  ASSERT_TRUE(Detects<Regex>("[§€０-９]"));
   ASSERT_TRUE(Detects<Regex>("(?i)ab|cd"));
   ASSERT_TRUE(Detects<Regex>("a|"));
   ASSERT_TRUE(Detects<Regex>("a|b+"));
@@ -697,7 +704,10 @@ TEST(PatternTokenizerFastSplit, property_oracle) {
                                    {"(\\d+)", 0},      {"[,;]+", 0},
                                    {",|;;", -1},       {"ab|cd", -1},
                                    {"(?:,|;;)+", -1},  {"(?i),|;;", -1},
-                                   {"§x|€y", -1},      {"abc|d|ef", -1}};
+                                   {"§x|€y", -1},      {"abc|d|ef", -1},
+                                   {"[§€]", -1},       {"§|€", -1},
+                                   {"[§€]+", -1},      {"[,;§]", -1},
+                                   {"[€汉]", -1}};
   constexpr std::array<std::string_view, 32> kAlphabet = {"a",
                                                           "b",
                                                           "c",

--- a/tests/libs/iresearch/analysis/pattern_tokenizer_tests.cpp
+++ b/tests/libs/iresearch/analysis/pattern_tokenizer_tests.cpp
@@ -636,7 +636,18 @@ TEST(PatternTokenizerFastSplit, eligibility) {
   ASSERT_TRUE(Detects<delim::OneCharFinder>("(,)"));
   ASSERT_TRUE(Detects<Regex>("(,)", 1));
   ASSERT_TRUE(Detects<Regex>(":{2}"));
-  ASSERT_TRUE(Detects<Regex>(",|;;"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>(",|;;"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("ab|cd"));
+  ASSERT_TRUE(Detects<Regex>("a|ab"));
+  ASSERT_TRUE(Detects<Regex>("ab|a"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("(?:,|;;)+"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("(?i),|;;"));
+  ASSERT_TRUE(Detects<Regex>("§|€"));
+  ASSERT_TRUE(Detects<delim::MultiStringFinder>("§x|€y"));
+  ASSERT_TRUE(Detects<Regex>("(?i)ab|cd"));
+  ASSERT_TRUE(Detects<Regex>("a|"));
+  ASSERT_TRUE(Detects<Regex>("a|b+"));
+  ASSERT_TRUE(Detects<Regex>(",|;;", 0));
   ASSERT_TRUE(Detects<Regex>("\\p{L}"));
   ASSERT_TRUE(Detects<Regex>("x?"));
 
@@ -683,7 +694,10 @@ TEST(PatternTokenizerFastSplit, property_oracle) {
                                    {"[0-9]+", 0},      {"[^,]+", 0},
                                    {"[a-z]+", 0},      {"\\d+", 0},
                                    {"[^\\n]+", 0},     {".+", 0},
-                                   {"(\\d+)", 0},      {"[,;]+", 0}};
+                                   {"(\\d+)", 0},      {"[,;]+", 0},
+                                   {",|;;", -1},       {"ab|cd", -1},
+                                   {"(?:,|;;)+", -1},  {"(?i),|;;", -1},
+                                   {"§x|€y", -1},      {"abc|d|ef", -1}};
   constexpr std::array<std::string_view, 32> kAlphabet = {"a",
                                                           "b",
                                                           "c",

--- a/tests/sqllogic/sdb/pg/site_docs/compatibility/system_table_claims.test
+++ b/tests/sqllogic/sdb/pg/site_docs/compatibility/system_table_claims.test
@@ -95,13 +95,19 @@ INSERT INTO stc_parent VALUES (1, 'a')
 statement ok
 INSERT INTO stc_child VALUES (1, 1, 5, 'n', 'ok')
 
-# sys_tables: pg_aggregate (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_aggregate" LIMIT 0;
+# sys_tables: pg_aggregate (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_aggregate";
+----
+populated
+t
 
-# sys_tables: pg_am (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_am" LIMIT 0;
+# sys_tables: pg_am (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_am";
+----
+populated
+t
 
 # sys_tables: pg_amop (🟡)
 statement ok
@@ -111,9 +117,12 @@ SELECT * FROM pg_catalog."pg_amop" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_amproc" LIMIT 0;
 
-# sys_tables: pg_attrdef (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_attrdef" LIMIT 0;
+# sys_tables: pg_attrdef (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_attrdef";
+----
+populated
+t
 
 # sys_tables: pg_attribute (🟢)
 query
@@ -122,13 +131,19 @@ SELECT count(*) > 0 AS populated FROM pg_catalog."pg_attribute";
 populated
 t
 
-# sys_tables: pg_authid (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_authid" LIMIT 0;
+# sys_tables: pg_authid (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_authid";
+----
+populated
+t
 
-# sys_tables: pg_auth_members (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_auth_members" LIMIT 0;
+# sys_tables: pg_auth_members (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_auth_members";
+----
+populated
+t
 
 # sys_tables: pg_cast (🟡)
 statement ok
@@ -156,9 +171,12 @@ t
 statement ok
 SELECT * FROM pg_catalog."pg_conversion" LIMIT 0;
 
-# sys_tables: pg_database (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_database" LIMIT 0;
+# sys_tables: pg_database (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_database";
+----
+populated
+t
 
 # sys_tables: pg_db_role_setting (🟡)
 statement ok
@@ -168,17 +186,26 @@ SELECT * FROM pg_catalog."pg_db_role_setting" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_default_acl" LIMIT 0;
 
-# sys_tables: pg_depend (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_depend" LIMIT 0;
+# sys_tables: pg_depend (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_depend";
+----
+populated
+t
 
-# sys_tables: pg_description (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_description" LIMIT 0;
+# sys_tables: pg_description (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_description";
+----
+populated
+t
 
-# sys_tables: pg_enum (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_enum" LIMIT 0;
+# sys_tables: pg_enum (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_enum";
+----
+populated
+t
 
 # sys_tables: pg_event_trigger (🟡)
 statement ok
@@ -192,7 +219,7 @@ SELECT * FROM pg_catalog."pg_extension" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_foreign_data_wrapper" LIMIT 0;
 
-# sys_tables: pg_foreign_server (🟡)
+# sys_tables: pg_foreign_server (🟢)
 statement ok
 SELECT * FROM pg_catalog."pg_foreign_server" LIMIT 0;
 
@@ -200,9 +227,12 @@ SELECT * FROM pg_catalog."pg_foreign_server" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_foreign_table" LIMIT 0;
 
-# sys_tables: pg_index (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_index" LIMIT 0;
+# sys_tables: pg_index (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_index";
+----
+populated
+t
 
 # sys_tables: pg_inherits (🟡)
 statement ok
@@ -212,9 +242,12 @@ SELECT * FROM pg_catalog."pg_inherits" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_init_privs" LIMIT 0;
 
-# sys_tables: pg_language (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_language" LIMIT 0;
+# sys_tables: pg_language (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_language";
+----
+populated
+t
 
 # sys_tables: pg_largeobject (🟡)
 statement ok
@@ -231,9 +264,12 @@ SELECT count(*) > 0 AS populated FROM pg_catalog."pg_namespace";
 populated
 t
 
-# sys_tables: pg_opclass (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_opclass" LIMIT 0;
+# sys_tables: pg_opclass (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_opclass";
+----
+populated
+t
 
 # sys_tables: pg_operator (🟡)
 statement ok
@@ -255,9 +291,12 @@ SELECT * FROM pg_catalog."pg_partitioned_table" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_policy" LIMIT 0;
 
-# sys_tables: pg_proc (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_proc" LIMIT 0;
+# sys_tables: pg_proc (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_proc";
+----
+populated
+t
 
 # sys_tables: pg_publication (🟡)
 statement ok
@@ -279,21 +318,30 @@ SELECT * FROM pg_catalog."pg_range" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_replication_origin" LIMIT 0;
 
-# sys_tables: pg_rewrite (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_rewrite" LIMIT 0;
+# sys_tables: pg_rewrite (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_rewrite";
+----
+populated
+t
 
 # sys_tables: pg_seclabel (🟡)
 statement ok
 SELECT * FROM pg_catalog."pg_seclabel" LIMIT 0;
 
-# sys_tables: pg_sequence (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_sequence" LIMIT 0;
+# sys_tables: pg_sequence (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_sequence";
+----
+populated
+t
 
-# sys_tables: pg_shdepend (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_shdepend" LIMIT 0;
+# sys_tables: pg_shdepend (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_shdepend";
+----
+populated
+t
 
 # sys_tables: pg_shdescription (🟡)
 statement ok
@@ -323,17 +371,23 @@ SELECT * FROM pg_catalog."pg_subscription" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_subscription_rel" LIMIT 0;
 
-# sys_tables: pg_tablespace (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_tablespace" LIMIT 0;
+# sys_tables: pg_tablespace (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_tablespace";
+----
+populated
+t
 
 # sys_tables: pg_transform (🟡)
 statement ok
 SELECT * FROM pg_catalog."pg_transform" LIMIT 0;
 
-# sys_tables: pg_trigger (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_trigger" LIMIT 0;
+# sys_tables: pg_trigger (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_trigger";
+----
+populated
+t
 
 # sys_tables: pg_ts_config (🟡)
 statement ok
@@ -390,13 +444,19 @@ SELECT * FROM pg_catalog."pg_cursors" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_file_settings" LIMIT 0;
 
-# sys_views: pg_group (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_group" LIMIT 0;
+# sys_views: pg_group (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_group";
+----
+populated
+t
 
-# sys_views: pg_hba_file_rules (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_hba_file_rules" LIMIT 0;
+# sys_views: pg_hba_file_rules (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_hba_file_rules";
+----
+populated
+t
 
 # sys_views: pg_ident_file_mappings (🟡)
 statement ok
@@ -441,9 +501,12 @@ SELECT * FROM pg_catalog."pg_replication_origin_status" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_replication_slots" LIMIT 0;
 
-# sys_views: pg_roles (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_roles" LIMIT 0;
+# sys_views: pg_roles (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_roles";
+----
+populated
+t
 
 # sys_views: pg_rules (🟡)
 statement ok
@@ -453,9 +516,12 @@ SELECT * FROM pg_catalog."pg_rules" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_seclabels" LIMIT 0;
 
-# sys_views: pg_sequences (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_sequences" LIMIT 0;
+# sys_views: pg_sequences (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_sequences";
+----
+populated
+t
 
 # sys_views: pg_settings (🟢)
 query
@@ -464,9 +530,12 @@ SELECT count(*) > 0 AS populated FROM pg_catalog."pg_settings";
 populated
 t
 
-# sys_views: pg_shadow (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_shadow" LIMIT 0;
+# sys_views: pg_shadow (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_shadow";
+----
+populated
+t
 
 # sys_views: pg_shmem_allocations (🟡)
 statement ok
@@ -499,9 +568,12 @@ SELECT * FROM pg_catalog."pg_timezone_abbrevs" LIMIT 0;
 statement ok
 SELECT * FROM pg_catalog."pg_timezone_names" LIMIT 0;
 
-# sys_views: pg_user (🟡)
-statement ok
-SELECT * FROM pg_catalog."pg_user" LIMIT 0;
+# sys_views: pg_user (🟢)
+query
+SELECT count(*) > 0 AS populated FROM pg_catalog."pg_user";
+----
+populated
+t
 
 # sys_views: pg_user_mappings (🟡)
 statement ok
@@ -514,25 +586,34 @@ SELECT count(*) > 0 AS populated FROM pg_catalog."pg_views";
 populated
 t
 
-# sys_infoschema: information_schema_catalog_name (🟡)
-statement ok
-SELECT * FROM information_schema."information_schema_catalog_name" LIMIT 0;
+# sys_infoschema: information_schema_catalog_name (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."information_schema_catalog_name";
+----
+populated
+t
 
 # sys_infoschema: administrable_role_authorizations (🟡)
 statement ok
 SELECT * FROM information_schema."administrable_role_authorizations" LIMIT 0;
 
-# sys_infoschema: applicable_roles (🟡)
-statement ok
-SELECT * FROM information_schema."applicable_roles" LIMIT 0;
+# sys_infoschema: applicable_roles (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."applicable_roles";
+----
+populated
+t
 
 # sys_infoschema: attributes (🟡)
 statement ok
 SELECT * FROM information_schema."attributes" LIMIT 0;
 
-# sys_infoschema: character_sets (🟡)
-statement ok
-SELECT * FROM information_schema."character_sets" LIMIT 0;
+# sys_infoschema: character_sets (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."character_sets";
+----
+populated
+t
 
 # sys_infoschema: check_constraint_routine_usage (🟡)
 statement ok
@@ -611,21 +692,33 @@ t
 statement ok
 SELECT * FROM information_schema."domain_constraints" LIMIT 0;
 
-# sys_infoschema: domain_udt_usage (🟡)
-statement ok
-SELECT * FROM information_schema."domain_udt_usage" LIMIT 0;
+# sys_infoschema: domain_udt_usage (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."domain_udt_usage";
+----
+populated
+t
 
-# sys_infoschema: domains (🟡)
-statement ok
-SELECT * FROM information_schema."domains" LIMIT 0;
+# sys_infoschema: domains (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."domains";
+----
+populated
+t
 
-# sys_infoschema: element_types (🟡)
-statement ok
-SELECT * FROM information_schema."element_types" LIMIT 0;
+# sys_infoschema: element_types (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."element_types";
+----
+populated
+t
 
-# sys_infoschema: enabled_roles (🟡)
-statement ok
-SELECT * FROM information_schema."enabled_roles" LIMIT 0;
+# sys_infoschema: enabled_roles (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."enabled_roles";
+----
+populated
+t
 
 # sys_infoschema: foreign_data_wrapper_options (🟡)
 statement ok
@@ -658,13 +751,19 @@ SELECT count(*) > 0 AS populated FROM information_schema."key_column_usage";
 populated
 t
 
-# sys_infoschema: parameters (🟡)
-statement ok
-SELECT * FROM information_schema."parameters" LIMIT 0;
+# sys_infoschema: parameters (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."parameters";
+----
+populated
+t
 
-# sys_infoschema: referential_constraints (🟡)
-statement ok
-SELECT * FROM information_schema."referential_constraints" LIMIT 0;
+# sys_infoschema: referential_constraints (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."referential_constraints";
+----
+populated
+t
 
 # sys_infoschema: role_column_grants (🟢)
 query
@@ -673,9 +772,12 @@ SELECT count(*) > 0 AS populated FROM information_schema."role_column_grants";
 populated
 t
 
-# sys_infoschema: role_routine_grants (🟡)
-statement ok
-SELECT * FROM information_schema."role_routine_grants" LIMIT 0;
+# sys_infoschema: role_routine_grants (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."role_routine_grants";
+----
+populated
+t
 
 # sys_infoschema: role_table_grants (🟢)
 query
@@ -688,17 +790,23 @@ t
 statement ok
 SELECT * FROM information_schema."role_udt_grants" LIMIT 0;
 
-# sys_infoschema: role_usage_grants (🟡)
-statement ok
-SELECT * FROM information_schema."role_usage_grants" LIMIT 0;
+# sys_infoschema: role_usage_grants (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."role_usage_grants";
+----
+populated
+t
 
 # sys_infoschema: routine_column_usage (🟡)
 statement ok
 SELECT * FROM information_schema."routine_column_usage" LIMIT 0;
 
-# sys_infoschema: routine_privileges (🟡)
-statement ok
-SELECT * FROM information_schema."routine_privileges" LIMIT 0;
+# sys_infoschema: routine_privileges (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."routine_privileges";
+----
+populated
+t
 
 # sys_infoschema: routine_routine_usage (🟡)
 statement ok
@@ -712,9 +820,12 @@ SELECT * FROM information_schema."routine_sequence_usage" LIMIT 0;
 statement ok
 SELECT * FROM information_schema."routine_table_usage" LIMIT 0;
 
-# sys_infoschema: routines (🟡)
-statement ok
-SELECT * FROM information_schema."routines" LIMIT 0;
+# sys_infoschema: routines (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."routines";
+----
+populated
+t
 
 # sys_infoschema: schemata (🟢)
 query
@@ -723,25 +834,37 @@ SELECT count(*) > 0 AS populated FROM information_schema."schemata";
 populated
 t
 
-# sys_infoschema: sequences (🟡)
-statement ok
-SELECT * FROM information_schema."sequences" LIMIT 0;
+# sys_infoschema: sequences (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."sequences";
+----
+populated
+t
 
 # sys_infoschema: sql_features (🟡)
 statement ok
 SELECT * FROM information_schema."sql_features" LIMIT 0;
 
-# sys_infoschema: sql_implementation_info (🟡)
-statement ok
-SELECT * FROM information_schema."sql_implementation_info" LIMIT 0;
+# sys_infoschema: sql_implementation_info (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."sql_implementation_info";
+----
+populated
+t
 
-# sys_infoschema: sql_parts (🟡)
-statement ok
-SELECT * FROM information_schema."sql_parts" LIMIT 0;
+# sys_infoschema: sql_parts (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."sql_parts";
+----
+populated
+t
 
-# sys_infoschema: sql_sizing (🟡)
-statement ok
-SELECT * FROM information_schema."sql_sizing" LIMIT 0;
+# sys_infoschema: sql_sizing (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."sql_sizing";
+----
+populated
+t
 
 # sys_infoschema: table_constraints (🟢)
 query
@@ -772,17 +895,23 @@ SELECT * FROM information_schema."transforms" LIMIT 0;
 statement ok
 SELECT * FROM information_schema."triggered_update_columns" LIMIT 0;
 
-# sys_infoschema: triggers (🟡)
-statement ok
-SELECT * FROM information_schema."triggers" LIMIT 0;
+# sys_infoschema: triggers (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."triggers";
+----
+populated
+t
 
 # sys_infoschema: udt_privileges (🟡)
 statement ok
 SELECT * FROM information_schema."udt_privileges" LIMIT 0;
 
-# sys_infoschema: usage_privileges (🟡)
-statement ok
-SELECT * FROM information_schema."usage_privileges" LIMIT 0;
+# sys_infoschema: usage_privileges (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."usage_privileges";
+----
+populated
+t
 
 # sys_infoschema: user_defined_types (🟡)
 statement ok
@@ -804,9 +933,12 @@ SELECT * FROM information_schema."view_column_usage" LIMIT 0;
 statement ok
 SELECT * FROM information_schema."view_routine_usage" LIMIT 0;
 
-# sys_infoschema: view_table_usage (🟡)
-statement ok
-SELECT * FROM information_schema."view_table_usage" LIMIT 0;
+# sys_infoschema: view_table_usage (🟢)
+query
+SELECT count(*) > 0 AS populated FROM information_schema."view_table_usage";
+----
+populated
+t
 
 # sys_infoschema: views (🟢)
 query


### PR DESCRIPTION
The function called absl's AsciiStrToLower once per token. That helper is
defined out of line, so folding cost more than the split itself: 42 ms of
the 308 ms it took to split 67.5 MiB, and +81% over a plain copy on a corpus
of 9-byte tokens. The split_by_non_alpha tokenizer folds 32-byte blocks
through AsciiFoldRing instead, which is what made the two paths diverge.

Fold on the way into the result vector, which the function has to write
anyway, using CaseConvertAsciiExact: the lane tiers of CaseConvertAsciiTerm
without its out-of-line call, and safe below 8 bytes, which the Term tiers
are not. The fold now costs about a tenth of the copy it rides
on rather than most of it again, and no scratch buffer is needed.

The benchmark grows four arms that emit the same tokens and differ only in
where the fold happens, since the existing BmFunction arm keeps no tokens
and so cannot be compared with BmSplit. Median ns per MiB, 9-byte tokens
then 64-byte tokens: copy only 820,023 / 52,910; per token through absl
1,486,415 / 62,561; per token through the lane tiers 919,815 / 56,012; once
per value through absl 792,173 / 71,384. Folding per value is free on short
tokens but pays a second pass over the whole value on long ones, so the
per-token lane fold is the only strategy that stays near the floor on both.


---

perf: the pattern tokenizer splits on an alternation of literals

DetectSplit read a literal, a literal string and a character class, and
handed each to the finder that fits. An alternation it left to RE2, even
though the finder for a set of literals was already there and already
wired to the multi_delimiter tokenizer -- `,|;` was only fast because RE2
folds an alternation of single runes into a character class first.

Collected in source order, which is the order MatchAt answers in, so the
delimiter chosen at a position is the one RE2 would have chosen. A
sub-expression that is not a literal, an empty branch, and fold-case over
anything but ASCII non-letters are all still refused, as they are for a
single literal.

`, |! |-_` over the mixed corpus: 265 us against 1021 us on the regex
path, medians of 7, 3.68 GiB/s against 979 MiB/s.


---

perf: a character class of a few runes splits without RE2 too

A class was read as a byte set, which only works while every rune it
holds is ASCII, or while it holds every rune above ASCII and so every
byte above it. `[§€]` is neither, and went to RE2 -- as did `§|€`, since
RE2 folds an alternation of single runes into a class before we see it.

Such a class is a set of literals like any other: each rune encoded once
and handed to the same finder the alternation branch uses. Capped at
eight runes, which the class states outright as its rune count, so a
range like `[\x{4E00}-\x{9FFF}]` is refused before it is walked. The
set is the delimiter itself, so only a split states it -- a group taking
the class as the token still needs the complement a byte set can express
and a list of literals cannot.

`[,;§]` over the mixed corpus: 170 us against 1649 us on the regex path,
medians of 7, 5.75 GiB/s against 607 MiB/s. Fewer distinct first bytes
than the alternation arm, so the block prefilter carries more of it.

