### PR TITLE
fix: one scanner per query parse, so two of them cannot collide

### DIFF
--- a/libs/iresearch/include/iresearch/parser/lucene_lexer.cpp
+++ b/libs/iresearch/include/iresearch/parser/lucene_lexer.cpp
@@ -121,21 +121,38 @@ typedef unsigned int flex_uint32_t;
  */
 #define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
+/* An opaque pointer. */
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void* yyscan_t;
+#endif
+
+/* For convenience, these vars (plus the bison vars far below)
+   are macros in the reentrant scanner. */
+#define yyin yyg->yyin_r
+#define yyout yyg->yyout_r
+#define yyextra yyg->yyextra_r
+#define yyleng yyg->yyleng_r
+#define yytext yyg->yytext_r
+#define yylineno (YY_CURRENT_BUFFER_LVALUE->yy_bs_lineno)
+#define yycolumn (YY_CURRENT_BUFFER_LVALUE->yy_bs_column)
+#define yy_flex_debug yyg->yy_flex_debug_r
+
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
-#define BEGIN (yy_start) = 1 + 2 *
+#define BEGIN yyg->yy_start = 1 + 2 *
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
-#define YY_START (((yy_start) - 1) / 2)
+#define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart( yyin  )
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -165,10 +182,6 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern int yyleng;
-
-extern FILE *yyin, *yyout;
-
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
@@ -183,13 +196,13 @@ extern FILE *yyin, *yyout;
 		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		*yy_cp = (yy_hold_char); \
+		*yy_cp = yyg->yy_hold_char; \
 		YY_RESTORE_YY_MORE_OFFSET \
-		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
+		yyg->yy_c_buf_p = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-#define unput(c) yyunput( c, (yytext_ptr)  )
+#define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -256,77 +269,57 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-/* Stack of input buffers. */
-static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
-static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
-
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
  * "scanner state".
  *
  * Returns the top of the stack, or NULL.
  */
-#define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
-                          ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
+#define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
+                          ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
-#define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
+#define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-/* yy_hold_char holds the character lost when yytext is formed. */
-static char yy_hold_char;
-static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int yyleng;
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-/* Points to current character in buffer. */
-static char *yy_c_buf_p = NULL;
-static int yy_init = 0;		/* whether we need to initialize */
-static int yy_start = 0;	/* start state number */
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-/* Flag which is used to allow yywrap()'s to do buffer switches
- * instead of setting up a fresh yyin.  A bit of a hack ...
- */
-static int yy_did_buffer_switch_on_eof;
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-void yyrestart ( FILE *input_file  );
-void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
-void yy_delete_buffer ( YY_BUFFER_STATE b  );
-void yy_flush_buffer ( YY_BUFFER_STATE b  );
-void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state ( void );
-
-static void yyensure_buffer_stack ( void );
-static void yy_load_buffer_state ( void );
-static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
-#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
-
-YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
-
-void *yyalloc ( yy_size_t  );
-void *yyrealloc ( void *, yy_size_t  );
-void yyfree ( void *  );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 #define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        yyensure_buffer_stack (); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        yyensure_buffer_stack (); \
+        yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
@@ -334,37 +327,28 @@ void yyfree ( void *  );
 
 /* Begin user sect3 */
 
-#define yywrap() (/*CONSTCOND*/1)
+#define yywrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
 typedef flex_uint8_t YY_CHAR;
 
-FILE *yyin = NULL, *yyout = NULL;
-
 typedef int yy_state_type;
 
-extern int yylineno;
-int yylineno = 1;
+#define yytext_ptr yytext_r
 
-extern char *yytext;
-#ifdef yytext_ptr
-#undef yytext_ptr
-#endif
-#define yytext_ptr yytext
-
-static yy_state_type yy_get_previous_state ( void );
-static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
-static int yy_get_next_buffer ( void );
-static void yynoreturn yy_fatal_error ( const char* msg  );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
-	(yytext_ptr) = yy_bp; \
+	yyg->yytext_ptr = yy_bp; \
 	yyleng = (int) (yy_cp - yy_bp); \
-	(yy_hold_char) = *yy_cp; \
+	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
-	(yy_c_buf_p) = yy_cp;
+	yyg->yy_c_buf_p = yy_cp;
 #define YY_NUM_RULES 56
 #define YY_END_OF_BUFFER 57
 /* This struct is not used in this scanner,
@@ -616,12 +600,6 @@ static const flex_int16_t yy_chk[522] =
       185
     } ;
 
-static yy_state_type yy_last_accepting_state;
-static char *yy_last_accepting_cpos;
-
-extern int yy_flex_debug;
-int yy_flex_debug = 0;
-
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
  */
