### PR TITLE
feat: a typed object catalog over the embedded docs

### DIFF
--- a/docs/sql/functions/docs.md
+++ b/docs/sql/functions/docs.md
@@ -1,0 +1,134 @@
+---
+title: Documentation Functions
+split: headings
+---
+
+import SqlLogicTest from "@site/src/components/SqlLogicTest";
+
+SereneDB ships its own documentation inside the server binary. At startup the server
+builds the `sdb_docs` schema from it, so the reference material always matches the
+running version and is available with no network access.
+
+The schema holds two tables and a set of functions over them:
+
+| Object | Description |
+| :--- | :--- |
+| `sdb_docs.docs` | One row per documentation page or section, with a full-text index over it. |
+| `sdb_docs.meta` | The hash and layout version of the embedded documentation. |
+
+`sdb_docs` is read-only for every user, including superusers. The server rebuilds it
+when the embedded documentation or its layout changes; writing to it raises an error.
+
+## Documentation paths
+
+Every row is addressed by a `path`. A page indexed as a whole is addressed by its file
+name, and a page split into sections is addressed by its file name followed by the
+chain of headings that leads to the section:
+
+```text
+sql/indexes/index.md#Indexes
+sql/functions/timestamp.md#Timestamp_Functions#Scalar_Timestamp_Functions#date_trunc(part,_timestamp)
+```
+
+Spaces in a heading become underscores and a literal `#` in a heading is escaped as
+`\#`, so the unescaped `#` characters count the heading depth. Paths returned by
+`sdb_docs.search()`, `sdb_docs.sections()` and `sdb_docs.objects()` can be passed
+directly to `sdb_docs.read()`.
+
+## The object catalog
+
+`sdb_docs.objects()` presents the documentation as a catalog of objects rather than a
+set of pages. Each row names one documented thing and says what kind of thing it is,
+which is what makes a name lookup unambiguous: `create` is documented as a client
+method and as part of several statements, but it is not a SQL function, and the
+catalog says so.
+
+| Kind | Contents |
+| :--- | :--- |
+| `function` | Scalar, aggregate, window and table functions. |
+| `statement` | SQL statements such as `CREATE TABLE`. |
+| `tokenizer` | Text search dictionary templates such as `stem` and `ngram`. |
+| `type` | Data types, with their aliases. |
+| `setting` | Configuration options. |
+| `index_type` | Index access methods: `inverted` and `art`. |
+
+<SqlLogicTest id="sql/functions/docs/example_001" />
+
+## Reference
+
+#### `sdb_docs.objects()`
+
+Returns one row per documented object. `name` is the bare identifier, `signature` is
+the full form as documented, and `path` addresses the documentation for that object.
+Overloads appear as separate rows sharing a `name`.
+
+<SqlLogicTest id="sql/functions/docs/example_002" />
+
+| Column | Description | Type |
+| :--- | :--- | :--- |
+| `kind` | The kind of object, from the table above. | `TEXT` |
+| `name` | The bare identifier, for example `date_trunc` or `DECIMAL`. | `TEXT` |
+| `signature` | The documented form, for example `date_trunc(part, timestamp)`. | `TEXT` |
+| `summary` | A single-line description, or `NULL` when the documentation has no lead paragraph. | `TEXT` |
+| `aliases` | Alternative names, for data types and settings that have them. | `TEXT` |
+| `path` | The documentation path, for `sdb_docs.read()`. | `TEXT` |
+| `page` | The file part of `path`. | `TEXT` |
+| `category` | For functions, the documentation page they are grouped under. | `TEXT` |
+| `breadcrumb` | The chain of headings above the object. | `TEXT` |
+
+Filter it with an ordinary `WHERE` clause:
+
+<SqlLogicTest id="sql/functions/docs/example_003" />
+
+<SqlLogicTest id="sql/functions/docs/example_004" />
+
+#### `sdb_docs.search(query, max_hits)`
+
+Full-text search over titles, breadcrumbs and body text, ranked with BM25. Returns
+`path`, `title`, `breadcrumb`, a `snippet` of the first 400 characters and the `score`.
+
+<SqlLogicTest id="sql/functions/docs/example_005" />
+
+#### `sdb_docs.read(path)`
+
+Returns the Markdown source of one page or section, or `NULL` when the path does not
+exist.
+
+<SqlLogicTest id="sql/functions/docs/example_006" />
+
+#### `sdb_docs.sections(prefix)`
+
+Lists every documentation row whose path starts with `prefix`, ordered by path. A
+directory prefix lists the pages beneath it, and a page or section path lists the
+sections beneath that.
+
+<SqlLogicTest id="sql/functions/docs/example_007" />
+
+#### `sdb_docs.reference(name)`
+
+Finds documentation rows whose title is `name` or whose title is `name` applied to
+arguments. It matches on title text alone and has no notion of object kind; prefer
+`sdb_docs.objects()` when the kind matters.
+
+<SqlLogicTest id="sql/functions/docs/example_008" />
+
+#### `sdb_docs.summary(content)`
+
+Reduces a documentation body to a single-line description: the lead paragraph with
+whitespace collapsed and link markup removed, falling back to the `Description` cell
+for pages that open with a table. Returns `NULL` for a body with no prose of its own,
+such as a heading that only groups other headings.
+
+<SqlLogicTest id="sql/functions/docs/example_009" />
+
+## Reading documentation in `psql`
+
+`sdb_docs.read()` returns Markdown containing newlines, which `psql` boxes into its
+aligned output by default. Switch to unaligned, untabulated output to read it:
+
+```sql
+\pset format unaligned
+\pset tuples_only on
+\pset pager always
+SELECT sdb_docs.read('sql/indexes/index.md#Indexes');
+```