@@ -629,7 +607,6 @@ int yy_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *yytext;
 /*
  DISCLAIMER
 
@@ -653,11 +630,13 @@ char *yytext;
 #include <fast_float/fast_float.h>
 
 #include <cstring>
+#include <stdexcept>
 #include <string_view>
 
 #include "lucene_parser.hpp"
 
-static YY_BUFFER_STATE current_buffer = nullptr;
+#pragma clang diagnostic ignored "-Wunused-function"
+#define YY_FATAL_ERROR(msg) throw std::runtime_error(msg)
 #define YY_NO_INPUT 1
 /* Inside quotes the words are words: `and` is a term there rather than an
    operator, and a phrase is a list of parts rather than one string to be
@@ -692,40 +671,88 @@ static YY_BUFFER_STATE current_buffer = nullptr;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals ( void );
+/* Holds the entire state of the reentrant scanner. */
+struct yyguts_t
+    {
+
+    /* User-defined. Not touched by flex. */
+    YY_EXTRA_TYPE yyextra_r;
+
+    /* The rest are the same as the globals declared in the non-reentrant scanner. */
+    FILE *yyin_r, *yyout_r;
+    size_t yy_buffer_stack_top; /**< index of top of stack. */
+    size_t yy_buffer_stack_max; /**< capacity of stack. */
+    YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
+    char yy_hold_char;
+    int yy_n_chars;
+    int yyleng_r;
+    char *yy_c_buf_p;
+    int yy_init;
+    int yy_start;
+    int yy_did_buffer_switch_on_eof;
+    int yy_start_stack_ptr;
+    int yy_start_stack_depth;
+    int *yy_start_stack;
+    yy_state_type yy_last_accepting_state;
+    char* yy_last_accepting_cpos;
+
+    int yylineno_r;
+    int yy_flex_debug_r;
+
+    char *yytext_r;
+    int yy_more_flag;
+    int yy_more_len;
+
+    YYSTYPE * yylval_r;
+
+    }; /* end struct yyguts_t */
+
+static int yy_init_globals ( yyscan_t yyscanner );
+
+    /* This must go here because YYSTYPE and YYLTYPE are included
+     * from bison output in section 1.*/
+    #    define yylval yyg->yylval_r
+
+int yylex_init (yyscan_t* scanner);
+
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy ( void );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yyget_debug ( void );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yyset_debug ( int debug_flag  );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yyget_extra ( void );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yyset_extra ( YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yyget_in ( void );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yyset_in  ( FILE * _in_str  );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yyget_out ( void );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yyset_out  ( FILE * _out_str  );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int yyget_leng ( void );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yyget_text ( void );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yyget_lineno ( void );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yyset_lineno ( int _line_number  );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-YYSTYPE * yyget_lval ( void );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yyset_lval ( YYSTYPE * yylval_param  );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
+
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
+
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -733,9 +760,9 @@ void yyset_lval ( YYSTYPE * yylval_param  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap ( void );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yywrap ( void );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
@@ -744,18 +771,18 @@ extern int yywrap ( void );
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy ( char *, const char *, int );
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen ( const char * );
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
-static int yyinput ( void );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input ( void );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
@@ -829,7 +856,7 @@ static int input ( void );
 
 /* Report a fatal error. */
 #ifndef YY_FATAL_ERROR
-#define YY_FATAL_ERROR(msg) yy_fatal_error( msg )
+#define YY_FATAL_ERROR(msg) yy_fatal_error( msg , yyscanner)
 #endif
 
 /* end tables serialization structures and prototypes */
@@ -841,10 +868,10 @@ static int input ( void );
 #define YY_DECL_IS_OURS 1
 
 extern int yylex \
-               (YYSTYPE * yylval_param );
+               (YYSTYPE * yylval_param , yyscan_t yyscanner);
 
 #define YY_DECL int yylex \
-               (YYSTYPE * yylval_param )
+               (YYSTYPE * yylval_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
 /* Code executed at the beginning of each rule, after yytext and yyleng
@@ -869,21 +896,20 @@ YY_DECL
 	yy_state_type yy_current_state;
 	char *yy_cp, *yy_bp;
 	int yy_act;
-
-        YYSTYPE * yylval;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     yylval = yylval_param;
 
-	if ( !(yy_init) )
+	if ( !yyg->yy_init )
 		{
-		(yy_init) = 1;
+		yyg->yy_init = 1;
 
 #ifdef YY_USER_INIT
 		YY_USER_INIT;
 #endif
 
-		if ( ! (yy_start) )
-			(yy_start) = 1;	/* first start state */
+		if ( ! yyg->yy_start )
+			yyg->yy_start = 1;	/* first start state */
 
 		if ( ! yyin )
 			yyin = stdin;
@@ -892,37 +918,37 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			yyensure_buffer_stack ();
+			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer( yyin, YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( yyscanner );
 		}
 
 	{
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
-		yy_cp = (yy_c_buf_p);
+		yy_cp = yyg->yy_c_buf_p;
 
 		/* Support of yytext. */
-		*yy_cp = (yy_hold_char);
+		*yy_cp = yyg->yy_hold_char;
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
 		 * the current run.
 		 */
 		yy_bp = yy_cp;
 
-		yy_current_state = (yy_start);
+		yy_current_state = yyg->yy_start;
 yy_match:
 		do
 			{
 			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
-				(yy_last_accepting_state) = yy_current_state;
-				(yy_last_accepting_cpos) = yy_cp;
+				yyg->yy_last_accepting_state = yy_current_state;
+				yyg->yy_last_accepting_cpos = yy_cp;
 				}
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
@@ -933,16 +959,12 @@ yy_match:
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 462 );
+		while ( yy_current_state != 185 );
+		yy_cp = yyg->yy_last_accepting_cpos;
+		yy_current_state = yyg->yy_last_accepting_state;
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
-		if ( yy_act == 0 )
-			{ /* have to back up */
-			yy_cp = (yy_last_accepting_cpos);
-			yy_current_state = (yy_last_accepting_state);
-			yy_act = yy_accept[yy_current_state];
-			}
 
 		YY_DO_BEFORE_ACTION;
 
@@ -952,9 +974,9 @@ do_action:	/* This label is used only to access EOF actions. */
 	{ /* beginning of action switch */
 			case 0: /* must back up */
 			/* undo the effects of YY_DO_BEFORE_ACTION */
-			*yy_cp = (yy_hold_char);
-			yy_cp = (yy_last_accepting_cpos);
-			yy_current_state = (yy_last_accepting_state);
+			*yy_cp = yyg->yy_hold_char;
+			yy_cp = yyg->yy_last_accepting_cpos;
+			yy_current_state = yyg->yy_last_accepting_state;
 			goto yy_find_action;
 
 case 1:
@@ -964,9 +986,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 /* rule 2 can match eol */
-*yy_cp = (yy_hold_char); /* undo effects of setting up yytext */
+*yy_cp = yyg->yy_hold_char; /* undo effects of setting up yytext */
 YY_LINENO_REWIND_TO(yy_bp + 1);
-(yy_c_buf_p) = yy_cp = yy_bp + 1;
+yyg->yy_c_buf_p = yy_cp = yy_bp + 1;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
 {
@@ -1311,10 +1333,10 @@ case YY_STATE_EOF(RANGE):
 	case YY_END_OF_BUFFER:
 		{
 		/* Amount of text matched not including the EOB char. */
-		int yy_amount_of_matched_text = (int) (yy_cp - (yytext_ptr)) - 1;
+		int yy_amount_of_matched_text = (int) (yy_cp - yyg->yytext_ptr) - 1;
 
 		/* Undo the effects of YY_DO_BEFORE_ACTION. */
-		*yy_cp = (yy_hold_char);
+		*yy_cp = yyg->yy_hold_char;
 		YY_RESTORE_YY_MORE_OFFSET
 
 		if ( YY_CURRENT_BUFFER_LVALUE->yy_buffer_status == YY_BUFFER_NEW )
@@ -1328,7 +1350,7 @@ case YY_STATE_EOF(RANGE):
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
+			yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
@@ -1340,13 +1362,13 @@ case YY_STATE_EOF(RANGE):
 		 * end-of-buffer state).  Contrast this with the test
 		 * in input().
 		 */
-		if ( (yy_c_buf_p) <= &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)] )
+		if ( yyg->yy_c_buf_p <= &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars] )
 			{ /* This was really a NUL. */
 			yy_state_type yy_next_state;
 
-			(yy_c_buf_p) = (yytext_ptr) + yy_amount_of_matched_text;
+			yyg->yy_c_buf_p = yyg->yytext_ptr + yy_amount_of_matched_text;
 
-			yy_current_state = yy_get_previous_state(  );
+			yy_current_state = yy_get_previous_state( yyscanner );
 
 			/* Okay, we're now positioned to make the NUL
 			 * transition.  We couldn't have
@@ -1357,32 +1379,33 @@ case YY_STATE_EOF(RANGE):
 			 * will run more slowly).
 			 */
 
-			yy_next_state = yy_try_NUL_trans( yy_current_state );
+			yy_next_state = yy_try_NUL_trans( yy_current_state , yyscanner);
 
-			yy_bp = (yytext_ptr) + YY_MORE_ADJ;
+			yy_bp = yyg->yytext_ptr + YY_MORE_ADJ;
 
 			if ( yy_next_state )
 				{
 				/* Consume the NUL. */
-				yy_cp = ++(yy_c_buf_p);
+				yy_cp = ++yyg->yy_c_buf_p;
 				yy_current_state = yy_next_state;
 				goto yy_match;
 				}
 
 			else
 				{
-				yy_cp = (yy_c_buf_p);
+				yy_cp = yyg->yy_last_accepting_cpos;
+				yy_current_state = yyg->yy_last_accepting_state;
 				goto yy_find_action;
 				}
 			}
 
-		else switch ( yy_get_next_buffer(  ) )
+		else switch ( yy_get_next_buffer( yyscanner ) )
 			{
 			case EOB_ACT_END_OF_FILE:
 				{
-				(yy_did_buffer_switch_on_eof) = 0;
+				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( yywrap(  ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1393,7 +1416,7 @@ case YY_STATE_EOF(RANGE):
 					 * YY_NULL, it'll still work - another
 					 * YY_NULL will get returned.
 					 */
-					(yy_c_buf_p) = (yytext_ptr) + YY_MORE_ADJ;
+					yyg->yy_c_buf_p = yyg->yytext_ptr + YY_MORE_ADJ;
 
 					yy_act = YY_STATE_EOF(YY_START);
 					goto do_action;
@@ -1401,30 +1424,30 @@ case YY_STATE_EOF(RANGE):
 
 				else
 					{
-					if ( ! (yy_did_buffer_switch_on_eof) )
+					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
 					}
 				break;
 				}
 
 			case EOB_ACT_CONTINUE_SCAN:
-				(yy_c_buf_p) =
-					(yytext_ptr) + yy_amount_of_matched_text;
+				yyg->yy_c_buf_p =
+					yyg->yytext_ptr + yy_amount_of_matched_text;
 
-				yy_current_state = yy_get_previous_state(  );
+				yy_current_state = yy_get_previous_state( yyscanner );
 
-				yy_cp = (yy_c_buf_p);
-				yy_bp = (yytext_ptr) + YY_MORE_ADJ;
+				yy_cp = yyg->yy_c_buf_p;
+				yy_bp = yyg->yytext_ptr + YY_MORE_ADJ;
 				goto yy_match;
 
 			case EOB_ACT_LAST_MATCH:
-				(yy_c_buf_p) =
-				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)];
+				yyg->yy_c_buf_p =
+				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars];
 
-				yy_current_state = yy_get_previous_state(  );
+				yy_current_state = yy_get_previous_state( yyscanner );
 
-				yy_cp = (yy_c_buf_p);
-				yy_bp = (yytext_ptr) + YY_MORE_ADJ;
+				yy_cp = yyg->yy_c_buf_p;
+				yy_bp = yyg->yytext_ptr + YY_MORE_ADJ;
 				goto yy_find_action;
 			}
 		break;
@@ -1445,20 +1468,21 @@ case YY_STATE_EOF(RANGE):
  *	EOB_ACT_CONTINUE_SCAN - continue scanning from current position
  *	EOB_ACT_END_OF_FILE - end of file
  */
-static int yy_get_next_buffer (void)
+static int yy_get_next_buffer (yyscan_t yyscanner)
 {
-    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	char *source = (yytext_ptr);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = yyg->yytext_ptr;
 	int number_to_move, i;
 	int ret_val;
 
-	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
+	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
 		YY_FATAL_ERROR(
 		"fatal flex scanner internal error--end of buffer missed" );
 
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_fill_buffer == 0 )
 		{ /* Don't try to fill the buffer, so this is an EOF. */
-		if ( (yy_c_buf_p) - (yytext_ptr) - YY_MORE_ADJ == 1 )
+		if ( yyg->yy_c_buf_p - yyg->yytext_ptr - YY_MORE_ADJ == 1 )
 			{
 			/* We matched a single character, the EOB, so
 			 * treat this as a final EOF.
@@ -1478,7 +1502,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1487,7 +1511,7 @@ static int yy_get_next_buffer (void)
 		/* don't do the read, it's not guaranteed to return an EOF,
 		 * just force an EOF
 		 */
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars) = 0;
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars = 0;
 
 	else
 		{
@@ -1501,7 +1525,7 @@ static int yy_get_next_buffer (void)
 			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
-				(int) ((yy_c_buf_p) - b->yy_ch_buf);
+				(int) (yyg->yy_c_buf_p - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
@@ -1515,7 +1539,7 @@ static int yy_get_next_buffer (void)
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
 					yyrealloc( (void *) b->yy_ch_buf,
-							 (yy_size_t) (b->yy_buf_size + 2)  );
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
@@ -1525,7 +1549,7 @@ static int yy_get_next_buffer (void)
 				YY_FATAL_ERROR(
 				"fatal error - scanner input buffer overflow" );
 
-			(yy_c_buf_p) = &b->yy_ch_buf[yy_c_buf_p_offset];
+			yyg->yy_c_buf_p = &b->yy_ch_buf[yy_c_buf_p_offset];
 
 			num_to_read = YY_CURRENT_BUFFER_LVALUE->yy_buf_size -
 						number_to_move - 1;
@@ -1537,17 +1561,17 @@ static int yy_get_next_buffer (void)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			(yy_n_chars), num_to_read );
+			yyg->yy_n_chars, num_to_read );
 
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
 
-	if ( (yy_n_chars) == 0 )
+	if ( yyg->yy_n_chars == 0 )
 		{
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart( yyin  );
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -1561,42 +1585,43 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
-			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
 		/* "- 2" to take care of EOB's */
 		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
-	(yy_n_chars) += number_to_move;
-	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)] = YY_END_OF_BUFFER_CHAR;
-	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] = YY_END_OF_BUFFER_CHAR;
+	yyg->yy_n_chars += number_to_move;
+	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars] = YY_END_OF_BUFFER_CHAR;
+	YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] = YY_END_OF_BUFFER_CHAR;
 