--- a/server/docs/docs_loader.cpp
+++ b/server/docs/docs_loader.cpp
@@ -20,7 +20,9 @@
 
 #include "docs/docs_loader.h"
 
+#include <absl/algorithm/container.h>
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_replace.h>
 #include <absl/time/time.h>
 
 #include <algorithm>
@@ -54,12 +56,166 @@ namespace {
 
 constexpr std::string_view kSchema = StaticStrings::kDocsSchema;
 constexpr std::string_view kTable = "sdb_docs.docs";
-constexpr std::string_view kIndexRelation = "sdb_docs.docs_fts";
 constexpr std::string_view kMeta = "sdb_docs.meta";
-constexpr std::string_view kIndex = "docs_fts";
-constexpr std::string_view kTokenizer = "sdb_docs.tokenizer";
-constexpr int kLayout = 12;
+constexpr int kLayout = 13;
 constexpr size_t kInsertBatch = 32;
+
+constexpr std::string_view kSchemaToken = "@schema@";
+
+std::string Sql(std::string_view statement) {
+  return absl::StrReplaceAll(statement, {{kSchemaToken, kSchema}});
+}
+
+constexpr std::string_view kResetSql = R"sql(
+DROP FUNCTION IF EXISTS @schema@.search(TEXT, INTEGER);
+DROP FUNCTION IF EXISTS @schema@.read(TEXT);
+DROP FUNCTION IF EXISTS @schema@.sections(TEXT);
+DROP FUNCTION IF EXISTS @schema@.reference(TEXT);
+DROP FUNCTION IF EXISTS @schema@.objects();
+DROP FUNCTION IF EXISTS @schema@.summary(TEXT);
+DROP TABLE IF EXISTS @schema@.docs;
+DROP TABLE IF EXISTS @schema@.meta;
+DROP TEXT SEARCH DICTIONARY IF EXISTS @schema@.tokenizer;
+
+CREATE TEXT SEARCH DICTIONARY @schema@.tokenizer
+  (template = 'segmentation', case = 'lower', break = 'alpha',
+   frequency = true, position = true);
+
+CREATE TABLE @schema@.docs (
+  path TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  breadcrumb TEXT NOT NULL,
+  content TEXT NOT NULL,
+  content_text TEXT NOT NULL
+) WITH (storage = 'search', compaction_interval = 0);
+
+CREATE INDEX docs_fts ON @schema@.docs USING inverted (
+  title @schema@.tokenizer,
+  breadcrumb @schema@.tokenizer,
+  content_text @schema@.tokenizer);
+)sql";
+
+constexpr std::string_view kGrantSql = R"sql(
+GRANT USAGE ON SCHEMA @schema@ TO PUBLIC;
+GRANT SELECT ON @schema@.docs TO PUBLIC;
+GRANT SELECT ON @schema@.meta TO PUBLIC;
+)sql";
+
+constexpr std::string_view kFinalizeSql[]{
+  R"sql(VACUUM (REFRESH_TABLE) @schema@.docs)sql",
+  R"sql(
+CREATE FUNCTION @schema@.search(query TEXT, max_hits INTEGER)
+RETURNS TABLE(path TEXT, title TEXT, breadcrumb TEXT, snippet TEXT,
+              score DOUBLE PRECISION)
+LANGUAGE SQL BEGIN ATOMIC
+  SELECT d.path, d.title, d.breadcrumb,
+         left(regexp_replace(d.content_text, '\s+', ' ', 'g'), 400),
+         BM25(d.tableoid)
+  FROM @schema@.docs_fts d
+  WHERE d.title @@ query OR d.breadcrumb @@ query OR d.content_text @@ query
+  ORDER BY BM25(d.tableoid) DESC, d.path
+  LIMIT max_hits;
+END)sql",
+  R"sql(
+CREATE FUNCTION @schema@.read(doc_path TEXT) RETURNS TEXT
+LANGUAGE SQL BEGIN ATOMIC
+  SELECT content FROM @schema@.docs WHERE path = doc_path;
+END)sql",
+  R"sql(
+CREATE FUNCTION @schema@.sections(prefix TEXT)
+RETURNS TABLE(path TEXT, title TEXT, breadcrumb TEXT)
+LANGUAGE SQL BEGIN ATOMIC
+  SELECT path, title, breadcrumb FROM @schema@.docs
+  WHERE starts_with(path, prefix) ORDER BY path;
+END)sql",
+  R"sql(
+CREATE FUNCTION @schema@.reference(name TEXT)
+RETURNS TABLE(path TEXT, title TEXT, breadcrumb TEXT)
+LANGUAGE SQL BEGIN ATOMIC
+  SELECT path, title, breadcrumb FROM @schema@.docs
+  WHERE lower(title) = lower(name)
+     OR starts_with(lower(title), lower(name) || '(')
+  ORDER BY path;
+END)sql",
+  R"sql(
+CREATE FUNCTION @schema@.summary(doc_content TEXT) RETURNS TEXT
+LANGUAGE SQL BEGIN ATOMIC
+SELECT regexp_replace(coalesce(
+  nullif(regexp_replace(trim(CASE
+    WHEN regexp_matches(regexp_replace(ltrim(doc_content),
+                                       '^# [^' || chr(10) || ']*' || chr(10) || '+', ''),
+                        '^(\||#|```|> |[-*+] |[0-9]+\. )') THEN ''
+    ELSE split_part(regexp_replace(ltrim(doc_content),
+                                   '^# [^' || chr(10) || ']*' || chr(10) || '+', ''),
+                    chr(10) || chr(10), 1) END), '\s+', ' ', 'g'), ''),
+  nullif(trim(regexp_replace(
+    regexp_extract(doc_content, '\|\s*\*\*Description\*\*\s*\|([^|]*)\|', 1),
+    '\s+', ' ', 'g')), '')), '\[([^\]]*)\]\([^)]*\)', '\1', 'g');
+END)sql",
+  R"sql(
+CREATE FUNCTION @schema@.objects()
+RETURNS TABLE(kind TEXT, name TEXT, signature TEXT, summary TEXT, aliases TEXT,
+              path TEXT, page TEXT, category TEXT, breadcrumb TEXT)
+LANGUAGE SQL BEGIN ATOMIC
+WITH d AS (
+  SELECT path, title, breadcrumb, content, split_part(path, '#', 1) AS page,
+         path = split_part(path, '#', 1) || '#' ||
+                replace(replace(title, '#', '\#'), ' ', '_') AS is_title_row
+  FROM @schema@.docs
+),
+rows AS (
+  SELECT d.page AS page, d.path AS path, d.breadcrumb AS breadcrumb,
+         u.tbl.headers[1] AS first_header,
+         CASE WHEN u.tbl.headers[1] = 'Index'
+              THEN regexp_extract(v.cells[1], '\]\(\.?/?([^)]*?)(?:/index)?\.mdx?\)', 1)
+              ELSE regexp_replace(v.cells[1], '\[([^\]]*)\]\([^)]*\)', '\1', 'g') END AS name,
+         CASE WHEN list_contains(u.tbl.headers, 'Aliases')
+              THEN nullif(v.cells[list_position(u.tbl.headers, 'Aliases')], '') END AS aliases,
+         regexp_replace(CASE WHEN list_contains(u.tbl.headers, 'Description')
+                             THEN v.cells[list_position(u.tbl.headers, 'Description')]
+                             WHEN list_contains(u.tbl.headers, 'Purpose')
+                             THEN v.cells[list_position(u.tbl.headers, 'Purpose')] END,
+                        '\[([^\]]*)\]\([^)]*\)', '\1', 'g') AS summary
+  FROM d, unnest(md_extract_tables_json(d.content)) AS u(tbl),
+          unnest(u.tbl.table_data) AS v(cells)
+  WHERE d.is_title_row
+),
+rows_named AS (
+  SELECT page, path, breadcrumb, first_header, name, aliases, summary,
+         CASE WHEN regexp_matches(name, '^[A-Za-z_][A-Za-z0-9_]*\(')
+              THEN regexp_extract(name, '^([A-Za-z_][A-Za-z0-9_]*)\(', 1)
+              ELSE name END AS bare
+  FROM rows
+)
+SELECT 'function' AS kind,
+       regexp_extract(title, '^(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)\(', 1) AS name,
+       title AS signature, @schema@.summary(content) AS summary, NULL AS aliases,
+       path AS path, page AS page,
+       regexp_replace(regexp_replace(page, '^sql/functions/', ''), '(/index)?\.mdx?$', '') AS category,
+       breadcrumb AS breadcrumb
+FROM d WHERE starts_with(page, 'sql/functions/') AND position('#' IN path) > 0
+   AND regexp_matches(title, '^(?:[A-Za-z_][A-Za-z0-9_]*\.)?[A-Za-z_][A-Za-z0-9_]*\(')
+UNION ALL
+SELECT 'statement', title, title, @schema@.summary(content), NULL, path, page, NULL, breadcrumb
+FROM d WHERE starts_with(page, 'sql/statements/') AND is_title_row
+   AND NOT starts_with(page, 'sql/statements/create_text_search_dictionary/')
+UNION ALL
+SELECT 'tokenizer', title, title, @schema@.summary(content), NULL, path, page, NULL, breadcrumb
+FROM d WHERE starts_with(page, 'sql/statements/create_text_search_dictionary/') AND is_title_row
+   AND page <> 'sql/statements/create_text_search_dictionary/index.md'
+UNION ALL
+SELECT 'type', bare, name, summary, aliases, path, page, NULL, breadcrumb
+FROM rows_named WHERE page = 'sql/data_types/overview.md' AND first_header = 'Name'
+UNION ALL
+SELECT 'setting', bare, name, summary, aliases, path, page, NULL, breadcrumb
+FROM rows_named WHERE page = 'configuration/overview.md' AND first_header = 'Name'
+UNION ALL
+SELECT 'index_type', bare, name, summary, NULL, path, page, NULL, breadcrumb
+FROM rows_named WHERE page = 'sql/indexes/index.md' AND first_header = 'Index';
+END)sql",
+  R"sql(CREATE TABLE @schema@.meta (hash TEXT, layout INTEGER))sql",
+};
+
 class Loader {
  public:
   Loader(std::string_view database, ObjectId database_id)
@@ -99,79 +255,21 @@ class Loader {
   }
 
   bool Rebuild() {
-    for (const auto& sql : {
-           absl::StrCat("DROP FUNCTION IF EXISTS ", kSchema,
-                        ".search(TEXT, INTEGER)"),
-           absl::StrCat("DROP FUNCTION IF EXISTS ", kSchema, ".read(TEXT)"),
-           absl::StrCat("DROP FUNCTION IF EXISTS ", kSchema, ".sections(TEXT)"),
-           absl::StrCat("DROP FUNCTION IF EXISTS ", kSchema,
-                        ".reference(TEXT)"),
-           absl::StrCat("DROP TABLE IF EXISTS ", kTable),
-           absl::StrCat("DROP TABLE IF EXISTS ", kMeta),
-           absl::StrCat("DROP TEXT SEARCH DICTIONARY IF EXISTS ", kTokenizer),
-           absl::StrCat("CREATE TEXT SEARCH DICTIONARY ", kTokenizer,
-                        " (template = 'segmentation', case = 'lower', "
-                        "break = 'alpha', frequency = true, position = true)"),
-           absl::StrCat("CREATE TABLE ", kTable,
-                        " (path TEXT PRIMARY KEY, title TEXT NOT NULL, "
-                        "breadcrumb TEXT NOT NULL, "
-                        "content TEXT NOT NULL, content_text TEXT NOT NULL) "
-                        "WITH (storage = 'search', compaction_interval = 0)"),
-           absl::StrCat("CREATE INDEX ", kIndex, " ON ", kTable,
-                        " USING inverted (title ", kTokenizer, ", breadcrumb ",
-                        kTokenizer, ", content_text ", kTokenizer, ")"),
-         }) {
-      if (!Run(sql)) {
-        return false;
-      }
-    }
-    if (!Insert()) {
+    if (!Run(Sql(kResetSql)) || !Insert() || !RunAll(kFinalizeSql)) {
       return false;
     }
-    for (const auto& sql : {
-           absl::StrCat("VACUUM (REFRESH_TABLE) ", kTable),
-           absl::StrCat(
-             "CREATE FUNCTION ", kSchema,
-             ".search(query TEXT, max_hits INTEGER) RETURNS TABLE(path TEXT, "
-             "title TEXT, breadcrumb TEXT, snippet TEXT, score DOUBLE "
-             "PRECISION) LANGUAGE SQL BEGIN ATOMIC SELECT d.path, d.title, "
-             "d.breadcrumb, left(regexp_replace(d.content_text, '\\s+', ' ', "
-             "'g'), 400), BM25(d.tableoid) FROM ",
-             kIndexRelation,
-             " d WHERE d.title @@ query OR d.breadcrumb @@ query OR "
-             "d.content_text @@ query ORDER BY BM25(d.tableoid) DESC, d.path "
-             "LIMIT max_hits; END"),
-           absl::StrCat("CREATE FUNCTION ", kSchema,
-                        ".read(doc_path TEXT) RETURNS TEXT LANGUAGE SQL BEGIN "
-                        "ATOMIC SELECT content FROM ",
-                        kTable, " WHERE path = doc_path; END"),
-           absl::StrCat("CREATE FUNCTION ", kSchema,
-                        ".sections(prefix TEXT) RETURNS TABLE(path TEXT, title "
-                        "TEXT, breadcrumb TEXT) LANGUAGE SQL BEGIN ATOMIC "
-                        "SELECT path, title, breadcrumb FROM ",
-                        kTable,
-                        " WHERE starts_with(path, prefix) ORDER BY path; END"),
-           absl::StrCat("CREATE FUNCTION ", kSchema,
-                        ".reference(name TEXT) RETURNS TABLE(path TEXT, title "
-                        "TEXT, breadcrumb TEXT) LANGUAGE SQL BEGIN ATOMIC "
-                        "SELECT path, title, breadcrumb FROM ",
-                        kTable,
-                        " WHERE lower(title) = lower(name) OR "
-                        "starts_with(lower(title), lower(name) || '(') ORDER "
-                        "BY path; END"),
-           absl::StrCat("CREATE TABLE ", kMeta, " (hash TEXT, layout INTEGER)"),
-           absl::StrCat("INSERT INTO ", kMeta, " VALUES ('", GetDocsHash(),
-                        "', ", kLayout, ")"),
-           absl::StrCat("GRANT USAGE ON SCHEMA ", StaticStrings::kDocsSchema,
-                        " TO PUBLIC"),
-           absl::StrCat("GRANT SELECT ON ", kTable, " TO PUBLIC"),
-           absl::StrCat("GRANT SELECT ON ", kMeta, " TO PUBLIC"),
-         }) {
-      if (!Run(sql)) {
-        return false;
-      }
+    if (!Run(absl::StrCat("INSERT INTO ", kMeta, " VALUES ('", GetDocsHash(),
+                          "', ", kLayout, ")"))) {
+      return false;
     }
-    return true;
+    return Run(Sql(kGrantSql));
+  }
+
+  template<size_t N>
+  bool RunAll(const std::string_view (&statements)[N]) {
+    return absl::c_all_of(statements, [this](std::string_view statement) {
+      return Run(Sql(statement));
+    });
   }
 
   bool Run(const std::string& sql) {

--- a/server/network/http/mcp/tools.cpp
+++ b/server/network/http/mcp/tools.cpp
@@ -163,12 +163,105 @@ yaclib::Task<ToolResult> ListDocs(RequestContext& ctx, const ToolArgs& args) {
   co_return ToolResult{std::move(text)};
 }
 
+// The catalog keyed by object rather than by page: one line per documented
+// function, statement, tokenizer, type, setting or index type.
+yaclib::Task<ToolResult> ListObjects(RequestContext& ctx,
+                                     const ToolArgs& args) {
+  const auto kind = args.kind.value_or("");
+  auto result = co_await ctx.RunQuery(
+    absl::StrCat(
+      "SELECT kind, signature, coalesce(summary, '') AS summary "
+      "FROM sdb_docs.objects() ",
+      kind.empty() ? "" : absl::StrCat("WHERE kind = ", SqlLiteral(kind), " "),
+      "ORDER BY kind, name, path"),
+    /*writes=*/false);
+  if (result->HasError()) {
+    co_return Error(absl::StrCat("list_objects failed: ", result->GetError()));
+  }
+  if (result->RowCount() == 0) {
+    co_return Error(absl::StrCat(
+      "No objects of kind: ", kind,
+      ". Known kinds: function, statement, tokenizer, type, setting, "
+      "index_type."));
+  }
+  std::string text;
+  for (size_t row = 0; row < result->RowCount(); ++row) {
+    absl::StrAppend(&text, row == 0 ? "" : "\n",
+                    Cell(*result, "signature", row));
+    if (kind.empty()) {
+      absl::StrAppend(&text, " (", Cell(*result, "kind", row), ")");
+    }
+    if (const auto summary = Cell(*result, "summary", row); !summary.empty()) {
+      absl::StrAppend(&text, " - ", summary);
+    }
+  }
+  co_return ToolResult{std::move(text)};
+}
+
+// Every object carrying the name, because a caller that does not know an
+// object's kind cannot disambiguate one.
+yaclib::Task<ToolResult> DescribeObject(RequestContext& ctx,
+                                        const ToolArgs& args) {
+  if (!args.name || absl::StripAsciiWhitespace(*args.name).empty()) {
+    co_return Error("describe_object: name must not be empty");
+  }
+  auto result = co_await ctx.RunQuery(
+    absl::StrCat("SELECT o.kind, o.signature, o.breadcrumb, o.path, d.content "
+                 "FROM sdb_docs.objects() o JOIN sdb_docs.docs d USING (path) "
+                 "WHERE lower(o.name) = lower(",
+                 SqlLiteral(*args.name), ") ORDER BY o.kind, o.path"),
+    /*writes=*/false);
+  if (result->HasError()) {
+    co_return Error(
+      absl::StrCat("describe_object failed: ", result->GetError()));
+  }
+  if (result->RowCount() == 0) {
+    auto similar = co_await ctx.RunQuery(
+      absl::StrCat("SELECT kind, signature FROM sdb_docs.objects() WHERE name "
+                   "ILIKE '%' || ",
+                   SqlLiteral(*args.name),
+                   " || '%' ORDER BY length(name), name LIMIT 10"),
+      /*writes=*/false);
+    std::string text =
+      absl::StrCat("No documented object named: ", *args.name, ".");
+    if (!similar->HasError() && similar->RowCount() > 0) {
+      absl::StrAppend(&text, "\n\nMaybe you meant:");
+      for (size_t row = 0; row < similar->RowCount(); ++row) {
+        absl::StrAppend(&text, "\n  ", Cell(*similar, "signature", row), " (",
+                        Cell(*similar, "kind", row), ")");
+      }
+    } else {
+      absl::StrAppend(&text,
+                      " Use list_objects to see what exists, or search_docs to "
+                      "search the prose.");
+    }
+    co_return Error(std::move(text));
+  }
+  std::string text;
+  for (size_t row = 0; row < result->RowCount(); ++row) {
+    absl::StrAppend(&text, row == 0 ? "" : "\n\n---\n\n",
+                    Cell(*result, "signature", row), " (",
+                    Cell(*result, "kind", row),
+                    ")\npath: ", Cell(*result, "path", row), "\n");
+    if (const auto breadcrumb = Cell(*result, "breadcrumb", row);
+        !breadcrumb.empty()) {
+      absl::StrAppend(&text, "in: ", breadcrumb, "\n");
+    }
+    if (const auto content = Cell(*result, "content", row); !content.empty()) {
+      absl::StrAppend(&text, "\n", content);
+    }
+  }
+  co_return ToolResult{std::move(text)};
+}
+
 using ToolFn = yaclib::Task<ToolResult> (*)(RequestContext&, const ToolArgs&);
 
-constexpr std::array<std::pair<std::string_view, ToolFn>, 3> kTools{{
+constexpr std::array<std::pair<std::string_view, ToolFn>, 5> kTools{{
   {"search_docs", &SearchDocs},
   {"read_doc", &ReadDoc},
   {"list_docs", &ListDocs},
+  {"list_objects", &ListObjects},
+  {"describe_object", &DescribeObject},
 }};
 
 }  // namespace
@@ -212,6 +305,31 @@ const ToolsList& Tools() {
                                         .description =
                                           "Path prefix to filter by; omit for "
                                           "all pages"}}}}},
+      {.name = "list_objects",
+       .description =
+         "List everything SereneDB documents, one line per object, as "
+         "'signature (kind) - summary'. Consult this before writing "
+         "SereneDB-specific SQL: SereneDB is not Postgres full-text search, so "
+         "a function you expect may not exist under the name you expect. Pass "
+         "a kind to keep the list small.",
+       .inputSchema =
+         {.properties = {{"kind",
+                          {.type = "string",
+                           .description =
+                             "One of function, statement, tokenizer, type, "
+                             "setting, index_type; omit for everything"}}}}},
+      {.name = "describe_object",
+       .description =
+         "Return the full documentation for a named object. Reports every "
+         "object carrying the name, since one name can be a function and a "
+         "data type at once. Use it to confirm a function exists and to read "
+         "its signature before calling it.",
+       .inputSchema = {.properties = {{"name",
+                                       {.type = "string",
+                                        .description =
+                                          "Bare object name as returned by "
+                                          "list_objects, e.g. 'ts_phrase'"}}},
+                       .required = {"name"}}},
     }};
   return list;
 }

--- a/server/network/http/mcp/tools.h
+++ b/server/network/http/mcp/tools.h
@@ -36,6 +36,8 @@ struct ToolArgs {
   std::optional<std::string> query;
   std::optional<std::string> path;
   std::optional<std::string> prefix;
+  std::optional<std::string> kind;
+  std::optional<std::string> name;
   std::optional<int64_t> limit;
 };
 

--- a/tests/drivers/python/test_mcp_api.py
+++ b/tests/drivers/python/test_mcp_api.py
@@ -122,7 +122,13 @@ def test_ping(conn):
 def test_tools_list(conn):
     tools = rpc(conn, "tools/list")["result"]["tools"]
     names = [t["name"] for t in tools]
-    assert names == ["search_docs", "read_doc", "list_docs"]
+    assert names == [
+        "search_docs",
+        "read_doc",
+        "list_docs",
+        "list_objects",
+        "describe_object",
+    ]
     for tool in tools:
         assert tool["description"]
         assert tool["inputSchema"]["type"] == "object"
@@ -250,3 +256,72 @@ def test_list_docs_sections(conn):
     assert lines[0] == "sql/functions/search/scoring.md#Relevance_Scoring - Relevance Scoring"
     assert "sql/functions/search/scoring.md#Relevance_Scoring#Scorer_Functions - Scorer Functions (Relevance Scoring)" in lines
     assert len(lines) > 5