-	(yytext_ptr) = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[0];
+	yyg->yytext_ptr = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[0];
 
 	return ret_val;
 }
 
 /* yy_get_previous_state - get the state just before the EOB char was reached */
 
-    static yy_state_type yy_get_previous_state (void)
+    static yy_state_type yy_get_previous_state (yyscan_t yyscanner)
 {
 	yy_state_type yy_current_state;
 	char *yy_cp;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	yy_current_state = (yy_start);
+	yy_current_state = yyg->yy_start;
 
-	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
+	for ( yy_cp = yyg->yytext_ptr + YY_MORE_ADJ; yy_cp < yyg->yy_c_buf_p; ++yy_cp )
 		{
 		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
-			(yy_last_accepting_state) = yy_current_state;
-			(yy_last_accepting_cpos) = yy_cp;
+			yyg->yy_last_accepting_state = yy_current_state;
+			yyg->yy_last_accepting_cpos = yy_cp;
 			}
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
@@ -1615,16 +1640,17 @@ static int yy_get_next_buffer (void)
  * synopsis
  *	next_state = yy_try_NUL_trans( current_state );
  */
-    static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
+    static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state , yyscan_t yyscanner)
 {
 	int yy_is_jam;
-    	char *yy_cp = (yy_c_buf_p);
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner; /* This var may be unused depending upon options. */
+	char *yy_cp = yyg->yy_c_buf_p;
 
 	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
-		(yy_last_accepting_state) = yy_current_state;
-		(yy_last_accepting_cpos) = yy_cp;
+		yyg->yy_last_accepting_state = yy_current_state;
+		yyg->yy_last_accepting_cpos = yy_cp;
 		}
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
@@ -1635,7 +1661,8 @@ static int yy_get_next_buffer (void)
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 185);
 
-		return yy_is_jam ? 0 : yy_current_state;
+	(void)yyg;
+	return yy_is_jam ? 0 : yy_current_state;
 }
 
 #ifndef YY_NO_UNPUT
@@ -1644,32 +1671,33 @@ static int yy_get_next_buffer (void)
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
-    static int yyinput (void)
+    static int yyinput (yyscan_t yyscanner)
 #else
-    static int input  (void)
+    static int input  (yyscan_t yyscanner)
 #endif
 
 {
 	int c;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	*(yy_c_buf_p) = (yy_hold_char);
+	*yyg->yy_c_buf_p = yyg->yy_hold_char;
 
-	if ( *(yy_c_buf_p) == YY_END_OF_BUFFER_CHAR )
+	if ( *yyg->yy_c_buf_p == YY_END_OF_BUFFER_CHAR )
 		{
 		/* yy_c_buf_p now points to the character we want to return.
 		 * If this occurs *before* the EOB characters, then it's a
 		 * valid NUL; if not, then we've hit the end of the buffer.
 		 */
-		if ( (yy_c_buf_p) < &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars)] )
+		if ( yyg->yy_c_buf_p < &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars] )
 			/* This was really a NUL. */
-			*(yy_c_buf_p) = '\0';
+			*yyg->yy_c_buf_p = '\0';
 
 		else
 			{ /* need more input */
-			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
-			++(yy_c_buf_p);
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			++yyg->yy_c_buf_p;
 
-			switch ( yy_get_next_buffer(  ) )
+			switch ( yy_get_next_buffer( yyscanner ) )
 				{
 				case EOB_ACT_LAST_MATCH:
 					/* This happens because yy_g_n_b()
@@ -1683,34 +1711,34 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart( yyin );
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap(  ) )
+					if ( yywrap( yyscanner ) )
 						return 0;
 
-					if ( ! (yy_did_buffer_switch_on_eof) )
+					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
 #ifdef __cplusplus
-					return yyinput();
+					return yyinput(yyscanner);
 #else
-					return input();
+					return input(yyscanner);
 #endif
 					}
 
 				case EOB_ACT_CONTINUE_SCAN:
-					(yy_c_buf_p) = (yytext_ptr) + offset;
+					yyg->yy_c_buf_p = yyg->yytext_ptr + offset;
 					break;
 				}
 			}
 		}
 
-	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve yytext */
-	(yy_hold_char) = *++(yy_c_buf_p);
+	c = *(unsigned char *) yyg->yy_c_buf_p;	/* cast for 8-bit char's */
+	*yyg->yy_c_buf_p = '\0';	/* preserve yytext */
+	yyg->yy_hold_char = *++yyg->yy_c_buf_p;
 
 	return c;
 }
@@ -1718,76 +1746,79 @@ static int yy_get_next_buffer (void)
 
 /** Immediately switch to a different input stream.
  * @param input_file A readable stream.
- *
+ * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void yyrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! YY_CURRENT_BUFFER ){
-        yyensure_buffer_stack ();
+        yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer( yyin, YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
-	yy_load_buffer_state(  );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
- *
+ * @param yyscanner The scanner object.
  */
-    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
 	 *		yypush_buffer_state(new_buffer);
      */
-	yyensure_buffer_stack ();
+	yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
-		*(yy_c_buf_p) = (yy_hold_char);
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = (yy_c_buf_p);
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
+		*yyg->yy_c_buf_p = yyg->yy_hold_char;
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = yyg->yy_c_buf_p;
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state(  );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
 	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
-	(yy_did_buffer_switch_on_eof) = 1;
+	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void yy_load_buffer_state  (void)
+static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
-    	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
+	yyg->yytext_ptr = yyg->yy_c_buf_p = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
 	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
-	(yy_hold_char) = *(yy_c_buf_p);
+	yyg->yy_hold_char = *yyg->yy_c_buf_p;
 }
 
 /** Allocate and initialize an input buffer state.
  * @param file A readable stream.
  * @param size The character buffer size in bytes. When in doubt, use @c YY_BUF_SIZE.
- *
+ * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -1796,23 +1827,24 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer( b, file );
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
  * @param b a buffer created with yy_create_buffer()
- *
+ * @param yyscanner The scanner object.
  */
-    void yy_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! b )
 		return;
@@ -1821,21 +1853,22 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree( (void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	yyfree( (void *) b  );
+	yyfree( (void *) b , yyscanner );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
  */
-    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	yy_flush_buffer( b );
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1849,18 +1882,19 @@ static void yy_load_buffer_state  (void)
         b->yy_bs_column = 0;
     }
 
-        b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
+        b->yy_is_interactive = 0;
 
 	errno = oerrno;
 }
 
 /** Discard all buffered characters. On the next scan, YY_INPUT will be called.
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
- *
+ * @param yyscanner The scanner object.
  */
-    void yy_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
-    	if ( ! b )
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	if ( ! b )
 		return;
 
 	b->yy_n_chars = 0;
@@ -1878,114 +1912,117 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
  *  the current state. This function will allocate the stack
  *  if necessary.
  *  @param new_buffer The new state.
- *
+ *  @param yyscanner The scanner object.
  */
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
-    	if (new_buffer == NULL)
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	if (new_buffer == NULL)
 		return;
 
-	yyensure_buffer_stack();
+	yyensure_buffer_stack(yyscanner);
 
 	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