+
+
+def test_list_objects_by_kind(conn):
+    text, is_error = call_tool(conn, "list_objects", {"kind": "index_type"})
+    assert not is_error
+    lines = sorted(text.split("\n"))
+    assert len(lines) == 2
+    assert lines[0].startswith("art - ")
+    assert lines[1].startswith("inverted - ")
+
+
+def test_list_objects_all_kinds_are_labelled(conn):
+    text, is_error = call_tool(conn, "list_objects", {})
+    assert not is_error
+    lines = text.split("\n")
+    assert len(lines) > 400
+    kinds = {"function", "statement", "tokenizer", "type", "setting", "index_type"}
+    seen = set()
+    for line in lines:
+        for kind in kinds:
+            if f"({kind})" in line:
+                seen.add(kind)
+    assert seen == kinds
+
+
+def test_list_objects_unknown_kind(conn):
+    text, is_error = call_tool(conn, "list_objects", {"kind": "nonesuch"})
+    assert is_error and "Known kinds" in text
+
+
+def test_describe_object(conn):
+    text, is_error = call_tool(conn, "describe_object", {"name": "ts_phrase"})
+    assert not is_error
+    assert text.startswith("ts_phrase(")
+    assert "(function)" in text.split("\n")[0]
+    assert "path: sql/functions/search/full-text.md#" in text
+
+
+def test_describe_object_reports_every_kind(conn):
+    text, is_error = call_tool(conn, "describe_object", {"name": "minhash"})
+    assert not is_error
+    headers = [
+        line for line in text.split("\n") if line.endswith(("(function)", "(tokenizer)"))
+    ]
+    assert len(headers) == 2
+    assert "\n---\n" in text
+
+
+def test_describe_object_is_case_insensitive(conn):
+    text, is_error = call_tool(conn, "describe_object", {"name": "TS_PHRASE"})
+    assert not is_error and text.startswith("ts_phrase(")
+
+
+def test_describe_object_unknown_suggests(conn):
+    text, is_error = call_tool(conn, "describe_object", {"name": "to_tsvector"})
+    assert is_error
+    assert "No documented object named: to_tsvector" in text
+
+
+def test_describe_object_unknown_lists_similar(conn):
+    text, is_error = call_tool(conn, "describe_object", {"name": "phrase"})
+    assert is_error
+    assert "Maybe you meant:" in text
+    assert "ts_phrase(" in text
+
+
+def test_describe_object_empty_name(conn):
+    text, is_error = call_tool(conn, "describe_object", {"name": "   "})
+    assert is_error and "name" in text