-		*(yy_c_buf_p) = (yy_hold_char);
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = (yy_c_buf_p);
-		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
+		*yyg->yy_c_buf_p = yyg->yy_hold_char;
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_pos = yyg->yy_c_buf_p;
+		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
 
 	/* Only push if top exists. Otherwise, replace top. */
 	if (YY_CURRENT_BUFFER)
-		(yy_buffer_stack_top)++;
+		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state(  );
-	(yy_did_buffer_switch_on_eof) = 1;
+	yy_load_buffer_state( yyscanner );
+	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
 /** Removes and deletes the top of the stack, if present.
  *  The next element becomes the new top.
- *
+ *  @param yyscanner The scanner object.
  */
-void yypop_buffer_state (void)
+void yypop_buffer_state (yyscan_t yyscanner)
 {
-    	if (!YY_CURRENT_BUFFER)
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yy_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
-	if ((yy_buffer_stack_top) > 0)
-		--(yy_buffer_stack_top);
+	if (yyg->yy_buffer_stack_top > 0)
+		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state(  );
-		(yy_did_buffer_switch_on_eof) = 1;
+		yy_load_buffer_state( yyscanner );
+		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
 
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void yyensure_buffer_stack (void)
+static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
 	yy_size_t num_to_alloc;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	if (!(yy_buffer_stack)) {
+	if (!yyg->yy_buffer_stack) {
 
 		/* First allocation is just for 2 elements, since we don't know if this
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
       num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
-								);
-		if ( ! (yy_buffer_stack) )
+								, yyscanner);
+		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
-		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
+		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
 
-		(yy_buffer_stack_max) = num_to_alloc;
-		(yy_buffer_stack_top) = 0;
+		yyg->yy_buffer_stack_max = num_to_alloc;
+		yyg->yy_buffer_stack_top = 0;
 		return;
 	}
 
-	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
+	if (yyg->yy_buffer_stack_top >= (yyg->yy_buffer_stack_max) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
 		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
-		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
-								((yy_buffer_stack),
+		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
+								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
-								);
-		if ( ! (yy_buffer_stack) )
+								, yyscanner);
+		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
-		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
-		(yy_buffer_stack_max) = num_to_alloc;
+		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
+		yyg->yy_buffer_stack_max = num_to_alloc;
 	}
 }
 
 /** Setup the input buffer state to scan directly from a user-specified character buffer.
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
- *
+ * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 
@@ -1995,7 +2032,7 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 		/* They forgot to leave room for the EOB's. */
 		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
@@ -2009,7 +2046,7 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer( b  );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
@@ -2017,25 +2054,25 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 /** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
- *
+ * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (const char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
 
-	return yy_scan_bytes( yystr, (int) strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
- *
+ * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -2044,7 +2081,7 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) yyalloc( n  );
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -2053,7 +2090,7 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer( buf, n );
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -2069,9 +2106,11 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (const char* msg )
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
-			fprintf( stderr, "%s\n", msg );
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2084,106 +2123,249 @@ static void yynoreturn yy_fatal_error (const char* msg )
 		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		yytext[yyleng] = (yy_hold_char); \
-		(yy_c_buf_p) = yytext + yyless_macro_arg; \
-		(yy_hold_char) = *(yy_c_buf_p); \
-		*(yy_c_buf_p) = '\0'; \
+		yytext[yyleng] = yyg->yy_hold_char; \
+		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
+		yyg->yy_hold_char = *yyg->yy_c_buf_p; \
+		*yyg->yy_c_buf_p = '\0'; \
 		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
 /* Accessor  methods (get/set functions) to struct members. */
 
-/** Get the current line number.
- *
+/** Get the user-defined data for this scanner.
+ * @param yyscanner The scanner object.
  */
-int yyget_lineno  (void)
+YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyextra;
+}
+
+/** Get the current line number.
+ * @param yyscanner The scanner object.
+ */
+int yyget_lineno  (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        if (! YY_CURRENT_BUFFER)
+            return 0;
 
     return yylineno;
 }
 
-/** Get the input stream.
- *
+/** Get the current column number.
+ * @param yyscanner The scanner object.
  */
-FILE *yyget_in  (void)
+int yyget_column  (yyscan_t yyscanner)
 {
-        return yyin;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        if (! YY_CURRENT_BUFFER)
+            return 0;
+
+    return yycolumn;
+}
+
+/** Get the input stream.
+ * @param yyscanner The scanner object.
+ */
+FILE *yyget_in  (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyin;
 }
 
 /** Get the output stream.
- *
+ * @param yyscanner The scanner object.
  */
-FILE *yyget_out  (void)
+FILE *yyget_out  (yyscan_t yyscanner)
 {
-        return yyout;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyout;
 }
 
 /** Get the length of the current token.
- *
+ * @param yyscanner The scanner object.
  */
-int yyget_leng  (void)
+int yyget_leng  (yyscan_t yyscanner)
 {
-        return yyleng;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yyleng;
 }
 
 /** Get the current token.
- *
+ * @param yyscanner The scanner object.
  */
 
-char *yyget_text  (void)
+char *yyget_text  (yyscan_t yyscanner)
 {
-        return yytext;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yytext;
+}
+
+/** Set the user-defined data. This data is never touched by the scanner.
+ * @param user_defined The data to be associated with this scanner.
+ * @param yyscanner The scanner object.
+ */
+void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yyextra = user_defined ;
 }
 
 /** Set the current line number.
  * @param _line_number line number
- *
+ * @param yyscanner The scanner object.
  */
-void yyset_lineno (int  _line_number )
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        /* lineno is only valid if an input buffer exists. */
+        if (! YY_CURRENT_BUFFER )
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
 
     yylineno = _line_number;
+}
+
+/** Set the current column.
+ * @param _column_no column number
+ * @param yyscanner The scanner object.
+ */
+void yyset_column (int  _column_no , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+        /* column is only valid if an input buffer exists. */
+        if (! YY_CURRENT_BUFFER )
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
+
+    yycolumn = _column_no;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
  * @param _in_str A readable stream.
- *
+ * @param yyscanner The scanner object.
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  _in_str )
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
-        yyin = _in_str ;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yyin = _in_str ;
 }
 
-void yyset_out (FILE *  _out_str )
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
-        yyout = _out_str ;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yyout = _out_str ;
 }
 
-int yyget_debug  (void)
+int yyget_debug  (yyscan_t yyscanner)
 {
-        return yy_flex_debug;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yy_flex_debug;
 }
 
-void yyset_debug (int  _bdebug )
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
-        yy_flex_debug = _bdebug ;
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yy_flex_debug = _bdebug ;
 }
 