--- a/tests/sqllogic/sdb/pg/site_docs/sql/functions/docs.test
+++ b/tests/sqllogic/sdb/pg/site_docs/sql/functions/docs.test
@@ -1,0 +1,78 @@
+# Examples for the documentation-function page. The embedded docs are built by
+# the server at startup, so these need no setup; they assert that each example
+# still runs rather than pinning output that changes whenever docs/ changes.
+
+# DOCS_TEST: example_001
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT kind, count(*) FROM sdb_docs.objects() GROUP BY kind ORDER BY count(*) DESC;
+
+# DOCS_TEST: example_002
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT name, signature, summary
+FROM sdb_docs.objects()
+WHERE kind = 'function' AND name = 'date_trunc'
+ORDER BY path;
+
+# DOCS_TEST: example_003
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT name, summary FROM sdb_docs.objects() WHERE kind = 'tokenizer' ORDER BY name;
+
+# DOCS_TEST: example_004
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT name, aliases FROM sdb_docs.objects() WHERE kind = 'type' AND aliases IS NOT NULL ORDER BY name;
+
+# DOCS_TEST: example_005
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT path, title, breadcrumb, score FROM sdb_docs.search('inverted index options', 5);
+
+# DOCS_TEST: example_006
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT sdb_docs.read('sql/indexes/index.md#Indexes');
+
+# DOCS_TEST: example_007
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT path, title FROM sdb_docs.sections('sql/functions/search/') ORDER BY path;
+
+# DOCS_TEST: example_008
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT path, title, breadcrumb FROM sdb_docs.reference('date_trunc');
+
+# DOCS_TEST: example_009
+
+# DOCS_TEST_BODY
+
+connection docs database=postgres
+statement ok
+SELECT sdb_docs.summary(content) FROM sdb_docs.docs WHERE path = 'sql/indexes/index.md#Indexes';