-static int yy_init_globals (void)
+/* Accessor methods for yylval and yylloc */
+
+YYSTYPE * yyget_lval  (yyscan_t yyscanner)
 {
-        /* Initialization is the same as for the non-reentrant scanner.
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    return yylval;
+}
+
+void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    yylval = yylval_param;
+}
+
+/* User-visible API */
+
+/* yylex_init is special because it creates the scanner itself, so it is
+ * the ONLY reentrant function that doesn't take the scanner as the last argument.
+ * That's why we explicitly handle the declaration, instead of using our macros.
+ */
+int yylex_init(yyscan_t* ptr_yy_globals)
+{
+    if (ptr_yy_globals == NULL){
+        errno = EINVAL;
+        return 1;
+    }
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
+
+    if (*ptr_yy_globals == NULL){
+        errno = ENOMEM;
+        return 1;
+    }
+
+    /* By setting to 0xAA, we expose bugs in yy_init_globals. Leave at 0x00 for releases. */
+    memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
+
+    return yy_init_globals ( *ptr_yy_globals );
+}
+
+/* yylex_init_extra has the same functionality as yylex_init, but follows the
+ * convention of taking the scanner as the last argument. Note however, that
+ * this is a *pointer* to a scanner, as it will be allocated by this call (and
+ * is the reason, too, why this function also must handle its own declaration).
+ * The user defined value in the first argument will be available to yyalloc in
+ * the yyextra field.
+ */
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
+{
+    struct yyguts_t dummy_yyguts;
+
+    yyset_extra (yy_user_defined, &dummy_yyguts);
+
+    if (ptr_yy_globals == NULL){
+        errno = EINVAL;
+        return 1;
+    }
+
+    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+
+    if (*ptr_yy_globals == NULL){
+        errno = ENOMEM;
+        return 1;
+    }
+
+    /* By setting to 0xAA, we expose bugs in
+    yy_init_globals. Leave at 0x00 for releases. */
+    memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
+
+    yyset_extra (yy_user_defined, *ptr_yy_globals);
+
+    return yy_init_globals ( *ptr_yy_globals );
+}
+
+static int yy_init_globals (yyscan_t yyscanner)
+{
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+    /* Initialization is the same as for the non-reentrant scanner.
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = NULL;
-    (yy_buffer_stack_top) = 0;
-    (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = NULL;
-    (yy_init) = 0;
-    (yy_start) = 0;
+    yyg->yy_buffer_stack = NULL;
+    yyg->yy_buffer_stack_top = 0;
+    yyg->yy_buffer_stack_max = 0;
+    yyg->yy_c_buf_p = NULL;
+    yyg->yy_init = 0;
+    yyg->yy_start = 0;
+
+    yyg->yy_start_stack_ptr = 0;
+    yyg->yy_start_stack_depth = 0;
+    yyg->yy_start_stack =  NULL;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
@@ -2201,24 +2383,32 @@ static int yy_init_globals (void)
 }
 
 /* yylex_destroy is for both reentrant and non-reentrant scanners. */
-int yylex_destroy  (void)
+int yylex_destroy  (yyscan_t yyscanner)
 {
+    struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer( YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		yypop_buffer_state();
+		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	yyfree((yy_buffer_stack) );
-	(yy_buffer_stack) = NULL;
+	yyfree(yyg->yy_buffer_stack , yyscanner);
+	yyg->yy_buffer_stack = NULL;
+
+    /* Destroy the start condition stack. */
+        yyfree( yyg->yy_start_stack , yyscanner );
+        yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
      * yylex() is called, initialization will occur. */
-    yy_init_globals( );
+    yy_init_globals( yyscanner);
 
+    /* Destroy the main struct (reentrant only). */
+    yyfree ( yyscanner , yyscanner );
+    yyscanner = NULL;
     return 0;
 }
 
@@ -2227,8 +2417,10 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, const char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
 
 	int i;
 	for ( i = 0; i < n; ++i )
@@ -2237,7 +2429,7 @@ static void yy_flex_strncpy (char* s1, const char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (const char * s )
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2247,13 +2439,17 @@ static int yy_flex_strlen (const char * s )
 }
 #endif
 
-void *yyalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
-			return malloc(size);
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	return malloc(size);
 }
 
-void *yyrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
 
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
@@ -2265,27 +2461,32 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	return realloc(ptr, size);
 }
 
-void yyfree (void * ptr )
+void yyfree (void * ptr , yyscan_t yyscanner)
 {
-			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-void LexerSetInput(std::string_view input) {
-    if (current_buffer) {
-        yy_delete_buffer(current_buffer);
+namespace sdb {
+
+Scanner::Scanner(std::string_view input) {
+    if (yylex_init(&yyscanner) != 0) {
+        throw std::runtime_error("cannot initialize the query scanner");
     }
-    /* A query that failed to parse while inside quotes left the scanner
-       there, and the one after it would be read as the rest of a phrase --
-       silently, since a word is a word in both. Every query starts outside. */
-    BEGIN(INITIAL);
-    current_buffer = yy_scan_bytes(input.data(), static_cast<int>(input.size()));
+    _buffer = yy_scan_bytes(input.data(), static_cast<int>(input.size()),
+                            yyscanner);
+    if (_buffer == nullptr) {
+        yylex_destroy(yyscanner);
+        throw std::runtime_error("cannot buffer the query");
+    }
 }
 
-void LexerCleanup() {
-    if (current_buffer) {
-        yy_delete_buffer(current_buffer);
-        current_buffer = nullptr;
-    }
+Scanner::~Scanner() {
+    yy_delete_buffer(static_cast<YY_BUFFER_STATE>(_buffer), yyscanner);
+    yylex_destroy(yyscanner);
 }
+
+}  // namespace sdb

--- a/libs/iresearch/include/iresearch/parser/lucene_lexer.l
+++ b/libs/iresearch/include/iresearch/parser/lucene_lexer.l
@@ -23,17 +23,21 @@
 #include <fast_float/fast_float.h>
 
 #include <cstring>
+#include <stdexcept>
 #include <string_view>
 
 #include "lucene_parser.hpp"
 
-static YY_BUFFER_STATE current_buffer = nullptr;
+#pragma clang diagnostic ignored "-Wunused-function"
+#define YY_FATAL_ERROR(msg) throw std::runtime_error(msg)
 %}
 
 %option noyywrap
 %option nounput
 %option noinput
 %option bison-bridge
+%option reentrant
+%option never-interactive
 
 /* Inside quotes the words are words: `and` is a term there rather than an
    operator, and a phrase is a list of parts rather than one string to be
@@ -256,20 +260,23 @@ PWORD       ([^ \t\r\n"~*?\\]|{ESCAPED})
 
 %%
 
-void LexerSetInput(std::string_view input) {
-    if (current_buffer) {
-        yy_delete_buffer(current_buffer);
+namespace sdb {
+
+Scanner::Scanner(std::string_view input) {
+    if (yylex_init(&yyscanner) != 0) {
+        throw std::runtime_error("cannot initialize the query scanner");
     }
-    /* A query that failed to parse while inside quotes left the scanner
-       there, and the one after it would be read as the rest of a phrase --
-       silently, since a word is a word in both. Every query starts outside. */
-    BEGIN(INITIAL);
-    current_buffer = yy_scan_bytes(input.data(), static_cast<int>(input.size()));
+    _buffer = yy_scan_bytes(input.data(), static_cast<int>(input.size()),
+                            yyscanner);
+    if (_buffer == nullptr) {
+        yylex_destroy(yyscanner);
+        throw std::runtime_error("cannot buffer the query");
+    }
 }
 
-void LexerCleanup() {
-    if (current_buffer) {
-        yy_delete_buffer(current_buffer);
-        current_buffer = nullptr;
-    }
+Scanner::~Scanner() {
+    yy_delete_buffer(static_cast<YY_BUFFER_STATE>(_buffer), yyscanner);
+    yylex_destroy(yyscanner);
 }
+
+}  // namespace sdb

--- a/libs/iresearch/include/iresearch/parser/lucene_parser.cpp
+++ b/libs/iresearch/include/iresearch/parser/lucene_parser.cpp
@@ -68,7 +68,7 @@
 
 
 /* First part of user prologue.  */
-#line 42 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 65 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
 
 #include "parser.hpp"
 
@@ -185,10 +185,10 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 /* Unqualified %code blocks.  */
-#line 48 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 71 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
 
-int yylex(YYSTYPE* yylval);
-void yyerror(sdb::ParserContext& ctx, const char *s);
+int yylex(YYSTYPE* yylval, yyscan_t yyscanner);
+void yyerror(sdb::ParserContext& ctx, yyscan_t yyscanner, const char *s);
 
 #line 193 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
 
@@ -575,16 +575,16 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,    95,    95,    99,   100,   101,   102,   106,   107,   108,
-     109,   113,   114,   115,   118,   119,   120,   121,   125,   126,
-     130,   138,   139,   142,   149,   153,   156,   163,   164,   165,
-     166,   167,   168,   169,   170,   171,   172,   173,   174,   178,
-     178,   188,   188,   193,   194,   195,   195,   200,   201,   202,
-     203,   213,   213,   215,   215,   217,   218,   219,   220,   221,
-     225,   225,   227,   227,   229,   229,   231,   231,   236,   236,
-     238,   238,   240,   250,   251,   255,   256,   257,   258,   259,
-     260,   263,   265,   266,   267,   271,   272,   276,   277,   281,
-     283,   285,   287,   292,   293
+       0,   119,   119,   123,   124,   125,   126,   130,   131,   132,
+     133,   137,   138,   139,   142,   143,   144,   145,   149,   150,
+     154,   162,   163,   166,   173,   177,   180,   187,   188,   189,
+     190,   191,   192,   193,   194,   195,   196,   197,   198,   202,
+     202,   212,   212,   217,   218,   219,   219,   224,   225,   226,
+     227,   237,   237,   239,   239,   241,   242,   243,   244,   245,
+     249,   249,   251,   251,   253,   253,   255,   255,   260,   260,
+     262,   262,   264,   274,   275,   279,   280,   281,   282,   283,
+     284,   287,   289,   290,   291,   295,   296,   300,   301,   305,
+     307,   309,   311,   316,   317
 };
 #endif
 
@@ -898,7 +898,7 @@ enum { YYENOMEM = -2 };
       }                                                           \
     else                                                          \
       {                                                           \
-        yyerror (ctx, YY_("syntax error: cannot back up")); \
+        yyerror (ctx, yyscanner, YY_("syntax error: cannot back up")); \
         YYERROR;                                                  \
       }                                                           \
   while (0)
@@ -931,7 +931,7 @@ do {                                                                      \
     {                                                                     \
       YYFPRINTF (stderr, "%s ", Title);                                   \
       yy_symbol_print (stderr,                                            \
-                  Kind, Value, ctx); \
+                  Kind, Value, ctx, yyscanner); \
       YYFPRINTF (stderr, "\n");                                           \
     }                                                                     \
 } while (0)
@@ -943,11 +943,12 @@ do {                                                                      \
 
 static void
 yy_symbol_value_print (FILE *yyo,
-                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, sdb::ParserContext& ctx)
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, sdb::ParserContext& ctx, yyscan_t yyscanner)
 {
   FILE *yyoutput = yyo;
   YY_USE (yyoutput);
   YY_USE (ctx);
+  YY_USE (yyscanner);
   if (!yyvaluep)
     return;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
@@ -962,12 +963,12 @@ yy_symbol_value_print (FILE *yyo,
 
 static void
 yy_symbol_print (FILE *yyo,
-                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, sdb::ParserContext& ctx)
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, sdb::ParserContext& ctx, yyscan_t yyscanner)
 {
   YYFPRINTF (yyo, "%s %s (",
              yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyo, yykind, yyvaluep, ctx);
+  yy_symbol_value_print (yyo, yykind, yyvaluep, ctx, yyscanner);
   YYFPRINTF (yyo, ")");
 }
 
@@ -1001,7 +1002,7 @@ do {                                                            \
 
 static void
 yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
-                 int yyrule, sdb::ParserContext& ctx)
+                 int yyrule, sdb::ParserContext& ctx, yyscan_t yyscanner)
 {
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
@@ -1014,7 +1015,7 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
                        YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
-                       &yyvsp[(yyi + 1) - (yynrhs)], ctx);
+                       &yyvsp[(yyi + 1) - (yynrhs)], ctx, yyscanner);
       YYFPRINTF (stderr, "\n");
     }
 }