--- a/tests/sqllogic/sdb/pg/system/sdb_docs.test
+++ b/tests/sqllogic/sdb/pg/system/sdb_docs.test
@@ -89,7 +89,7 @@ query
 SELECT length(hash), layout FROM sdb_docs.meta;
 ----
 length	layout
-64	12
+64	13
 
 # The breadcrumb is indexed: a breadcrumb match names an ancestor heading.
 connection docs database=postgres

--- a/tests/sqllogic/sdb/pg/system/sdb_docs_objects.test
+++ b/tests/sqllogic/sdb/pg/system/sdb_docs_objects.test
@@ -1,0 +1,136 @@
+# Structure of the typed object catalog derived from the embedded docs, checked
+# as invariants over every row so that adding or editing documentation pages
+# does not touch this file. Counts are loose lower bounds for the same reason.
+
+connection docs database=postgres
+query
+SELECT count(*) FROM sdb_docs.objects()
+WHERE kind IS NULL OR name IS NULL OR name = '' OR signature IS NULL OR path IS NULL;
+----
+count
+0
+
+# Every row points at a row of the docs table.
+connection docs database=postgres
+query
+SELECT count(*) FROM sdb_docs.objects() o
+WHERE NOT EXISTS (SELECT 1 FROM sdb_docs.docs d WHERE d.path = o.path);
+----
+count
+0
+
+# The page column is the file part of the path.
+connection docs database=postgres
+query
+SELECT count(*) FROM sdb_docs.objects() WHERE page <> split_part(path, '#', 1);
+----
+count
+0
+
+# Names are bare identifiers: no markdown, no signature, no leading whitespace.
+connection docs database=postgres
+query
+SELECT count(*) FROM sdb_docs.objects() WHERE name ~ '[`\[\]()]' OR name <> trim(name);
+----
+count
+0
+
+# A function's signature is its name applied to arguments, optionally qualified
+# by the schema the function lives in.
+connection docs database=postgres
+query
+SELECT bool_and(starts_with(signature, name || '(')
+                OR strpos(signature, '.' || name || '(') > 0)
+FROM sdb_docs.objects() WHERE kind = 'function';
+----
+bool_and
+t
+
+# Summaries are a single collapsed line, and nearly every object has one.
+connection docs database=postgres
+query
+SELECT count(*) FILTER (WHERE summary LIKE '%' || chr(10) || '%'),
+       count(*) FILTER (WHERE summary IS NULL) * 10 < count(*)
+FROM sdb_docs.objects();
+----
+count	?column?
+0	t
+
+# An object is identified by its kind, name and the doc row it came from.
+# Overloads legitimately repeat (kind, name), so the path is part of the key.
+connection docs database=postgres
+query
+SELECT count(*) FROM (
+  SELECT kind, name, path FROM sdb_docs.objects() GROUP BY 1, 2, 3 HAVING count(*) > 1);
+----
+count
+0
+
+# Every kind is populated.
+connection docs database=postgres
+query
+SELECT count(*) FILTER (WHERE kind = 'function') > 400,
+       count(*) FILTER (WHERE kind = 'statement') > 30,
+       count(*) FILTER (WHERE kind = 'tokenizer') > 20,
+       count(*) FILTER (WHERE kind = 'type') > 20,
+       count(*) FILTER (WHERE kind = 'setting') > 100,
+       count(*) FILTER (WHERE kind = 'index_type') = 2
+FROM sdb_docs.objects();
+----
+?column?	?column?	?column?	?column?	?column?	?column?
+t	t	t	t	t	t
+
+# Spot resolution across kinds.
+connection docs database=postgres
+query
+SELECT count(*) FILTER (WHERE kind = 'function' AND name = 'date_trunc') > 1,
+       count(*) FILTER (WHERE kind = 'statement' AND name = 'CREATE TABLE') = 1,
+       count(*) FILTER (WHERE kind = 'type' AND name = 'VARCHAR' AND aliases LIKE '%TEXT%') = 1,
+       count(*) FILTER (WHERE kind = 'index_type' AND name = 'inverted') = 1,
+       count(*) FILTER (WHERE kind = 'tokenizer' AND name = 'stem') = 1
+FROM sdb_docs.objects();
+----
+?column?	?column?	?column?	?column?	?column?
+t	t	t	t	t
+
+# The catalog knows object kinds, so a name documented only as a client method
+# or as parser syntax is never reported as a SQL function.
+connection docs database=postgres
+query
+SELECT count(*) FROM sdb_docs.objects()
+WHERE kind = 'function' AND lower(name) IN ('create', 'delete', 'similarity_search', 'drop_table');
+----
+count
+0
+
+# The feature documents itself: schema-qualified headings classify as functions.
+connection docs database=postgres
+query
+SELECT count(*) > 0 FROM sdb_docs.objects() WHERE kind = 'function' AND name = 'objects';
+----
+?column?
+t
+
+# Summaries carry no markdown link syntax.
+connection docs database=postgres
+query
+SELECT count(*) FROM sdb_docs.objects() WHERE summary ~ '\]\([^)]*\)';
+----
+count
+0
+
+connection docs database=postgres
+statement error
+DROP FUNCTION sdb_docs.objects();
+----
+db error: ERROR: schema "sdb_docs" is read-only
+DETAIL: The embedded documentation is rebuilt from the server binary at startup.
+
+
+connection docs database=postgres
+statement error
+CREATE OR REPLACE FUNCTION sdb_docs.summary(doc_content TEXT) RETURNS TEXT LANGUAGE SQL BEGIN ATOMIC SELECT ''; END;
+----
+db error: ERROR: schema "sdb_docs" is read-only
+DETAIL: The embedded documentation is rebuilt from the server binary at startup.
+