@@ -1022,7 +1023,7 @@ yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
 # define YY_REDUCE_PRINT(Rule)          \
 do {                                    \
   if (yydebug)                          \
-    yy_reduce_print (yyssp, yyvsp, Rule, ctx); \
+    yy_reduce_print (yyssp, yyvsp, Rule, ctx, yyscanner); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
@@ -1063,10 +1064,11 @@ int yydebug;
 
 static void
 yydestruct (const char *yymsg,
-            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, sdb::ParserContext& ctx)
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, sdb::ParserContext& ctx, yyscan_t yyscanner)
 {
   YY_USE (yyvaluep);
   YY_USE (ctx);
+  YY_USE (yyscanner);
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
@@ -1086,7 +1088,7 @@ yydestruct (const char *yymsg,
 `----------*/
 
 int
-yyparse (sdb::ParserContext& ctx)
+yyparse (sdb::ParserContext& ctx, yyscan_t yyscanner)
 {
 /* Lookahead token kind.  */
 int yychar;
@@ -1253,7 +1255,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token\n"));
-      yychar = yylex (&yylval);
+      yychar = yylex (&yylval, yyscanner);
     }
 
   if (yychar <= YYEOF)
@@ -1341,516 +1343,516 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* query: clause_list  */
-#line 95 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 119 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.EndClauseList(); }
-#line 1346 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1348 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 3: /* clause_list: mod_clause  */
-#line 99 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 123 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::Or); }
-#line 1352 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1354 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 4: /* clause_list: clause_list mod_clause  */
-#line 100 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 124 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::Or); }
-#line 1358 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1360 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 5: /* clause_list: clause_list AND mod_clause  */
-#line 101 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 125 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::And); }
-#line 1364 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1366 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 6: /* clause_list: clause_list OR mod_clause  */
-#line 102 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 126 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddClause(sdb::Conjunction::Or); }
-#line 1370 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1372 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 7: /* mod_clause: term_expr  */
-#line 106 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 130 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::None; }
-#line 1376 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1378 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 8: /* mod_clause: PLUS term_expr  */
-#line 107 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 131 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::Required; }
-#line 1382 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1384 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 9: /* mod_clause: MINUS term_expr  */
-#line 108 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 132 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::Not; }
-#line 1388 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1390 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 10: /* mod_clause: NOT term_expr  */
-#line 109 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 133 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.last_mod = sdb::Modifier::Not; }
-#line 1394 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1396 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 11: /* term_expr: boosted_expr  */
-#line 113 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 137 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1400 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1402 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 12: /* term_expr: STAR COLON STAR  */
-#line 114 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 138 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddAll(); }
-#line 1406 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1408 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 13: /* term_expr: field_prefix term_expr  */
-#line 115 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 139 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1412 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1414 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 14: /* term_expr: field_name LT range_bound  */
-#line 118 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 142 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange("*", (yyvsp[0].sv), false, false); }
-#line 1418 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1420 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 15: /* term_expr: field_name LE range_bound  */
-#line 119 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 143 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange("*", (yyvsp[0].sv), false, true); }
-#line 1424 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1426 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 16: /* term_expr: field_name GT range_bound  */
-#line 120 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 144 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[0].sv), "*", false, false); }
-#line 1430 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1432 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 17: /* term_expr: field_name GE range_bound  */
-#line 121 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 145 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[0].sv), "*", true, false); }
-#line 1436 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1438 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 20: /* field_name: TERM  */
-#line 130 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 154 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     {
                                       if (!ctx.CheckField((yyvsp[0].sv))) {
                                         YYABORT;
                                       }
                                     }
-#line 1446 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1448 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 21: /* boosted_expr: modified_term  */
-#line 138 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 162 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1452 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1454 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 22: /* boosted_expr: modified_term CARET threshold  */
-#line 139 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 163 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyvsp[-2].filter)->SetBoost((yyvsp[0].fnum)); (yyval.filter) = (yyvsp[-2].filter); }
-#line 1458 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1460 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 23: /* boosted_expr: modified_term CARET threshold FUZZY  */
-#line 143 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 167 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyvsp[-3].filter)->SetBoost((yyvsp[-1].fnum));
                                       (yyval.filter) = &ctx.ApplyFuzzy((yyvsp[-3].filter), (yyvsp[0].fuzzy).has_value,
                                                            (yyvsp[0].fuzzy).value); }
-#line 1466 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1468 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 24: /* modified_term: base_term  */
-#line 149 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 173 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1472 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1474 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 25: /* modified_term: TERM FUZZY  */
-#line 153 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 177 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].fuzzy).has_value
                                           ? &ctx.AddFuzzySimilarity((yyvsp[-1].sv), (yyvsp[0].fuzzy).value)
                                           : &ctx.AddFuzzy((yyvsp[-1].sv), 2); }
-#line 1480 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1482 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 26: /* modified_term: phrase FUZZY  */
-#line 156 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 180 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { if ((yyvsp[0].fuzzy).has_value) {
                                         ctx.SetSlop((yyvsp[-1].filter), static_cast<int>((yyvsp[0].fuzzy).value));
                                       }
                                       (yyval.filter) = (yyvsp[-1].filter); }
-#line 1489 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1491 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 27: /* base_term: TERM  */
-#line 163 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 187 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddTerm((yyvsp[0].sv)); }
-#line 1495 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1497 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 28: /* base_term: NUMBER  */
-#line 164 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 188 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddTerm((yyvsp[0].num).text); }
-#line 1501 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1503 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 29: /* base_term: FLOAT  */
-#line 165 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 189 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddTerm((yyvsp[0].flt).text); }
-#line 1507 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1509 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 30: /* base_term: phrase  */
-#line 166 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 190 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1513 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1515 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 31: /* base_term: REGEX  */
-#line 167 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 191 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRegex((yyvsp[0].sv)); }
-#line 1519 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1521 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 32: /* base_term: PREFIX  */
-#line 168 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 192 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddPrefix((yyvsp[0].sv)); }
-#line 1525 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1527 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 33: /* base_term: WILDCARD  */
-#line 169 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 193 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddWildcard((yyvsp[0].sv)); }
-#line 1531 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1533 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 34: /* base_term: range_expr  */
-#line 170 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 194 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1537 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1539 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 35: /* base_term: ngram_expr  */
-#line 171 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 195 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1543 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1545 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 36: /* base_term: group  */
-#line 172 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 196 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = (yyvsp[0].filter); }
-#line 1549 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1551 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 37: /* base_term: group AT NUMBER  */
-#line 173 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 197 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.SetMinMatch((yyvsp[-2].filter), (yyvsp[0].num).value); (yyval.filter) = (yyvsp[-2].filter); }
-#line 1555 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1557 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 38: /* base_term: STAR  */
-#line 174 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 198 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddFieldExists(); }
-#line 1561 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1563 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 39: /* @1: %empty  */
-#line 178 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 202 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     {
                                       (yyval.filter) = ctx.current_root;
                                       ctx.current_root = &ctx.BeginGroup();
                                     }
-#line 1570 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1572 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 40: /* group: LPAREN @1 clause_list RPAREN  */
-#line 182 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 206 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndGroup((yyvsp[-2].filter)); }
-#line 1576 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1578 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 41: /* $@2: %empty  */
-#line 188 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 212 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginPhrase(); }
-#line 1582 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1584 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 42: /* phrase: QUOTE $@2 phrase_body QUOTE  */
-#line 189 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 213 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndPhrase(); }
-#line 1588 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1590 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 45: /* $@3: %empty  */
-#line 195 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 219 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.SetGap((yyvsp[0].gap).min, (yyvsp[0].gap).max); }
-#line 1594 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1596 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 47: /* phrase_part: TERM  */
-#line 200 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 224 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddPhraseTerm((yyvsp[0].sv)); }
-#line 1600 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1602 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 48: /* phrase_part: PREFIX  */
-#line 201 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 225 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddPhrasePrefix((yyvsp[0].sv)); }
-#line 1606 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1608 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 49: /* phrase_part: WILDCARD  */
-#line 202 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 226 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddPhraseWildcard((yyvsp[0].sv)); }
-#line 1612 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1614 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 50: /* phrase_part: TERM FUZZY  */
-#line 203 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 227 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddPhraseFuzzy(
                                         (yyvsp[-1].sv), (yyvsp[0].fuzzy).has_value
                                               ? static_cast<int>((yyvsp[0].fuzzy).value)
                                               : 2); }
-#line 1621 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1623 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 51: /* $@4: %empty  */
-#line 213 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 237 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginNGram((yyvsp[0].fnum)); }
-#line 1627 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1629 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 52: /* ngram_expr: FN_NGRAM LPAREN threshold $@4 ngram_terms RPAREN  */
-#line 214 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 238 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndNGram(); }
-#line 1633 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1635 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 53: /* $@5: %empty  */
-#line 215 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 239 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginPhrase(); }
-#line 1639 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1641 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 54: /* ngram_expr: FN_PHRASE LPAREN $@5 phrase_body RPAREN  */
-#line 216 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 240 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndPhrase(); }
-#line 1645 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1647 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 55: /* ngram_expr: FN_WILDCARD LPAREN WILDCARD RPAREN  */
-#line 217 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 241 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                           { (yyval.filter) = &ctx.AddWildcard((yyvsp[-1].sv)); }
-#line 1651 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1653 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 56: /* ngram_expr: FN_WILDCARD LPAREN PREFIX RPAREN  */
-#line 218 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 242 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                           { (yyval.filter) = &ctx.AddWildcard((yyvsp[-1].sv)); }
-#line 1657 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1659 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 57: /* ngram_expr: FN_WILDCARD LPAREN TERM RPAREN  */
-#line 219 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 243 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                           { (yyval.filter) = &ctx.AddWildcard((yyvsp[-1].sv)); }
-#line 1663 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1665 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 58: /* ngram_expr: FN_FUZZY LPAREN TERM RPAREN  */
-#line 220 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 244 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                           { (yyval.filter) = &ctx.AddFuzzy((yyvsp[-1].sv), 2); }
-#line 1669 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1671 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 59: /* ngram_expr: FN_FUZZY LPAREN TERM NUMBER RPAREN  */
-#line 221 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 245 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                           { (yyval.filter) = &ctx.AddFuzzy((yyvsp[-2].sv), (yyvsp[-1].num).value); }
-#line 1675 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1677 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 60: /* $@6: %empty  */
-#line 225 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 249 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginFn(); }
-#line 1681 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1683 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 61: /* ngram_expr: FN_OR LPAREN $@6 fn_terms RPAREN  */
-#line 226 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 250 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndFnAny(); }
-#line 1687 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1689 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 62: /* $@7: %empty  */
-#line 227 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 251 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginFn(); }
-#line 1693 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1695 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 63: /* ngram_expr: FN_UNORDERED LPAREN $@7 fn_terms RPAREN  */
-#line 228 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 252 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndFnAll(); }
-#line 1699 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1701 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 64: /* $@8: %empty  */
-#line 229 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 253 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginFn(); }
-#line 1705 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1707 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 65: /* ngram_expr: FN_ATLEAST LPAREN NUMBER $@8 fn_terms RPAREN  */
-#line 230 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 254 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndFnAtLeast((yyvsp[-3].num).value); }
-#line 1711 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1713 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 66: /* $@9: %empty  */
-#line 231 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 255 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.BeginFn(); }
-#line 1717 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1719 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 67: /* ngram_expr: FN_ORDERED LPAREN $@9 fn_terms RPAREN  */
-#line 232 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 256 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndFnOrdered(); }
-#line 1723 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1725 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 68: /* $@10: %empty  */
-#line 236 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 260 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                                  { ctx.BeginFn(); }
-#line 1729 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1731 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 69: /* ngram_expr: FN_MAXGAPS LPAREN NUMBER FN_ORDERED LPAREN $@10 fn_terms RPAREN RPAREN  */
-#line 237 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 261 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndFnMaxGaps((yyvsp[-6].num).value); }
-#line 1735 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1737 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 70: /* $@11: %empty  */
-#line 238 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 262 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                                   { ctx.BeginFn(); }
-#line 1741 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1743 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 71: /* ngram_expr: FN_MAXWIDTH LPAREN NUMBER FN_ORDERED LPAREN $@11 fn_terms RPAREN RPAREN  */
-#line 239 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 263 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.EndFnMaxWidth((yyvsp[-6].num).value); }
-#line 1747 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1749 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 72: /* ngram_expr: FN_OTHER LPAREN fn_args RPAREN  */
-#line 240 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 264 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                       { ctx.Unsupported((yyvsp[-3].sv)); (yyval.filter) = nullptr; }
-#line 1753 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1755 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 75: /* fn_source: TERM  */
-#line 255 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 279 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddFnTerm((yyvsp[0].sv)); }
-#line 1759 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1761 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 76: /* fn_source: PREFIX  */
-#line 256 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 280 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddFnOther("a prefix"); }
-#line 1765 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1767 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 77: /* fn_source: WILDCARD  */
-#line 257 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 281 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddFnOther("a wildcard"); }
-#line 1771 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1773 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 78: /* fn_source: REGEX  */
-#line 258 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 282 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddFnOther("a regular expression"); }
-#line 1777 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1779 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 79: /* fn_source: phrase  */
-#line 259 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 283 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddFnOther("a phrase"); }
-#line 1783 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1785 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 80: /* fn_source: ngram_expr  */
-#line 260 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 284 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddFnOther("a function"); }
-#line 1789 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1791 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 85: /* threshold: NUMBER  */
-#line 271 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 295 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.fnum) = static_cast<float>((yyvsp[0].num).value); }
-#line 1795 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1797 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 86: /* threshold: FLOAT  */
-#line 272 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 296 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.fnum) = (yyvsp[0].flt).value; }
-#line 1801 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1803 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 87: /* ngram_terms: TERM  */
-#line 276 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 300 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddNGram((yyvsp[0].sv)); }
-#line 1807 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1809 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 88: /* ngram_terms: ngram_terms TERM  */
-#line 277 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 301 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { ctx.AddNGram((yyvsp[0].sv)); }
-#line 1813 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1815 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 89: /* range_expr: LBRACKET range_bound TO range_bound RBRACKET  */
-#line 282 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 306 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), true, true); }
-#line 1819 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1821 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 90: /* range_expr: LBRACE range_bound TO range_bound RBRACE  */
-#line 284 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 308 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), false, false); }
-#line 1825 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1827 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 91: /* range_expr: LBRACKET range_bound TO range_bound RBRACE  */
-#line 286 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 310 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), true, false); }
-#line 1831 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1833 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 92: /* range_expr: LBRACE range_bound TO range_bound RBRACKET  */
-#line 288 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 312 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.filter) = &ctx.AddRange((yyvsp[-3].sv), (yyvsp[-1].sv), false, true); }
-#line 1837 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1839 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 93: /* range_bound: TERM  */
-#line 292 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 316 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.sv) = (yyvsp[0].sv); }
-#line 1843 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1845 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
   case 94: /* range_bound: STAR  */
-#line 293 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 317 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
                                     { (yyval.sv) = (yyvsp[0].sv); }
-#line 1849 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1851 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
     break;
 
 
-#line 1853 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
+#line 1855 "libs/iresearch/include/iresearch/parser/lucene_parser.cpp"
 
       default: break;
     }
@@ -1897,7 +1899,7 @@ yyerrlab:
   if (!yyerrstatus)
     {
       ++yynerrs;
-      yyerror (ctx, YY_("syntax error"));
+      yyerror (ctx, yyscanner, YY_("syntax error"));
     }
 
   if (yyerrstatus == 3)
@@ -1914,7 +1916,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, ctx);
+                      yytoken, &yylval, ctx, yyscanner);
           yychar = YYEMPTY;
         }
     }
@@ -1970,7 +1972,7 @@ yyerrlab1:
 
 
       yydestruct ("Error: popping",
-                  YY_ACCESSING_SYMBOL (yystate), yyvsp, ctx);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, ctx, yyscanner);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2008,7 +2010,7 @@ yyabortlab:
 | yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
 `-----------------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (ctx, YY_("memory exhausted"));
+  yyerror (ctx, yyscanner, YY_("memory exhausted"));
   yyresult = 2;
   goto yyreturnlab;
 
@@ -2023,7 +2025,7 @@ yyreturnlab:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, ctx);
+                  yytoken, &yylval, ctx, yyscanner);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -2032,7 +2034,7 @@ yyreturnlab:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, ctx);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, ctx, yyscanner);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -2043,19 +2045,14 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 296 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 320 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
 
 
-void yyerror(sdb::ParserContext& ctx, const char *s) {
+void yyerror(sdb::ParserContext& ctx, yyscan_t, const char *s) {
     ctx.error_message = s;
 }
 
-extern void LexerSetInput(std::string_view input);
-extern void LexerCleanup(void);
-
 bool sdb::ParseQuery(sdb::ParserContext& ctx, std::string_view input) {
-    LexerSetInput(input);
-    int result = yyparse(ctx);
-    LexerCleanup();
-    return result == 0;
+    sdb::Scanner scanner{input};
+    return yyparse(ctx, scanner.yyscanner) == 0;
 }

--- a/libs/iresearch/include/iresearch/parser/lucene_parser.hpp
+++ b/libs/iresearch/include/iresearch/parser/lucene_parser.hpp
@@ -59,13 +59,36 @@ extern int yydebug;
 namespace irs { class Filter; }
 namespace sdb { struct ParserContext; }
 
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void* yyscan_t;
+#endif
+
+namespace sdb {
+
+class Scanner {
+ public:
+    explicit Scanner(std::string_view input);
+    ~Scanner();
+
+    Scanner(const Scanner&) = delete;
+    Scanner& operator=(const Scanner&) = delete;
+
+    yyscan_t yyscanner = nullptr;
+
+ private:
+    void* _buffer = nullptr;
+};
+
+}
+
 struct StringSpan {
     const char* data;
     size_t len;
     operator std::string_view() const { return {data, len}; }
 };
 
-#line 68 "libs/iresearch/include/iresearch/parser/lucene_parser.hpp"
+#line 91 "libs/iresearch/include/iresearch/parser/lucene_parser.hpp"
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
@@ -125,7 +148,7 @@ struct StringSpan {
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 55 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
+#line 79 "libs/iresearch/include/iresearch/parser/lucene_parser.y"
 
     StringSpan sv;
     // A number is a count where one is asked for and a term everywhere else,
@@ -139,7 +162,7 @@ union YYSTYPE
     struct { int min; int max; } gap;
     irs::Filter* filter;
 
-#line 142 "libs/iresearch/include/iresearch/parser/lucene_parser.hpp"
+#line 165 "libs/iresearch/include/iresearch/parser/lucene_parser.hpp"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -150,7 +173,7 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-int yyparse (sdb::ParserContext& ctx);
+int yyparse (sdb::ParserContext& ctx, yyscan_t yyscanner);
 
 
 #endif /* !YY_YY_LIBS_IRESEARCH_INCLUDE_IRESEARCH_PARSER_LUCENE_PARSER_HPP_INCLUDED  */

--- a/libs/iresearch/include/iresearch/parser/lucene_parser.y
+++ b/libs/iresearch/include/iresearch/parser/lucene_parser.y
@@ -32,6 +32,29 @@
 namespace irs { class Filter; }
 namespace sdb { struct ParserContext; }
 
+#ifndef YY_TYPEDEF_YY_SCANNER_T
+#define YY_TYPEDEF_YY_SCANNER_T
+typedef void* yyscan_t;
+#endif
+
+namespace sdb {
+
+class Scanner {
+ public:
+    explicit Scanner(std::string_view input);
+    ~Scanner();
+
+    Scanner(const Scanner&) = delete;
+    Scanner& operator=(const Scanner&) = delete;
+
+    yyscan_t yyscanner = nullptr;
+
+ private:
+    void* _buffer = nullptr;
+};
+
+}
+
 struct StringSpan {
     const char* data;
     size_t len;
@@ -46,11 +69,12 @@ struct StringSpan {
 %}
 
 %code {
-int yylex(YYSTYPE* yylval);
-void yyerror(sdb::ParserContext& ctx, const char *s);
+int yylex(YYSTYPE* yylval, yyscan_t yyscanner);
+void yyerror(sdb::ParserContext& ctx, yyscan_t yyscanner, const char *s);
 }
 
 %parse-param { sdb::ParserContext& ctx }
+%param { yyscan_t yyscanner }
 
 %union {
     StringSpan sv;
@@ -295,16 +319,11 @@ range_bound:
 
 %%
 
-void yyerror(sdb::ParserContext& ctx, const char *s) {
+void yyerror(sdb::ParserContext& ctx, yyscan_t, const char *s) {
     ctx.error_message = s;
 }
 
-extern void LexerSetInput(std::string_view input);
-extern void LexerCleanup(void);
-
 bool sdb::ParseQuery(sdb::ParserContext& ctx, std::string_view input) {
-    LexerSetInput(input);
-    int result = yyparse(ctx);
-    LexerCleanup();
-    return result == 0;
+    sdb::Scanner scanner{input};
+    return yyparse(ctx, scanner.yyscanner) == 0;
 }

--- a/tests/libs/iresearch/parser/lucene_parser_test.cpp
+++ b/tests/libs/iresearch/parser/lucene_parser_test.cpp
@@ -20,6 +20,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <thread>
+#include <vector>
+#include <cstdint>
 #include <string>
 
 #include "basics/down_cast.h"
@@ -2142,4 +2146,76 @@ TEST_F(LuceneParserTest, FnMaxWidthOverAPair) {
 
 TEST_F(LuceneParserTest, FnMaxWidthTooNarrowIsRefused) {
   EXPECT_ANY_THROW(sdb::ParseQuery(ctx, "fn:maxwidth(1 fn:ordered(a b))"));
+}
+
+namespace {
+
+enum class ParseOutcome : uint8_t { Accepted, Rejected, Threw };
+
+ParseOutcome ParseOnce(std::string_view query) {
+  irs::BooleanFilter root;
+  auto tokenizer = irs::analysis::SegmentationTokenizer::Make(
+    irs::analysis::SegmentationTokenizer::Options{});
+  sdb::ParserContext ctx{root, kFieldId, *tokenizer};
+  ctx.default_field_name = "content";
+  try {
+    return sdb::ParseQuery(ctx, query) ? ParseOutcome::Accepted
+                                       : ParseOutcome::Rejected;
+  } catch (...) {
+    return ParseOutcome::Threw;
+  }
+}
+
+constexpr std::string_view kConcurrentQueries[] = {
+  "hello",
+  "quick AND brown",
+  "+fox -red",
+  "\"hello world\"",
+  "hel*",
+  "content:alpha OR beta",
+  "[a TO z]",
+  "term~2",
+  "alpha^2.5",
+  "fn:ordered(alpha beta)",
+  "\"unterminated",
+  "[unclosed",
+  "((((",
+  "a AND",
+};
+
+}  // namespace
+
+TEST(LuceneParserConcurrency, ParsesDoNotShareScannerState) {
+  constexpr size_t kThreads = 16;
+  constexpr size_t kRounds = 400;
+  constexpr size_t kQueries = std::size(kConcurrentQueries);
+
+  std::array<ParseOutcome, kQueries> expected{};
+  for (size_t q = 0; q < kQueries; ++q) {
+    expected[q] = ParseOnce(kConcurrentQueries[q]);
+  }
+
+  std::vector<std::vector<ParseOutcome>> seen(
+    kThreads, std::vector<ParseOutcome>(kQueries, ParseOutcome::Accepted));
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (size_t t = 0; t < kThreads; ++t) {
+    threads.emplace_back([t, &seen] {
+      for (size_t round = 0; round < kRounds; ++round) {
+        const size_t q = (round + t) % kQueries;
+        seen[t][q] = ParseOnce(kConcurrentQueries[q]);
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  for (size_t t = 0; t < kThreads; ++t) {
+    for (size_t q = 0; q < kQueries; ++q) {
+      EXPECT_EQ(expected[q], seen[t][q])
+        << "thread " << t << " read `" << kConcurrentQueries[q]
+        << "` differently than a parse on its own";
+    }
+  }
 }


### PR DESCRIPTION
`ParseQuery` drove a non-reentrant flex scanner through file-scope state with no lock. `LexerSetInput` deleted the buffer the previous call had installed, so a second thread freed the buffer the first was still reading. Two queries parsed at once either returned a syntax error for a query that has none, or tripped flex's own `end of buffer missed` check, which ends in `exit()` and takes the server with it.

The dev job of run 34590900596 hit the first form on `to_tsquery('quick AND brown')`, in a test file the branch under test never touched.

The parser was already pure, so only the scanner side changes:

- `%option reentrant` on the lexer, and a `Scanner` that owns one scanner and its buffer for the length of one parse, so both are released even when a semantic action throws.
- `%param { yyscan_t yyscanner }` on the grammar, which feeds both `yyparse` and the generated `yylex` call.
- The `BEGIN(INITIAL)` reset is gone. A parse now starts there because its scanner is new, so the failed-quoted-query case it covered no longer exists.
- `YY_FATAL_ERROR` throws instead of calling `exit()`. A query is user input, and a server must not die of one.

`LuceneParserConcurrency.ParsesDoNotShareScannerState` parses fourteen queries from sixteen threads, including ones that fail inside a phrase and inside a range, and compares every outcome against a parse on its own. It segfaults on the old scanner.

The generated sources are regenerated and committed, since builds without flex and bison fall back to them.