### PR DESCRIPTION
## Why

`sdb_docs.docs` is **page shaped**: rows are documentation pages and headings keyed by file path. Nothing in it says what *kind* of thing a name refers to, so a name lookup is ambiguous:

- `sdb_docs.reference('create')` returns a **LangChain Python method**, because the only link between a name and its docs is a fuzzy title match.
- There is no way to ask "what aggregate functions exist?" or "does `ts_phrase` exist, and what is its signature?" without searching prose.

## What

`sdb_docs.objects()` derives one row per documented object from the same markdown, and `sdb_docs.summary()` is the one line description it uses. **No new tables** — both are SQL functions over `sdb_docs.docs`, classifying by path prefix and heading shape.

| kind | count |
| --- | --- |
| function | 628 |
| setting | 166 |
| statement | 45 |
| type | 31 |
| tokenizer | 28 |
| index_type | 2 |

892 of the 900 carry a summary. Three cases needed care:

- a `split: headings` title row opens with its own `# H1`, which has to be skipped **without** letting a container heading borrow its child's prose (`Scorers` correctly has no summary);
- aggregates document themselves with a `| **Description** |` table rather than a lead paragraph, which recovers 71 of 77 otherwise empty function summaries;
- index types spell their identifiers only in the **link target**, not the label, so `inverted` and `art` come from `./inverted/index.md` and `./art.md` rather than "Inverted Index".

The regex allows an optional schema prefix so the new page's own `sdb_docs.objects()` heading classifies, i.e. the feature appears in its own catalog.

## MCP

`list_objects` and `describe_object`. The three existing tools are all keyed on doc paths, so an agent cannot cheaply confirm a function exists before emitting SQL against it. `describe_object` reports **every** object carrying a name, since one name can be a function and a tokenizer at once (`minhash`). Asking for `to_tsvector` now returns a clear "no such object" rather than nothing useful.

Measured: the whole function vocabulary is ~20k tokens with summaries, ~1.7k as bare names.

## Also

- Documents the `sdb_docs` schema, which had **no page at all** — this covers the four pre-existing functions too.
- Folds the SQL in `docs_loader.cpp` into named constants so the statements read as SQL instead of `StrCat` fragments. `Rebuild()` goes from ~90 lines to 9.
- `kLayout` 12 -> 13, so existing datadirs rebuild.

## Testing

- `sdb/pg/system/sdb_docs.test`, `sdb_docs_objects.test` (new, structural invariants over every row) and `site_docs/sql/functions/docs.test` (new, nine runnable examples) pass on **both** pg-wire-simple and pg-wire-extended.
- `test_mcp_api.py`: 31 passed, including 8 new cases.
- Verified that the layout bump actually triggers a rebuild against an **existing** datadir, not just a fresh one.

## Depends on

serenedb/duckdb_markdown#1. `objects()` fans `md_extract_tables_json` across worker threads, which makes an existing abort in cmark-gfm reachable: `cmark_gfm_core_extensions_ensure_registered()` guards itself with a plain `static int`, and `cmark_register_node_flag()` calls `abort()` when a flag is registered twice. Measured at 1 abort in 10 cold starts before the fix, 0 in 35 after.

**This should land after that submodule fix and the pin bump**, or CI here may flake intermittently.